### PR TITLE
fix(settings): resolve every reported Settings issue

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import { AppSwitcher } from '@/shell/AppSwitcher';
 import { AppDeck, FullscreenStage, type DeckAppCtx } from '@/shell/AppDeck';
 import { Homescreen }  from '@/shell/Homescreen';
 import { useBadgeStore } from '@/stores/badgeStore';
+import { useBatteryStore } from '@/stores/batteryStore';
 import { useDownloadStore, useDownloadingIds } from '@/stores/downloadStore';
 import { useLocaleStore } from '@/stores/localeStore';
 import { HomeIndicator } from '@/shell/HomeIndicator';
@@ -227,6 +228,7 @@ function AppContent() {
         setSavedLayout(data.homeLayout ? parseLayout(data.homeLayout) : loadHomeLayout());
         setLocked(data.locked);
         setBattery(data.battery);
+        useBatteryStore.getState().setLevel(data.battery);
         if (data.frameColor) setFrameColor(data.frameColor);
         setLeaving(false);
         setEntering(true);
@@ -486,7 +488,7 @@ function AppContent() {
     }, []);
 
     useNuiEvent('sd-phone:battery', useCallback((pct) => {
-        if (typeof pct === 'number') setBattery(pct);
+        if (typeof pct === 'number') { setBattery(pct); useBatteryStore.getState().setLevel(pct); }
     }, []));
 
     const [notifs, setNotifs] = useState<NotificationItem[]>([]);

--- a/web/src/apps/settings/Settings.tsx
+++ b/web/src/apps/settings/Settings.tsx
@@ -2,9 +2,11 @@ import { t } from '@/i18n';
 import { useSessionState } from '@/hooks/useSessionState';
 import { DisplayBrightnessPage } from './appearance/DisplayBrightnessPage';
 import { FaceUnlockPage } from './security/FaceUnlockPage';
+import { BatteryPage } from './general/BatteryPage';
 import { GeneralPage } from './general/GeneralPage';
 import { NotificationsPage } from './notifications/NotificationsPage';
 import { PhoneSettingsPage } from './security/PhoneSettingsPage';
+import { PrivacySecurityPage } from './security/PrivacySecurityPage';
 import { ProfileCard } from './account/ProfileCard';
 import { SoundHapticsPage } from './sound/SoundHapticsPage';
 import { SearchBar } from '@/ui/SearchBar';
@@ -14,7 +16,7 @@ import { SettingsGroup } from './SettingsGroup';
 import { PushLayer } from './SettingsSubPage';
 import { WallpaperPage } from './appearance/WallpaperPage';
 
-type SubPage = 'general' | 'display' | 'wallpaper' | 'notifications' | 'sound-haptics' | 'face-unlock' | 'phone' | null;
+type SubPage = 'general' | 'display' | 'wallpaper' | 'notifications' | 'sound-haptics' | 'face-unlock' | 'phone' | 'battery' | 'privacy' | null;
 
 export function Settings({ onClose }: { onClose: () => void }) {
     const [subPage, setSubPage] = useSessionState<SubPage>('settings:subPage', null);
@@ -40,6 +42,8 @@ export function Settings({ onClose }: { onClose: () => void }) {
         if (id === 'sound-haptics') setSubPage('sound-haptics');
         if (id === 'face-unlock')   setSubPage('face-unlock');
         if (id === 'phone')         setSubPage('phone');
+        if (id === 'battery')       setSubPage('battery');
+        if (id === 'privacy')       setSubPage('privacy');
     }
 
     const sub =
@@ -50,6 +54,8 @@ export function Settings({ onClose }: { onClose: () => void }) {
         : subPage === 'sound-haptics' ? <SoundHapticsPage      onBack={handleBack} />
         : subPage === 'face-unlock'   ? <FaceUnlockPage        onBack={handleBack} />
         : subPage === 'phone'         ? <PhoneSettingsPage     onBack={handleBack} />
+        : subPage === 'battery'       ? <BatteryPage           onBack={handleBack} />
+        : subPage === 'privacy'       ? <PrivacySecurityPage   onBack={handleBack} onOpenFaceUnlock={() => setSubPage('face-unlock')} />
         : null;
 
     return (

--- a/web/src/apps/settings/appearance/WallpaperPage.tsx
+++ b/web/src/apps/settings/appearance/WallpaperPage.tsx
@@ -6,6 +6,7 @@ import { formatClockTime, formatLongDate, useClock } from '@/hooks/useClock';
 import { useIosPush } from '@/hooks/useIosPush';
 import { PushLayer } from '../SettingsSubPage';
 import { useTheme } from '@/stores/themeStore';
+import { resolveWallpaper } from '@/shell/wallpapers';
 import { AppIconSVG } from '@/shell/AppIconSVG';
 import { Toggle } from '@/ui/Toggle';
 import { WallpaperPickerPage } from './WallpaperPickerPage';
@@ -85,7 +86,7 @@ export function WallpaperPage({ onBack }: { onBack: () => void }) {
 function LockThumb({ wallpaper, time, date }: { wallpaper: string; time: string; date: string }) {
     return (
         <div className="relative flex-1 overflow-hidden rounded-[12px] shadow-md" style={{ aspectRatio: '390/844' }}>
-            <img src={wallpaper} className="absolute inset-0 h-full w-full object-cover" alt="" draggable={false} />
+            <img src={resolveWallpaper(wallpaper)} className="absolute inset-0 h-full w-full object-cover" alt="" draggable={false} />
             <div className="absolute inset-0 bg-gradient-to-b from-black/25 via-transparent to-black/20" />
 
             <div className="relative mt-4 flex justify-center">
@@ -107,7 +108,7 @@ function LockThumb({ wallpaper, time, date }: { wallpaper: string; time: string;
 function HomeThumb({ wallpaper }: { wallpaper: string }) {
     return (
         <div className="relative flex-1 overflow-hidden rounded-[12px] shadow-md" style={{ aspectRatio: '390/844' }}>
-            <img src={wallpaper} className="absolute inset-0 h-full w-full object-cover" alt="" draggable={false} />
+            <img src={resolveWallpaper(wallpaper)} className="absolute inset-0 h-full w-full object-cover" alt="" draggable={false} />
             <div className="absolute inset-0 bg-gradient-to-b from-black/10 to-black/35" />
 
             <div className="relative mt-4 grid grid-cols-4 gap-[4px] px-2">

--- a/web/src/apps/settings/general/AboutPage.tsx
+++ b/web/src/apps/settings/general/AboutPage.tsx
@@ -1,18 +1,30 @@
+import { useEffect, useState } from 'react';
+
 import { t } from '@/i18n';
+import { formatPhone } from '@/lib/phone';
+import { useContacts } from '@/stores/contactsStore';
 import { ListGroup, ListRow } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
+import { OS_VERSION } from './SoftwareUpdatePage';
 
 export function AboutPage({ onBack }: { onBack: () => void }) {
+    const { myName, myNumber, card, load } = useContacts('myName', 'myNumber', 'card', 'load');
+    useEffect(() => { void load(); }, [load]);
+    const [legalOpen, setLegalOpen] = useState(false);
+
+    const name   = card.name || myName || t('settings.myPhone', 'My Phone');
+    const number = myNumber ? formatPhone(myNumber) : '—';
+
     return (
-        <SubPage title={t('settings.about', 'About')} onBack={onBack}>
+        <SubPage title={t('settings.about', 'About')} onBack={onBack} sub={legalOpen ? <LegalPage onBack={() => setLegalOpen(false)} /> : null}>
             <ListGroup>
-                <ListRow label={t('settings.aboutName', 'Name')}         value="SD's Phone"       divider />
+                <ListRow label={t('settings.aboutName', 'Name')}         value={name}   divider />
                 <ListRow label={t('settings.aboutNetwork', 'Network')}      value="LifeInvader"      divider />
-                <ListRow label={t('settings.aboutPhoneNumber', 'Phone Number')} value="+1 (555) 018-2749" />
+                <ListRow label={t('settings.aboutPhoneNumber', 'Phone Number')} value={number} />
             </ListGroup>
 
             <ListGroup>
-                <ListRow label={t('settings.aboutSoftwareVersion', 'Software Version')} value="18.4.1"       divider />
+                <ListRow label={t('settings.aboutSoftwareVersion', 'Software Version')} value={OS_VERSION.replace(/^\D+/, '')} divider />
                 <ListRow label={t('settings.aboutModelName', 'Model Name')}       value="SD Phone Pro"  divider />
                 <ListRow label={t('settings.aboutModelNumber', 'Model Number')}     value="SP-2024"       divider />
                 <ListRow label={t('settings.aboutCapacity', 'Capacity')}         value="256 GB"        />
@@ -25,8 +37,21 @@ export function AboutPage({ onBack }: { onBack: () => void }) {
             </ListGroup>
 
             <ListGroup>
-                <ListRow label={t('settings.aboutLegalRegulatory', 'Legal & Regulatory')} />
+                <ListRow label={t('settings.aboutLegalRegulatory', 'Legal & Regulatory')} onPress={() => setLegalOpen(true)} />
             </ListGroup>
+        </SubPage>
+    );
+}
+
+function LegalPage({ onBack }: { onBack: () => void }) {
+    return (
+        <SubPage title={t('settings.aboutLegalRegulatory', 'Legal & Regulatory')} backLabel={t('settings.about', 'About')} onBack={onBack}>
+            <div className="mx-4 flex flex-col gap-4 rounded-[10px] bg-white px-4 py-4 text-[13px] leading-relaxed text-ios-gray dark:bg-surface">
+                <p>{t('settings.legalIntro', 'This device and its software are provided as part of your service agreement with LifeInvader Wireless.')}</p>
+                <p>{t('settings.legalWarranty', 'Hardware is covered by a one-year limited warranty. Unauthorized modification of the operating system voids all warranty coverage.')}</p>
+                <p>{t('settings.legalRf', 'This equipment complies with San Andreas RF exposure limits for portable devices. FCC ID: SA-SP2024.')}</p>
+                <p>{t('settings.legalTrademarks', 'All product names, logos and brands are property of their respective owners in the state of San Andreas.')}</p>
+            </div>
         </SubPage>
     );
 }

--- a/web/src/apps/settings/general/BatteryPage.tsx
+++ b/web/src/apps/settings/general/BatteryPage.tsx
@@ -1,0 +1,43 @@
+import { BatteryCharging } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { useBatteryStore } from '@/stores/batteryStore';
+import { ListGroup, ListRow, ToggleRow } from '@/ui/ListGroup';
+import { SubPage } from '../SettingsSubPage';
+
+export function BatteryPage({ onBack }: { onBack: () => void }) {
+    const level = useBatteryStore(s => s.level);
+    const low = level <= 20;
+
+    return (
+        <SubPage title={t('settings.battery', 'Battery')} backLabel={t('settings.settings', 'Settings')} onBack={onBack}>
+            <div className="mx-4 overflow-hidden rounded-[10px] bg-white px-4 py-4 dark:bg-surface">
+                <div className="flex items-center justify-between">
+                    <span className="text-[15px] font-semibold text-black dark:text-white">{t('settings.batteryLevel', 'Battery Level')}</span>
+                    <span className="text-[15px] font-semibold tabular-nums" style={{ color: low ? '#ff3b30' : undefined }}>
+                        {level}%
+                    </span>
+                </div>
+                <div className="my-2 h-[18px] w-full overflow-hidden rounded-full bg-ios-gray5 dark:bg-control">
+                    <div
+                        className="h-full rounded-full"
+                        style={{ width: `${level}%`, background: low ? '#ff3b30' : '#34c759' }}
+                    />
+                </div>
+                <div className="flex items-center gap-1.5 text-[12px] text-ios-gray">
+                    <BatteryCharging className="h-[14px] w-[14px]" strokeWidth={2} />
+                    {t('settings.batteryDrainNote', 'Battery drains while the phone is in use and recharges automatically over time.')}
+                </div>
+            </div>
+
+            <ListGroup footer={t('settings.lowPowerFooter', 'Low Power Mode reduces background activity until your phone recharges.')}>
+                <ToggleRow label={t('settings.lowPowerMode', 'Low Power Mode')} />
+            </ListGroup>
+
+            <ListGroup header={t('settings.batteryHealth', 'Battery health')}>
+                <ListRow label={t('settings.maximumCapacity', 'Maximum Capacity')} value="100%" chevron={false} divider />
+                <ListRow label={t('settings.peakPerformance', 'Peak Performance')} value={t('settings.performanceNormal', 'Normal')} chevron={false} />
+            </ListGroup>
+        </SubPage>
+    );
+}

--- a/web/src/apps/settings/general/PhoneStoragePage.tsx
+++ b/web/src/apps/settings/general/PhoneStoragePage.tsx
@@ -19,11 +19,11 @@ const APPS = [
 export function PhoneStoragePage({ onBack }: { onBack: () => void }) {
     return (
         <SubPage title={t('settings.phoneStorage', 'Phone Storage')} onBack={onBack}>
-            <div className="mx-4 overflow-hidden rounded-[10px] bg-white px-4 py-4">
+            <div className="mx-4 overflow-hidden rounded-[10px] bg-white px-4 py-4 dark:bg-surface">
                 <div className="mb-1 text-[13px] font-normal text-ios-gray">
                     {t('settings.storageCapacity', '{gb} GB Capacity', { gb: TOTAL_GB })}
                 </div>
-                <div className="my-2 h-[18px] w-full overflow-hidden rounded-full bg-ios-gray5">
+                <div className="my-2 h-[18px] w-full overflow-hidden rounded-full bg-ios-gray5 dark:bg-control">
                     <div
                         className="h-full rounded-full bg-ios-blue"
                         style={{ width: `${PCT}%` }}

--- a/web/src/apps/settings/general/SoftwareUpdatePage.tsx
+++ b/web/src/apps/settings/general/SoftwareUpdatePage.tsx
@@ -1,28 +1,50 @@
+import { useState } from 'react';
 import { Smartphone } from 'lucide-react';
 
 import { t } from '@/i18n';
 import { ListGroup, ListRow, ToggleRow } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
 
+export const OS_VERSION = 'sdOS 2.1.4';
+
 export function SoftwareUpdatePage({ onBack }: { onBack: () => void }) {
+    const [customizing, setCustomizing] = useState(false);
+
+    const subNode = customizing ? (
+        <CustomizeUpdatesPage onBack={() => setCustomizing(false)} />
+    ) : null;
+
     return (
-        <SubPage title={t('settings.softwareUpdate', 'Software Update')} onBack={onBack}>
-            <div className="mx-4 flex flex-col items-center gap-3 overflow-hidden rounded-[10px] bg-white px-4 py-6">
+        <SubPage title={t('settings.softwareUpdate', 'Software Update')} onBack={onBack} sub={subNode}>
+            <div className="mx-4 flex flex-col items-center gap-3 overflow-hidden rounded-[10px] bg-white px-4 py-6 dark:bg-surface">
                 <div className="flex h-[64px] w-[64px] items-center justify-center rounded-[14px] bg-ios-blue shadow-md">
                     <Smartphone className="h-9 w-9 text-white" strokeWidth={1.75} />
                 </div>
                 <div className="text-center">
-                    <div className="text-[17px] font-semibold text-black">iOS 18.4.1</div>
+                    <div className="text-[17px] font-semibold text-black dark:text-white">{OS_VERSION}</div>
                     <div className="mt-0.5 text-[13px] text-ios-gray">{t('settings.softwareUpToDate', 'Your software is up to date.')}</div>
                 </div>
-                <div className="text-[12px] text-ios-gray">{t('settings.softwareLastChecked', 'Last checked: Today at 20:22')}</div>
             </div>
 
             <ListGroup
                 footer={t('settings.autoUpdatesFooter', 'Automatic updates allow your phone to download and install updates overnight when connected to power.')}
             >
                 <ToggleRow label={t('settings.automaticUpdates', 'Automatic Updates')} defaultOn divider />
-                <ListRow   label={t('settings.customizeAutomaticUpdates', 'Customize Automatic Updates')} />
+                <ListRow   label={t('settings.customizeAutomaticUpdates', 'Customize Automatic Updates')} onPress={() => setCustomizing(true)} />
+            </ListGroup>
+        </SubPage>
+    );
+}
+
+function CustomizeUpdatesPage({ onBack }: { onBack: () => void }) {
+    return (
+        <SubPage title={t('settings.automaticUpdates', 'Automatic Updates')} backLabel={t('settings.softwareUpdate', 'Software Update')} onBack={onBack}>
+            <ListGroup
+                header={t('settings.autoInstallHeader', 'Automatically install')}
+                footer={t('settings.autoInstallFooter', 'Updates download and install overnight while your phone is charging.')}
+            >
+                <ToggleRow label={t('settings.osUpdates', 'System Updates')} defaultOn divider />
+                <ToggleRow label={t('settings.securityUpdates', 'Security Fixes')} defaultOn />
             </ListGroup>
         </SubPage>
     );

--- a/web/src/apps/settings/security/PhoneSettingsPage.tsx
+++ b/web/src/apps/settings/security/PhoneSettingsPage.tsx
@@ -1,21 +1,24 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ChevronLeft, ChevronRight, Copy, Plus, Trash2 } from 'lucide-react';
 
 import { t } from '@/i18n';
+import { formatPhone } from '@/lib/phone';
+import { useContacts } from '@/stores/contactsStore';
 import { useIosPush } from '@/hooks/useIosPush';
 import { ListGroup, ToggleRow } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
 
-const MY_NUMBER = '(123) 456-7890';
-
 
 export function PhoneSettingsPage({ onBack }: { onBack: () => void }) {
+    const { myNumber, load } = useContacts('myNumber', 'load');
+    useEffect(() => { void load(); }, [load]);
+    const number = myNumber ? formatPhone(myNumber) : '—';
     const [showCallerId] = useState(true);
     const [copied,       setCopied]       = useState(false);
     const [showBlocked,  setShowBlocked]  = useState(false);
 
     function copyNumber() {
-        navigator.clipboard?.writeText(MY_NUMBER).catch(() => {});
+        navigator.clipboard?.writeText(number).catch(() => {});
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
     }
@@ -33,7 +36,7 @@ export function PhoneSettingsPage({ onBack }: { onBack: () => void }) {
                     <span className="flex-1 text-[17px] font-normal text-black dark:text-white">
                         {t('settings.myNumber', 'My Number')}
                     </span>
-                    <span className="mr-2 text-[15px] text-ios-gray">{MY_NUMBER}</span>
+                    <span className="mr-2 text-[15px] text-ios-gray">{number}</span>
                     <button
                         type="button"
                         onClick={copyNumber}

--- a/web/src/apps/settings/security/PrivacySecurityPage.tsx
+++ b/web/src/apps/settings/security/PrivacySecurityPage.tsx
@@ -1,0 +1,26 @@
+import { t } from '@/i18n';
+import { ListGroup, ListRow, ToggleRow } from '@/ui/ListGroup';
+import { SubPage } from '../SettingsSubPage';
+
+export function PrivacySecurityPage({ onBack, onOpenFaceUnlock }: { onBack: () => void; onOpenFaceUnlock: () => void }) {
+    return (
+        <SubPage title={t('settings.privacySecurity', 'Privacy & Security')} backLabel={t('settings.settings', 'Settings')} onBack={onBack}>
+            <ListGroup footer={t('settings.privacySecurityFooter', 'Protect your phone with a passcode and control what apps can access.')}>
+                <ListRow label={t('settings.faceUnlockPasscode', 'Face Unlock & Passcode')} onPress={onOpenFaceUnlock} />
+            </ListGroup>
+
+            <ListGroup header={t('settings.privacyHeader', 'Privacy')}>
+                <ToggleRow label={t('settings.locationServices', 'Location Services')} defaultOn divider />
+                <ToggleRow label={t('settings.shareAnalytics', 'Share Analytics')} divider />
+                <ToggleRow label={t('settings.personalizedAds', 'Personalized Ads')} />
+            </ListGroup>
+
+            <ListGroup
+                header={t('settings.securityHeader', 'Security')}
+                footer={t('settings.trackingFooter', 'Apps that want to track your activity across other apps must ask for permission first.')}
+            >
+                <ToggleRow label={t('settings.askAppsToTrack', 'Ask Apps Not to Track')} defaultOn />
+            </ListGroup>
+        </SubPage>
+    );
+}

--- a/web/src/shell/SetupFlow.tsx
+++ b/web/src/shell/SetupFlow.tsx
@@ -127,12 +127,14 @@ export function SetupFlow({ onDone, onHelloChange }: Props) {
                 {stage === 'pin' && (
                     <PinStage
                         onSet={(value) => { setPin(value); next(); }}
-                        onSkip={() => { setPin(null); next(); }}
+                        onSkip={() => { setPin(null); setFaceUnlock(false); next(); }}
                     />
                 )}
                 {stage === 'face' && (
                     <FaceStage
+                        hasPin={pin !== null}
                         onEnable={() => { setFaceUnlock(true); next(); }}
+                        onNeedPin={() => go('pin', 'backward')}
                         onSkip={() => { setFaceUnlock(false); next(); }}
                     />
                 )}
@@ -554,10 +556,12 @@ function PinStage({
 
 
 function FaceStage({
-    onEnable, onSkip,
+    hasPin, onEnable, onNeedPin, onSkip,
 }: {
-    onEnable: () => void;
-    onSkip:   () => void;
+    hasPin:    boolean;
+    onEnable:  () => void;
+    onNeedPin: () => void;
+    onSkip:    () => void;
 }) {
     return (
         <div className="flex flex-1 flex-col px-6">
@@ -572,6 +576,11 @@ function FaceStage({
                 <p className="mt-3 max-w-[300px] text-center text-[18px] leading-snug text-ios-gray">
                     {t('setup.faceUnlockObstructed', 'Face Unlock only works when your face is not obstructed.')}
                 </p>
+                {!hasPin && (
+                    <p className="mt-3 max-w-[300px] text-center text-[15px] leading-snug text-ios-orange">
+                        {t('setup.faceUnlockNeedsPin', 'Face Unlock requires a passcode as a backup. You’ll be asked to set one first.')}
+                    </p>
+                )}
             </div>
 
             <div className="flex-1" />
@@ -579,10 +588,10 @@ function FaceStage({
             <div className="flex flex-col items-center gap-3 pb-16">
                 <button
                     type="button"
-                    onClick={onEnable}
+                    onClick={hasPin ? onEnable : onNeedPin}
                     className="w-full rounded-[18px] bg-ios-blue py-[17px] text-[19px] font-semibold text-white shadow-[0_6px_18px_rgba(10,132,255,0.3)] transition-transform active:scale-[0.98] active:opacity-90"
                 >
-                    {t('setup.enableFaceUnlock', 'Enable Face Unlock')}
+                    {hasPin ? t('setup.enableFaceUnlock', 'Enable Face Unlock') : t('setup.setPasscodeFirst', 'Set Passcode First')}
                 </button>
                 <button
                     type="button"

--- a/web/src/stores/batteryStore.ts
+++ b/web/src/stores/batteryStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+// Battery level lives in App.tsx (fed by the 'sd-phone:battery' NUI event); mirrored here so
+// apps like Settings can read it without prop-threading through the deck.
+interface BatteryState {
+    level: number;
+    setLevel: (pct: number) => void;
+}
+
+export const useBatteryStore = create<BatteryState>((set) => ({
+    level: 100,
+    setLevel: (pct) => set({ level: Math.max(0, Math.min(100, Math.round(pct))) }),
+}));


### PR DESCRIPTION
About page
  Name and Phone Number were hardcoded strings ("SD's Phone",
  "+1 (555) 018-2749"). Both now come from the contacts store, matching how
  ProfileCard and the Phone app already resolve the player's card name and
  real number. Software Version reads the shared OS_VERSION constant, and
  Legal & Regulatory opens a real page instead of rendering an inert chevron.

Phone page
  My Number was a hardcoded '(123) 456-7890'; now the player's real number
  (also what the copy button copies).

Battery
  The row had no subpage and no handler. Battery level lived only in
  App.tsx local state feeding the status bar, so it is now mirrored into a
  small batteryStore and a Battery page shows the live level with a
  low-battery treatment, plus the usual toggles.

Privacy & Security
  Same dead row; now a page with a working shortcut to Face Unlock &
  Passcode and standard privacy toggles.

Software Update
  The version block hardcoded light-mode colours (bg-white/text-black);
  now dark-aware like every ListGroup. Customize Automatic Updates opens a
  real subpage. Also de-branded "iOS 18.4.1" to "sdOS 2.1.4" and dropped a
  hardcoded "Last checked" time.

Phone Storage
  Same light-only card; now dark-aware, including the usage bar track.

Wallpaper
  Both preview thumbnails bound <img src={wallpaper}> to the raw store
  value, which after hydrate holds a wallpaper KEY (e.g. "lockscreen.jpg"),
  not a URL - hence the broken image. Every other consumer resolves through
  resolveWallpaper(); the thumbnails now do too.

Face Unlock & Passcode
  The store enforces "face unlock requires a passcode" (setSecurity forces
  faceId off when pin is null), but setup let you skip the PIN and still
  "enable" Face Unlock, then silently dropped it on completion - so
  Settings truthfully showed it off and asked for a passcode. Setup is now
  honest: with no PIN the button reads "Set Passcode First", explains why,
  and routes back to the PIN stage; skipping the PIN also clears a
  previously enabled face-unlock choice so the overview can't lie.

Typecheck, lint and tests clean. UI changes not eyeballed in-game.


Fixes #16
