### PR TITLE
feat(services): per-job commission on paid business invoices

### DIFF
--- a/configs/services.lua
+++ b/configs/services.lua
@@ -30,7 +30,8 @@ return {
     -- resolvable); the section is hidden on ESX, like the Jobs tab.
     -- Payout: when a society bank is available the payment is credited to the
     -- business account; otherwise it falls back to the sending employee's own
-    -- bank (see bridge/server/society.lua).
+    -- bank (see bridge/server/society.lua). A per-company `commission` (below)
+    -- splits off a cut of the society-credited payment to the sending employee.
     InvoicesEnabled = true,
     -- Smallest and largest amount a single invoice may be for.
     MinInvoiceAmount = 1,
@@ -43,6 +44,12 @@ return {
     -- bank, employees, quit) - they just won't appear in the directory.
     -- `bossGrade` is an ESX-ONLY fallback (overrides DefaultBossGrade for this
     -- company); QBCore/QBox ignore it and use the grade's isboss flag.
+    -- `commission` is an OPTIONAL fraction 0.0-1.0 of a paid business invoice
+    -- that goes to the sending employee, with the remainder going to the society
+    -- account (the two always sum to the invoice amount, so no money is minted).
+    -- Absent or 0 means the whole amount goes to the society. Only applies when a
+    -- society bank is available; the no-society fallback already pays the sending
+    -- employee in full, so no commission is split there.
     Companies = {
         {
             job = 'police',
@@ -74,6 +81,7 @@ return {
             emoji = '⚙️',
             canCall = false,
             bossGrade = 2,
+            commission = 0.1,
             coords = { x = -347.3, y = -133.8, z = 39.0 },
         },
         {
@@ -84,6 +92,7 @@ return {
             emoji = '🚕',
             canCall = false,
             bossGrade = 2,
+            commission = 0.15,
             coords = { x = 895.7, y = -179.3, z = 74.7 },
         },
     },

--- a/server/services/invoices.lua
+++ b/server/services/invoices.lua
@@ -453,7 +453,8 @@ end
 
 ---Pays a pending invoice addressed to the caller. Target-initiated only: re-checks ownership,
 ---pending status (atomically) and funds server-side, debits the payer's bank, then credits the
----business society account (or the sending employee's own bank when no society bank exists).
+---business society account (or the sending employee's own bank when no society bank exists). A
+---society-credited business invoice splits off the company's `commission` cut to the sender.
 ---@param src number
 ---@param payload { id?: string }
 ---@return table
@@ -489,10 +490,36 @@ function invoices.pay(src, payload)
     local code = codeOf(id)
     bank.removeMoney(src, amount, ('Invoice %s'):format(code))
 
-    local credited, viaSociety = false, false
+    -- Business commission: a per-company fraction of a society-credited invoice goes to the
+    -- sending employee instead of the society, so the two legs always sum to the invoice amount
+    -- and no money is minted. Clamped to 0-1; a sub-$1 cut is dropped.
+    local credited, viaSociety, commission = false, false, 0
     if not personal and society.available() then
-        credited   = society.addMoney(inv.job, amount, ('Invoice %s from %s'):format(code, inv.sender_number or ''))
+        local rate = (byJob[inv.job] and tonumber(byJob[inv.job].commission)) or 0
+        if rate < 0 then rate = 0 elseif rate > 1 then rate = 1 end
+        local cut = math.floor(amount * rate)
+        if cut < 1 then cut = 0 end
+
+        credited   = society.addMoney(inv.job, amount - cut, ('Invoice %s from %s'):format(code, inv.sender_number or ''))
         viaSociety = credited
+
+        if credited and cut > 0 then
+            -- Pay the sending employee their cut (online -> bank, offline -> DB write). On failure
+            -- top the society up to the full amount so nothing is lost; never refund the payer.
+            local esrc = player.getSourceByIdentifier(inv.sender_cid)
+            local paid
+            if esrc then
+                bank.addMoney(esrc, cut, ('Commission · %s'):format(code))
+                paid = true
+            else
+                paid = bank.addOffline(inv.sender_cid, cut)
+            end
+            if paid then
+                commission = cut
+            else
+                society.addMoney(inv.job, cut, ('Invoice %s from %s'):format(code, inv.sender_number or ''))
+            end
+        end
     end
     if not credited then
         local ssrc = player.getSourceByIdentifier(inv.sender_cid)
@@ -524,6 +551,13 @@ function invoices.pay(src, payload)
             category = 'invoice',
         })
     end
+    if commission > 0 then
+        bankActions.addExternal(inv.sender_cid, {
+            label    = ('Commission · %s'):format(code),
+            amount   = commission,
+            category = 'income',
+        })
+    end
 
     local ssrc = player.getSourceByIdentifier(inv.sender_cid)
     if ssrc then
@@ -531,11 +565,13 @@ function invoices.pay(src, payload)
         local payerShown = personal
             and (contactNameFor(inv.sender_cid, digits(inv.target_number or '')) or util.formatNumber(inv.target_number or ''))
             or (inv.target_name or 'A customer')
+        local body = ('%s paid your invoice for %s.'):format(payerShown, formatMoney(amount))
+        if commission > 0 then body = body .. (' You earned %s commission.'):format(formatMoney(commission)) end
         TriggerClientEvent('sd-phone:client:notify', ssrc, {
             app   = personal and 'bank' or 'services',
             appId = personal and 'bank' or 'services',
             title = personal and 'Wallet' or label,
-            body  = ('%s paid your invoice for %s.'):format(payerShown, formatMoney(amount)),
+            body  = body,
             time  = 'now',
         })
         if personal then TriggerClientEvent('sd-phone:client:services:invoices', ssrc, {}) end
@@ -543,11 +579,12 @@ function invoices.pay(src, payload)
     notifyBusiness(inv.job)
 
     ---First-party hook: fires once per paid invoice; viaSociety tells whether the business account
-    ---or the sender's personal bank received the money.
+    ---or the sender's personal bank received the money. commission is the cut split from a
+    ---society-credited business invoice to the sending employee (0 when none).
     TriggerEvent('sd-phone:server:services:invoicePaid', {
         id = id, job = inv.job, label = label,
         senderCid = inv.sender_cid, targetCid = inv.target_cid, targetSource = src,
-        amount = amount, viaSociety = viaSociety, timestamp = os.time(),
+        amount = amount, viaSociety = viaSociety, commission = commission, timestamp = os.time(),
     })
 
     return ok({ balance = bank.getBalance(src) or (balance - amount), invoices = invoices.received(src).data.invoices })


### PR DESCRIPTION
## Summary

Adds an optional per-company commission on paid **business** invoices (issue #76).

Each `configs/services.lua` Companies entry gains an optional `commission` key: a fraction `0.0-1.0` of the invoice amount, documented alongside `bossGrade` (absent or `0` = no commission). It is clamped defensively server-side. Example values are set on the `mechanic` (`0.1`) and `taxi` (`0.15`) entries; `police`/`ambulance` keep no commission.

**Split, not mint.** When a paid business invoice is credited to the society, the commission is `math.floor(amount * rate)` (dropped when `< 1`). The society receives `amount - commission` and the sending employee (`inv.sender_cid`) receives `commission`, so the two legs always sum to the invoice amount and no money is created. The existing behaviour with no commission configured is byte-for-byte unchanged (society gets the full amount).

**Only the society path pays commission.** When no society bank is available, the existing fallback already credits the sending employee the full amount; adding a commission there would double-pay, so it is skipped. Personal invoices never pay commission.

**Fallback / failure semantics.**
- Employee credit works online (`bank.addMoney(ssrc, ...)`) and offline (`bank.addOffline(inv.sender_cid, ...)`).
- If the employee-credit leg fails, the society is topped up to the full amount so no money is lost, and `commission` stays `0`. The payer is **never** refunded for a commission-leg failure (their debit and the society credit both succeeded).
- The society-credit leg remains the gate for `viaSociety`; a full society-credit failure still falls through to the employee-full-amount fallback exactly as before.

Surfaced through:
- A `Commission · <CODE>` Wallet row for the employee via `bankActions.addExternal` (`amount = commission`, `category = 'income'`), carrying the invoice's `codeOf` reference.
- The paid banner to the sender is extended with `You earned $X commission.` when `commission > 0`; wording is unchanged when `0`.
- The `sd-phone:server:services:invoicePaid` hook payload now carries `commission` (number, `0` when none), documented in the hook's doc comment.

No UI changes: the Wallet transaction list and notification carry the feature end to end.

## Type of Change

- [x] New Feature

## Related Issues

Closes #76

## Testing

- `luac -p server/services/invoices.lua` — passes.
- `luac -p configs/services.lua` — passes.
- No `web/src` changes, so the web gates (tsc/eslint/vitest/knip) do not apply and were not run.
- Not tested in-game.

- [ ] Tested locally
- [ ] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

None. `commission` is optional; absent or `0` reproduces the previous payout exactly. The `invoicePaid` hook only gains a field.

---

## Checklist

- [x] My code follows the existing style of the project.
- [ ] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [ ] I have verified this works on the latest version of sd-phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
