### PR TITLE
fix(garages): render status labels so they follow the active locale

### DIFF
--- a/web/src/apps/garages/Garages.tsx
+++ b/web/src/apps/garages/Garages.tsx
@@ -135,15 +135,23 @@ function VehicleThumb({ v, show, size, radius, iconSize, iconStroke = 2 }: {
     );
 }
 
-const STATUS_BADGE: Record<VehicleStatus, { label: string; tone: PillTone }> = {
-    stored:  { label: t('garages.statusStored', 'Stored'),   tone: 'green' },
-    out:     { label: t('garages.statusOut', 'Out'),         tone: 'orange' },
-    impound: { label: t('garages.statusImpound', 'Impound'), tone: 'red' },
+const STATUS_TONE: Record<VehicleStatus, PillTone> = {
+    stored:  'green',
+    out:     'orange',
+    impound: 'red',
 };
 
+// Resolved at render, not module load, so the label follows the active locale after a
+// language switch or a late catalog load instead of freezing to the import-time language.
+function statusLabel(status: VehicleStatus): string {
+    if (status === 'stored')  return t('garages.statusStored', 'Stored');
+    if (status === 'impound') return t('garages.statusImpound', 'Impound');
+    return t('garages.statusOut', 'Out');
+}
+
 function StatusPill({ status, className = '' }: { status: VehicleStatus; className?: string }) {
-    const b = STATUS_BADGE[status] ?? STATUS_BADGE.out;
-    return <Pill tone={b.tone} className={className}>{b.label}</Pill>;
+    const tone = STATUS_TONE[status] ?? STATUS_TONE.out;
+    return <Pill tone={tone} className={className}>{statusLabel(status)}</Pill>;
 }
 
 function VehicleCard({ v, showImages, onOpen }: { v: Vehicle; showImages: boolean; onOpen: () => void }) {


### PR DESCRIPTION
## Summary

In the Garages app, viewing a garaged vehicle could show its status pill in the wrong language (reported: Polish `Zaparkowany`) while the rest of the app was English.

Root cause: the stored/out/impound labels were built into a **module-level** `STATUS_BADGE` const in `web/src/apps/garages/Garages.tsx`. Because `t()` there runs exactly once when the lazy garages chunk is first imported, the labels froze to whatever locale was active at import time. Every other `t()` in the file is called at render time, so on a later language switch the store update re-renders the tree and those strings flip to the new language, but the three status pills keep the stale import-time language. A player who first opened Garages under a non-English catalog (Polish) and then switched to English got exactly the reported mix: status pill Polish, everything else English.

Fix: move the label lookup into a small render-time `statusLabel()` helper using the same `t('garages.status*', 'English fallback')` pattern as the neighbouring strings, and keep the pill tone in a static `STATUS_TONE` map (tones need no i18n). All three status labels now track the active catalog on every render. No locale files changed; `locales/en.json` already carries the correct English values and `locales/pl.json` keeps its legitimate Polish translations.

A repo-wide grep for Polish diacritics in `web/src` is clean apart from `Cześć` in `SetupFlow.tsx`, which is the intentional multilingual "Hello" welcome screen and unrelated to this bug.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

Closes #65

## Testing

Ran the web gates from `web/`:

- `npx tsc --noEmit` — zero errors
- `npx eslint src` — zero errors (29 pre-existing warnings, none added, none in garages)
- `npx vitest run` — 7 files, 73 tests pass

No in-game test was performed.

- [x] Tested locally
- [ ] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

None.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [ ] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [ ] I have verified this works on the latest version of sd-phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)