### PR TITLE
fix(phone): open instantly - SIM resolve moved off the reveal path

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -432,7 +432,8 @@ RegisterKeyMapping('+sdphone_look', 'Phone: Hold to look around', 'keyboard', co
 ---Opens the phone after a phone item is used, adopting the item variant's frame colour when it
 ---passes the FRAME_COLORS whitelist.
 ---@param color string|nil frame colour of the used item variant
----@param sim { hasSim: boolean, number: string|nil }|nil SIM snapshot (unique phones only)
+---@param sim { hasSim: boolean, number: string|nil }|nil SIM snapshot (kept for signature compat; the server now defers and sends nil)
+---@param simPending boolean|nil true while the server resolves the SIM in the background (unique phones)
 RegisterNetEvent('sd-phone:client:openFromItem', function(color, sim, simPending)
     if color and FRAME_COLORS[color] then currentFrameColor = color end
     if sim then
@@ -453,6 +454,19 @@ end)
 RegisterNetEvent('sd-phone:client:simState', function(state)
     if type(state) ~= 'table' then return end
     currentSimState = state.enabled and { hasSim = state.hasSim == true, number = state.number } or nil
+    -- The active SIM'd phone's colour wins: a pending keybind open answered with the owned
+    -- colour before the resolve, so correct the frame, the hand prop and the UI rail here.
+    if state.color and FRAME_COLORS[state.color] and state.color ~= currentFrameColor then
+        currentFrameColor = state.color
+        if shouldHold() then
+            removePhoneProp()
+            attachPhoneProp(PlayerPedId())
+            broadcastHoldState()
+        end
+        if phoneState.open then
+            SendNUIMessage({ action = 'sd-phone:frameColor', data = { color = state.color } })
+        end
+    end
     if phoneState.open then
         SendNUIMessage({
             action = 'sd-phone:simState',

--- a/client/main.lua
+++ b/client/main.lua
@@ -407,7 +407,11 @@ local function TogglePhone()
     local color = res
     if type(res) == 'table' then
         color = res.color
-        currentSimState = { hasSim = res.hasSim == true, number = res.number }
+        if res.pending then
+            currentSimState = currentSimState or { hasSim = true, number = nil }
+        else
+            currentSimState = { hasSim = res.hasSim == true, number = res.number }
+        end
     else
         currentSimState = nil
     end
@@ -429,9 +433,17 @@ RegisterKeyMapping('+sdphone_look', 'Phone: Hold to look around', 'keyboard', co
 ---passes the FRAME_COLORS whitelist.
 ---@param color string|nil frame colour of the used item variant
 ---@param sim { hasSim: boolean, number: string|nil }|nil SIM snapshot (unique phones only)
-RegisterNetEvent('sd-phone:client:openFromItem', function(color, sim)
+RegisterNetEvent('sd-phone:client:openFromItem', function(color, sim, simPending)
     if color and FRAME_COLORS[color] then currentFrameColor = color end
-    currentSimState = sim and { hasSim = sim.hasSim == true, number = sim.number } or nil
+    if sim then
+        currentSimState = { hasSim = sim.hasSim == true, number = sim.number }
+    elseif simPending then
+        -- SIM resolve is still running server-side; keep the last snapshot (optimistic
+        -- has-service on a cold start) until the simState push corrects it.
+        currentSimState = currentSimState or { hasSim = true, number = nil }
+    else
+        currentSimState = nil
+    end
     OpenPhone()
 end)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,18 +78,6 @@ local simState = require 'server.sim.state'
 ---rare, so the session cache is dropped first - the open always reflects the live inventory.
 ---@param source integer player server id
 ---@return { hasSim: boolean, number: string|nil, color: string|nil }|nil
-local function simDescribe(source)
-    if not simState.active then return nil end
-    local session = require('server.sim.session')
-    session.invalidate(source)
-    local s = session.resolve(source)
-    return {
-        hasSim = s ~= nil and s.hasSim or false,
-        number = s and s.number or nil,
-        color  = s and s.color or nil,
-    }
-end
-
 ---Registers each configured phone item (config.Phone.Items) as a usable item; using one opens
 ---the phone with the variant's frame colour (plus the SIM snapshot under unique phones). The
 ---used slot marks that exact phone as the active one, so a player carrying several SIM'd
@@ -101,7 +89,12 @@ local function RegisterPhoneItems()
                 local usedSlot = (type(itemArg) == 'table' and tonumber(itemArg.slot)) or tonumber(slotArg)
                 require('server.sim.session').setActive(source, { slot = usedSlot, color = entry.color })
             end
-            TriggerClientEvent('sd-phone:client:openFromItem', source, entry.color, simDescribe(source))
+            -- Open immediately: the SIM resolve does inventory scans + awaited DB writes, so it
+            -- runs AFTER the reveal and reconciles through the live simState push.
+            TriggerClientEvent('sd-phone:client:openFromItem', source, entry.color, nil, simState.active)
+            if simState.active then
+                CreateThread(function() require('server.sim.session').push(source) end)
+            end
         end)
     end
 end
@@ -133,17 +126,14 @@ end
 ---client can open into the "No SIM" state (the SIM's phone wins the colour pick).
 lib.callback.register('sd-phone:server:phone:resolveOpen', function(source, preferred)
     local color = ResolveOwnedColor(source, preferred)
-    if simState.active and type(preferred) == 'string' then
+    if not simState.active then return color end
+    if not color then return nil end
+    if type(preferred) == 'string' then
         require('server.sim.session').setActive(source, { color = preferred })
     end
-    local sim = simDescribe(source)
-    if not sim then return color end
-    if not color then return nil end
-    return {
-        color  = sim.color or color,
-        hasSim = sim.hasSim,
-        number = sim.number,
-    }
+    -- Same deferral as the item path: answer with the colour now, resolve the SIM after.
+    CreateThread(function() require('server.sim.session').push(source) end)
+    return { color = color, pending = true }
 end)
 
 -- Boot: registers the usable phone items once, then prints the startup banner.

--- a/server/main.lua
+++ b/server/main.lua
@@ -74,10 +74,6 @@ require 'server.compat.lbphone.init'
 ---@type table SIM feature flags (server.sim.state): active + mode.
 local simState = require 'server.sim.state'
 
----The player's SIM snapshot for the open flow, or nil while unique phones are off. Opening is
----rare, so the session cache is dropped first - the open always reflects the live inventory.
----@param source integer player server id
----@return { hasSim: boolean, number: string|nil, color: string|nil }|nil
 ---Registers each configured phone item (config.Phone.Items) as a usable item; using one opens
 ---the phone with the variant's frame colour (plus the SIM snapshot under unique phones). The
 ---used slot marks that exact phone as the active one, so a player carrying several SIM'd
@@ -121,9 +117,9 @@ local function ResolveOwnedColor(source, preferred)
     return nil
 end
 
----Keybind open request: may this player open a phone, and in which colour? Read-only. Returns
----the bare colour string normally; under unique phones a table { color, hasSim, number } so the
----client can open into the "No SIM" state (the SIM's phone wins the colour pick).
+---Keybind open request: may this player open a phone, and in which colour? Returns the bare
+---colour string normally; under unique phones { color, pending = true } and the deferred
+---simState push corrects hasSim/number - and the colour, since the SIM'd phone's wins.
 lib.callback.register('sd-phone:server:phone:resolveOpen', function(source, preferred)
     local color = ResolveOwnedColor(source, preferred)
     if not simState.active then return color end

--- a/server/sim/session.lua
+++ b/server/sim/session.lua
@@ -208,6 +208,7 @@ function session.push(source)
         enabled = true,
         hasSim  = s ~= nil and s.hasSim or false,
         number  = s and s.number or nil,
+        color   = s and s.color or nil,
     })
 end
 


### PR DESCRIPTION
## Summary

Using a phone item took ~3 seconds before the UI appeared, while the inventory's use animation played instantly. Under unique-phones, both open paths (item use and keybind) blocked on a full SIM resolve before the client was told to open: `simDescribe()` force-invalidated the session cache and re-ran an inventory scan plus sequential awaited DB calls per SIM (`ensureRegistered`, `getPhoneNumber`, `setPhoneNumber`) on every single open.

Both paths now tell the client to open immediately and run the SIM resolve in a follow-up thread that reconciles through the existing live `simState` push (the same one used when a SIM is inserted or moved). While the resolve is pending the client keeps its last SIM snapshot (optimistic has-service on a cold start), so the worst case is a brief lockscreen before a "No SIM" correction instead of seconds of nothing. `simDescribe` is removed; `resolveOpen` now answers from in-memory inventory counts only.

Stock mode (no unique phones) is unaffected — it never did the resolve.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor
- [x] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

Related to #56 (unique phones / SIM sessions introduced the resolve on the open path)

## Testing

Tested in-game on a live multiplayer dev server with unique-phones active: phone item open (UI now appears together with the pose animation, effectively instantly), keybind open, and a fresh join (cold SIM cache).

- [x] Tested locally
- [x] Tested with latest sd-phone
- [x ] Tested with latest ox_lib
- [x ] Tested with latest ox_inventory
- [x] Multiplayer tested

## Breaking Changes

No. The `resolveOpen` callback's response shape changed (`{ color, pending }` instead of `{ color, hasSim, number }`), but it is an internal callback consumed only by this resource's own client, shipped in the same change.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.
