### PR TITLE
fix(notes): keep sketch board white in dark mode

### DIFF
--- a/web/src/apps/notes/SketchCanvas.tsx
+++ b/web/src/apps/notes/SketchCanvas.tsx
@@ -162,7 +162,11 @@ export function SketchCanvas({ initial, onSave, onCancel }: Props) {
     }
 
     const pageBg  = isDark ? 'rgb(var(--base))' : '#d4d4d4';
-    const canvasBg = isDark ? '#0d0d0e' : '#ffffff';
+    // The board stays white in BOTH themes. toDataURL() captures only the canvas bitmap -
+    // this background is CSS on the wrapper and is never baked into the saved PNG - so a
+    // dark board made strokes look one way while editing and another way once saved, since
+    // both render paths (NoteEditor thumbnail + fullscreen preview) composite over #fff.
+    const canvasBg = '#ffffff';
     const tray    = isDark ? 'rgb(var(--elevated))' : '#f2f2f7';
 
     return (


### PR DESCRIPTION
Sketches looked different after saving in dark mode.

canvas.toDataURL() captures only the canvas bitmap; the board colour is CSS
on the wrapper div and is never baked into the PNG. So the saved sketch is
dark strokes on a TRANSPARENT background. The editor composited that over
#0d0d0e in dark mode, while both render paths composite it over #fff
(NoteEditor thumbnail and fullscreen preview) - same pixels, inverted
backdrop.

Pin the board to white in both themes so what you draw is what you get. The
default pen (#1d1d1f) already suits a white board, and the surrounding page
and tool tray still follow the theme.


Fixes #12
