### PR TITLE
feat(services): business invoicing with banking pay + paid notifications

### DIFF
--- a/client/apps/services.lua
+++ b/client/apps/services.lua
@@ -30,6 +30,19 @@ proxy('sd-phone:services:removeJob',      'sd-phone:server:services:removeJob')
 proxy('sd-phone:services:acceptInvite',   'sd-phone:server:services:acceptInvite')
 proxy('sd-phone:services:declineInvite',  'sd-phone:server:services:declineInvite')
 
+-- Thin delegates for business invoicing: send/list/cancel from the business side, received/pay
+-- from the target's Banking app.
+proxy('sd-phone:services:invoices:list',     'sd-phone:server:services:invoices:list')
+proxy('sd-phone:services:invoices:create',   'sd-phone:server:services:invoices:create')
+proxy('sd-phone:services:invoices:cancel',   'sd-phone:server:services:invoices:cancel')
+proxy('sd-phone:services:invoices:received', 'sd-phone:server:services:invoices:received')
+proxy('sd-phone:services:invoices:pay',      'sd-phone:server:services:invoices:pay')
+
+---Server nudge: re-pull invoices (a new one was sent, paid, or cancelled). No payload.
+RegisterNetEvent('sd-phone:client:services:invoices', function()
+    SendNUIMessage({ action = 'sd-phone:services:invoices' })
+end)
+
 ---Server nudge: re-pull the jobs/offers list. No payload.
 RegisterNetEvent('sd-phone:client:services:jobsChanged', function()
     SendNUIMessage({ action = 'sd-phone:services:jobsChanged' })

--- a/configs/services.lua
+++ b/configs/services.lua
@@ -24,6 +24,18 @@ return {
     -- Drop the player off duty when they switch active job (mirrors sd-multijob).
     SwitchOffDuty = true,
 
+    -- Business invoicing. On-duty employees send a banking invoice from their
+    -- business to another player; the target pays it from the Banking app and
+    -- the sender is notified. Only active on QBCore/QBox (on-duty state must be
+    -- resolvable); the section is hidden on ESX, like the Jobs tab.
+    -- Payout: when a society bank is available the payment is credited to the
+    -- business account; otherwise it falls back to the sending employee's own
+    -- bank (see bridge/server/society.lua).
+    InvoicesEnabled = true,
+    -- Smallest and largest amount a single invoice may be for.
+    MinInvoiceAmount = 1,
+    MaxInvoiceAmount = 1000000,
+
     -- One entry per company. `job` is the framework job name (the key everything
     -- keys off). `coords` powers the client-side "Locate" waypoint. Listing a job
     -- here adds it to the public directory and enables Job Calls / company

--- a/server/services/actions.lua
+++ b/server/services/actions.lua
@@ -230,10 +230,11 @@ end
 function actions.directory(src)
     local cid = player.getIdentifier(src)
     return ok({
-        companies     = actions.companyList(),
-        myCompany     = buildMyCompany(src),
-        multijob      = job.supportsMultijob(),
-        pendingOffers = cid and #jobstore.listInvites(cid) or 0,
+        companies       = actions.companyList(),
+        myCompany       = buildMyCompany(src),
+        multijob        = job.supportsMultijob(),
+        invoicesEnabled = SV.InvoicesEnabled ~= false,
+        pendingOffers   = cid and #jobstore.listInvites(cid) or 0,
     })
 end
 

--- a/server/services/init.lua
+++ b/server/services/init.lua
@@ -4,10 +4,14 @@ local store     = require 'server.services.store'
 local msgstore  = require 'server.services.msgstore'
 ---@type table Saved-jobs store (server.services.jobstore): multijob list, job offers, pending fires.
 local jobstore  = require 'server.services.jobstore'
+---@type table Business-invoices store (server.services.invoicestore): the phone_service_invoices rows.
+local invoicestore = require 'server.services.invoicestore'
 ---@type table Authoritative Services handlers (server.services.actions): directory, money, roster, inbox.
 local actions   = require 'server.services.actions'
 ---@type table Jobs-tab handlers (server.services.jobs): saved-job list/switch/remove + offer accept/decline.
 local jobs      = require 'server.services.jobs'
+---@type table Business-invoices handlers (server.services.invoices): create/list/cancel/received/pay.
+local invoices  = require 'server.services.invoices'
 ---@type table Framework detection (bridge.shared.framework): name is 'qb' or 'esx'.
 local framework = require 'bridge.shared.framework'
 ---@type table Shared server helpers (server.util): the { success, message? } envelope constructors.
@@ -19,6 +23,7 @@ CreateThread(function()
         store.ensureSchema()
         msgstore.ensureSchema()
         jobstore.ensureSchema()
+        invoicestore.ensureSchema()
     end)
     if not ok then
         print(('^1[sd-phone:services]^0 schema bootstrap failed: %s'):format(err))
@@ -68,6 +73,13 @@ lib.callback.register('sd-phone:server:services:switchJob', function(src, payloa
 lib.callback.register('sd-phone:server:services:removeJob', function(src, payload) return jobs.remove(src, payload) end)
 lib.callback.register('sd-phone:server:services:acceptInvite', function(src, payload) return jobs.accept(src, payload) end)
 lib.callback.register('sd-phone:server:services:declineInvite', function(src, payload) return jobs.decline(src, payload) end)
+
+-- Business invoicing callbacks: thin delegates into server.services.invoices.
+lib.callback.register('sd-phone:server:services:invoices:list', function(src) return invoices.list(src) end)
+lib.callback.register('sd-phone:server:services:invoices:create', function(src, payload) return invoices.create(src, payload) end)
+lib.callback.register('sd-phone:server:services:invoices:cancel', function(src, payload) return invoices.cancel(src, payload) end)
+lib.callback.register('sd-phone:server:services:invoices:received', function(src) return invoices.received(src) end)
+lib.callback.register('sd-phone:server:services:invoices:pay', function(src, payload) return invoices.pay(src, payload) end)
 
 ---Public export: exports['sd-phone']:getCompanyDirectory(). Returns the configured company
 ---directory rows in config order, as a fresh array each call.

--- a/server/services/invoices.lua
+++ b/server/services/invoices.lua
@@ -1,0 +1,339 @@
+---@type table sd-phone config root (configs/config.lua).
+local config      = require 'configs.config'
+---@type table Business-invoices store (server.services.invoicestore): the phone_service_invoices rows.
+local store       = require 'server.services.invoicestore'
+---@type table Society bridge (bridge.server.society): company account credit + name resolution.
+local society     = require 'bridge.server.society'
+---@type table Banking bridge (bridge.server.banking): the target's personal bank debit + credit.
+local bank        = require 'bridge.server.banking'
+---@type table Job bridge (bridge.server.job): current job/duty reads + the multijob capability probe.
+local job         = require 'bridge.server.job'
+---@type table Player bridge (bridge.server.player): citizenid/name/source lookups.
+local player      = require 'bridge.server.player'
+---@type table Settings store (server.settings.store): phone-number ownership lookups.
+local settings    = require 'server.settings.store'
+---@type table Banking actions (server.banking.actions): log-only Wallet entries for both sides.
+local bankActions = require 'server.banking.actions'
+---@type table Shared server helpers (server.util): envelope constructors + string/number guards.
+local util        = require 'server.util'
+
+---@type table Services config (configs/services.lua).
+local SV       = config.Services
+---@type table[] Configured company entries (SV.Companies).
+local COMPANIES = SV.Companies or {}
+---@type integer Smallest invoice amount.
+local MIN      = SV.MinInvoiceAmount or 1
+---@type integer Largest invoice amount.
+local MAX_AMT  = SV.MaxInvoiceAmount or 1000000
+---@type integer Cap on how many rows the sent/received lists return.
+local LIST_CAP = 50
+
+---@type table<string, table> Company config entry by job name, for O(1) directory-metadata lookups.
+local byJob = {}
+for _, c in ipairs(COMPANIES) do byJob[c.job] = c end
+
+-- Jobs that never count as employment for invoicing (unemployed is always included).
+---@type table<string, boolean>
+local BLACKLIST = {}
+for _, j in ipairs(SV.JobBlacklist or { 'unemployed' }) do BLACKLIST[j] = true end
+BLACKLIST[SV.UnemployedJob or 'unemployed'] = true
+
+local ok, fail, digits, trim, finite = util.ok, util.fail, util.digits, util.trim, util.finite
+
+---@type table Invoices module; every handler returns the { success, data?, message? } envelope. The
+---table returned at end of file.
+local invoices = {}
+
+---Formats an amount as "$1,234" with thousands separators, sign dropped, for notification copy.
+---@param amount number
+---@return string
+local function formatMoney(amount)
+    local s = tostring(math.floor(math.abs(tonumber(amount) or 0)))
+    local k
+    repeat s, k = s:gsub('^(%d+)(%d%d%d)', '%1,%2') until k == 0
+    return '$' .. s
+end
+
+---A business's display label: the configured company label, then the framework label, then the
+---raw job name.
+---@param jobName string
+---@return string
+local function labelOf(jobName)
+    local e = byJob[jobName]
+    if e then return e.label end
+    return job.getLabel(jobName) or jobName
+end
+
+---Resolves the caller's active business for invoicing. Succeeds only on a duty-capable framework
+---(QBCore/QBox) when the caller holds a real (non-blacklisted) job and is on duty. Returns
+---`(jobName, citizenid)` on success, `(nil, errorMessage)` otherwise.
+---@param src number
+---@return string|nil jobName, string citizenidOrError
+local function requireOnDutyBusiness(src)
+    if not job.supportsMultijob() then return nil, 'Not available here' end
+    local cid = player.getIdentifier(src)
+    if not cid then return nil, 'Player not found' end
+    local myJob = job.getName(src)
+    if not myJob or BLACKLIST[myJob] then return nil, "You're not in a job" end
+    if job.getDuty(src) ~= true then return nil, 'You must be on duty to do that' end
+    return myJob, cid
+end
+
+---Pushes a live "re-pull your invoices" nudge to every online member of a business.
+---@param jobName string
+local function notifyBusiness(jobName)
+    if not jobName or BLACKLIST[jobName] then return end
+    for _, tsrc in pairs(player.onlineCidMap()) do
+        if job.getName(tsrc) == jobName then
+            TriggerClientEvent('sd-phone:client:services:invoices', tsrc, {})
+        end
+    end
+end
+
+---Shapes one invoice row for the business's sent list.
+---@param r table phone_service_invoices row
+---@return table
+local function shapeSent(r)
+    return {
+        id       = r.id,
+        amount   = tonumber(r.amount) or 0,
+        note     = r.note or '',
+        status   = r.status or 'pending',
+        toName   = (r.target_name and r.target_name ~= '') and r.target_name or util.formatNumber(r.target_number or ''),
+        toNumber = r.target_number or '',
+        from     = (r.sender_name and r.sender_name ~= '') and r.sender_name or '',
+        ts       = (tonumber(r.created_at) or 0) * 1000,
+        paidAt   = r.paid_at and (tonumber(r.paid_at) * 1000) or nil,
+    }
+end
+
+---Shapes one pending invoice row for the target's received list (Banking).
+---@param r table phone_service_invoices row
+---@return table
+local function shapeReceived(r)
+    local e = byJob[r.job]
+    return {
+        id     = r.id,
+        job    = r.job,
+        label  = (r.label and r.label ~= '') and r.label or labelOf(r.job),
+        color  = (e and e.color) or '#0A84FF',
+        emoji  = (e and e.emoji) or '💼',
+        amount = tonumber(r.amount) or 0,
+        note   = r.note or '',
+        status = r.status or 'pending',
+        from   = (r.sender_name and r.sender_name ~= '') and r.sender_name or '',
+        ts     = (tonumber(r.created_at) or 0) * 1000,
+    }
+end
+
+---Returns the invoices sent from the caller's business, newest first. Read-only; returns an empty
+---list (never an error) when the caller isn't an employee or the framework can't do multijob, so
+---the section renders cleanly.
+---@param src number
+---@return table
+function invoices.list(src)
+    if not job.supportsMultijob() then return ok({ invoices = {} }) end
+    local cid = player.getIdentifier(src)
+    if not cid then return fail('Player not found') end
+    local myJob = job.getName(src)
+    if not myJob or BLACKLIST[myJob] then return ok({ invoices = {} }) end
+
+    local out = {}
+    for _, r in ipairs(store.listByJob(myJob, LIST_CAP)) do out[#out + 1] = shapeSent(r) end
+    return ok({ invoices = out })
+end
+
+---Creates an invoice from the caller's business to the owner of a phone number. Trust boundary:
+---the caller must be an on-duty employee, the amount a positive integer within the configured
+---bounds, and the target an existing character other than the caller.
+---@param src number
+---@param payload { number?: string, amount?: number, note?: string }
+---@return table
+function invoices.create(src, payload)
+    payload = type(payload) == 'table' and payload or {}
+    local myJob, cidOrErr = requireOnDutyBusiness(src)
+    if not myJob then return fail(cidOrErr) end
+    local cid = cidOrErr
+
+    local amount = tonumber(payload.amount)
+    if not finite(amount) then return fail('Enter a valid amount') end
+    amount = math.floor(amount)
+    if amount < MIN then return fail('Enter a valid amount') end
+    if amount > MAX_AMT then return fail('That amount is too large') end
+
+    local number = digits(payload.number)
+    if number == '' then return fail('Enter a recipient number') end
+
+    local myNumber = digits(settings.ensurePhoneNumber(cid) or '')
+    if number == myNumber then return fail("You can't invoice yourself") end
+
+    local targetCid = settings.getCitizenByNumber(number)
+    if not targetCid then return fail('No one owns that number') end
+    if targetCid == cid then return fail("You can't invoice yourself") end
+
+    local note = trim(payload.note):sub(1, 140)
+
+    local tsrc       = player.getSourceByIdentifier(targetCid)
+    local targetName = tsrc and player.getName(tsrc) or (society.namesByCids({ targetCid })[targetCid])
+    local label      = labelOf(myJob)
+
+    local id = store.newId()
+    store.insert({
+        id           = id,
+        job          = myJob,
+        label        = label,
+        senderCid    = cid,
+        senderName   = player.getName(src),
+        senderNumber = myNumber,
+        targetCid    = targetCid,
+        targetName   = targetName,
+        targetNumber = number,
+        amount       = amount,
+        note         = note ~= '' and note or nil,
+        createdAt    = os.time(),
+    })
+
+    if tsrc then
+        TriggerClientEvent('sd-phone:client:notify', tsrc, {
+            app = 'bank', appId = 'bank', title = label,
+            body = ('%s sent you an invoice for %s.'):format(label, formatMoney(amount)),
+            time = 'now',
+        })
+        TriggerClientEvent('sd-phone:client:services:invoices', tsrc, {})
+    end
+
+    ---First-party hook: fires once per created invoice; targetSource is nil when the target is offline.
+    TriggerEvent('sd-phone:server:services:invoiceCreated', {
+        id = id, source = src, job = myJob, label = label,
+        senderCid = cid, senderNumber = myNumber,
+        targetCid = targetCid, targetSource = tsrc, targetNumber = number,
+        amount = amount, note = note, timestamp = os.time(),
+    })
+
+    notifyBusiness(myJob)
+    return invoices.list(src)
+end
+
+---Cancels a pending invoice. The caller must be an on-duty employee of the business the invoice
+---belongs to (the sender or a colleague). Idempotent against an already-settled invoice.
+---@param src number
+---@param payload { id?: string }
+---@return table
+function invoices.cancel(src, payload)
+    payload = type(payload) == 'table' and payload or {}
+    local myJob, cidOrErr = requireOnDutyBusiness(src)
+    if not myJob then return fail(cidOrErr) end
+
+    local id  = tostring(payload.id or '')
+    local inv = store.get(id)
+    if not inv then return fail('Invoice not found') end
+    if inv.job ~= myJob then return fail("That invoice isn't from your business") end
+    if inv.status ~= 'pending' then return fail('That invoice is no longer pending') end
+    if not store.markCancelled(id) then return fail('That invoice is no longer pending') end
+
+    local tsrc = player.getSourceByIdentifier(inv.target_cid)
+    if tsrc then TriggerClientEvent('sd-phone:client:services:invoices', tsrc, {}) end
+    notifyBusiness(myJob)
+    return invoices.list(src)
+end
+
+---Returns the pending invoices addressed to the caller. Read-only.
+---@param src number
+---@return table
+function invoices.received(src)
+    local cid = player.getIdentifier(src)
+    if not cid then return fail('Player not found') end
+
+    local out = {}
+    for _, r in ipairs(store.listReceivedPending(cid, LIST_CAP)) do out[#out + 1] = shapeReceived(r) end
+    return ok({ invoices = out })
+end
+
+---Pays a pending invoice addressed to the caller. Target-initiated only: re-checks ownership,
+---pending status (atomically) and funds server-side, debits the payer's bank, then credits the
+---business society account (or the sending employee's own bank when no society bank exists).
+---@param src number
+---@param payload { id?: string }
+---@return table
+function invoices.pay(src, payload)
+    payload = type(payload) == 'table' and payload or {}
+    local cid = player.getIdentifier(src)
+    if not cid then return fail('Player not found') end
+
+    local id  = tostring(payload.id or '')
+    local inv = store.get(id)
+    if not inv then return fail('Invoice not found') end
+    if inv.target_cid ~= cid then return fail('That invoice is not yours') end
+    if inv.status ~= 'pending' then return fail('That invoice is no longer pending') end
+
+    local amount = math.floor(tonumber(inv.amount) or 0)
+    if amount <= 0 then return fail('Invalid invoice') end
+
+    local balance = bank.getBalance(src) or 0
+    if balance < amount then return fail('Insufficient funds') end
+
+    local label = (inv.label and inv.label ~= '') and inv.label or labelOf(inv.job)
+
+    -- Flip pending -> paid first: the atomic guard means a second concurrent pay loses here,
+    -- before any money moves.
+    if not store.markPaid(id, os.time()) then return fail('That invoice is no longer pending') end
+
+    bank.removeMoney(src, amount, ('Invoice · %s'):format(label))
+
+    local credited, viaSociety = false, false
+    if society.available() then
+        credited   = society.addMoney(inv.job, amount, ('Invoice from %s'):format(inv.sender_number or ''))
+        viaSociety = credited
+    end
+    if not credited then
+        local ssrc = player.getSourceByIdentifier(inv.sender_cid)
+        if ssrc then
+            bank.addMoney(ssrc, amount, ('Invoice payment · %s'):format(label))
+            credited = true
+        else
+            credited = bank.addOffline(inv.sender_cid, amount)
+        end
+    end
+
+    if not credited then
+        -- Payout leg failed: refund the payer and put the invoice back to pending.
+        bank.addMoney(src, amount, 'Invoice refund')
+        store.revertToPending(id)
+        return fail('Could not complete the payment')
+    end
+
+    -- Phone Wallet log for both sides (log-only; the money already moved above).
+    bankActions.addExternal(inv.target_cid, {
+        label = ('Invoice · %s'):format(label), amount = -amount,
+        category = 'services', counterparty = inv.sender_number,
+    })
+    if not viaSociety then
+        bankActions.addExternal(inv.sender_cid, {
+            label    = ('Invoice paid · %s'):format(inv.target_name or util.formatNumber(inv.target_number or '')),
+            amount   = amount,
+            category = 'income',
+        })
+    end
+
+    local ssrc = player.getSourceByIdentifier(inv.sender_cid)
+    if ssrc then
+        TriggerClientEvent('sd-phone:client:notify', ssrc, {
+            app = 'services', appId = 'services', title = label,
+            body = ('%s paid your invoice for %s.'):format(inv.target_name or 'A customer', formatMoney(amount)),
+            time = 'now',
+        })
+    end
+    notifyBusiness(inv.job)
+
+    ---First-party hook: fires once per paid invoice; viaSociety tells whether the business account
+    ---or the sender's personal bank received the money.
+    TriggerEvent('sd-phone:server:services:invoicePaid', {
+        id = id, job = inv.job, label = label,
+        senderCid = inv.sender_cid, targetCid = inv.target_cid, targetSource = src,
+        amount = amount, viaSociety = viaSociety, timestamp = os.time(),
+    })
+
+    return ok({ balance = bank.getBalance(src) or (balance - amount), invoices = invoices.received(src).data.invoices })
+end
+
+return invoices

--- a/server/services/invoices.lua
+++ b/server/services/invoices.lua
@@ -25,6 +25,8 @@ local COMPANIES = SV.Companies or {}
 local MIN      = SV.MinInvoiceAmount or 1
 ---@type integer Largest invoice amount.
 local MAX_AMT  = SV.MaxInvoiceAmount or 1000000
+---@type boolean Master on/off for business invoicing (SV.InvoicesEnabled; defaults on).
+local ENABLED  = SV.InvoicesEnabled ~= false
 ---@type integer Cap on how many rows the sent/received lists return.
 local LIST_CAP = 50
 
@@ -132,6 +134,7 @@ end
 ---@param src number
 ---@return table
 function invoices.list(src)
+    if not ENABLED then return ok({ invoices = {} }) end
     if not job.supportsMultijob() then return ok({ invoices = {} }) end
     local cid = player.getIdentifier(src)
     if not cid then return fail('Player not found') end
@@ -150,6 +153,7 @@ end
 ---@param payload { number?: string, amount?: number, note?: string }
 ---@return table
 function invoices.create(src, payload)
+    if not ENABLED then return fail('Invoicing is disabled') end
     payload = type(payload) == 'table' and payload or {}
     local myJob, cidOrErr = requireOnDutyBusiness(src)
     if not myJob then return fail(cidOrErr) end
@@ -220,6 +224,7 @@ end
 ---@param payload { id?: string }
 ---@return table
 function invoices.cancel(src, payload)
+    if not ENABLED then return fail('Invoicing is disabled') end
     payload = type(payload) == 'table' and payload or {}
     local myJob, cidOrErr = requireOnDutyBusiness(src)
     if not myJob then return fail(cidOrErr) end
@@ -241,6 +246,7 @@ end
 ---@param src number
 ---@return table
 function invoices.received(src)
+    if not ENABLED then return ok({ invoices = {} }) end
     local cid = player.getIdentifier(src)
     if not cid then return fail('Player not found') end
 
@@ -256,6 +262,7 @@ end
 ---@param payload { id?: string }
 ---@return table
 function invoices.pay(src, payload)
+    if not ENABLED then return fail('Invoicing is disabled') end
     payload = type(payload) == 'table' and payload or {}
     local cid = player.getIdentifier(src)
     if not cid then return fail('Player not found') end

--- a/server/services/invoicestore.lua
+++ b/server/services/invoicestore.lua
@@ -1,0 +1,120 @@
+---@type table Business-invoices store module; the table returned at end of file.
+local store = {}
+
+---@type table Shared server helpers (server.util): id generation.
+local util = require 'server.util'
+
+---Creates the business-invoices table. One row per invoice keyed by id, indexed for the sender's
+---business list (job) and the target's received list (target_cid, status).
+function store.ensureSchema()
+    MySQL.query.await([[
+        CREATE TABLE IF NOT EXISTS phone_service_invoices (
+            id            VARCHAR(48)  NOT NULL,
+            job           VARCHAR(64)  NOT NULL,
+            label         VARCHAR(128) DEFAULT NULL,
+            sender_cid    VARCHAR(64)  NOT NULL,
+            sender_name   VARCHAR(128) DEFAULT NULL,
+            sender_number VARCHAR(32)  DEFAULT NULL,
+            target_cid    VARCHAR(64)  NOT NULL,
+            target_name   VARCHAR(128) DEFAULT NULL,
+            target_number VARCHAR(32)  DEFAULT NULL,
+            amount        INT          NOT NULL,
+            note          VARCHAR(255) DEFAULT NULL,
+            status        VARCHAR(16)  NOT NULL DEFAULT 'pending',
+            created_at    INT          NOT NULL,
+            paid_at       INT          DEFAULT NULL,
+            PRIMARY KEY (id),
+            INDEX idx_job (job, created_at),
+            INDEX idx_target (target_cid, status, created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    ]])
+end
+
+---Generates a fresh invoice id.
+---@return string
+function store.newId()
+    return 'bill_' .. util.newId(16)
+end
+
+---Inserts one invoice row (status defaults to pending).
+---@param rec { id: string, job: string, label?: string, senderCid: string, senderName?: string, senderNumber?: string, targetCid: string, targetName?: string, targetNumber?: string, amount: number, note?: string, createdAt: number }
+function store.insert(rec)
+    MySQL.insert.await([[
+        INSERT INTO phone_service_invoices
+            (id, job, label, sender_cid, sender_name, sender_number,
+             target_cid, target_name, target_number, amount, note, status, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+    ]], {
+        rec.id, rec.job, rec.label, rec.senderCid, rec.senderName, rec.senderNumber,
+        rec.targetCid, rec.targetName, rec.targetNumber,
+        math.floor(tonumber(rec.amount) or 0), rec.note, rec.createdAt,
+    })
+end
+
+---Fetches a single invoice by id. Read-only.
+---@param id string
+---@return table|nil
+function store.get(id)
+    if not id or id == '' then return nil end
+    return MySQL.single.await('SELECT * FROM phone_service_invoices WHERE id = ?', { id })
+end
+
+---Every invoice sent from a business, newest first. Read-only.
+---@param job string
+---@param limit? number row cap (default 50)
+---@return table[]
+function store.listByJob(job, limit)
+    if not job or job == '' then return {} end
+    return MySQL.query.await(
+        'SELECT * FROM phone_service_invoices WHERE job = ? ORDER BY created_at DESC LIMIT ?',
+        { job, limit or 50 }) or {}
+end
+
+---Pending invoices addressed to a player, newest first. Read-only.
+---@param targetCid string
+---@param limit? number row cap (default 50)
+---@return table[]
+function store.listReceivedPending(targetCid, limit)
+    if not targetCid or targetCid == '' then return {} end
+    return MySQL.query.await(
+        "SELECT * FROM phone_service_invoices WHERE target_cid = ? AND status = 'pending' ORDER BY created_at DESC LIMIT ?",
+        { targetCid, limit or 50 }) or {}
+end
+
+---Atomically flips a pending invoice to paid. Returns true only when a pending row was updated,
+---which guards against a double payment.
+---@param id string
+---@param ts number paid-at unix seconds
+---@return boolean flipped
+function store.markPaid(id, ts)
+    if not id or id == '' then return false end
+    local affected = MySQL.update.await(
+        "UPDATE phone_service_invoices SET status = 'paid', paid_at = ? WHERE id = ? AND status = 'pending'",
+        { ts, id })
+    return (tonumber(affected) or 0) > 0
+end
+
+---Reverts a just-paid invoice back to pending (used when the payout leg fails after the debit).
+---@param id string
+---@return boolean reverted
+function store.revertToPending(id)
+    if not id or id == '' then return false end
+    local affected = MySQL.update.await(
+        "UPDATE phone_service_invoices SET status = 'pending', paid_at = NULL WHERE id = ? AND status = 'paid'",
+        { id })
+    return (tonumber(affected) or 0) > 0
+end
+
+---Atomically flips a pending invoice to cancelled. Returns true only when a pending row was
+---updated. Idempotent.
+---@param id string
+---@return boolean cancelled
+function store.markCancelled(id)
+    if not id or id == '' then return false end
+    local affected = MySQL.update.await(
+        "UPDATE phone_service_invoices SET status = 'cancelled' WHERE id = ? AND status = 'pending'",
+        { id })
+    return (tonumber(affected) or 0) > 0
+end
+
+return store

--- a/web/src/apps/banking/Banking.tsx
+++ b/web/src/apps/banking/Banking.tsx
@@ -12,6 +12,7 @@ import { AllTransactions } from './AllTransactions';
 import { SendMoney, prefillTransferAgain } from './SendMoney';
 import { FleecaCard } from './FleecaCard';
 import { TxRows } from './TxRow';
+import { ReceivedInvoices } from './ReceivedInvoices';
 
 const CARD_EXPIRY = '08/29';
 
@@ -59,6 +60,8 @@ export function Banking({ onClose: _onClose }: { onClose: () => void }) {
                         {t('banking.send', 'Send')}
                     </button>
                 </div>
+
+                <ReceivedInvoices onPaid={refresh} />
 
                 <div className="mb-3 mt-6 flex items-center justify-between">
                     <h2 className="text-[20px] font-bold tracking-tight">{t('banking.latestTransactions', 'Latest Transactions')}</h2>

--- a/web/src/apps/banking/ReceivedInvoices.tsx
+++ b/web/src/apps/banking/ReceivedInvoices.tsx
@@ -1,0 +1,94 @@
+import { useCallback, useState } from 'react';
+
+import { useAsyncData } from '@/hooks/useAsyncData';
+import { useNuiEvent } from '@/hooks/useNuiEvent';
+import { AlertDialog } from '@/ui/AlertDialog';
+import { t } from '@/i18n';
+import { fetchReceivedInvoices, payInvoice, type ReceivedInvoice } from '@/apps/services/servicesApi';
+import { formatMoney } from './data';
+
+export function ReceivedInvoices({ onPaid }: { onPaid: () => void }) {
+    const { data, refetch } = useAsyncData(fetchReceivedInvoices, []);
+    useNuiEvent('sd-phone:services:invoices', useCallback(() => { refetch(); }, [refetch]));
+
+    const [paying, setPaying] = useState<ReceivedInvoice | null>(null);
+    const [busy,   setBusy]   = useState(false);
+    const [error,  setError]  = useState<string | null>(null);
+
+    const invoices = data ?? [];
+    if (invoices.length === 0) return null;
+
+    async function doPay(inv: ReceivedInvoice) {
+        if (busy) return;
+        setBusy(true);
+        const res = await payInvoice(inv.id);
+        setBusy(false);
+        if (res.success) { refetch(); onPaid(); }
+        else setError(res.message ?? t('banking.somethingWentWrong', 'Something went wrong'));
+    }
+
+    return (
+        <>
+            <h2 className="mb-3 mt-6 text-[20px] font-bold tracking-tight">{t('banking.invoices', 'Invoices')}</h2>
+            <div className="overflow-hidden rounded-[16px] bg-[#e5e5e5] dark:bg-surface">
+                {invoices.map((inv, i) => (
+                    <div key={inv.id}>
+                        {i > 0 && <div className="pointer-events-none ml-16 bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+                        <div className="flex items-center gap-3 px-4 py-3.5">
+                            <div
+                                className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-[11px] text-[20px] shadow-sm"
+                                style={{ background: inv.color }}
+                                aria-hidden
+                            >
+                                {inv.emoji}
+                            </div>
+                            <div className="min-w-0 flex-1">
+                                <div className="truncate text-[17px] font-semibold text-black dark:text-white">{inv.label}</div>
+                                <div className="truncate text-[15px] font-medium text-ios-gray">
+                                    {inv.note
+                                        ? inv.note
+                                        : inv.from
+                                            ? t('banking.invoiceFrom', 'From {name}', { name: inv.from })
+                                            : t('banking.invoiceDue', 'Invoice due')}
+                                </div>
+                            </div>
+                            <div className="flex shrink-0 flex-col items-end gap-1.5">
+                                <span className="text-[17px] font-bold tabular-nums text-black dark:text-white">{formatMoney(inv.amount, { whole: true })}</span>
+                                <button
+                                    type="button"
+                                    disabled={busy}
+                                    onClick={() => setPaying(inv)}
+                                    className="rounded-full bg-ios-blue px-4 py-1 text-[14px] font-semibold text-white active:opacity-70 disabled:opacity-40"
+                                >
+                                    {t('banking.pay', 'Pay')}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {paying && (
+                <AlertDialog
+                    title={t('banking.payInvoiceTitle', 'Pay {label}?', { label: paying.label })}
+                    message={t('banking.payInvoiceMsg', "Pay {amount} to {label}? This can't be undone.", { amount: formatMoney(paying.amount, { whole: true }), label: paying.label })}
+                    confirmLabel={t('banking.pay', 'Pay')}
+                    cancelLabel={t('banking.cancel', 'Cancel')}
+                    onCancel={() => setPaying(null)}
+                    onConfirm={() => { const inv = paying; setPaying(null); void doPay(inv); }}
+                />
+            )}
+
+            {error && (
+                <AlertDialog
+                    title={t('banking.couldntComplete', "Couldn't complete that")}
+                    message={error}
+                    confirmLabel={t('banking.ok', 'OK')}
+                    hideCancel
+                    onCancel={() => setError(null)}
+                    onConfirm={() => setError(null)}
+                />
+            )}
+        </>
+    );
+}

--- a/web/src/apps/services/ActionsTab.tsx
+++ b/web/src/apps/services/ActionsTab.tsx
@@ -22,9 +22,10 @@ function prevGrade(grades: Grade[], current: number): Grade | null {
     return grades.filter(g => g.level < current).sort((a, b) => b.level - a.level)[0] ?? null;
 }
 
-export function ActionsTab({ myCompany, multijob = false, onChanged }: {
+export function ActionsTab({ myCompany, multijob = false, invoicesEnabled = false, onChanged }: {
     myCompany: MyCompany | null;
     multijob?: boolean;
+    invoicesEnabled?: boolean;
     onChanged: (mc: MyCompany | null | undefined) => void;
 }) {
     const [amountFor, setAmountFor] = useState<null | 'deposit' | 'withdraw'>(null);
@@ -77,7 +78,7 @@ export function ActionsTab({ myCompany, multijob = false, onChanged }: {
 
     const showMoney     = myCompany.isBoss && myCompany.available;
     const showEmployees = myCompany.isBoss;
-    const showInvoices  = multijob && myCompany.duty;
+    const showInvoices  = invoicesEnabled && multijob && myCompany.duty;
     const dutyOff       = !myCompany.duty;
 
     return (

--- a/web/src/apps/services/ActionsTab.tsx
+++ b/web/src/apps/services/ActionsTab.tsx
@@ -8,6 +8,7 @@ import { PromptDialog } from '@/ui/PromptDialog';
 import { Toggle } from '@/ui/Toggle';
 import { t } from '@/i18n';
 import { fmtMoney, type Employee } from './data';
+import { InvoicesSection } from './InvoicesSection';
 import {
     demote, deposit, fire, hire, promote, quitCompany, setDuty, setJobCalls, setJobMessages, withdraw,
     type Grade, type MyCompany, type ServiceResult,
@@ -76,6 +77,7 @@ export function ActionsTab({ myCompany, multijob = false, onChanged }: {
 
     const showMoney     = myCompany.isBoss && myCompany.available;
     const showEmployees = myCompany.isBoss;
+    const showInvoices  = multijob && myCompany.duty;
     const dutyOff       = !myCompany.duty;
 
     return (
@@ -160,6 +162,8 @@ export function ActionsTab({ myCompany, multijob = false, onChanged }: {
                         </div>
                     </>
                 )}
+
+                {showInvoices && <InvoicesSection />}
 
                 <SectionHeader>{t('services.employment', 'Employment')}</SectionHeader>
                 <div className="overflow-hidden rounded-[12px] bg-[#e5e5e5] dark:bg-surface">

--- a/web/src/apps/services/InvoiceComposer.tsx
+++ b/web/src/apps/services/InvoiceComposer.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { UserRound } from 'lucide-react';
+
+import { Sheet } from '@/ui/Sheet';
+import { AlertDialog } from '@/ui/AlertDialog';
+import { ContactPickerSheet } from '@/shared/ContactPickerSheet';
+import { t } from '@/i18n';
+import { digits } from '@/lib/format';
+import { formatPhonePartial } from '@/lib/phone';
+import { createInvoice, type SentInvoice } from './servicesApi';
+
+export function InvoiceComposer({ onClose, onSent }: {
+    onClose: () => void;
+    onSent:  (invoices: SentInvoice[]) => void;
+}) {
+    const [number,  setNumber]  = useState('');
+    const [amount,  setAmount]  = useState('');
+    const [note,    setNote]    = useState('');
+    const [picking, setPicking] = useState(false);
+    const [busy,    setBusy]    = useState(false);
+    const [error,   setError]   = useState<string | null>(null);
+
+    const amountNum = parseInt(amount || '0', 10);
+    const canSend   = digits(number).length >= 3 && amountNum > 0 && !busy;
+
+    async function submit(close: () => void) {
+        if (!canSend) return;
+        setBusy(true); setError(null);
+        const res = await createInvoice(digits(number), amountNum, note.trim());
+        setBusy(false);
+        if (res.success) { onSent(res.data?.invoices ?? []); close(); }
+        else setError(res.message ?? t('services.somethingWentWrong', 'Something went wrong'));
+    }
+
+    const fieldCls = 'w-full rounded-[10px] bg-white px-3.5 py-3 text-[17px] text-black outline-none placeholder:text-black/30 dark:bg-surface dark:text-white dark:placeholder:text-white/30';
+    const labelCls = 'mb-1.5 px-1 text-[13px] font-semibold uppercase tracking-wide text-ios-gray';
+
+    return (
+        <Sheet onClose={onClose} fit="content" title={t('services.newInvoice', 'New Invoice')} className="font-sf bg-[#d4d4d4] dark:bg-base">
+            {({ close }) => (
+                <div className="px-4 pb-3 pt-1">
+                    <div>
+                        <div className={labelCls}>{t('services.recipient', 'Recipient')}</div>
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="tel"
+                                inputMode="tel"
+                                aria-label={t('services.recipientNumber', 'Recipient number')}
+                                value={number ? formatPhonePartial(number) : ''}
+                                onChange={e => setNumber(digits(e.target.value).slice(0, 24))}
+                                placeholder={t('services.phonePlaceholder', '(555) 123-4567')}
+                                className={fieldCls}
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setPicking(true)}
+                                aria-label={t('common.selectContact', 'Select Contact')}
+                                className="flex h-[46px] w-[46px] shrink-0 items-center justify-center rounded-[10px] bg-white text-ios-blue active:opacity-60 dark:bg-surface"
+                            >
+                                <UserRound className="h-[22px] w-[22px]" strokeWidth={2.2} />
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="mt-4">
+                        <div className={labelCls}>{t('services.amount', 'Amount')}</div>
+                        <div className="flex items-center rounded-[10px] bg-white px-3.5 dark:bg-surface">
+                            <span className="text-[17px] font-medium text-ios-gray">$</span>
+                            <input
+                                type="text"
+                                inputMode="numeric"
+                                aria-label={t('services.amount', 'Amount')}
+                                value={amount ? amountNum.toLocaleString('en-US') : ''}
+                                onChange={e => setAmount(digits(e.target.value).replace(/^0+/, '').slice(0, 9))}
+                                placeholder="0"
+                                className="w-full bg-transparent py-3 pl-1 text-[17px] tabular-nums text-black outline-none placeholder:text-black/30 dark:text-white dark:placeholder:text-white/30"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="mt-4">
+                        <div className={labelCls}>{t('services.noteOptional', 'Note (optional)')}</div>
+                        <input
+                            type="text"
+                            value={note}
+                            maxLength={140}
+                            onChange={e => setNote(e.target.value)}
+                            placeholder={t('services.notePlaceholder', "What's this invoice for?")}
+                            className={fieldCls}
+                        />
+                    </div>
+
+                    <button
+                        type="button"
+                        disabled={!canSend}
+                        onClick={() => void submit(close)}
+                        className="mt-6 w-full rounded-[13px] bg-ios-blue py-3.5 text-center text-[17px] font-semibold text-white active:opacity-75 disabled:opacity-40"
+                    >
+                        {t('services.sendInvoice', 'Send Invoice')}
+                    </button>
+
+                    {picking && (
+                        <ContactPickerSheet
+                            onClose={() => setPicking(false)}
+                            onPick={c => { setNumber(digits(c.phone || '').slice(0, 24)); setPicking(false); }}
+                        />
+                    )}
+
+                    {error && (
+                        <AlertDialog
+                            title={t('services.couldntComplete', "Couldn't complete that")}
+                            message={error}
+                            confirmLabel={t('services.ok', 'OK')}
+                            hideCancel
+                            onCancel={() => setError(null)}
+                            onConfirm={() => setError(null)}
+                        />
+                    )}
+                </div>
+            )}
+        </Sheet>
+    );
+}

--- a/web/src/apps/services/InvoicesSection.tsx
+++ b/web/src/apps/services/InvoicesSection.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useState } from 'react';
+import type { ReactNode } from 'react';
+import { FileText, Plus, X } from 'lucide-react';
+
+import { useAsyncData } from '@/hooks/useAsyncData';
+import { useNuiEvent } from '@/hooks/useNuiEvent';
+import { AlertDialog } from '@/ui/AlertDialog';
+import { t } from '@/i18n';
+import { fmtMoney } from './data';
+import { InvoiceComposer } from './InvoiceComposer';
+import { cancelInvoice, fetchSentInvoices, type InvoiceStatus, type SentInvoice } from './servicesApi';
+
+export function InvoicesSection() {
+    const { data, refetch } = useAsyncData(fetchSentInvoices, []);
+    useNuiEvent('sd-phone:services:invoices', useCallback(() => { refetch(); }, [refetch]));
+
+    const [composing,  setComposing]  = useState(false);
+    const [cancelling, setCancelling] = useState<SentInvoice | null>(null);
+    const [busy,       setBusy]       = useState(false);
+    const [error,      setError]      = useState<string | null>(null);
+
+    const invoices = data ?? [];
+
+    async function doCancel(inv: SentInvoice) {
+        if (busy) return;
+        setBusy(true);
+        const res = await cancelInvoice(inv.id);
+        setBusy(false);
+        if (res.success) refetch();
+        else setError(res.message ?? t('services.somethingWentWrong', 'Something went wrong'));
+    }
+
+    return (
+        <>
+            <SectionHeader>{t('services.invoices', 'Invoices')}</SectionHeader>
+            <div className="overflow-hidden rounded-[12px] bg-[#e5e5e5] dark:bg-surface">
+                <button
+                    type="button"
+                    onClick={() => setComposing(true)}
+                    className="flex w-full items-center gap-3.5 px-4 py-3.5 text-left transition-colors hover:bg-black/[0.06] active:bg-black/10 dark:hover:bg-white/[0.07] dark:active:bg-white/10"
+                >
+                    <Tile color="#0A84FF"><FileText className="h-[18px] w-[18px] text-white" strokeWidth={2.25} /></Tile>
+                    <div className="min-w-0 flex-1">
+                        <div className="truncate text-[18px] font-medium text-black dark:text-white">{t('services.sendInvoice', 'Send Invoice')}</div>
+                        <div className="truncate text-[16px] font-medium text-ios-gray">{t('services.billAnotherPlayer', 'Bill another player from your business.')}</div>
+                    </div>
+                    <Plus className="h-[22px] w-[22px] text-black/35 dark:text-white/35" strokeWidth={2.25} />
+                </button>
+
+                {invoices.map(inv => (
+                    <div key={inv.id}>
+                        <Divider />
+                        <InvoiceRow
+                            invoice={inv}
+                            disabled={busy}
+                            onCancel={() => setCancelling(inv)}
+                        />
+                    </div>
+                ))}
+            </div>
+
+            {composing && (
+                <InvoiceComposer
+                    onClose={() => setComposing(false)}
+                    onSent={() => { setComposing(false); refetch(); }}
+                />
+            )}
+
+            {cancelling && (
+                <AlertDialog
+                    title={t('services.cancelInvoiceTitle', 'Cancel invoice?')}
+                    message={t('services.cancelInvoiceMsg', 'This invoice to {name} will be withdrawn. They will no longer be able to pay it.', { name: cancelling.toName })}
+                    confirmLabel={t('services.cancelInvoice', 'Cancel Invoice')}
+                    cancelLabel={t('services.keepInvoice', 'Keep')}
+                    destructive
+                    onCancel={() => setCancelling(null)}
+                    onConfirm={() => { const inv = cancelling; setCancelling(null); void doCancel(inv); }}
+                />
+            )}
+
+            {error && (
+                <AlertDialog
+                    title={t('services.couldntComplete', "Couldn't complete that")}
+                    message={error}
+                    confirmLabel={t('services.ok', 'OK')}
+                    hideCancel
+                    onCancel={() => setError(null)}
+                    onConfirm={() => setError(null)}
+                />
+            )}
+        </>
+    );
+}
+
+function InvoiceRow({ invoice, disabled, onCancel }: { invoice: SentInvoice; disabled: boolean; onCancel: () => void }) {
+    const pending = invoice.status === 'pending';
+    return (
+        <div className="flex items-center gap-3 px-4 py-3.5">
+            <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                    <span className="truncate text-[17px] font-medium text-black dark:text-white">{invoice.toName}</span>
+                    <StatusPill status={invoice.status} />
+                </div>
+                <div className="truncate text-[15px] font-medium text-ios-gray">
+                    {invoice.note || t('services.noNote', 'No note')}
+                </div>
+            </div>
+            <span className="shrink-0 text-[17px] font-semibold tabular-nums text-black dark:text-white">{fmtMoney(invoice.amount)}</span>
+            {pending && (
+                <button
+                    type="button"
+                    disabled={disabled}
+                    onClick={onCancel}
+                    aria-label={t('services.cancelInvoiceAria', 'Cancel invoice to {name}', { name: invoice.toName })}
+                    className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-full text-ios-red transition-colors hover:bg-black/[0.06] active:bg-black/10 disabled:opacity-40 dark:hover:bg-white/[0.07] dark:active:bg-white/10"
+                >
+                    <X className="h-[19px] w-[19px]" strokeWidth={2.4} />
+                </button>
+            )}
+        </div>
+    );
+}
+
+function StatusPill({ status }: { status: InvoiceStatus }) {
+    const map: Record<InvoiceStatus, { label: string; cls: string }> = {
+        pending:   { label: t('services.statusPending', 'Pending'),     cls: 'bg-ios-orange/15 text-ios-orange' },
+        paid:      { label: t('services.statusPaid', 'Paid'),           cls: 'bg-ios-green/15 text-ios-green' },
+        cancelled: { label: t('services.statusCancelled', 'Cancelled'), cls: 'bg-black/[0.08] text-ios-gray dark:bg-white/10' },
+    };
+    const m = map[status];
+    return <span className={`shrink-0 rounded-full px-2 py-[1px] text-[12px] font-semibold ${m.cls}`}>{m.label}</span>;
+}
+
+function SectionHeader({ children }: { children: ReactNode }) {
+    return <div className="px-1 pb-2 pt-7 text-[19px] font-bold tracking-tight text-black dark:text-white">{children}</div>;
+}
+
+function Tile({ color, children }: { color: string; children: ReactNode }) {
+    return (
+        <div className="flex h-[36px] w-[36px] shrink-0 items-center justify-center rounded-[10px] shadow-sm" style={{ background: color }}>
+            {children}
+        </div>
+    );
+}
+
+function Divider() {
+    return <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />;
+}

--- a/web/src/apps/services/Services.tsx
+++ b/web/src/apps/services/Services.tsx
@@ -60,7 +60,7 @@ export function Services({ onClose: _onClose }: { onClose: () => void }) {
                             ? <JobsTab onJobChanged={refresh} />
                             : activeTab === 'messages'
                                 ? <ServiceMessagesTab inbox={inbox} loaded={inboxLoaded} onInboxChange={setInbox} onMarkRead={markRead} />
-                                : <ActionsTab myCompany={dir?.myCompany ?? null} multijob={showJobs} onChanged={patchMyCompany} />}
+                                : <ActionsTab myCompany={dir?.myCompany ?? null} multijob={showJobs} invoicesEnabled={dir?.invoicesEnabled ?? false} onChanged={patchMyCompany} />}
                 </div>
             </div>
 

--- a/web/src/apps/services/servicesApi.ts
+++ b/web/src/apps/services/servicesApi.ts
@@ -200,3 +200,72 @@ export const switchJob     = (job: string) => jobsMutate('sd-phone:services:swit
 export const removeJob     = (job: string) => jobsMutate('sd-phone:services:removeJob', { job });
 export const acceptInvite  = (id: string)  => jobsMutate('sd-phone:services:acceptInvite', { id });
 export const declineInvite = (id: string)  => jobsMutate('sd-phone:services:declineInvite', { id });
+
+export type InvoiceStatus = 'pending' | 'paid' | 'cancelled';
+
+export interface SentInvoice {
+    id:       string;
+    amount:   number;
+    note:     string;
+    status:   InvoiceStatus;
+    toName:   string;
+    toNumber: string;
+    from:     string;
+    ts:       number;
+    paidAt?:  number;
+}
+
+export interface ReceivedInvoice {
+    id:     string;
+    job:    string;
+    label:  string;
+    color:  string;
+    emoji:  string;
+    amount: number;
+    note:   string;
+    status: InvoiceStatus;
+    from:   string;
+    ts:     number;
+}
+
+const DEV_SENT_INVOICES: SentInvoice[] = [
+    { id: 's1', amount: 1200, note: 'Repair · engine rebuild', status: 'pending', toName: 'Maya Lopez',   toNumber: '3105550199', from: 'Sam Nicol', ts: Date.now() - 300_000 },
+    { id: 's2', amount: 450,  note: 'Tow fee',                 status: 'paid',    toName: 'Ryan Carter',  toNumber: '3105550148', from: 'Sam Nicol', ts: Date.now() - 3_600_000, paidAt: Date.now() - 3_000_000 },
+    { id: 's3', amount: 800,  note: '',                        status: 'cancelled', toName: 'John Doe',   toNumber: '5551234',    from: 'Sam Nicol', ts: Date.now() - 7_200_000 },
+];
+
+const DEV_RECEIVED_INVOICES: ReceivedInvoice[] = [
+    { id: 'r1', job: 'mechanic', label: 'Mechanic', color: '#3A3A3C', emoji: '⚙️', amount: 1200, note: 'Repair · engine rebuild', status: 'pending', from: 'Tommy V', ts: Date.now() - 240_000 },
+];
+
+export async function fetchSentInvoices(): Promise<SentInvoice[]> {
+    if (!isFiveM) return DEV_SENT_INVOICES;
+    return (await apiData<{ invoices: SentInvoice[] }>('sd-phone:services:invoices:list'))?.invoices ?? [];
+}
+
+export async function fetchReceivedInvoices(): Promise<ReceivedInvoice[]> {
+    if (!isFiveM) return DEV_RECEIVED_INVOICES;
+    return (await apiData<{ invoices: ReceivedInvoice[] }>('sd-phone:services:invoices:received'))?.invoices ?? [];
+}
+
+export type SentInvoicesResult = Envelope<{ invoices: SentInvoice[] }>;
+
+export async function createInvoice(number: string, amount: number, note: string): Promise<SentInvoicesResult> {
+    if (!isFiveM) return { success: true, data: { invoices: DEV_SENT_INVOICES } };
+    return (await fetchNui<SentInvoicesResult>('sd-phone:services:invoices:create', { number, amount, note }))
+        ?? { success: false, message: t('services.noResponse', 'No response from server') };
+}
+
+export async function cancelInvoice(id: string): Promise<SentInvoicesResult> {
+    if (!isFiveM) return { success: true, data: { invoices: DEV_SENT_INVOICES.filter(i => i.id !== id) } };
+    return (await fetchNui<SentInvoicesResult>('sd-phone:services:invoices:cancel', { id }))
+        ?? { success: false, message: t('services.noResponse', 'No response from server') };
+}
+
+export type PayInvoiceResult = Envelope<{ balance: number; invoices: ReceivedInvoice[] }>;
+
+export async function payInvoice(id: string): Promise<PayInvoiceResult> {
+    if (!isFiveM) return { success: true, data: { balance: 0, invoices: DEV_RECEIVED_INVOICES.filter(i => i.id !== id) } };
+    return (await fetchNui<PayInvoiceResult>('sd-phone:services:invoices:pay', { id }))
+        ?? { success: false, message: t('services.noResponse', 'No response from server') };
+}

--- a/web/src/apps/services/servicesApi.ts
+++ b/web/src/apps/services/servicesApi.ts
@@ -25,6 +25,7 @@ export interface Directory {
     companies:  Company[];
     myCompany?: MyCompany | null;
     multijob?:  boolean;
+    invoicesEnabled?: boolean;
     pendingOffers?: number;
 }
 
@@ -50,7 +51,7 @@ const DEV_MY_COMPANY: MyCompany = {
     employees: EMPLOYEES,
 };
 
-const DEV_DIRECTORY: Directory = { companies: COMPANIES, myCompany: DEV_MY_COMPANY, multijob: true, pendingOffers: 1 };
+const DEV_DIRECTORY: Directory = { companies: COMPANIES, myCompany: DEV_MY_COMPANY, multijob: true, invoicesEnabled: true, pendingOffers: 1 };
 
 export async function fetchDirectory(): Promise<Directory> {
     if (!isFiveM) return DEV_DIRECTORY;

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -317,6 +317,7 @@ export type NuiMessage =
     | { action: 'sd-phone:services:inbox' }
     | { action: 'sd-phone:services:jobsChanged' }
     | { action: 'sd-phone:services:rosterChanged' }
+    | { action: 'sd-phone:services:invoices' }
     | { action: 'sd-phone:homes:refresh' }
     | { action: 'customApps:set';     data: CustomAppDef[] }
     | { action: 'customApps:message'; data: { id: string; message: unknown } };


### PR DESCRIPTION
## Summary

Adds business invoicing to the Services app, as requested in #62: on-duty employees can send a banking invoice from their business to another player and are notified when it is paid.

**Design**

- **Data model.** A new `phone_service_invoices` table (id, job, label, sender identity, target identity, amount, note, status `pending`/`paid`/`cancelled`, created_at, paid_at), created in `server/services/invoicestore.lua` and bootstrapped alongside the other services tables. Indexed for the business's sent list `(job, created_at)` and the target's received list `(target_cid, status, created_at)`.
- **Identity key.** The target is stored as a **citizenid**, resolved from the phone number the sender types via `settings.getCitizenByNumber` (the same number-to-owner lookup the Banking transfer uses). Storing the persistent citizenid mirrors the job-offer precedent and keeps the received list stable while the target is offline; the typed number and display names are also stored for the UI.
- **Callbacks.** `server/services/invoices.lua` exposes create / list / cancel / received / pay under `sd-phone:server:services:invoices:*`, proxied through the existing `client.nui` pass-through. Every path validates at the trust boundary:
  - **create** requires an on-duty employee on a duty-capable framework, a positive integer amount within `MinInvoiceAmount`/`MaxInvoiceAmount`, and an existing target that is not the sender.
  - **pay** is target-initiated only; it re-checks ownership, re-checks pending status, and re-checks funds server-side, and **atomically flips pending -> paid before any money moves** so a double click cannot pay twice.
  - **cancel** is limited to an on-duty member of the invoice's own business (the sender or a colleague).
- **Payout (society vs personal).** There *is* a society credit path in the bridge, so payment is credited to the **business society account** via `bridge/server/society.addMoney` when a society bank is available. When no society provider is running it **falls back to crediting the sending employee's personal bank** (online via the banking bridge, offline via `bank.addOffline`), and the fallback is documented in the config comment. The payer is always debited through the `bank` money bridge, with a refund + status revert if the payout leg fails.
- **Framework gating.** Invoicing is gated on `job.supportsMultijob()` (QBCore/QBox), because on-duty state cannot be resolved on ESX. The Services Invoices section is hidden and the server refuses create/cancel there, exactly like the Jobs tab.
- **Notifications.** On paid, the sender gets a banner + app badge through the existing `sd-phone:client:notify` stream (appId `services`); the target gets one on receipt (appId `bank`). Offline senders simply see the updated status on next open (no offline mailbox).
- **UI.** Services > Actions gains an Invoices section for on-duty employees: a Send Invoice composer (recipient number with contact picker, amount, note) plus the business's sent list with status pills and a cancel action. Banking gains a received-invoices section with an `AlertDialog`-confirmed Pay action. Both reuse existing primitives (`Sheet`, `AlertDialog`, `ContactPickerSheet`, `useAsyncData`, `useNuiEvent`), refetch on the `sd-phone:services:invoices` push, and are fully `t()`-i18n'd with no em dashes.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

Closes #62

## Testing

Static gates only; no in-game test was performed.

- `web/` `npx tsc --noEmit` — 0 errors.
- `web/` `npx eslint src` — 0 errors (29 pre-existing warnings, none added).
- `web/` `npx vitest run` — 7 files, 73 tests, all passing.
- `luac -p` on every changed Lua file (`configs/services.lua`, `server/services/init.lua`, `server/services/invoices.lua`, `server/services/invoicestore.lua`, `client/apps/services.lua`) — all parse clean.

- [ ] Tested locally
- [ ] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

None. Adds a new table and callbacks; no existing schema, exports, or events change. The `phone_service_invoices` table is created on boot next to the other services tables.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [ ] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [ ] I have verified this works on the latest version of sd-phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
