### PR TITLE
fix(mail): banner on new mail, draft editing, vault offer, mailbox header

### DIFF
--- a/client/apps/mail.lua
+++ b/client/apps/mail.lua
@@ -12,6 +12,7 @@ proxyCallback('sd-phone:mail:saveDraft',  'sd-phone:server:mail:saveDraft')
 proxyCallback('sd-phone:mail:markRead',   'sd-phone:server:mail:markRead')
 proxyCallback('sd-phone:mail:toggleFlag', 'sd-phone:server:mail:toggleFlag')
 proxyCallback('sd-phone:mail:moveToBin',  'sd-phone:server:mail:moveToBin')
+proxyCallback('sd-phone:mail:discardDraft', 'sd-phone:server:mail:discardDraft')
 proxyCallback('sd-phone:mail:move',       'sd-phone:server:mail:move')
 proxyCallback('sd-phone:mail:deleteAccount', 'sd-phone:server:mail:deleteAccount')
 

--- a/server/mail/actions.lua
+++ b/server/mail/actions.lua
@@ -144,14 +144,23 @@ end
 actions.serializeMessage = serializeMessage
 
 ---Delivery fan-out: resolves each entry's citizenid to a live source and, when online, sends
----the message as a live UI event plus a badge repush. Offline citizens are skipped.
+---the message as a live UI event, a phone banner, and a badge repush. Offline citizens are
+---skipped.
 ---@param pushes { citizenid: string, message: table }[]
 function actions.deliver(pushes)
     if type(pushes) ~= 'table' then return end
     for i = 1, #pushes do
         local src = player.getSourceByIdentifier(pushes[i].citizenid)
         if src then
-            TriggerClientEvent('sd-phone:client:mail:received', src, pushes[i].message)
+            local msg  = pushes[i].message
+            local from = msg.from or {}
+            TriggerClientEvent('sd-phone:client:mail:received', src, msg)
+            TriggerClientEvent('sd-phone:client:notify', src, {
+                app = 'mail', appId = 'mail',
+                title = (from.name and from.name ~= '') and from.name or (from.email or 'Mail'),
+                body  = (msg.subject and msg.subject ~= '') and msg.subject or 'New email',
+                time  = 'now', quietInApp = true,
+            })
             badges.push(src)
         end
     end
@@ -593,10 +602,26 @@ function actions.move(source, payload)
         return { success = false, message = 'Bad folder' }
     end
     store.mutateMessage(payload.accountEmail, payload.messageId or '', function(m)
-        if m.folder == folder then return nil end
+        -- Returning nil would hard-delete; a same-folder move must be a no-op.
+        if m.folder == folder then return m end
         m.folder = folder
         if folder == 'bin' then m.flagged = false end
         return m
+    end)
+    return ok()
+end
+
+---Hard-deletes a draft (and only a draft): used when an edited draft is re-sent or re-saved so
+---the stale copy doesn't linger. Any other folder is left untouched. Ownership-gated.
+---@param source number
+---@param payload { accountEmail?: string, messageId?: string }
+---@return table
+function actions.discardDraft(source, payload)
+    payload = payload or {}
+    local _, err = requireOwnership(source, payload.accountEmail); if err then return err end
+    store.mutateMessage(payload.accountEmail, payload.messageId or '', function(m)
+        if m.folder ~= 'drafts' then return m end
+        return nil
     end)
     return ok()
 end

--- a/server/mail/init.lua
+++ b/server/mail/init.lua
@@ -82,6 +82,13 @@ lib.callback.register('sd-phone:server:mail:moveToBin', function(src, payload)
     return result
 end)
 
+---Discarding a draft repushes the badge snapshot.
+lib.callback.register('sd-phone:server:mail:discardDraft', function(src, payload)
+    local result = actions.discardDraft(src, payload)
+    badges.push(src)
+    return result
+end)
+
 ---Move repushes the badge snapshot.
 lib.callback.register('sd-phone:server:mail:move', function(src, payload)
     local result = actions.move(src, payload)

--- a/web/src/apps/mail/Mail.tsx
+++ b/web/src/apps/mail/Mail.tsx
@@ -10,7 +10,7 @@ import { MAIL_DOMAIN, accountsConfirmReset, accountsMyNumber, accountsRequestRes
 import { isAuthed, signIn as unlockMail, signOut as lockMail } from '@/stores/authStore';
 import { Compose } from './Compose';
 import {
-    getFolderLabels, deleteAccount, listMail, loadActiveAccountId, loadFolderOrder, markRead,
+    getFolderLabels, deleteAccount, discardDraft, listMail, loadActiveAccountId, loadFolderOrder, markRead,
     moveToBin, moveTo, saveActiveAccountId, saveDraft, saveFolderOrder, sendMail, signIn as mailSignIn,
     signOut, signUp as mailSignUp, toggleFlag,
 } from './data';
@@ -35,7 +35,7 @@ export function Mail({ onClose }: { onClose: () => void }) {
     const [folderOrder,     setFolderOrder]     = useState<Folder[]>(() => loadFolderOrder());
     const [activeAccountId, setActiveAccountId] = useState<string | null>(() => loadActiveAccountId());
     const [nav,             setNav]             = useSessionState<Navigation>('mail:nav', { stage: 'mailboxes' });
-    const [composeFor,      setComposeFor]      = useSessionState<{ accountId?: string; to?: string; subject?: string; body?: string } | null>('mail:composeFor', null);
+    const [composeFor,      setComposeFor]      = useSessionState<{ accountId?: string; to?: string; subject?: string; body?: string; draftId?: string } | null>('mail:composeFor', null);
 
     const refresh = useCallback(async () => {
         const next = await listMail();
@@ -133,12 +133,19 @@ export function Mail({ onClose }: { onClose: () => void }) {
             console.warn('[sd-phone:mail] send failed:', result);
             return;
         }
-        setMessages(prev => [result, ...prev]);
+        const draftId = composeFor?.draftId;
+        if (draftId) {
+            setMessages(prev => [result, ...prev.filter(m => m.id !== draftId)]);
+            void discardDraft(account.email, draftId);
+        } else {
+            setMessages(prev => [result, ...prev]);
+        }
         setComposeFor(null);
     }
 
     function handleSaveDraft(draft: { accountId: string; to: string[]; subject: string; body: string }) {
         const account = accounts.find(a => a.id === draft.accountId) ?? accounts[0];
+        const draftId = composeFor?.draftId;
         setComposeFor(null);
         if (!account) return;
         void saveDraft({
@@ -147,7 +154,14 @@ export function Mail({ onClose }: { onClose: () => void }) {
             subject:   draft.subject,
             body:      draft.body,
         }).then(result => {
-            if (typeof result !== 'string') setMessages(prev => [result, ...prev]);
+            if (typeof result === 'string') return;
+            // Re-saving an edited draft replaces the stale copy.
+            if (draftId) {
+                setMessages(prev => [result, ...prev.filter(m => m.id !== draftId)]);
+                void discardDraft(account.email, draftId);
+            } else {
+                setMessages(prev => [result, ...prev]);
+            }
         });
     }
 
@@ -264,6 +278,11 @@ export function Mail({ onClose }: { onClose: () => void }) {
                     onOpen={id => {
                         const target = messages.find(m => m.id === id);
                         if (target) void handleMarkRead(target);
+                        // Drafts reopen in the composer for editing instead of the read-only viewer.
+                        if (target?.folder === 'drafts') {
+                            setComposeFor({ accountId: target.accountId, to: target.to.join(', '), subject: target.subject, body: target.body, draftId: target.id });
+                            return;
+                        }
                         setNav({ stage: 'detail', folder: nav.folder, msgId: id, accountId: nav.accountId, accountName: nav.accountName });
                     }}
                     onCompose={() => setComposeFor({ accountId: nav.accountId })}

--- a/web/src/apps/mail/MailboxList.tsx
+++ b/web/src/apps/mail/MailboxList.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import {
-    AlertOctagon, AtSign, ChevronRight, FileText, Flag, GripVertical, Inbox, Send, SquarePen, Trash2,
+    AlertOctagon, ChevronRight, FileText, Flag, GripVertical, Inbox, Send, SquarePen, Trash2,
 } from 'lucide-react';
 import type { ComponentType } from 'react';
 
@@ -124,10 +124,7 @@ export function MailboxList({
                         <div className="truncate text-[34px] font-bold tracking-tight leading-tight">
                             {activeAccount.name}
                         </div>
-                        <div className="mt-0.5 flex items-center gap-1 text-[15px] text-ios-blue">
-                            <AtSign className="h-[15px] w-[15px] shrink-0" strokeWidth={2.5} />
-                            <span className="truncate">{activeAccount.email}</span>
-                        </div>
+                        <div className="mt-0.5 truncate text-[15px] text-ios-blue">{activeAccount.email}</div>
                     </>
                 ) : (
                     <>

--- a/web/src/apps/mail/data.ts
+++ b/web/src/apps/mail/data.ts
@@ -327,6 +327,15 @@ export async function moveToBin(accountEmail: string, messageId: string): Promis
     await fetchNui<Envelope<unknown>>('sd-phone:mail:moveToBin', { accountEmail, messageId });
 }
 
+export async function discardDraft(accountEmail: string, messageId: string): Promise<void> {
+    if (!isFiveM) {
+        const i = MOCK.messages.findIndex(m => m.id === messageId && m.folder === 'drafts');
+        if (i >= 0) MOCK.messages.splice(i, 1);
+        return;
+    }
+    await fetchNui<Envelope<unknown>>('sd-phone:mail:discardDraft', { accountEmail, messageId });
+}
+
 export async function moveTo(accountEmail: string, messageId: string, folder: Folder): Promise<void> {
     if (!isFiveM) {
         const m = MOCK.messages.find(x => x.id === messageId);

--- a/web/src/shared/ChangePasswordPage.tsx
+++ b/web/src/shared/ChangePasswordPage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { t } from '@/i18n';
 import { portalToPhoneScreen } from '@/ui/portal';
+import { AlertDialog } from '@/ui/AlertDialog';
 import { ChangePasswordForm } from './AppAuth';
 import type { AppAuthTheme } from './AppAuth';
-import { accountsChangePassword, accountsListPasswords, accountsMe } from '@/core/accountsApi';
+import { accountsChangePassword, accountsListPasswords, accountsMe, accountsSavePassword } from '@/core/accountsApi';
 
 export function ChangePasswordPage({ app, appName, icon, theme, identity: identityProp, onClose }: {
     app:       string;
@@ -16,6 +17,10 @@ export function ChangePasswordPage({ app, appName, icon, theme, identity: identi
 }) {
     const [identity, setIdentity] = useState<string | null>(identityProp ?? null);
     const [savedPassword, setSavedPassword] = useState<string | null>(null);
+    const hasVaultEntry = useRef(false);
+    // Set after a successful change when no vault row exists; triggers the save offer on close.
+    const pendingOffer = useRef<string | null>(null);
+    const [offer, setOffer] = useState<string | null>(null);
 
     useEffect(() => {
         let alive = true;
@@ -29,10 +34,27 @@ export function ChangePasswordPage({ app, appName, icon, theme, identity: identi
             setIdentity(id);
             const entries = await accountsListPasswords();
             const entry = entries.find(e => e.app === app && (e.username === id || e.email === id));
-            if (alive) setSavedPassword(entry?.password ?? null);
+            if (alive) {
+                hasVaultEntry.current = !!entry;
+                setSavedPassword(entry?.password ?? null);
+            }
         })();
         return () => { alive = false; };
     }, [app, identityProp]);
+
+    function handleBack() {
+        if (pendingOffer.current) { setOffer(pendingOffer.current); return; }
+        onClose();
+    }
+
+    async function saveToVault(password: string) {
+        await accountsSavePassword(app, {
+            username: identity ?? '',
+            password,
+            email: identity?.includes('@') ? identity : undefined,
+        });
+        onClose();
+    }
 
     const form = (
         <div className="absolute inset-0 z-50">
@@ -44,10 +66,24 @@ export function ChangePasswordPage({ app, appName, icon, theme, identity: identi
                 savedPassword={savedPassword}
                 onSubmit={async (current, next) => {
                     const r = await accountsChangePassword(app, identity ?? '', current, next);
-                    return r.ok ? null : (r.message ?? t('common.couldNotChangePassword', 'Could not change password'));
+                    if (!r.ok) return r.message ?? t('common.couldNotChangePassword', 'Could not change password');
+                    // The server only UPDATEs an existing vault row; offer to create one otherwise.
+                    if (!hasVaultEntry.current) pendingOffer.current = next;
+                    return null;
                 }}
-                onBack={onClose}
+                onBack={handleBack}
             />
+
+            {offer && (
+                <AlertDialog
+                    title={t('common.saveToPasswords', 'Save to Passwords?')}
+                    message={t('common.savePasswordsBody', 'Keep your {appName} username and password in the Passwords app so you can always find them.', { appName })}
+                    confirmLabel={t('common.save', 'Save')}
+                    cancelLabel={t('common.notNow', 'Not Now')}
+                    onCancel={onClose}
+                    onConfirm={() => void saveToVault(offer)}
+                />
+            )}
         </div>
     );
 


### PR DESCRIPTION
No phone notification on new mail
  actions.deliver pushed the live inbox event and repushed the badge - which
  is why the app icon badge moved - but never fired sd-phone:client:notify.
  It now sends the standard banner (sender as title, subject as body,
  quietInApp so an open Mail app isn't double-notified), matching the
  messages/photogram pattern.

Extra @ in the mailbox list
  The account header rendered an AtSign icon in front of the full address,
  so "you@lifeinvader.com" read as "@you@lifeinvader.com". The address
  already contains its @; the icon is gone.

Drafts couldn't be edited
  Opening a draft went to the read-only MailDetail, whose only affordance
  is Reply - hence the reported reply-and-strip-the-quote workaround.
  Opening a message from Drafts now seeds the composer with its to/subject/
  body. Sending or re-saving discards the stale draft row via a new
  discardDraft action (hard-delete, gated to the drafts folder only);
  cancelling leaves the original untouched. saveDraft always inserts a new
  row, so without the discard every edit would have piled up duplicates.

  Also fixes a latent hard-delete in actions.move: mutateMessage() treats a
  nil return as "remove the row", and move returned nil for a same-folder
  move - so filing a message into the folder it was already in deleted it.
  Now a no-op.

Password change didn't update the Passwords app
  The server already syncs the vault on change - but with an UPDATE that
  matches zero rows when the login was never saved, and the form even
  claims "Also updates the password saved in your Passwords app". The
  shared ChangePasswordPage now knows whether a vault row existed and, when
  none did, offers "Save to Passwords?" after a successful change (the same
  prompt sign-in uses). Existing rows keep being synced server-side as
  before. This fixes the same gap for every app using the shared page, not
  just Mail.

Typecheck, lint, tests clean. Lua paths not runtime-verified; worth one
smoke test of receive-banner and draft round-trip.


Fixes #10
