### PR TITLE
fix(maps): stop location sharing leaking names; polish the sheet UI

### DIFF
--- a/server/friends/actions.lua
+++ b/server/friends/actions.lua
@@ -205,12 +205,17 @@ function actions.respond(src, msgId, phone, accept)
 
     local rsrc = player.getSourceByIdentifier(rcid)
     if rsrc then
+        -- Shown as the requester sees them: saved contact name, else the number - never
+        -- the responder's character name.
+        local myNumber = digits(settings.ensurePhoneNumber(owner))
+        local card = contactInfo(rcid)[myNumber]
+        local shown = card and card.name or (myNumber ~= '' and myNumber) or 'Someone'
         TriggerClientEvent('sd-phone:client:notify', rsrc, {
             app   = 'maps',
             appId = 'maps',
             title = 'Maps',
             body  = ('%s %s your location sharing request.'):format(
-                player.getName(src) or 'Someone', accept and 'accepted' or 'declined'),
+                shown, accept and 'accepted' or 'declined'),
             time  = 'now',
         })
     end

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -380,8 +380,10 @@ local function sendDirect(source, cid, myNumber, target, kind, body, meta, ts, m
 
         targetSrc = player.getSourceByIdentifier(targetCid)
         if targetSrc and not withheld then
+            -- No character-name fallback: an unsaved sender shows as their number, matching
+            -- the buildConversation reload path (and not leaking identities).
             local theirContacts = contactMapFor(targetCid)
-            local participant   = resolveParticipant(myNumber, theirContacts[myNumber], player.getName(source))
+            local participant   = resolveParticipant(myNumber, theirContacts[myNumber])
             local msg           = buildMessage(inId, myNumber, kind, body, meta, ts, false, digits(settings.getPhoneNumber(targetCid)))
 
             TriggerClientEvent('sd-phone:client:messages:incoming', targetSrc, {

--- a/web/src/apps/maps/Maps.tsx
+++ b/web/src/apps/maps/Maps.tsx
@@ -420,7 +420,7 @@ export function Maps({ onClose }: { onClose: () => void }) {
                             value: tab,
                             label: tab === 'pins' ? t('maps.tabPins', 'Pins') : tab === 'companies' ? t('maps.tabCompanies', 'Companies') : t('maps.tabPeople', 'People'),
                         }))}
-                        className={sheetTabs.length === 3 ? 'w-[260px]' : 'w-[200px]'}
+                        fit
                     />
                     {sheetTab === 'pins' ? (
                         <div className="flex items-center gap-3">
@@ -433,14 +433,17 @@ export function Maps({ onClose }: { onClose: () => void }) {
                         <span className="text-[15px] text-ios-gray">{companies.length}</span>
                     ) : (
                         <div className="flex items-center gap-3">
-                            <button
-                                onClick={toggleAvatars}
-                                aria-label={showAvatars ? t('maps.showInitials', 'Show initials instead of photos') : t('maps.showContactPhotos', 'Show contact photos')}
-                                title={showAvatars ? t('maps.showingPhotos', 'Showing photos') : t('maps.showingInitials', 'Showing initials')}
-                                className={(showAvatars ? 'text-ios-blue' : 'text-ios-gray') + ' active:opacity-60'}
-                            >
-                                <ImageIcon className="h-[20px] w-[20px]" strokeWidth={2.2} />
-                            </button>
+                            {/* Hidden when no friend has a photo - the toggle would visibly do nothing. */}
+                            {friends.some(f => f.avatar) && (
+                                <button
+                                    onClick={toggleAvatars}
+                                    aria-label={showAvatars ? t('maps.showInitials', 'Show initials instead of photos') : t('maps.showContactPhotos', 'Show contact photos')}
+                                    title={showAvatars ? t('maps.showingPhotos', 'Showing photos') : t('maps.showingInitials', 'Showing initials')}
+                                    className={(showAvatars ? 'text-ios-blue' : 'text-ios-gray') + ' active:opacity-60'}
+                                >
+                                    <ImageIcon className="h-[20px] w-[20px]" strokeWidth={2.2} />
+                                </button>
+                            )}
                             <span className="text-[15px] text-ios-gray">
                                 {t('maps.sharingCount', '{count} sharing', { count: visibleFriends.length })}
                             </span>
@@ -462,7 +465,7 @@ export function Maps({ onClose }: { onClose: () => void }) {
                     />
                 ) : sheetTab === 'companies' ? (
                     <>
-                    <SearchBar value={companyQuery} onChange={setCompanyQuery} placeholder={t('maps.searchCompanies', 'Search Companies')} className="mx-4 mb-2" />
+                    <SearchBar value={companyQuery} onChange={setCompanyQuery} placeholder={t('maps.searchCompanies', 'Search Companies')} className="mx-4 mt-1 mb-2" />
                     <div ref={compListRef} className="no-scrollbar relative overflow-y-auto px-4 pb-4" style={{ height: 240 }}>
                         {companyMatches.length === 0 ? (
                             <p className="py-6 text-center text-[15px] text-ios-gray">
@@ -505,7 +508,7 @@ export function Maps({ onClose }: { onClose: () => void }) {
                     </>
                 ) : (
                 <>
-                <SearchBar value={query} onChange={setQuery} placeholder={t('maps.searchPins', 'Search Pins')} className="mx-4 mb-2" />
+                <SearchBar value={query} onChange={setQuery} placeholder={t('maps.searchPins', 'Search Pins')} className="mx-4 mt-1 mb-2" />
 
                 <div ref={pinsListRef} className="no-scrollbar relative overflow-y-auto px-4 pb-4" style={{ height: 240 }}>
                     {shown.length === 0 ? (

--- a/web/src/ui/SegmentedControl.tsx
+++ b/web/src/ui/SegmentedControl.tsx
@@ -1,10 +1,12 @@
 import { t } from '@/i18n';
 
-export function SegmentedControl<T extends string>({ value, onChange, options, className }: {
+export function SegmentedControl<T extends string>({ value, onChange, options, className, fit = false }: {
     value:      T;
     onChange:   (value: T) => void;
     options:    readonly { value: T; label: string; dot?: boolean; badge?: number }[];
     className?: string;
+    /** Size segments to their label + side padding instead of an equal split of a fixed width. */
+    fit?:       boolean;
 }) {
     return (
         <div className={`flex rounded-[9px] bg-black/[0.06] p-[2px] dark:bg-white/[0.12] ${className ?? ''}`}>
@@ -13,7 +15,7 @@ export function SegmentedControl<T extends string>({ value, onChange, options, c
                     key={opt.value}
                     type="button"
                     onClick={() => onChange(opt.value)}
-                    className={`flex-1 rounded-[8px] py-1.5 text-[15px] font-medium transition-colors ${
+                    className={`${fit ? 'px-3.5' : 'flex-1'} rounded-[8px] py-1.5 text-[15px] font-medium transition-colors ${
                         value === opt.value
                             ? 'bg-white text-black shadow-sm dark:bg-control dark:text-white'
                             : 'text-black/80 dark:text-white/80'


### PR DESCRIPTION
Name leak (the reported repro)
  A share request to an unsaved number showed the requester's CHARACTER
  name in the recipient's notification and renamed their Messages thread to
  it - while the requester's own thread correctly kept the bare number.

  The request card travels as a normal 1:1 message, and sendDirect's live
  push passed player.getName() as the fallback display name when the
  recipient hasn't saved the sender. The DB/reload path (buildConversation)
  has no such fallback, which is why the name reverted to a number after a
  reload and why the two sides disagreed. The fallback is now dropped, so
  an unsaved sender always shows as their number - on the push, the thread
  name, and the phone notification. Note this hardens ALL direct messages,
  not just location requests; texting a stranger no longer reveals who you
  are.

  The accept/decline notification back to the requester had the same leak
  with no contact lookup at all (player.getName of the responder). It now
  resolves through the requester's own contacts and falls back to the
  number.

Sheet UI
  - The Pins/Companies/People segmented control was an equal split of a
    fixed 260px, which "Companies" nearly overflowed. SegmentedControl
    gains an opt-in `fit` mode (label + side padding instead of flex-1);
    only Maps uses it, so the other eight consumers are untouched.
  - Search bars gain mt-1 so the gap above matches the mb-2 below (the
    42px header only contributes ~3px of its own).
  - The photos/initials toggle next to the sharing count is functional but
    invisible when no friend has an avatar, which made it read as a dead
    button; it is now hidden unless someone actually has a photo.

Typecheck, lint, tests clean. The Lua paths are not runtime-verified; the
two-player repro from the issue is the right smoke test.


Fixes #11
