### PR TITLE
Async app loading & focus/wipe fixes

### DIFF
--- a/client/admin.lua
+++ b/client/admin.lua
@@ -17,6 +17,13 @@ AddEventHandler('sd-phone:client:openState', function(open)
     end
 end)
 
+-- A wipe reloads the NUI, destroying the admin-panel React tree. Clear our open flag so the
+-- openState handler above won't re-assert focus over a panel that no longer exists; main.lua
+-- drops the actual focus.
+AddEventHandler('sd-phone:client:wipeFocus', function()
+    adminOpen = false
+end)
+
 ---Opens the panel. Fired by the server-side /phoneadmin command (server/admin/init.lua), which
 ---is the permission gate - this event never opens anything the callbacks wouldn't refuse.
 ---Keep-input is forced off so the game gets no movement/camera input while the panel is up

--- a/client/main.lua
+++ b/client/main.lua
@@ -173,14 +173,21 @@ end
 ---config.Phone.HoldAnimation is off.
 local function startPose()
     if not config.Phone.HoldAnimation then return end
-    local ped = PlayerPedId()
-    RequestAnimDict(config.Phone.AnimDict)
-    local started = GetGameTimer()
-    while not HasAnimDictLoaded(config.Phone.AnimDict) and GetGameTimer() - started < 1000 do Wait(0) end
-    if not IsEntityPlayingAnim(ped, config.Phone.AnimDict, config.Phone.AnimName, 3) then
-        TaskPlayAnim(ped, config.Phone.AnimDict, config.Phone.AnimName, 6.0, -1.0, -1, 49, 0.0, false, false, false)
-    end
-    attachPhoneProp(ped)
+    -- Load the dict and play the pose on its own thread: the anim is cosmetic and must never
+    -- gate the phone opening. Blocking here (up to 1s waiting on the dict) used to stall the
+    -- NUI reveal since OpenPhone runs this synchronously before focusing the UI.
+    CreateThread(function()
+        RequestAnimDict(config.Phone.AnimDict)
+        local started = GetGameTimer()
+        while not HasAnimDictLoaded(config.Phone.AnimDict) and GetGameTimer() - started < 1000 do Wait(0) end
+        -- The player may have closed the phone (or the camera took the pose) during the load.
+        if not shouldHold() then return end
+        local ped = PlayerPedId()
+        if not IsEntityPlayingAnim(ped, config.Phone.AnimDict, config.Phone.AnimName, 3) then
+            TaskPlayAnim(ped, config.Phone.AnimDict, config.Phone.AnimName, 6.0, -1.0, -1, 49, 0.0, false, false, false)
+        end
+        attachPhoneProp(ped)
+    end)
 end
 
 ---Stop the hold anim (only when it's actually our clip playing) and remove the prop.
@@ -322,11 +329,6 @@ local function OpenPhone()
     TriggerEvent('sd-phone:client:openState', true)
     TriggerServerEvent('sd-phone:server:phone:setOpen', true)
 
-    local installedRes  = lib.callback.await('sd-phone:server:apps:list', false)
-    if not phoneState.open then return end
-    local installedApps = (installedRes and installedRes.success and installedRes.data and installedRes.data.installed) or {}
-    local homeLayout    = (installedRes and installedRes.success and installedRes.data and installedRes.data.layout) or nil
-
     SetNuiFocus(true, true)
     if config.Phone.AllowMovement then
         typingInPhone = false
@@ -370,6 +372,22 @@ local function OpenPhone()
     })
 
     debugPrint('phone opened')
+
+    -- Installed apps + saved home layout need a server round-trip. Fetch them AFTER the phone is
+    -- on screen (the home screen sits behind the lockscreen anyway) and push them in as a
+    -- follow-up, so the round-trip never gates the reveal. The NUI paints instantly from its own
+    -- fallbacks and reconciles when this lands.
+    CreateThread(function()
+        local installedRes = lib.callback.await('sd-phone:server:apps:list', false)
+        if not phoneState.open then return end
+        SendNUIMessage({
+            action = 'sd-phone:apps',
+            data   = {
+                installedApps = (installedRes and installedRes.success and installedRes.data and installedRes.data.installed) or {},
+                homeLayout    = (installedRes and installedRes.success and installedRes.data and installedRes.data.layout) or nil,
+            },
+        })
+    end)
 end
 
 ---Closes the phone NUI, announces the close, releases NUI focus, and drops the pose unless the
@@ -451,10 +469,15 @@ RegisterNetEvent('sd-phone:client:simState', function(state)
 end)
 
 ---Admin wipe (server /wipemyphone): closes the phone and tells the React app to clear its local
----storage and reload.
+---storage and reload. The reload tears down the phone AND the admin-panel React trees, so any NUI
+---focus they were holding must be dropped here - otherwise the reloaded (empty) NUI keeps focus
+---with no UI left to release it, and the player is stuck. wipeFocus lets the panels clear their
+---own open flags first so a later phone close doesn't re-assert focus over nothing.
 RegisterNetEvent('sd-phone:client:wipe', function()
+    TriggerEvent('sd-phone:client:wipeFocus')
     if phoneState.open then ClosePhone() end
     SendNUIMessage({ action = 'sd-phone:wipe' })
+    SetNuiFocus(false, false)
 end)
 
 ---React to Lua: the NUI requests the phone be closed (swipe down / back gesture).

--- a/client/payphone.lua
+++ b/client/payphone.lua
@@ -38,6 +38,12 @@ AddEventHandler('sd-phone:client:openState', function(open)
     end
 end)
 
+-- A wipe reloads the NUI; clear our session flag so the openState handler above won't re-assert
+-- focus over a payphone UI that no longer exists (main.lua drops the actual focus).
+AddEventHandler('sd-phone:client:wipeFocus', function()
+    activeLocation = nil
+end)
+
 ---Rounded-coords key for a booth, matching what the server distance-checks against.
 ---@param coords vector3
 ---@return string

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -196,6 +196,12 @@ function AppContent() {
     const [landscape,       setLandscape]       = useState(false);
     const [installedApps,   setInstalledApps]   = useState<Set<string>>(new Set());
     const [savedLayout,     setSavedLayout]     = useState<SavedLayout | null>(null);
+    // In FiveM the installed apps + saved layout arrive via the sd-phone:apps follow-up (kept off
+    // the open round-trip). Hold the home grid until they land: the Homescreen seeds its slot
+    // layout once at mount, so mounting it against the transient empty layout would auto-arrange
+    // and then persist that arrangement back, clobbering the real one. The dev harness resolves
+    // both synchronously on open, so it's ready immediately.
+    const [appsReady,       setAppsReady]       = useState(!isFiveM);
     const [frameColor,      setFrameColor]      = useState<string>(DEFAULT_FRAME_COLOR);
     const downloadingIds = useDownloadingIds();
     const downloadQueue = useRef<string[]>([]);
@@ -320,8 +326,12 @@ function AppContent() {
         setSwitcherClosing(false);
         setSwitcherReady(false);
         setNotifs([]);
+        // In FiveM the installed list + saved layout arrive via the sd-phone:apps follow-up (kept
+        // off the open round-trip so the phone reveals instantly); only the dev harness fetches
+        // them inline here.
         if (data.installedApps) setInstalledApps(new Set([...data.installedApps, ...installedCustomIds()]));
-        else void listInstalledApps().then(ids => setInstalledApps(new Set([...ids, ...installedCustomIds()])));
+        else if (!isFiveM) void listInstalledApps().then(ids => setInstalledApps(new Set([...ids, ...installedCustomIds()])));
+        setAppsReady(!isFiveM);
         // Under unique phones the localStorage layout fallback is another profile's - server only.
         setSavedLayout(data.homeLayout ? parseLayout(data.homeLayout) : (data.sim?.enabled ? null : loadHomeLayout()));
         setLocked(data.locked);
@@ -333,6 +343,15 @@ function AppContent() {
         if (isFiveM) void fetchNui<Record<string, number>>('sd-phone:badges:get').then(m => useBadgeStore.getState().setServer(m ?? {}));
         if (isFiveM) void fetchNui<{ on: boolean }>('sd-phone:flashlight:state').then(r => setFlashlightOn(!!r?.on));
         useCustomAppsStore.getState().hydrate();
+    }, []));
+
+    // Follow-up to sd-phone:open: the authoritative installed-apps list and saved home layout,
+    // fetched after the reveal so the server round-trip never delayed the phone appearing.
+    useNuiEvent('sd-phone:apps', useCallback((data) => {
+        if (!data) return;
+        setInstalledApps(new Set([...(data.installedApps ?? []), ...installedCustomIds()]));
+        setSavedLayout(data.homeLayout ? parseLayout(data.homeLayout) : null);
+        setAppsReady(true);
     }, []));
 
     useNuiEvent('sd-phone:simState', useCallback((data) => {
@@ -1115,7 +1134,7 @@ function AppContent() {
                         onOpenCamera={openCameraFromLock}
                     />
                 ) : (
-                    !cameraMode && (
+                    !cameraMode && appsReady && (
                         <Homescreen
                             apps={effectiveApps}
                             dock={view.dock}

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -176,6 +176,7 @@ interface MusicSharePush {
 
 export type NuiMessage =
     | { action: 'sd-phone:open';    data: OpenPayload }
+    | { action: 'sd-phone:apps';    data: { installedApps?: string[]; homeLayout?: string | null } }
     | { action: 'sd-phone:simState'; data: SimStatePush }
     | { action: 'sd-phone:frameColor'; data: { color: string } }
     | { action: 'sd-phone:music:receive'; data: MusicSharePush }


### PR DESCRIPTION
## Summary
Move the phone hold animation load to a background thread so anim dict loading won't block the NUI reveal. Defer fetching installed apps and home layout until after OpenPhone; main.lua now sends a follow-up 'sd-phone:apps' message. web/App.tsx adds appsReady, listens for 'sd-phone:apps', and prevents the Homescreen from mounting until apps/layout arrive (avoids clobbering saved layouts). Add a NuiMessage type for 'sd-phone:apps'. Add 'sd-phone:client:wipeFocus' handlers (admin & payphone), call it before wipe, and clear NUI focus on wipe to avoid stuck focus.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [x] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

Closes #

or

Related to #

## Testing

Describe how this was tested.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [x] Tested with latest ox_lib
- [x] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

I dont think so

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.