### PR TITLE
fix(darkchat): centre room code inside its badge

### DIFF
--- a/web/src/apps/darkchat/RoomsList.tsx
+++ b/web/src/apps/darkchat/RoomsList.tsx
@@ -89,7 +89,7 @@ function RoomRow({ room, onOpen }: { room: Room; onOpen: () => void }) {
                 <div className="flex items-center gap-2">
                     <span className="truncate text-[19px] font-semibold text-white">{room.name}</span>
                     {room.isPrivate && room.code && (
-                        <span className="shrink-0 rounded-md bg-white/10 px-1.5 py-[1px] text-[11px] font-semibold tracking-wider text-white/55">{room.code}</span>
+                        <span className="shrink-0 rounded-md bg-white/10 px-1.5 py-[4px] text-[11px] font-semibold leading-none tracking-wider text-white/55">{room.code}</span>
                     )}
                 </div>
                 <p className="truncate text-[15px] text-white/45">{room.topic}</p>


### PR DESCRIPTION
The room-code pill used `text-[11px]` with no `leading-*`. A Tailwind
arbitrary font-size sets font-size only and does not reset line-height, so
the span inherited preflight's unitless 1.5 -> a 16.5px line box around 11px
text. Room codes are all-caps/digits with no descenders, so the glyph mass
sat in the upper half and the bottom gap read as roughly double the top -
the code looked stuck to the top of the badge.

Add `leading-none` (matching the same pattern in photogram's StoriesRow) and
bump the vertical padding 1px -> 4px so the pill keeps its previous ~18.5px
height while the text is now actually centred.


Fixes #19
