### PR TITLE
ci: release automation and source cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build + checks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install deps
+        run: npm ci
+
+      # `build` is `tsc --noEmit && vite build`, so this also typechecks.
+      - name: Build NUI
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Knip (dead-code)
+        run: npm run knip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+# Fires when a GitHub Release is published (Releases > Draft a new release > Publish).
+# Builds the NUI fresh and attaches a lean, drop-in resource zip to that release.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: build + package
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build NUI
+        working-directory: web
+        run: |
+          npm ci
+          npm run build
+
+      # Explicit allowlist of runtime files -> dist/sd-phone/ so the zip extracts
+      # to a correctly named resource folder. web/src, node_modules, dev configs
+      # and the root screenshot PNGs are intentionally left out.
+      - name: Stage resource
+        run: |
+          mkdir -p dist/sd-phone/web
+          cp fxmanifest.lua README.md dist/sd-phone/
+          cp -r bridge client server configs locales images dist/sd-phone/
+          cp -r web/build dist/sd-phone/web/build
+
+      - name: Zip
+        run: |
+          cd dist
+          zip -qr "../sd-phone-${TAG}.zip" sd-phone
+
+      - name: Attach to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${TAG}" "sd-phone-${TAG}.zip" --clobber

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ Full guide: [docs.samueldev.shop/resources/phone/installation](https://docs.samu
 2. Add the phone items to your inventory, one per frame colour (`phone_black`, `phone_blue`, `phone_green`, `phone_orange`, `phone_pink`, `phone_purple`, `phone_red`, `phone_yellow`). Ready-made ox_inventory definitions and item icons are in the [installation docs](https://docs.samueldev.shop/resources/phone/installation); the icons ship in this repo's `images/` folder. Players can also open with the keybind (default F1), gated on owning a phone item.
 3. Set your API keys in `configs/server/apikeys.lua`: a [Fivemanage](https://refer.fivemanage.com/samuel) token of type **Media** in `FivemanageMedia` (required for the Camera, Photos and Voice Memos apps to upload), and optionally a GIPHY key for the Messages GIF picker.
 
-The pre-built UI ships at `web/build/`, so a fresh clone runs without touching npm. To rebuild after UI changes: `cd web && npm install && npm run build`.
+**Download the [latest release](https://github.com/Samuels-Development/sd-phone/releases)** (the packaged `sd-phone-*.zip`), not the green *Code -> Download ZIP*. The release zip carries the compiled UI and runs as-is; the source zip is code only and has no `web/build/`, so the phone opens blank.
+
+Building from a git clone yourself: `cd web && npm ci && npm run build`. The output lands in the gitignored `web/build/`; the server logs a clear error on boot if it is missing.
 
 ## Unique Phones & SIM Cards (optional)
 

--- a/docs/superpowers/specs/2026-07-19-release-automation-design.md
+++ b/docs/superpowers/specs/2026-07-19-release-automation-design.md
@@ -1,0 +1,101 @@
+# Release automation and source cleanup
+
+Date: 2026-07-19
+Status: Approved
+
+## Problem
+
+`web/build/` (the compiled Vite/React NUI) is force-added into the source tree past
+the `web/build/` gitignore rule. Every rebuild rotates content-hashed chunk filenames,
+so committing the output produces thousands of lines of churn and is fragile: a plain
+`git add` stages the *deletions* of old chunks but silently skips the new ones (ignored
+files need `git add -f`). PR #50 hit exactly this, landing an `index.html` that referenced
+138 chunks never committed, i.e. a broken phone on a fresh clone.
+
+## Goal
+
+Stop tracking the build in source. Ship the compiled resource as a packaged zip attached
+to GitHub Releases, built by CI. Add PR checks so every change is validated. Keep a
+working distribution path available at every moment during the transition.
+
+## Non-goals
+
+- No change to how the NUI itself is built (`npm run build` stays `tsc --noEmit && vite build`).
+- No auto-committing of build output back to the repo.
+- No refactor of app/runtime code beyond a small startup guard.
+
+## Sequencing (safety-critical)
+
+Ordered so `main` is never left without a working distribution path:
+
+1. Branch `ci/release-automation`: add both workflows, runtime guard, README install
+   section, version bump to `0.9.0`. Build stays tracked at this stage.
+2. Open a PR. The new `ci.yml` runs on that PR, self-validating build + lint + test + knip.
+3. Squash-merge to `main`.
+4. Cut release `v0.9.0` (`gh release create`) -> `release.yml` builds and attaches
+   `sd-phone-v0.9.0.zip`. Download and verify the zip is complete.
+5. Only after a verified release exists: `git rm -r --cached web/build` so `main` is
+   source-only.
+
+Rationale: `release.yml` rebuilds `web/build` from scratch, so it never depends on the
+tracked copy. Untracking last means one working distribution path exists at all times.
+
+## Components
+
+### CI workflow: `.github/workflows/ci.yml`
+
+- Triggers: `pull_request` and `push` to `main`. `concurrency` cancels superseded PR runs.
+- Job: ubuntu, Node 22, npm cache keyed on `web/package-lock.json`, `working-directory: web`.
+- Steps: `npm ci` -> `npm run build` -> `npm run lint` -> `npm run test` -> `npm run knip`.
+- These match the project's existing green gates (knip-zero, 0-error eslint, vitest), so
+  no existing code trips them. `npm run build` covers typecheck via `tsc --noEmit`.
+
+### Release workflow: `.github/workflows/release.yml`
+
+- Trigger: `release: published`. `permissions: contents: write`.
+- Steps: checkout -> Node 22 -> `cd web && npm ci && npm run build` -> stage a lean
+  allowlist into `dist/sd-phone/` -> zip -> upload to the triggering release.
+- Allowlist (copied in): `fxmanifest.lua`, `bridge/ client/ server/ configs/ locales/
+  images/`, and `web/build/` (carries `index.html`, `assets/`, `components.js`).
+- Excluded: `web/src`, `node_modules`, dev configs, `.github`, `docs`, root screenshot PNGs.
+- Zip name: `sd-phone-<tag>.zip`. Upload via the runner's built-in `gh release upload
+  "$TAG"` using `GITHUB_TOKEN` (no third-party action).
+- Explicit allowlist (not exclude-all) keeps the artifact predictable; a future runtime
+  dir is a one-line addition here.
+
+### Runtime guard: `server/main.lua`
+
+Startup check so a missing build fails loudly instead of a blank phone:
+
+```lua
+if not LoadResourceFile(GetCurrentResourceName(), 'web/build/index.html') then
+    print('^1[sd-phone] NUI build not found (web/build/index.html missing).^0')
+    print('^3[sd-phone] Download the packaged release from GitHub Releases, or build it: cd web && npm ci && npm run build^0')
+end
+```
+
+`LoadResourceFile` returns `nil` when the file is absent (the cloned-but-unbuilt case).
+
+### Version bump
+
+- `fxmanifest.lua` and `web/package.json`: `0.1.0` -> `0.9.0`.
+
+### README
+
+- Installation section: download the latest release zip from GitHub Releases, not the
+  source "Download ZIP".
+- Build-from-source note for contributors: `cd web && npm ci && npm run build`.
+
+## Ongoing workflow after this lands
+
+- Maintainer drafts a release in the GitHub UI (tag `vX.Y.Z` + notes); the workflow
+  packages and attaches the zip.
+- Contributors change source only; CI validates their PRs. `web/build` is never touched
+  in source again.
+
+## Verification
+
+- CI green on the setup PR (proves both the gates and that `ci.yml` itself works).
+- `sd-phone-v0.9.0.zip` downloaded and inspected: contains `fxmanifest.lua`, the runtime
+  dirs, and a self-consistent `web/build` (every asset `index.html` references is present).
+- After untracking: `git ls-files web/build` returns nothing; working tree clean.

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 'yes'
 
 name 'sd-phone'
 author 'Samuel#0008'
-version '0.1.0'
+version '0.9.0'
 description 'iOS-themed in-game phone — lockscreen, homepage, NUI bridge'
 
 -- Both sides load ox_lib first (require / callback machinery), then the shared

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,3 +1,10 @@
+-- Build-presence guard: a source checkout without a compiled NUI (web/build is
+-- gitignored and shipped via GitHub Releases) would open to a blank phone.
+if not LoadResourceFile(GetCurrentResourceName(), 'web/build/index.html') then
+    print('^1[sd-phone] NUI build not found at web/build/index.html.^0')
+    print('^3[sd-phone] Download the packaged release from GitHub Releases, or build it: cd web && npm ci && npm run build^0')
+end
+
 ---@type table sd-phone config root (configs/config.lua).
 local config    = require 'configs.config'
 ---@type table Framework bridge (bridge.shared.framework): active framework detection + name.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -79,6 +79,7 @@
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
                 "@babel/generator": "^7.29.7",
@@ -337,6 +338,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
@@ -349,6 +351,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -660,8 +663,9 @@
             "cpu": [
                 "arm64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "netbsd"
             ],
@@ -693,8 +697,9 @@
             "cpu": [
                 "arm64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "openbsd"
             ],
@@ -726,8 +731,9 @@
             "cpu": [
                 "arm64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "openharmony"
             ],
@@ -1228,9 +1234,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1248,9 +1251,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1268,9 +1268,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1288,9 +1285,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1308,9 +1302,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1328,9 +1319,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1348,9 +1336,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1368,9 +1353,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1583,9 +1565,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1600,9 +1579,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1617,9 +1593,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1634,9 +1607,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1651,9 +1621,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1668,9 +1635,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1685,9 +1649,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1702,9 +1663,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1888,9 +1846,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1908,9 +1863,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1928,9 +1880,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1948,9 +1897,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1968,9 +1914,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1988,9 +1931,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2169,9 +2109,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2186,9 +2123,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2203,9 +2137,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2220,9 +2151,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2237,9 +2165,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2254,9 +2179,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2271,9 +2193,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2288,9 +2207,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2305,9 +2221,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2322,9 +2235,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2339,9 +2249,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2356,9 +2263,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2373,9 +2277,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2581,6 +2482,7 @@
             "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -2641,6 +2543,7 @@
             "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.64.0",
                 "@typescript-eslint/types": "8.64.0",
@@ -2952,6 +2855,7 @@
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3165,6 +3069,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.42",
                 "caniuse-lite": "^1.0.30001803",
@@ -3481,6 +3386,7 @@
             "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "workspaces": [
                 "packages/*"
             ],
@@ -4178,6 +4084,7 @@
             "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
             "dev": true,
             "license": "MPL-2.0",
+            "peer": true,
             "dependencies": {
                 "detect-libc": "^2.0.3"
             },
@@ -4315,9 +4222,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4339,9 +4243,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4363,9 +4264,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4387,9 +4285,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4900,9 +4795,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.19",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "version": "8.5.20",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+            "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
             "dev": true,
             "funding": [
                 {
@@ -4919,8 +4814,9 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -5108,6 +5004,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -5656,6 +5553,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5761,6 +5659,7 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -5927,8 +5826,9 @@
             "cpu": [
                 "ppc64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "aix"
             ],
@@ -5943,8 +5843,9 @@
             "cpu": [
                 "arm"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "android"
             ],
@@ -5959,8 +5860,9 @@
             "cpu": [
                 "arm64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "android"
             ],
@@ -5975,8 +5877,9 @@
             "cpu": [
                 "x64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "android"
             ],
@@ -5991,8 +5894,9 @@
             "cpu": [
                 "arm64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "darwin"
             ],
@@ -6007,8 +5911,9 @@
             "cpu": [
                 "x64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "darwin"
             ],
@@ -6023,8 +5928,9 @@
             "cpu": [
                 "arm64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "freebsd"
             ],
@@ -6039,8 +5945,9 @@
             "cpu": [
                 "x64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "freebsd"
             ],
@@ -6055,8 +5962,9 @@
             "cpu": [
                 "arm"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6071,8 +5979,9 @@
             "cpu": [
                 "arm64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6087,8 +5996,9 @@
             "cpu": [
                 "ia32"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6103,8 +6013,9 @@
             "cpu": [
                 "loong64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6119,8 +6030,9 @@
             "cpu": [
                 "mips64el"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6135,8 +6047,9 @@
             "cpu": [
                 "ppc64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6151,8 +6064,9 @@
             "cpu": [
                 "riscv64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6167,8 +6081,9 @@
             "cpu": [
                 "s390x"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6183,8 +6098,9 @@
             "cpu": [
                 "x64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "linux"
             ],
@@ -6199,8 +6115,9 @@
             "cpu": [
                 "x64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "netbsd"
             ],
@@ -6215,8 +6132,9 @@
             "cpu": [
                 "x64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "openbsd"
             ],
@@ -6231,8 +6149,9 @@
             "cpu": [
                 "x64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "sunos"
             ],
@@ -6247,8 +6166,9 @@
             "cpu": [
                 "arm64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "win32"
             ],
@@ -6263,8 +6183,9 @@
             "cpu": [
                 "ia32"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "win32"
             ],
@@ -6279,8 +6200,9 @@
             "cpu": [
                 "x64"
             ],
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "os": [
                 "win32"
             ],
@@ -6319,9 +6241,11 @@
             "version": "0.28.1",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
             "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-            "extraneous": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -6378,6 +6302,7 @@
             "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.5",
@@ -6545,6 +6470,7 @@
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sd-phone-ui",
-    "version": "0.1.0",
+    "version": "0.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sd-phone-ui",
-            "version": "0.1.0",
+            "version": "0.9.0",
             "dependencies": {
                 "@fontsource/great-vibes": "^5.2.8",
                 "@fontsource/inter": "^5.2.8",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sd-phone-ui",
     "private": true,
-    "version": "0.1.0",
+    "version": "0.9.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/web/src/admin/adminApi.ts
+++ b/web/src/admin/adminApi.ts
@@ -1,6 +1,6 @@
 import { apiCall, type Envelope } from '@/core/api';
 import type {
-    AdminAccount, AdminAuditEntry, AdminBirdyPost, AdminCall, AdminContentItem,
+    AdminAuditEntry, AdminBirdyPost, AdminCall, AdminContentItem,
     AdminMessage, AdminMute, AdminNumberRow, AdminOverview, AdminPlayerHit, AdminSimLookup, AdminStats,
 } from './types';
 
@@ -78,5 +78,3 @@ export const adminWipePhone = (cid: string, confirm: string) =>
 
 export const adminAudit = (cursor?: number | null) =>
     call<{ entries: AdminAuditEntry[]; nextCursor?: number | null }>('sd-phone:admin:audit', { cursor });
-
-export type { AdminAccount };

--- a/web/src/admin/types.ts
+++ b/web/src/admin/types.ts
@@ -20,7 +20,7 @@ export interface AdminMute {
     createdAt:  number;
 }
 
-export interface AdminAccount {
+interface AdminAccount {
     id:          number;
     app:         string;
     username:    string;
@@ -77,7 +77,7 @@ export interface AdminOverview {
     } | null;
 }
 
-export interface AdminSimRow {
+interface AdminSimRow {
     number:     string;
     identity:   string;
     ownerCid?:  string | null;

--- a/web/src/admin/ui.tsx
+++ b/web/src/admin/ui.tsx
@@ -126,7 +126,7 @@ export function LoadMore({ onClick, loading, hasMore }: { onClick: () => void; l
 
 // Modal rendered inside the panel window (absolute, not portal) so it stays
 // within the admin surface and inherits its stacking context.
-export function Modal({ title, children, onClose, width = 'w-[420px]' }: {
+function Modal({ title, children, onClose, width = 'w-[420px]' }: {
     title: string;
     children: ReactNode;
     onClose: () => void;


### PR DESCRIPTION
## Summary

Moves the compiled NUI out of source and ships it via GitHub Releases, built by CI. Fixes the class of breakage seen in #50, where a `git add` past the `web/build/` gitignore rule staged deletions of old chunks but silently skipped the new ones, leaving `index.html` pointing at chunks that were never committed.

## What's here

- **`ci.yml`** — on every PR and push to `main`: `npm ci` then `build` (which typechecks via `tsc --noEmit`), `lint`, `test`, `knip`. These are the project's existing green gates. This PR is validated by its own copy of the workflow.
- **`release.yml`** — on a published GitHub Release: builds the NUI fresh and attaches a lean `sd-phone-<tag>.zip` (runtime dirs + `web/build`; no `web/src`, `node_modules`, dev configs, `.github`, docs, or root screenshots). Verified locally: the staged tree has all 152 JS chunks + `components.js`, `index.html` references resolve with 0 missing, and 0 leaks.
- **Build-presence guard** in `server/main.lua`: logs a clear error if `web/build/index.html` is missing (a cloned-but-unbuilt checkout) instead of opening a blank phone.
- **README** install section now points to Releases, with a build-from-source note.
- **Version bump** to `0.9.0` (`fxmanifest.lua`, `package.json`, `package-lock.json` root fields).

## Sequencing (not in this PR)

`web/build` is still tracked here on purpose. After this merges, the plan is: cut release **v0.9.0** (the workflow builds + attaches the zip), verify the artifact, then a follow-up commit runs `git rm -r --cached web/build` so `main` becomes source-only. This guarantees a working distribution path exists at every moment.

Design spec: `docs/superpowers/specs/2026-07-19-release-automation-design.md`