### PR TITLE
fix(health): anchor time-awake to session start via a store

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -75,7 +75,8 @@ local FRAME_COLORS = {
     pink = true, purple = true, red = true, yellow = true,
 }
 
----@type integer Wall-clock ms captured once at script load; session start for the Health app.
+---@type integer Wall-clock ms of the session start (re-stamped on character load); the Health app's
+---"time awake" anchor. Seeded at script load as a fallback for opens before the character resolves.
 local SESSION_START_MS = GetCloudTimeAsInt() * 1000
 
 ---@return boolean true while the phone NUI is open
@@ -715,7 +716,9 @@ exports('isDisabled', function() return phoneDisabled end)
 ---the UI re-pulls its per-player state (wallpaper, tones, locale...) the moment the framework
 ---reports the player in - covering slow multichar picks and live character switches alike.
 local function pushCharacterLoaded()
+    SESSION_START_MS = GetCloudTimeAsInt() * 1000
     SendNUIMessage({ action = 'sd-phone:client:characterLoaded' })
+    SendNUIMessage({ action = 'sd-phone:session', data = { startMs = SESSION_START_MS } })
 end
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', pushCharacterLoaded)
 RegisterNetEvent('esx:playerLoaded', pushCharacterLoaded)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { AppDeck, FullscreenStage, type DeckAppCtx } from '@/shell/AppDeck';
 import { Homescreen }  from '@/shell/Homescreen';
 import { useBadgeStore } from '@/stores/badgeStore';
 import { useBatteryStore } from '@/stores/batteryStore';
+import { useSessionStore } from '@/stores/sessionStore';
 import { useDownloadStore, useDownloadingIds } from '@/stores/downloadStore';
 import { useLocaleStore } from '@/stores/localeStore';
 import { HomeIndicator } from '@/shell/HomeIndicator';
@@ -631,6 +632,10 @@ function AppContent() {
 
     useNuiEvent('sd-phone:battery', useCallback((pct) => {
         if (typeof pct === 'number') { setBattery(pct); useBatteryStore.getState().setLevel(pct); }
+    }, []));
+
+    useNuiEvent('sd-phone:session', useCallback((data) => {
+        if (data && typeof data.startMs === 'number') useSessionStore.getState().setStartMs(data.startMs);
     }, []));
 
     const [notifs, setNotifs] = useState<NotificationItem[]>([]);

--- a/web/src/apps/health/Health.tsx
+++ b/web/src/apps/health/Health.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Footprints, Heart, MoonStar, Route } from 'lucide-react';
 
 import { useNuiEvent } from '@/hooks/useNuiEvent';
+import { useSessionStore } from '@/stores/sessionStore';
 import { t } from '@/i18n';
 
 const SB_H = 54;
@@ -13,7 +14,6 @@ interface HealthProps {
 }
 
 const live = {
-    sessionStart: null as number | null,
     steps:        null as number | null,
     distanceM:    null as number | null,
     heartRate:    null as number | null,
@@ -21,9 +21,7 @@ const live = {
 window.addEventListener('message', (e: MessageEvent) => {
     const msg = e.data as { action?: string; data?: Record<string, unknown> } | undefined;
     if (!msg?.data) return;
-    if (msg.action === 'sd-phone:session') {
-        if (typeof msg.data.startMs === 'number') live.sessionStart = msg.data.startMs;
-    } else if (msg.action === 'sd-phone:health') {
+    if (msg.action === 'sd-phone:health') {
         if (typeof msg.data.steps     === 'number') live.steps     = msg.data.steps;
         if (typeof msg.data.distanceM === 'number') live.distanceM = msg.data.distanceM;
         if (typeof msg.data.heartRate === 'number') live.heartRate = msg.data.heartRate;
@@ -31,16 +29,12 @@ window.addEventListener('message', (e: MessageEvent) => {
 });
 
 export function Health({ onClose }: HealthProps) {
-    const [sessionStart, setSessionStart] = useState<number>(() => live.sessionStart ?? Date.now());
+    const storeStart = useSessionStore((s) => s.startMs);
+    const [fallbackStart]                 = useState<number>(() => Date.now());
     const [now,          setNow]          = useState<number>(() => Date.now());
     const [steps,        setSteps]        = useState<number>(() => live.steps ?? 0);
     const [distanceM,    setDistanceM]    = useState<number>(() => live.distanceM ?? 0);
     const [hr,           setHr]           = useState<number>(() => live.heartRate ?? 70);
-
-    useNuiEvent('sd-phone:session', useCallback((data) => {
-        if (!data || typeof data.startMs !== 'number') return;
-        setSessionStart(data.startMs);
-    }, []));
 
     useNuiEvent('sd-phone:health', useCallback((data) => {
         if (!data) return;
@@ -54,7 +48,7 @@ export function Health({ onClose }: HealthProps) {
         return () => window.clearInterval(id);
     }, []);
 
-    const awakeMs  = Math.max(0, now - sessionStart);
+    const awakeMs  = Math.max(0, now - (storeStart ?? fallbackStart));
     const distance = distanceM / M_PER_MILE;
 
     return (

--- a/web/src/stores/sessionStore.ts
+++ b/web/src/stores/sessionStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+// Session anchor (wall-clock ms of character load) fed by the 'sd-phone:session' NUI event in
+// App.tsx; the Health app reads it so "time awake" is correct on first open, whenever that happens.
+interface SessionState {
+    startMs: number | null;
+    setStartMs: (ms: number) => void;
+}
+
+export const useSessionStore = create<SessionState>((set) => ({
+    startMs: null,
+    setStartMs: (ms) => set({ startMs: ms }),
+}));


### PR DESCRIPTION
## Summary

The Health app's "Time Awake" counted from the app's own mount time, so opening Health 30 minutes into a session showed 0m 0s.

Root cause: the client pushes the session anchor once per phone open (`SendNUIMessage({ action = 'sd-phone:session', ... })`), but the Health app is lazy-loaded (`import('@/apps/health/Health')` in the app registry). Its module-level `window` listener and its `useNuiEvent('sd-phone:session')` subscription therefore weren't active when that one-shot push fired (before Health was ever navigated to), so it missed the anchor and fell back to `Date.now()`. It only "started counting" once a later push arrived while Health was mounted.

Fix:
- Add `web/src/stores/sessionStore.ts` and feed it from `App.tsx` via the single `useNuiEvent` dispatcher. App is always mounted, so it captures the `sd-phone:session` push regardless of whether Health has been opened. Health now reads the anchor from the store (with a `Date.now()` fallback for dev / pre-anchor).
- Re-anchor `SESSION_START_MS` on character load in `client/main.lua`. It was stamped once at script load (resource start), which on a long-running server is not a meaningful "awake" origin. Character load is the defensible anchor: `pushCharacterLoaded` (already fired on `QBCore:Client:OnPlayerLoaded` / `esx:playerLoaded`) now re-stamps the value and pushes a fresh `sd-phone:session` so an already-open phone updates on live character switches. The script-load value remains as a fallback for opens before the character resolves.

Health is the only consumer of `sd-phone:session` (the dev harness is the only other producer), so the contract change is safe.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

Closes #64

## Testing

- [x] Tested locally

Gates run in `web/`:
- `tsc --noEmit` - 0 errors
- `eslint src` - 0 errors (29 pre-existing warnings, none in changed files)
- `vitest run` - 7 files, 73 tests passed
- `luac -p client/main.lua` - passes

No in-game test was performed.

- [ ] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

None. The `sd-phone:session` message shape is unchanged; the semantic anchor moves from resource start to character load, which only affects the Health "Time Awake" value it feeds.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [ ] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [ ] I have verified this works on the latest version of sd-phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
