### PR TITLE
fix(control center): Record button opens the camera in VIDEO mode

### DIFF
--- a/web/src/apps/camera/Camera.tsx
+++ b/web/src/apps/camera/Camera.tsx
@@ -11,6 +11,7 @@ import { NearbyVoiceCapture, registerGatedMic, unregisterGatedMic, gateAcquire, 
 import { isVideoUrl } from '@/core/photosApi';
 import { getGameRender, type GameRender } from '@/render';
 import { useDeckActive } from '@/shell/deckActive';
+import { useLaunchIntent } from '@/shell/launchIntent';
 import { t } from '@/i18n';
 import { formatDuration } from '@/lib/time';
 import shutterSfx from '@/assets/camera/shutter.mp3';
@@ -100,6 +101,16 @@ export function Camera({ onClose, onLandscapeChange, onOpenApp, photoOnly = fals
         setHideHomeIndicator(true);
         return () => setHideHomeIndicator(false);
     }, [photoOnly, setHideHomeIndicator]);
+
+    // Control Center has separate Photo and Record buttons that both open this app, so
+    // the mode has to come from the launch itself. photoOnly callers stay pinned to
+    // PHOTO. Switching out of VIDEO already stops any in-flight recording below.
+    useLaunchIntent<{ mode?: string }>('camera', ({ mode: wanted }) => {
+        if (photoOnly || !wanted) return;
+        if ((MODE_OPTIONS as readonly string[]).includes(wanted)) {
+            setMode(wanted as typeof MODE_OPTIONS[number]);
+        }
+    });
 
     const canvasRef    = useRef<HTMLCanvasElement>(null);
     const viewportRef  = useRef<HTMLDivElement>(null);

--- a/web/src/shell/ControlCenter.tsx
+++ b/web/src/shell/ControlCenter.tsx
@@ -6,6 +6,7 @@ import {
 import type { LucideIcon } from 'lucide-react';
 
 import { fetchNui, isFiveM } from '@/core/nui';
+import { setLaunchIntent } from '@/shell/launchIntent';
 import { trackFraction } from '@/lib/zoom';
 import { useTheme } from '@/stores/themeStore';
 import { useMusic, useMusicProgress } from '@/apps/music/MusicContext';
@@ -41,7 +42,11 @@ export function ControlCenter({ open, onClose, onOpenApp, onWifi }: {
             if (r && typeof r.on === 'boolean') setFlash(r.on);
         });
     }
-    function launch(id: string) { onOpenApp(id); onClose(); }
+    function launch(id: string, intent?: unknown) {
+        if (intent !== undefined) setLaunchIntent(id, intent);
+        onOpenApp(id);
+        onClose();
+    }
 
     const mediaMode = !!music.current;
     const volValue  = mediaMode ? Math.round(music.volume * 100) : ringtoneVol;
@@ -84,10 +89,10 @@ export function ControlCenter({ open, onClose, onOpenApp, onWifi }: {
                     <div className="rounded-[36px] bg-white/[0.10] p-[22px]">
                         <div className="grid grid-cols-4 justify-items-center gap-y-[22px]">
                             <Circle icon={Plane}      on={airplaneMode}    onClick={toggleAirplane}                color="#ff9f0a"                 label={t('shell.airplaneMode','Airplane Mode')} />
-                            <Circle icon={Video}                            onClick={() => launch('camera')}                                       label={t('shell.record','Record')} />
+                            <Circle icon={Video}                            onClick={() => launch('camera', { mode: 'VIDEO' })}                    label={t('shell.record','Record')} />
                             <Circle icon={Flashlight} on={flash}           onClick={toggleFlash}                   color="#ffffff" glyph="#1c1c1e" label={t('shell.flashlight','Flashlight')} />
                             <Circle icon={Moon}       on={focus}           onClick={() => setFocus(v => !v)}       color="#5e5ce6"                 label={t('shell.focus','Focus')} />
-                            <Circle icon={Camera}                           onClick={() => launch('camera')}                                       label={t('shell.camera','Camera')} />
+                            <Circle icon={Camera}                           onClick={() => launch('camera', { mode: 'PHOTO' })}                    label={t('shell.camera','Camera')} />
                             <Circle icon={BatteryLow} on={lowPower}        onClick={() => setLowPower(v => !v)}    color="#ffd60a" glyph="#1c1c1e" label={t('shell.lowPowerMode','Low Power Mode')} />
                             <Circle icon={Contrast}   on={theme === 'dark'} onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')} color="#5e5ce6" label={t('shell.darkMode','Dark Mode')} />
                             <Circle icon={Smartphone} on={rotation}        onClick={() => setRotation(v => !v)}    color="#ff453a"                 label={t('shell.rotationLock','Rotation Lock')} />

--- a/web/src/shell/launchIntent.test.ts
+++ b/web/src/shell/launchIntent.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { consumeLaunchIntent, resetLaunchIntents, setLaunchIntent, subscribeLaunchIntent } from './launchIntent';
+
+// The hook is a thin wrapper over these; what matters for #13 is the delivery
+// semantics, which are pure and testable without a React renderer.
+describe('launchIntent', () => {
+    beforeEach(() => resetLaunchIntents());
+
+    it('delivers a queued intent to the app it was addressed to', () => {
+        setLaunchIntent('camera', { mode: 'VIDEO' });
+        expect(consumeLaunchIntent('camera')).toEqual({ mode: 'VIDEO' });
+    });
+
+    it('is one-shot, so a later open does not replay a stale intent', () => {
+        setLaunchIntent('camera', { mode: 'VIDEO' });
+        expect(consumeLaunchIntent('camera')).toEqual({ mode: 'VIDEO' });
+        expect(consumeLaunchIntent('camera')).toBeUndefined();
+    });
+
+    it('returns undefined when nothing was queued', () => {
+        expect(consumeLaunchIntent('camera')).toBeUndefined();
+    });
+
+    it('does not deliver one app\'s intent to another', () => {
+        setLaunchIntent('camera', { mode: 'VIDEO' });
+        expect(consumeLaunchIntent('notes')).toBeUndefined();
+        expect(consumeLaunchIntent('camera')).toEqual({ mode: 'VIDEO' });
+    });
+
+    it('notifies an app that is already mounted, so a retained app still gets the mode', () => {
+        const seen: unknown[] = [];
+        subscribeLaunchIntent('camera', () => seen.push(consumeLaunchIntent('camera')));
+
+        setLaunchIntent('camera', { mode: 'VIDEO' });
+        // The #13 case: second launch, different mode, no remount in between.
+        setLaunchIntent('camera', { mode: 'PHOTO' });
+
+        expect(seen).toEqual([{ mode: 'VIDEO' }, { mode: 'PHOTO' }]);
+    });
+
+    it('only wakes subscribers of the target app', () => {
+        const camera = vi.fn();
+        const notes  = vi.fn();
+        subscribeLaunchIntent('camera', camera);
+        subscribeLaunchIntent('notes', notes);
+
+        setLaunchIntent('camera', { mode: 'VIDEO' });
+
+        expect(camera).toHaveBeenCalledTimes(1);
+        expect(notes).not.toHaveBeenCalled();
+    });
+
+    it('stops notifying after unsubscribe', () => {
+        const fn = vi.fn();
+        const off = subscribeLaunchIntent('camera', fn);
+        off();
+        setLaunchIntent('camera', { mode: 'VIDEO' });
+        expect(fn).not.toHaveBeenCalled();
+    });
+
+    it('survives a subscriber unsubscribing during notify', () => {
+        const later = vi.fn();
+        const off = subscribeLaunchIntent('camera', () => off());
+        subscribeLaunchIntent('camera', later);
+        expect(() => setLaunchIntent('camera', { mode: 'VIDEO' })).not.toThrow();
+        expect(later).toHaveBeenCalledTimes(1);
+    });
+});

--- a/web/src/shell/launchIntent.ts
+++ b/web/src/shell/launchIntent.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+
+// A one-shot payload handed to an app as it is opened - "open the camera in VIDEO
+// mode", not just "open the camera".
+//
+// onOpenApp() only carries an app id, and widening it is not enough on its own:
+// AppDeck keeps apps ALIVE, so an app opened a second time does not remount and an
+// `initialMode`-style prop would only ever apply on the first open. Hence a channel
+// the app drains both on mount (opened cold) and on notify (already retained).
+//
+// Intents are one-shot: drained on read, so returning to an app later does not
+// silently re-apply an old launch payload.
+
+const pending   = new Map<string, unknown>();
+const listeners = new Map<string, Set<() => void>>();
+
+/** Queues the payload for `appId`. Call immediately BEFORE onOpenApp(appId). */
+export function setLaunchIntent(appId: string, intent: unknown): void {
+    pending.set(appId, intent);
+    const subs = listeners.get(appId);
+    if (subs) for (const fn of [...subs]) fn();
+}
+
+/** Takes the pending intent for `appId`, if any. One-shot: a second call returns undefined. */
+export function consumeLaunchIntent<T = unknown>(appId: string): T | undefined {
+    if (!pending.has(appId)) return undefined;
+    const intent = pending.get(appId) as T;
+    pending.delete(appId);
+    return intent;
+}
+
+/** Notifies when an intent is queued for `appId`. Returns the unsubscribe. */
+export function subscribeLaunchIntent(appId: string, fn: () => void): () => void {
+    let subs = listeners.get(appId);
+    if (!subs) { subs = new Set(); listeners.set(appId, subs); }
+    subs.add(fn);
+    return () => {
+        subs.delete(fn);
+        if (subs.size === 0) listeners.delete(appId);
+    };
+}
+
+/** Test seam: drops all queued intents. */
+export function resetLaunchIntents(): void {
+    pending.clear();
+}
+
+/**
+ * Applies a pending launch intent for `appId`, once per intent.
+ * @param apply called with the payload; safe to call setState from
+ */
+export function useLaunchIntent<T>(appId: string, apply: (intent: T) => void): void {
+    const applyRef = useRef(apply);
+    applyRef.current = apply;
+
+    useEffect(() => {
+        const drain = () => {
+            const intent = consumeLaunchIntent<T>(appId);
+            if (intent !== undefined) applyRef.current(intent);
+        };
+        // Cold open: the intent was queued before this component existed.
+        drain();
+        return subscribeLaunchIntent(appId, drain);
+    }, [appId]);
+}


### PR DESCRIPTION
The Record and Camera buttons were identical calls - both launch('camera') -
so Record always landed on PHOTO.

onOpenApp() carries only an app id, and widening it is not enough by itself:
AppDeck keeps apps alive, so the camera does not remount on a second open and
an `initialMode`-style prop would only ever apply the first time.

Add a small one-shot launch-intent channel instead. Control Center queues
{ mode } before opening, and the camera drains it both on mount (cold open)
and on notify (already retained), so switching Photo -> Record -> Photo lands
in the right mode every time. Intents are consumed on read, so reopening the
camera normally later does not replay an old mode.

photoOnly callers (streaks) stay pinned to PHOTO, and an unknown mode is
ignored. Switching out of VIDEO already stops an in-flight recording.

Covered by 8 unit tests over the delivery semantics: addressing, one-shot
drain, retained-app notify, and unsubscribe-during-notify.

Note: this issue's other half - the flashlight following camera direction -
is already fixed by PR #27, so it is deliberately untouched here.


Fixes #13
