### PR TITLE
fix(config): remove committed GIPHY API key

### DIFF
--- a/configs/server/apikeys.lua
+++ b/configs/server/apikeys.lua
@@ -19,6 +19,6 @@
 -- Left blank here, the uploader falls back to the legacy `sd_fivemanage_key` server convar
 -- (set in server.cfg) so existing setups keep working; new servers can just paste it below.
 return {
-    Giphy           = 'JI9bMQeLFlzXU1SREsKUkwBvRJV83Cpx',
+    Giphy           = '',
     FivemanageMedia = '',
 }


### PR DESCRIPTION
A working GIPHY API key shipped in configs/server/apikeys.lua. Blank it so
servers supply their own.

No code change needed: apiKey() already returns '' when unset, hasKey()
gates the picker, and giphyGet() bails before building a request, so the
GIF picker falls back to its existing "set up GIPHY" hint.

Note: the key remains in git history and should be revoked/regenerated at
developers.giphy.com regardless of this commit.


Fixes #9
