### PR TITLE
fix(wordle): stop typed letters reaching the game

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import { useAutoContrast } from '@/shell/useAutoContrast';
 import { VolumeHUD }   from '@/shell/VolumeHUD';
 import { SetupFlow }   from '@/shell/SetupFlow';
 import type { SetupResult } from '@/shell/SetupFlow';
+import { isKeyboardCaptured } from '@/hooks/useKeyboardCapture';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { seedSessionState } from '@/hooks/useSessionState';
 import { onOpenMail, onOpenMaps, onOpenMessages } from '@/shell/deeplink';
@@ -768,11 +769,14 @@ function AppContent() {
     useEffect(() => {
         function onKey(e: KeyboardEvent) {
             const tgt = e.target as HTMLElement | null;
-            const typing = !!tgt && (
+            // isKeyboardCaptured() covers apps that type without a text field (the word
+            // games read keys off window), so the L hotkey does not lock the phone
+            // mid-guess.
+            const typing = isKeyboardCaptured() || (!!tgt && (
                 tgt.tagName === 'INPUT'
                 || tgt.tagName === 'TEXTAREA'
                 || tgt.isContentEditable
-            );
+            ));
 
             if (e.key === 'Escape') {
                 if (switcherOpen)            { handleSwitcherDismiss(); return; }

--- a/web/src/apps/wordle/OnlineMatch.tsx
+++ b/web/src/apps/wordle/OnlineMatch.tsx
@@ -5,6 +5,7 @@ import { COLS, RANK, ROWS, scoreGuess } from './engine';
 import type { Cell } from './engine';
 import { wordForGame } from './words';
 import { useCountdown } from '@/hooks/useCountdown';
+import { useKeyboardCapture } from '@/hooks/useKeyboardCapture';
 import { TIME_LIMIT } from './stats';
 import { emptyProgress, type CoopState, type Progress } from './coopTypes';
 import { moveApi } from '@/apps/_games/onlineApi';
@@ -84,12 +85,15 @@ export function OnlineMatch({ pal, dk, gameId, opponent, pot, oppLeft, onResult,
         if (/^[A-Z]$/.test(k)) setCurrent(c => (c.length < COLS ? c + k : c));
     }, [phase, submit]);
 
+    // See SoloGame: this view types without a text field, so it claims the keyboard.
+    useKeyboardCapture();
+
     const keyRef = useRef(onKey); keyRef.current = onKey;
     useEffect(() => {
         function onKeyDown(e: KeyboardEvent) {
-            if (e.key === 'Enter') keyRef.current('ENTER');
-            else if (e.key === 'Backspace') keyRef.current('BACK');
-            else { const c = e.key.toUpperCase(); if (/^[A-Z]$/.test(c)) keyRef.current(c); }
+            if (e.key === 'Enter') { e.preventDefault(); keyRef.current('ENTER'); }
+            else if (e.key === 'Backspace') { e.preventDefault(); keyRef.current('BACK'); }
+            else { const c = e.key.toUpperCase(); if (/^[A-Z]$/.test(c)) { e.preventDefault(); keyRef.current(c); } }
         }
         window.addEventListener('keydown', onKeyDown);
         return () => window.removeEventListener('keydown', onKeyDown);

--- a/web/src/apps/wordle/OnlineMatch.tsx
+++ b/web/src/apps/wordle/OnlineMatch.tsx
@@ -6,6 +6,7 @@ import type { Cell } from './engine';
 import { wordForGame } from './words';
 import { useCountdown } from '@/hooks/useCountdown';
 import { useKeyboardCapture } from '@/hooks/useKeyboardCapture';
+import { useDeckActive } from '@/shell/deckActive';
 import { TIME_LIMIT } from './stats';
 import { emptyProgress, type CoopState, type Progress } from './coopTypes';
 import { moveApi } from '@/apps/_games/onlineApi';
@@ -88,8 +89,12 @@ export function OnlineMatch({ pal, dk, gameId, opponent, pot, oppLeft, onResult,
     // See SoloGame: this view types without a text field, so it claims the keyboard.
     useKeyboardCapture();
 
+    // Only listen while foreground - see SoloGame. A backgrounded but still-mounted match
+    // would keep preventDefault()-ing every key and starve text fields in other apps.
+    const deckActive = useDeckActive();
     const keyRef = useRef(onKey); keyRef.current = onKey;
     useEffect(() => {
+        if (!deckActive) return;
         function onKeyDown(e: KeyboardEvent) {
             if (e.key === 'Enter') { e.preventDefault(); keyRef.current('ENTER'); }
             else if (e.key === 'Backspace') { e.preventDefault(); keyRef.current('BACK'); }
@@ -97,7 +102,7 @@ export function OnlineMatch({ pal, dk, gameId, opponent, pot, oppLeft, onResult,
         }
         window.addEventListener('keydown', onKeyDown);
         return () => window.removeEventListener('keydown', onKeyDown);
-    }, []);
+    }, [deckActive]);
 
     useEffect(() => {
         if (timeLeft !== 0) return;

--- a/web/src/apps/wordle/SoloGame.tsx
+++ b/web/src/apps/wordle/SoloGame.tsx
@@ -5,6 +5,7 @@ import { COLS, KEY_ROWS, RANK, ROWS, scoreGuess } from './engine';
 import type { Cell } from './engine';
 import { randomWord } from './words';
 import { useCountdown } from '@/hooks/useCountdown';
+import { useKeyboardCapture } from '@/hooks/useKeyboardCapture';
 import { TIME_LIMIT } from './stats';
 import { t } from '@/i18n';
 import { formatDuration } from '@/lib/time';
@@ -67,12 +68,16 @@ export function SoloGame({ pal, onFinish, onNew }: {
         if (/^[A-Z]$/.test(k)) setCurrent(c => (c.length < COLS ? c + k : c));
     }, [status, submit]);
 
+    // No text field to type into, so claim the keyboard explicitly - otherwise every
+    // letter also reaches the game and fires inventory / weapon wheel / other binds.
+    useKeyboardCapture();
+
     const pressRef = useRef(press); pressRef.current = press;
     useEffect(() => {
         function onKey(e: KeyboardEvent) {
-            if (e.key === 'Enter') pressRef.current('ENTER');
-            else if (e.key === 'Backspace') pressRef.current('BACK');
-            else { const c = e.key.toUpperCase(); if (/^[A-Z]$/.test(c)) pressRef.current(c); }
+            if (e.key === 'Enter') { e.preventDefault(); pressRef.current('ENTER'); }
+            else if (e.key === 'Backspace') { e.preventDefault(); pressRef.current('BACK'); }
+            else { const c = e.key.toUpperCase(); if (/^[A-Z]$/.test(c)) { e.preventDefault(); pressRef.current(c); } }
         }
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);

--- a/web/src/apps/wordle/SoloGame.tsx
+++ b/web/src/apps/wordle/SoloGame.tsx
@@ -6,6 +6,7 @@ import type { Cell } from './engine';
 import { randomWord } from './words';
 import { useCountdown } from '@/hooks/useCountdown';
 import { useKeyboardCapture } from '@/hooks/useKeyboardCapture';
+import { useDeckActive } from '@/shell/deckActive';
 import { TIME_LIMIT } from './stats';
 import { t } from '@/i18n';
 import { formatDuration } from '@/lib/time';
@@ -72,8 +73,15 @@ export function SoloGame({ pal, onFinish, onNew }: {
     // letter also reaches the game and fires inventory / weapon wheel / other binds.
     useKeyboardCapture();
 
+    // Only listen while this is the foreground app. AppDeck keeps a played-then-home'd
+    // game mounted in the background, and a mount-scoped window listener would keep
+    // preventDefault()-ing every key, so text fields in other apps (Messages, DarkChat)
+    // receive nothing until the game is fully exited. Gate on deckActive so the listener
+    // detaches the instant the game is backgrounded and re-attaches when it returns.
+    const deckActive = useDeckActive();
     const pressRef = useRef(press); pressRef.current = press;
     useEffect(() => {
+        if (!deckActive) return;
         function onKey(e: KeyboardEvent) {
             if (e.key === 'Enter') { e.preventDefault(); pressRef.current('ENTER'); }
             else if (e.key === 'Backspace') { e.preventDefault(); pressRef.current('BACK'); }
@@ -81,7 +89,7 @@ export function SoloGame({ pal, onFinish, onNew }: {
         }
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
-    }, []);
+    }, [deckActive]);
 
     useEffect(() => {
         if (timeLeft === 0 && status === 'playing') { setStatus('lost'); done(false); }

--- a/web/src/hooks/useKeyboardCapture.ts
+++ b/web/src/hooks/useKeyboardCapture.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+
+import { fetchNui, isFiveM } from '@/core/nui';
+import { useDeckActive } from '@/shell/deckActive';
+
+// Claims the physical keyboard for an app that types WITHOUT a text field.
+//
+// The phone normally hands the keyboard back to the game via
+// SetNuiFocusKeepInput(true) (client/main.lua), and only releases it while a real
+// <input>/<textarea>/contentEditable is focused - App.tsx watches focusin/focusout
+// and pings the 'sd-phone:typing' NUI callback. Apps that read keys straight off
+// window (the word games) never trip that listener, so every letter typed also
+// reached the game and could fire inventory / weapon wheel / any RegisterKeyMapping
+// bind belonging to another resource.
+//
+// This hook drives the SAME callback imperatively, so no Lua change is needed.
+// Capture is gated on useDeckActive() rather than on mount, because AppDeck keeps
+// apps alive in the background - a mount-scoped claim would keep swallowing keys
+// after the user went back to the home screen or holstered the phone.
+//
+// Refcounted, since two capturing views can briefly overlap during a transition and
+// the last one to unmount must not release a claim the other still holds.
+let holders = 0;
+
+function setTyping(typing: boolean): void {
+    if (!isFiveM) return;
+    void fetchNui('sd-phone:typing', { typing });
+}
+
+function acquire(): void {
+    holders += 1;
+    if (holders === 1) setTyping(true);
+}
+
+function release(): void {
+    holders = Math.max(0, holders - 1);
+    if (holders === 0) setTyping(false);
+}
+
+/** True while some app holds the keyboard, so shell-level hotkeys can stand down too. */
+export function isKeyboardCaptured(): boolean {
+    return holders > 0;
+}
+
+/**
+ * Keeps game keybinds from firing while a keyboard-driven app is the foreground app.
+ * @param enabled pass false to hold the claim off (e.g. the game is over / a sheet is up)
+ */
+export function useKeyboardCapture(enabled = true): void {
+    const deckActive = useDeckActive();
+    const on = enabled && deckActive;
+
+    useEffect(() => {
+        if (!on) return;
+        acquire();
+        return release;
+    }, [on]);
+}


### PR DESCRIPTION
Typing a guess also fired game keybinds - inventory, weapon wheel, anything
bound by another resource via RegisterKeyMapping.

The phone gives the keyboard back to the game with SetNuiFocusKeepInput(true)
and only takes it while a real text field is focused: App.tsx watches
focusin/focusout and pings the 'sd-phone:typing' NUI callback. Wordle has no
<input> anywhere - both views read keys straight off window - so that
listener never fired and keep-input stayed on for the whole game.

Add a useKeyboardCapture() hook that drives the SAME callback imperatively,
so no Lua change is needed. It is gated on useDeckActive(), not on mount,
because AppDeck keeps apps alive in the background - a mount-scoped claim
would keep swallowing keys after the user returned to the home screen or
holstered the phone. Claims are refcounted so two briefly-overlapping views
cannot release each other's claim.

Also:
- preventDefault() on handled keys.
- The shell's L lock-hotkey now stands down while an app holds the keyboard,
  so typing an L mid-guess no longer locks the phone (same root cause).

Only wordle types without a text field today; the hook is there for any
future keyboard-driven app.


Fixes #22
