### PR TITLE
fix(client/main): add missing exports for phone items with ox_inventory

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -447,6 +447,12 @@ local function TogglePhone()
     OpenPhone()
 end
 
+-- Dynamically create exports for each defined phone item to work with ox_inventory.
+local phoneItems = config.Phone.Items
+for i = 1, #phoneItems do
+    exports(('usePhone_%s'):format(phoneItems[i].color), TogglePhone)
+end
+
 -- Keybind wiring. RegisterKeyMapping lets players rebind via Settings > Key Bindings; the
 -- default comes from config.Phone.Keybind. There is no chat command - the phone opens by using a
 -- phone item, or via this keybind (itself server-gated on ownership inside TogglePhone). The `-`


### PR DESCRIPTION
## Issue

The installation documentation provides an item list to use with ox_inventory. The items are defined to work with an export. The exports do not exist by default.

## Contents

This PR addresses this mistake by looping over the phone items listed in `configs/phone.lua` and automatically generating an export for each one.