### PR TITLE
fix(phone): open instantly - SIM resolve moved off the reveal path

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -407,7 +407,11 @@ local function TogglePhone()
     local color = res
     if type(res) == 'table' then
         color = res.color
-        currentSimState = { hasSim = res.hasSim == true, number = res.number }
+        if res.pending then
+            currentSimState = currentSimState or { hasSim = true, number = nil }
+        else
+            currentSimState = { hasSim = res.hasSim == true, number = res.number }
+        end
     else
         currentSimState = nil
     end
@@ -429,9 +433,17 @@ RegisterKeyMapping('+sdphone_look', 'Phone: Hold to look around', 'keyboard', co
 ---passes the FRAME_COLORS whitelist.
 ---@param color string|nil frame colour of the used item variant
 ---@param sim { hasSim: boolean, number: string|nil }|nil SIM snapshot (unique phones only)
-RegisterNetEvent('sd-phone:client:openFromItem', function(color, sim)
+RegisterNetEvent('sd-phone:client:openFromItem', function(color, sim, simPending)
     if color and FRAME_COLORS[color] then currentFrameColor = color end
-    currentSimState = sim and { hasSim = sim.hasSim == true, number = sim.number } or nil
+    if sim then
+        currentSimState = { hasSim = sim.hasSim == true, number = sim.number }
+    elseif simPending then
+        -- SIM resolve is still running server-side; keep the last snapshot (optimistic
+        -- has-service on a cold start) until the simState push corrects it.
+        currentSimState = currentSimState or { hasSim = true, number = nil }
+    else
+        currentSimState = nil
+    end
     OpenPhone()
 end)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,18 +78,6 @@ local simState = require 'server.sim.state'
 ---rare, so the session cache is dropped first - the open always reflects the live inventory.
 ---@param source integer player server id
 ---@return { hasSim: boolean, number: string|nil, color: string|nil }|nil
-local function simDescribe(source)
-    if not simState.active then return nil end
-    local session = require('server.sim.session')
-    session.invalidate(source)
-    local s = session.resolve(source)
-    return {
-        hasSim = s ~= nil and s.hasSim or false,
-        number = s and s.number or nil,
-        color  = s and s.color or nil,
-    }
-end
-
 ---Registers each configured phone item (config.Phone.Items) as a usable item; using one opens
 ---the phone with the variant's frame colour (plus the SIM snapshot under unique phones). The
 ---used slot marks that exact phone as the active one, so a player carrying several SIM'd
@@ -101,7 +89,12 @@ local function RegisterPhoneItems()
                 local usedSlot = (type(itemArg) == 'table' and tonumber(itemArg.slot)) or tonumber(slotArg)
                 require('server.sim.session').setActive(source, { slot = usedSlot, color = entry.color })
             end
-            TriggerClientEvent('sd-phone:client:openFromItem', source, entry.color, simDescribe(source))
+            -- Open immediately: the SIM resolve does inventory scans + awaited DB writes, so it
+            -- runs AFTER the reveal and reconciles through the live simState push.
+            TriggerClientEvent('sd-phone:client:openFromItem', source, entry.color, nil, simState.active)
+            if simState.active then
+                CreateThread(function() require('server.sim.session').push(source) end)
+            end
         end)
     end
 end
@@ -133,17 +126,14 @@ end
 ---client can open into the "No SIM" state (the SIM's phone wins the colour pick).
 lib.callback.register('sd-phone:server:phone:resolveOpen', function(source, preferred)
     local color = ResolveOwnedColor(source, preferred)
-    if simState.active and type(preferred) == 'string' then
+    if not simState.active then return color end
+    if not color then return nil end
+    if type(preferred) == 'string' then
         require('server.sim.session').setActive(source, { color = preferred })
     end
-    local sim = simDescribe(source)
-    if not sim then return color end
-    if not color then return nil end
-    return {
-        color  = sim.color or color,
-        hasSim = sim.hasSim,
-        number = sim.number,
-    }
+    -- Same deferral as the item path: answer with the colour now, resolve the SIM after.
+    CreateThread(function() require('server.sim.session').push(source) end)
+    return { color = color, pending = true }
 end)
 
 -- Boot: registers the usable phone items once, then prints the startup banner.


### PR DESCRIPTION
Using a phone item took ~3 seconds to show the UI while the use animation
played instantly. Under unique-phones both open paths blocked on
simDescribe(), which force-invalidated the SIM session cache and re-ran the
full resolve - an inventory scan plus sequential awaited DB calls per SIM
(ensureRegistered, getPhoneNumber, setPhoneNumber) - before the client was
even told to open. The keybind stalled the same way inside resolveOpen.

Both paths now tell the client to open immediately and run the SIM resolve
in a follow-up thread that reconciles through the existing live simState
push (the same one used when a SIM is inserted or moved). While the resolve
is pending the client keeps its last SIM snapshot, defaulting to
has-service on a cold start, so worst case is a sub-second lockscreen
before a No SIM correction instead of seconds of nothing. simDescribe is
gone; resolveOpen now answers from in-memory inventory counts only.

Stock mode (no unique phones) is unaffected - it never did the resolve.

