### PR TITLE
fix(services): list every framework job, not just the active one

### DIFF
--- a/bridge/server/job.lua
+++ b/bridge/server/job.lua
@@ -126,6 +126,34 @@ function job.supportsMultijob()
     return framework.name == 'qb'
 end
 
+---Every job the framework has assigned to this player, not just the active one. On QBox these
+---live in the `player_groups` table and are surfaced on the player object as PlayerData.jobs
+---(jobName -> grade level); plain QBCore and ESX have no multi-job model, so there it is just the
+---active job. The active job is always included and always wins, since it carries the live grade.
+---@param source number player server id
+---@return table<string, integer> jobs jobName -> grade level
+function job.getAll(source)
+    local out = {}
+    local p = player_mod.get(source)
+    if not p then return out end
+
+    if framework.name == 'qb' then
+        local jobs = p.PlayerData and p.PlayerData.jobs
+        if type(jobs) == 'table' then
+            for name, grade in pairs(jobs) do
+                if type(name) == 'string' then
+                    -- QBox stores a bare grade level; tolerate a { level = n } shape too.
+                    out[name] = type(grade) == 'table' and (tonumber(grade.level) or 0) or (tonumber(grade) or 0)
+                end
+            end
+        end
+    end
+
+    local active = job.getName(source)
+    if active then out[active] = job.getGrade(source) end
+    return out
+end
+
 ---Resolve a job's display label ('Police'): qb-core's Shared.Jobs first, then the pcall-guarded
 ---qbx_core GetJob export. Nil when unknown. Read-only.
 ---@param jobName string

--- a/server/services/jobs.lua
+++ b/server/services/jobs.lua
@@ -71,10 +71,6 @@ function jobs.list(src)
 
     local activeJob = job.getName(src)
 
-    -- Seed from the FRAMEWORK, not just the active job. On QBox a player can hold several
-    -- jobs (the `player_groups` table); previously only the active one was folded in, so a
-    -- job assigned outside the phone never appeared in the Jobs tab unless the player had
-    -- accepted a phone-issued offer for it. job.getAll() includes the active job too.
     local map    = store.getSaved(cid)
     local synced = false
     for jName, grade in pairs(job.getAll(src)) do

--- a/server/services/jobs.lua
+++ b/server/services/jobs.lua
@@ -57,7 +57,8 @@ local function savedCount(map)
 end
 
 ---Returns a player's saved jobs + pending offers, or `multijob = false` when the framework has
----no multi-job model; the caller's current framework job is seeded/refreshed into the map first.
+---no multi-job model; every job the FRAMEWORK has assigned (all of them on QBox, not just the
+---active one) is seeded/refreshed into the map first.
 ---@param src number
 ---@return table
 function jobs.list(src)
@@ -68,17 +69,24 @@ function jobs.list(src)
     local cid = player.getIdentifier(src)
     if not cid then return fail('Player not found') end
 
-    local activeJob   = job.getName(src)
-    local activeGrade = job.getGrade(src)
+    local activeJob = job.getName(src)
 
-    local map = store.getSaved(cid)
-    if activeJob and not BLACKLIST[activeJob] then
-        local prev = map[activeJob]
-        if not prev or prev.grade ~= activeGrade then
-            map[activeJob] = { grade = activeGrade }
-            store.setSaved(cid, map)
+    -- Seed from the FRAMEWORK, not just the active job. On QBox a player can hold several
+    -- jobs (the `player_groups` table); previously only the active one was folded in, so a
+    -- job assigned outside the phone never appeared in the Jobs tab unless the player had
+    -- accepted a phone-issued offer for it. job.getAll() includes the active job too.
+    local map    = store.getSaved(cid)
+    local synced = false
+    for jName, grade in pairs(job.getAll(src)) do
+        if not BLACKLIST[jName] then
+            local prev = map[jName]
+            if not prev or prev.grade ~= grade then
+                map[jName] = { grade = grade }
+                synced = true
+            end
         end
     end
+    if synced then store.setSaved(cid, map) end
 
     local list = {}
     for jName, info in pairs(map) do


### PR DESCRIPTION
On QBox a player can hold several jobs (qbx:max_jobs_per_player, stored in
the `player_groups` table), but the Jobs tab only ever showed the active one.

The phone keeps its own `phone_saved_jobs` table and was seeding it solely
from job.getName()/getGrade() - the ACTIVE job. Nothing in the repo read
player_groups at all, so a job assigned directly in qbx_core only appeared if
the player happened to have accepted a phone-issued offer for it. The bridge
had no way to ask for more: every accessor went through PlayerData.job.

- bridge: add job.getAll(source) returning jobName -> grade for every
  assigned job. On QBox these come off PlayerData.jobs (the player_groups
  projection); the active job is always merged in and wins, since it carries
  the live grade. Plain QBCore and ESX have no multi-job model, so they
  simply yield the active job - same behaviour as before.
- services: seed jobs.list() from job.getAll() instead of the active job,
  and persist only when something actually changed.

MaxSavedJobs is untouched: it caps accepting phone offers (enforced in
jobs.accept), so jobs the framework has genuinely assigned are always shown
rather than being hidden by the phone's own cap.

Not verified against a live QBox server; the PlayerData.jobs read is written
defensively (tolerates a bare grade or a { level } shape, and degrades to the
active job if absent). Worth confirming on the reporter's setup.


Fixes #26
