### PR TITLE
Fix: ox_inventory image path resovl

### DIFF
--- a/bridge/client/inventory.lua
+++ b/bridge/client/inventory.lua
@@ -21,8 +21,9 @@ local function chooseImageResolver()
     if not active then return function() return nil end end
 
     if active == 'ox_inventory' then
+        local root = GetConvar('inventory:imagepath', 'nui://ox_inventory/web/images')
         return function(item)
-            return ('nui://%s/web/images/%s.png'):format(active, item)
+            return ('%s/%s.png'):format(root, item)
         end
     end
 


### PR DESCRIPTION
## Issue

For servers using alternative methods to host ox_inventory image files, the application would fail to obtain the appropriate image files due to it always using the nui path.

## Contents

This PR addresses this mistake by calling the conVar `inventory:imagepath` and uses the associated value as the root to generate the path towards the image, hence resolving the issues of either images hosted by another resource or externally on a fileserver / CDN.