### PR TITLE
fix(messages): resolve conversation names live against saved contacts

### DIFF
--- a/web/src/apps/messages/Messages.tsx
+++ b/web/src/apps/messages/Messages.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { t } from '@/i18n';
 import { ChatView } from '@/shared/chat/ChatView';
@@ -17,9 +17,11 @@ import {
     removeGroupMemberApi, markReadApi,
     upsertConversation, appendMessage, replaceMessage, markConversationRead,
     deleteConversationApi, contactFromNumber, reactMessageApi, toggleReactionLocal,
-    applyReaction, type SendInput,
+    applyReaction, resolveConvParticipant, type SendInput,
 } from '@/shared/chat/messagesApi';
 import type { Reaction } from '@/shared/chat/data';
+import { useContacts, useContactsStore } from '@/stores/contactsStore';
+import { digits } from '@/lib/format';
 import { peekMessagesTarget, clearMessagesTarget } from '@/shell/deeplink';
 
 type Draft = Omit<SendInput, 'conversation'>;
@@ -34,6 +36,12 @@ export function Messages({ onClose }: { onClose: () => void }) {
 
     const [pending]        = useState(() => peekMessagesTarget());
     const [resolved, setResolved] = useState(!pending);
+
+    // The saved-contacts book, shared with the Phone app and kept live there (optimistic
+    // add/edit/delete + push events). Names are resolved against it at render so a contact
+    // change reflects in the conversation list / thread header without a Messages refetch.
+    const { contacts: liveCards } = useContacts('contacts');
+    useEffect(() => { void useContactsStore.getState().load(); }, []);
 
     useEffect(() => {
         clearMessagesTarget();
@@ -84,8 +92,28 @@ export function Messages({ onClose }: { onClose: () => void }) {
         if (openIdRef.current === incoming.id) markReadApi(incoming.id);
     }, []));
 
-    const conv = openId ? conversations.find(c => c.id === openId) ?? null : null;
-    const totalUnread = conversations.reduce((n, c) => n + unreadCount(c), 0);
+    const cardByNumber = useMemo(() => {
+        const m = new Map<string, Contact>();
+        for (const c of liveCards) {
+            const key = digits(c.phone ?? '');
+            if (key) m.set(key, { id: key, name: c.name, initials: c.initials, color: c.color, avatar: c.avatar, phone: key });
+        }
+        return m;
+    }, [liveCards]);
+
+    const resolvedConversations = useMemo(
+        () => conversations.map(c => resolveConvParticipant(c, cardByNumber)),
+        [conversations, cardByNumber],
+    );
+
+    // Recipient book for compose / add-member: the live shared book in-game, the fetched mock in dev.
+    const composeContacts = useMemo<Contact[]>(() => {
+        if (!isFiveM) return contacts;
+        return [...cardByNumber.values()].sort((a, b) => a.name.localeCompare(b.name));
+    }, [contacts, cardByNumber]);
+
+    const conv = openId ? resolvedConversations.find(c => c.id === openId) ?? null : null;
+    const totalUnread = resolvedConversations.reduce((n, c) => n + unreadCount(c), 0);
     const animateNav = useDidEnter(conversations.length > 0);
 
     const openConversation = useCallback((id: string) => {
@@ -310,7 +338,7 @@ export function Messages({ onClose }: { onClose: () => void }) {
         <div className="absolute inset-0 z-10 flex flex-col bg-[#d4d4d4] dark:bg-base text-black dark:text-white overflow-hidden">
             {resolved && (
                 <ConversationList
-                    conversations={conversations}
+                    conversations={resolvedConversations}
                     onOpen={openConversation}
                     onCompose={() => setComposing(true)}
                     onMarkRead={markRead}
@@ -324,7 +352,7 @@ export function Messages({ onClose }: { onClose: () => void }) {
                     conv={conv}
                     animateIn={animateNav}
                     totalUnread={totalUnread}
-                    contacts={contacts}
+                    contacts={composeContacts}
                     myNumber={myNumber}
                     onBack={() => setOpenId(null)}
                     onSend={draft => void sendMessage(conv.id, draft)}
@@ -339,7 +367,7 @@ export function Messages({ onClose }: { onClose: () => void }) {
 
             {resolved && composing && (
                 <NewMessage
-                    contacts={contacts}
+                    contacts={composeContacts}
                     myNumber={myNumber}
                     onCancel={() => setComposing(false)}
                     onSend={startConversation}

--- a/web/src/shared/chat/messagesApi.test.ts
+++ b/web/src/shared/chat/messagesApi.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { appendThreadMessage, patchThreadMessage } from './messagesApi';
+import { appendThreadMessage, contactFromNumber, patchThreadMessage, resolveConvParticipant } from './messagesApi';
+import type { Contact, Conversation } from './data';
 
 interface TestMsg { id: string; body: string }
 interface TestThread { id: string; topic?: string; messages: TestMsg[] }
@@ -64,5 +65,48 @@ describe('messagesApi.patchThreadMessage', () => {
         const threads = [thread('a', [msg])];
         const next = patchThreadMessage(threads, 'a', 'missing', m => ({ ...m, body: 'nope' }));
         expect(next[0].messages).toEqual([msg]);
+    });
+});
+
+describe('messagesApi.resolveConvParticipant', () => {
+    function conv(id: string, participant: Contact): Conversation {
+        return { id, participants: [participant], messages: [], pinned: false, muted: false };
+    }
+    const card = (over: Partial<Contact>): Contact => ({
+        id: '5551234567', name: 'Card', initials: 'C', color: '#000', phone: '5551234567', ...over,
+    });
+
+    it('reverts to the formatted number when a saved contact was deleted', () => {
+        const c = conv('5551234567', card({ name: 'John Smith' }));
+        const next = resolveConvParticipant(c, new Map());
+        expect(next.participants[0].name).toBe('(555) 123-4567');
+        expect(next.participants[0].avatar).toBeUndefined();
+    });
+
+    it('uses the live contact card when the number is saved (add / rename)', () => {
+        const c = conv('5551234567', card({ name: '(555) 123-4567', phone: '5551234567' }));
+        const map = new Map<string, Contact>([['5551234567', card({ name: 'Jane Doe', avatar: 'a.png' })]]);
+        const next = resolveConvParticipant(c, map);
+        expect(next.participants[0].name).toBe('Jane Doe');
+        expect(next.participants[0].avatar).toBe('a.png');
+    });
+
+    it('keeps a short service-code label (no revert to number)', () => {
+        const c = conv('74682', card({ id: '74682', name: 'Photogram', phone: '74682' }));
+        const next = resolveConvParticipant(c, new Map());
+        expect(next).toBe(c);
+        expect(next.participants[0].name).toBe('Photogram');
+    });
+
+    it('leaves group conversations untouched', () => {
+        const c: Conversation = { ...conv('g-1', card({ name: 'Anyone' })), groupName: 'Wolfpack' };
+        const next = resolveConvParticipant(c, new Map());
+        expect(next).toBe(c);
+    });
+
+    it('returns the same reference when an unsaved number already shows its formatted form', () => {
+        const c = conv('5551234567', contactFromNumber('5551234567'));
+        const next = resolveConvParticipant(c, new Map());
+        expect(next).toBe(c);
     });
 });

--- a/web/src/shared/chat/messagesApi.ts
+++ b/web/src/shared/chat/messagesApi.ts
@@ -1,6 +1,6 @@
 
 import { fetchNui, isFiveM } from '@/core/nui';
-import { colorFor, initialsFor } from '@/lib/format';
+import { colorFor, digits, initialsFor } from '@/lib/format';
 import { formatPhone } from '@/apps/phone/data';
 import { CONTACTS, CONVERSATIONS, ME, type Contact, type Conversation, type Message, type Reaction } from './data';
 import { apiCall, apiData } from '@/core/api';
@@ -31,6 +31,25 @@ export function contactFromNumber(number: string): Contact {
     const d = number.replace(/\D/g, '');
     const name = formatPhone(d);
     return { id: d, name, initials: initialsFor(name), color: colorFor(d || name), phone: d };
+}
+
+// Re-resolves a 1:1 conversation's display identity against the live contacts book, so a
+// contact rename/delete/add is reflected without a refetch. Groups keep their server-supplied
+// participants. Short numeric ids (service short codes) keep their server label, since those
+// senders are never saved contacts and carry a meaningful name (e.g. an app verification code).
+export function resolveConvParticipant(conv: Conversation, cardByNumber: Map<string, Contact>): Conversation {
+    if (conv.groupName) return conv;
+    const p   = conv.participants[0];
+    const key = digits(p?.phone ?? p?.id ?? conv.id ?? '');
+    if (!key) return conv;
+
+    const resolved = cardByNumber.get(key) ?? (key.length >= 7 ? contactFromNumber(key) : undefined);
+    if (!resolved) return conv;
+    if (p && p.name === resolved.name && p.avatar === resolved.avatar
+        && p.color === resolved.color && p.initials === resolved.initials) {
+        return conv;
+    }
+    return { ...conv, participants: [resolved] };
 }
 
 function cloneConv(c: Conversation): Conversation {


### PR DESCRIPTION
## Summary

Deleting a saved contact left its name showing on the Messages conversation (and, in reverse, adding/renaming a contact was not reflected).

**Root cause.** Conversation display names are resolved server-side at fetch time: `resolveParticipant` (server/messages/actions.lua) joins the viewer's saved contacts and bakes the name into `conversations[].participants[].name`, and the compose list is baked into `contacts[]`. The Messages app fetches this once on mount and is kept alive across phone close/open, so it holds those server-baked names indefinitely. Contact edits happen in a **different** app (Phone) against the shared `contactsStore`; nothing re-resolved the Messages component's cached participant names, so a delete/rename/add did not surface until the app was fully torn down and refetched.

The other name-render sites audited were already correct: the Phone app's recents resolve live via `toCallEntry(raw, contacts)` against the same store, and incoming notification titles are resolved server-side at delivery time against the current contacts. Only the Messages app was stale.

**Fix.** Resolve names live at render against the shared `contactsStore` (the same book the Phone app keeps current with optimistic add/edit/delete plus its push handlers), so contact changes reflect without a Messages refetch and without a new global event bus:

- New pure helper `resolveConvParticipant(conv, cardByNumber)` in `messagesApi.ts`. For a 1:1 thread it re-resolves the single participant: a live saved card wins (handles add + rename); otherwise the number reverts to its formatted form (handles delete). It returns the same object reference when nothing changed, so unchanged rows do not re-render.
- Short numeric ids (service short codes such as an app-verification sender `74682`) keep their server-supplied label, since those senders are never saved contacts and carry a meaningful name that the server does not persist. This avoids clobbering system texts while still reverting real 10-digit peer numbers.
- The compose / add-member recipient book is now sourced from the same live store in-game (the fetched mock is retained for the dev harness).
- Group threads are left untouched: their display name is `groupName`, and group members carry a character-name fallback that cannot be reconstructed client-side.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

Closes #58

## Testing

- [x] Tested locally

Ran the web gates from `web/`:

- `npx tsc --noEmit` — 0 errors.
- `npx eslint src` — 0 errors, 29 pre-existing warnings (no new warnings).
- `npx vitest run` — 78 passed (5 new `resolveConvParticipant` cases added to the existing `messagesApi.test.ts`: delete reverts to the formatted number, a live card wins for add/rename, a short service code keeps its label, group threads pass through, and an already-formatted unsaved number keeps its reference).

No in-game / multiplayer test was performed.

- [ ] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

None.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [ ] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [ ] I have verified this works on the latest version of sd-phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
