### PR TITLE
feat(photos): URL import with a server-side host whitelist

### DIFF
--- a/configs/photos.lua
+++ b/configs/photos.lua
@@ -26,11 +26,22 @@ return {
     MinAlbumNameLength = 1,
     MaxAlbumNameLength = 40,
 
-    -- Hosts players may import image URLs from (the Import button in Photos).
-    -- Exact hostnames, or '*.domain.com' to allow every subdomain. The check is
-    -- server-side; camera uploads bypass it (their URL comes from the uploader,
-    -- not the player). An empty list disables URL import and hides the button.
-    ImportHosts = {
-        '*.fivemanage.com',
+    -- Player URL import (the Import button in Photos). Imported URLs are stored and
+    -- rendered as-is, NOT re-hosted, so each viewer's client loads the image from its
+    -- source host. The check is server-side; camera uploads bypass it (their URL comes
+    -- from the server uploader, not the player).
+    AllowImport = true, -- master switch; false disables URL import and hides the button.
+
+    -- Hosts to always reject. Exact hostnames, or '*.domain.com' for every subdomain.
+    -- IP loggers and URL shorteners belong here: a shortener can redirect an otherwise
+    -- fine-looking link to anywhere, and the viewer's client would follow it.
+    ImportBlocklist = {
+        'grabify.link', '*.grabify.link',
+        'iplogger.org', '*.iplogger.org',
+        'bit.ly', 'tinyurl.com', 't.co',
     },
+
+    -- If non-empty, ONLY these hosts are allowed (the blocklist still applies on top).
+    -- Empty means allow any host that isn't blocked. Same '*.domain.com' wildcard syntax.
+    ImportAllowlist = {},
 }

--- a/configs/photos.lua
+++ b/configs/photos.lua
@@ -25,4 +25,12 @@ return {
     -- client and server agree.
     MinAlbumNameLength = 1,
     MaxAlbumNameLength = 40,
+
+    -- Hosts players may import image URLs from (the Import button in Photos).
+    -- Exact hostnames, or '*.domain.com' to allow every subdomain. The check is
+    -- server-side; camera uploads bypass it (their URL comes from the uploader,
+    -- not the player). An empty list disables URL import and hides the button.
+    ImportHosts = {
+        '*.fivemanage.com',
+    },
 }

--- a/server/photos/actions.lua
+++ b/server/photos/actions.lua
@@ -46,32 +46,46 @@ end
 ---@type integer Longest accepted photo URL in bytes, matching the phone_photos.url VARCHAR(512) column.
 local MAX_URL_BYTES = 512
 
----True when config.Photos.ImportHosts is non-empty, i.e. player URL import is enabled.
+---True when player URL import is enabled (config.Photos.AllowImport); drives the Import button.
 ---@return boolean
 function actions.importEnabled()
-    local hosts = photosCfg.ImportHosts
-    return type(hosts) == 'table' and #hosts > 0
+    return photosCfg.AllowImport == true
 end
 
----Whitelist check for PLAYER-supplied import URLs against config.Photos.ImportHosts. Entries
----match the hostname exactly, or any subdomain when prefixed '*.'. Camera uploads never pass
----through here - their URL comes from the server-side uploader.
+---True if `host` matches any entry in `list`: an exact hostname, or a '*.domain' subdomain
+---wildcard (which also matches the bare domain). A non-table `list` counts as empty.
+---@param host string lowercased hostname
+---@param list any
+---@return boolean
+local function hostMatchesList(host, list)
+    if type(list) ~= 'table' then return false end
+    for _, raw in ipairs(list) do
+        local entry = tostring(raw):lower()
+        if entry:sub(1, 2) == '*.' then
+            local suffix = entry:sub(2) -- '.domain.com'
+            if host:sub(-#suffix) == suffix or host == entry:sub(3) then return true end
+        elseif entry ~= '' and host == entry then
+            return true
+        end
+    end
+    return false
+end
+
+---Host check for PLAYER-supplied import URLs. Rejects unparseable/non-http URLs and any host
+---in config.Photos.ImportBlocklist; when ImportAllowlist is non-empty the host must also appear
+---there. Camera uploads never pass through here - their URL comes from the server-side uploader.
 ---@param url any
 ---@return boolean
 function actions.isAllowedImportUrl(url)
     if type(url) ~= 'string' then return false end
     local host = url:lower():match('^https?://([%w%.%-]+)[:/]') or url:lower():match('^https?://([%w%.%-]+)$')
     if not host then return false end
-    for _, entry in ipairs(photosCfg.ImportHosts or {}) do
-        entry = tostring(entry):lower()
-        if entry:sub(1, 2) == '*.' then
-            local suffix = entry:sub(2) -- '.domain.com'
-            if host:sub(-#suffix) == suffix or host == entry:sub(3) then return true end
-        elseif host == entry then
-            return true
-        end
+    if hostMatchesList(host, photosCfg.ImportBlocklist) then return false end
+    local allow = photosCfg.ImportAllowlist
+    if type(allow) == 'table' and #allow > 0 and not hostMatchesList(host, allow) then
+        return false
     end
-    return false
+    return true
 end
 
 ---Persists a photo URL against the caller: the URL must be a non-empty http(s) string within

--- a/server/photos/actions.lua
+++ b/server/photos/actions.lua
@@ -40,11 +40,39 @@ function actions.list(source)
     for i = 1, #rows do
         out[i] = shapePhoto(rows[i])
     end
-    return ok({ photos = out })
+    return ok({ photos = out, canImport = actions.importEnabled() })
 end
 
 ---@type integer Longest accepted photo URL in bytes, matching the phone_photos.url VARCHAR(512) column.
 local MAX_URL_BYTES = 512
+
+---True when config.Photos.ImportHosts is non-empty, i.e. player URL import is enabled.
+---@return boolean
+function actions.importEnabled()
+    local hosts = photosCfg.ImportHosts
+    return type(hosts) == 'table' and #hosts > 0
+end
+
+---Whitelist check for PLAYER-supplied import URLs against config.Photos.ImportHosts. Entries
+---match the hostname exactly, or any subdomain when prefixed '*.'. Camera uploads never pass
+---through here - their URL comes from the server-side uploader.
+---@param url any
+---@return boolean
+function actions.isAllowedImportUrl(url)
+    if type(url) ~= 'string' then return false end
+    local host = url:lower():match('^https?://([%w%.%-]+)[:/]') or url:lower():match('^https?://([%w%.%-]+)$')
+    if not host then return false end
+    for _, entry in ipairs(photosCfg.ImportHosts or {}) do
+        entry = tostring(entry):lower()
+        if entry:sub(1, 2) == '*.' then
+            local suffix = entry:sub(2) -- '.domain.com'
+            if host:sub(-#suffix) == suffix or host == entry:sub(3) then return true end
+        elseif host == entry then
+            return true
+        end
+    end
+    return false
+end
 
 ---Persists a photo URL against the caller: the URL must be a non-empty http(s) string within
 ---the column cap, and the gallery is pruned back under config.Photos.MaxPhotosPerPlayer.

--- a/server/photos/init.lua
+++ b/server/photos/init.lua
@@ -68,7 +68,7 @@ RegisterNetEvent('sd-phone:server:photos:upload', function(image, kind)
 end)
 
 ---Saves an already-hosted media URL for the caller and pushes photos:added with the new row.
----Player-supplied, so the URL must pass the config.Photos.ImportHosts whitelist.
+---Player-supplied, so the URL must pass config.Photos.AllowImport + the block/allow lists.
 lib.callback.register('sd-phone:server:photos:saveUrl', function(src, payload)
     if not actions.importEnabled() then
         return { success = false, message = 'URL import is disabled on this server' }

--- a/server/photos/init.lua
+++ b/server/photos/init.lua
@@ -68,7 +68,14 @@ RegisterNetEvent('sd-phone:server:photos:upload', function(image, kind)
 end)
 
 ---Saves an already-hosted media URL for the caller and pushes photos:added with the new row.
+---Player-supplied, so the URL must pass the config.Photos.ImportHosts whitelist.
 lib.callback.register('sd-phone:server:photos:saveUrl', function(src, payload)
+    if not actions.importEnabled() then
+        return { success = false, message = 'URL import is disabled on this server' }
+    end
+    if not actions.isAllowedImportUrl(payload and payload.url) then
+        return { success = false, message = 'Images from that site aren\'t allowed' }
+    end
     local res = actions.saveFromUrl(src, payload and payload.url)
     if res and res.success and res.data and res.data.photo then
         TriggerClientEvent('sd-phone:client:photos:added', src, res.data.photo)

--- a/web/src/apps/photos/GalleryTab.tsx
+++ b/web/src/apps/photos/GalleryTab.tsx
@@ -5,7 +5,7 @@ import { groupByDay, type Photo } from '@/core/photosApi';
 import { PhotoTile } from './PhotoTile';
 
 export function GalleryTab({
-    photos, selectionMode, selectedIds, onEnterSelect, onCancelSelect, onPhotoTap, onToggleSelect,
+    photos, selectionMode, selectedIds, onEnterSelect, onCancelSelect, onPhotoTap, onToggleSelect, onImport,
 }: {
     photos:         Photo[];
     selectionMode:  boolean;
@@ -14,12 +14,22 @@ export function GalleryTab({
     onCancelSelect: () => void;
     onPhotoTap:     (photo: Photo) => void;
     onToggleSelect: (photo: Photo) => void;
+    onImport?:      () => void;
 }) {
     const groups = useMemo(() => groupByDay(photos), [photos]);
 
     return (
         <div className="flex h-full flex-col">
-            <div className="flex h-12 shrink-0 items-center justify-end px-4">
+            <div className="flex h-12 shrink-0 items-center justify-end gap-2 px-4">
+                {onImport && !selectionMode && (
+                    <button
+                        type="button"
+                        onClick={onImport}
+                        className="rounded-full bg-black/[0.07] px-4 py-1.5 text-[15px] font-medium text-black/80 dark:bg-white/15 dark:text-white/85"
+                    >
+                        {t('photos.import', 'Import')}
+                    </button>
+                )}
                 <button
                     type="button"
                     onClick={selectionMode ? onCancelSelect : onEnterSelect}

--- a/web/src/apps/photos/Photos.tsx
+++ b/web/src/apps/photos/Photos.tsx
@@ -8,7 +8,7 @@ import { PromptDialog } from '@/ui/PromptDialog';
 import {
     apiAddPhotosToAlbum, apiCreateAlbum, apiDeleteAlbum, apiDeletePhoto,
     apiListAlbumPhotos, apiListAlbums, apiListPhotos, apiListSharedAlbums,
-    apiRemovePhotoFromAlbum, apiSetFavorite, mapPhoto,
+    apiRemovePhotoFromAlbum, apiSavePhotoFromUrl, apiSetFavorite, getCanImportPhotos, mapPhoto,
     type Album, type AlbumRef, type Photo,
 } from '@/core/photosApi';
 import { AlbumDetail } from './AlbumDetail';
@@ -33,6 +33,8 @@ export function Photos({ onClose }: { onClose: () => void }) {
     const [gallerySelected, setGallerySelected] = useState<Set<string>>(new Set());
 
     const [albumsEdit, setAlbumsEdit] = useState(false);
+    const [canImport,  setCanImport]  = useState(false);
+    const [importOpen, setImportOpen] = useState(false);
 
     const [openAlbum, setOpenAlbum] = useSessionState<AlbumRef | null>('photos:openAlbum', null);
     const [customAlbumPhotos, setCustomAlbumPhotos] = useState<Photo[]>([]);
@@ -50,6 +52,7 @@ export function Photos({ onClose }: { onClose: () => void }) {
             setPhotos(ps);
             setAlbums(as);
             setSharedAlbums(shared);
+            setCanImport(getCanImportPhotos());
             setLoading(false);
         })();
         return () => { cancelled = true; };
@@ -194,6 +197,7 @@ export function Photos({ onClose }: { onClose: () => void }) {
                                 onCancelSelect={exitGallerySelect}
                                 onPhotoTap={openViewerFromGallery}
                                 onToggleSelect={toggleGallerySelect}
+                                onImport={canImport ? () => setImportOpen(true) : undefined}
                             />
                         ) : (
                             <AlbumsTab
@@ -268,6 +272,26 @@ export function Photos({ onClose }: { onClose: () => void }) {
                     existingIds={new Set(customAlbumPhotos.map(p => p.id))}
                     onClose={() => setPhotoPicker(false)}
                     onConfirm={(ids) => { if (openAlbum.kind === 'custom') void addToAlbum(openAlbum.id, ids); setPhotoPicker(false); }}
+                />
+            )}
+
+            {importOpen && (
+                <PromptDialog
+                    title={t('photos.importTitle', 'Import Photo')}
+                    message={t('photos.importMessage', 'Paste a direct link to an image.')}
+                    placeholder="https://"
+                    inputMode="url"
+                    maxLength={512}
+                    confirmLabel={t('photos.import', 'Import')}
+                    onCancel={() => setImportOpen(false)}
+                    onConfirm={async url => {
+                        const trimmed = url.trim();
+                        if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) return t('photos.importInvalidUrl', 'Enter a full image URL');
+                        const r = await apiSavePhotoFromUrl(trimmed);
+                        if (!r.ok) return r.message ?? t('photos.importFailed', 'Could not import that image');
+                        setImportOpen(false);
+                        return null;
+                    }}
                 />
             )}
 

--- a/web/src/core/photosApi.ts
+++ b/web/src/core/photosApi.ts
@@ -71,9 +71,16 @@ export function mapPhoto(sp: ServerPhoto): Photo {
     return { id: sp.id, url: sp.url, favorite: !!sp.favorite, date: toIsoDate(sp.createdAt), video: isVideoUrl(sp.url) };
 }
 
+let canImportPhotos = !isFiveM;
+
+/** Whether the server allows URL import; valid after the first apiListPhotos() resolves. */
+export function getCanImportPhotos(): boolean { return canImportPhotos; }
+
 export async function apiListPhotos(): Promise<Photo[]> {
     if (!isFiveM) return DEV_PHOTOS;
-    return (await apiData<{ photos: ServerPhoto[] }>('sd-phone:photos:list'))?.photos.map(mapPhoto) ?? [];
+    const data = await apiData<{ photos: ServerPhoto[]; canImport?: boolean }>('sd-phone:photos:list');
+    canImportPhotos = data?.canImport === true;
+    return data?.photos.map(mapPhoto) ?? [];
 }
 
 export function warmPhotos(): void {
@@ -90,10 +97,10 @@ export function warmPhotos(): void {
     });
 }
 
-export async function apiSavePhotoFromUrl(url: string): Promise<boolean> {
-    if (!isFiveM) return true;
+export async function apiSavePhotoFromUrl(url: string): Promise<{ ok: boolean; message?: string }> {
+    if (!isFiveM) return { ok: true };
     const r = await apiCall<unknown>('sd-phone:photos:saveUrl', { url });
-    return r.success;
+    return r.success ? { ok: true } : { ok: false, message: r.message };
 }
 
 export async function apiSetFavorite(photoId: string, value: boolean): Promise<boolean> {


### PR DESCRIPTION
There was no way to import a picture - yet the entire server path already
existed (saveFromUrl, the photos:saveUrl callback, the client proxy, even
apiSavePhotoFromUrl in the web API layer). Nothing ever called it, and its
only validation was "http(s), <=512 chars".

- configs/photos.lua gains ImportHosts: exact hostnames or '*.domain.com'
  wildcards. Ships defaulting to '*.fivemanage.com' since the script already
  uses Fivemanage for camera uploads. Empty list disables import and hides
  the button.
- The whitelist gates ONLY the player-supplied photos:saveUrl callback.
  Camera uploads also flow through saveFromUrl with the uploader's CDN URL,
  so the check lives at the callback boundary, not inside saveFromUrl -
  changing the whitelist can never break camera capture.
- Host matching is strict: parsed from the URL with a charset that rejects
  userinfo@ tricks, apex + subdomain wildcard support, and suffix matching
  anchored on the dot so evilfivemanage.com does not pass *.fivemanage.com.
- Photos gains an Import button (hidden when the server disables import,
  via a canImport flag on the existing list response) opening a URL prompt;
  server rejections surface their message in the dialog. The saved photo
  arrives through the existing photos:added push.

Typecheck, lint, tests clean. Whitelist matcher traced by hand; worth one
in-game import against a Fivemanage URL and one against a foreign host.


Fixes #24
