### PR TITLE
feat(sim): device-owns-data identity mode for unique phones

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,12 @@ Building from a git clone yourself: `cd web && npm ci && npm run build`. The out
 
 ## Unique Phones & SIM Cards (optional)
 
-Off by default. Flip `Enabled = true` in `configs/simcards.lua` and phone numbers stop belonging to characters — they live on **SIM card items**. Whichever SIM is in a phone decides whose data that phone shows: messages, call log, contacts, photos, app logins, settings — everything. Steal someone's phone with the SIM inside and you're reading *their* phone; without any SIM, a phone opens to a **No SIM** screen with no service and every server action refused.
+Off by default. Flip `Enabled = true` in `configs/simcards.lua` and phone numbers stop belonging to characters — they live on **SIM card items**. A second switch, `DeviceIdentity`, decides who owns the *data*:
+
+- **`DeviceIdentity = true` (default) — the phone owns the data, the SIM only lends a number.** Each phone item gets a persistent identity the first time it's used, and that identity keys everything: messages, call log, contacts, photos, notes, app logins, settings, games. Popping the SIM out just drops your **number and service** — the phone still opens and every non-number app keeps working, the status bar reads **No Service**. Move a SIM to another phone and that phone gets your **number**, not your data. Steal a phone and you get *its* apps behind the owner's lockscreen (Face Unlock never works for you), but never their number unless the SIM is inside.
+- **`DeviceIdentity = false` (legacy) — the SIM owns the data.** Whichever SIM is in a phone decides whose data that phone shows — everything. Steal someone's phone with the SIM inside and you're reading *their* phone; without any SIM, a phone opens to a full-screen **No SIM** screen with no service and every server action refused.
+
+Either mode: the number follows the SIM, and Cloud Backup carries a character's data to a new phone (the number stays behind on the old SIM). Flipping an existing legacy server to the default device mode is safe and automatic — the first time each phone is used it **adopts** the identity of the SIM currently in it, so no data is copied or lost; only from then on does the number float free of the data.
 
 ### Setup
 
@@ -175,9 +180,9 @@ A player can carry **several phones, each with its own SIM**. Whichever phone th
 
 ### What players should know
 
-- **No SIM = no service.** The phone opens but shows the No SIM screen; nothing works until a SIM is installed.
-- **Your number lives on the SIM.** Move the SIM to another phone and the number (and the whole phone profile) moves with it. **A lost number is lost** — restores never bring numbers back.
-- **Passcodes still protect you.** A thief sees your lockscreen; if you set a passcode they must know it — Face Unlock never works for anyone but the SIM's original owner.
+- **No SIM = no service.** In the default device mode the phone still opens and non-number apps (photos, notes, settings, account apps, games) keep working — you just can't call or text and the bar shows **No Service** until a SIM is installed. In legacy mode a SIM-less phone is a dead **No SIM** screen.
+- **Your number lives on the SIM.** Move the SIM to another phone and the number moves with it — and in legacy mode the whole phone profile follows too. **A lost number is lost** — restores never bring numbers back.
+- **Passcodes still protect you.** A thief sees your lockscreen; if you set a passcode they must know it — Face Unlock never works for anyone but the phone's original owner.
 - **Cloud Backup** (Settings → SIM & Backup) belongs to your **character** and is protected by a **backup password** you set when turning it on (a copy is saved into your Passwords app). After losing your phone, get a new phone + blank SIM, press *Restore from Backup* and enter the password: your contacts, messages, photos, notes, settings and app logins are copied to the new phone. The number is **not** restored — your new SIM keeps its own number, and the old number stays on the old SIM.
 
 ### SIM exports

--- a/bridge/server/player.lua
+++ b/bridge/server/player.lua
@@ -110,6 +110,20 @@ function player.getSourceByIdentifier(citizenid)
     return nil
 end
 
+---Reachability resolver: the source carrying `citizenid` on ANY phone, not just the active one.
+---Identical to getSourceByIdentifier until unique phones wraps the two apart (calls ring a
+---pocketed phone; live UI pushes only land on the active one).
+---@param citizenid string|nil
+---@return number|nil source
+function player.getAnySourceByIdentifier(citizenid)
+    if not citizenid or citizenid == '' then return nil end
+    for _, src in ipairs(GetPlayers()) do
+        local s = tonumber(src)
+        if s and player.getIdentifier(s) == citizenid then return s end
+    end
+    return nil
+end
+
 ---`{ [citizenid] = source }` over framework-native identifiers, bypassing SIM indirection.
 ---@return table<string, number>
 function player.onlineRealCidMap()

--- a/client/apps/settings.lua
+++ b/client/apps/settings.lua
@@ -10,6 +10,7 @@ proxyCallback('sd-phone:settings:tones:remove', 'sd-phone:server:settings:tones:
 proxyCallback('sd-phone:settings:setAirplane',  'sd-phone:server:settings:setAirplane')
 proxyCallback('sd-phone:settings:setHour24',    'sd-phone:server:settings:setHour24')
 proxyCallback('sd-phone:settings:setReopenApp', 'sd-phone:server:settings:setReopenApp')
+proxyCallback('sd-phone:settings:setSetupDone', 'sd-phone:server:settings:setSetupDone')
 proxyCallback('sd-phone:settings:setTheme',     'sd-phone:server:settings:setTheme')
 proxyCallback('sd-phone:settings:setDarkTheme', 'sd-phone:server:settings:setDarkTheme')
 proxyCallback('sd-phone:settings:setLockClock', 'sd-phone:server:settings:setLockClock')

--- a/client/apps/sim.lua
+++ b/client/apps/sim.lua
@@ -5,4 +5,7 @@ local proxy = require 'client.nui'
 proxy('sd-phone:sim:get',            'sd-phone:server:sim:get')
 proxy('sd-phone:sim:eject',          'sd-phone:server:sim:eject')
 proxy('sd-phone:sim:backup:set',     'sd-phone:server:sim:backup:set')
+proxy('sd-phone:sim:backup:sync',    'sd-phone:server:sim:backup:sync')
+proxy('sd-phone:sim:backup:setAuto', 'sd-phone:server:sim:backup:setAuto')
+proxy('sd-phone:sim:backup:delete',  'sd-phone:server:sim:backup:delete')
 proxy('sd-phone:sim:backup:restore', 'sd-phone:server:sim:backup:restore')

--- a/client/main.lua
+++ b/client/main.lua
@@ -64,8 +64,10 @@ local phoneState = {
 ---@type boolean True while another resource has disabled the phone.
 local phoneDisabled = false
 
----@type { hasSim: boolean, number: string|nil }|nil Last SIM snapshot from the server; nil
----while unique phones are off (stock behaviour).
+---@type { hasSim: boolean, number: string|nil, device: boolean|nil, profile: string|nil }|nil
+---Last SIM snapshot from the server; nil while unique phones are off (stock behaviour). `device`
+---marks DeviceIdentity mode (phone opens without a SIM, "No Service" instead of a No-SIM wall);
+---`profile` is the device identity the UI namespaces per-phone state under in that mode.
 local currentSimState = nil
 
 ---@type string Current frame colour; always one of FRAME_COLORS.
@@ -345,6 +347,8 @@ local function OpenPhone()
                 enabled = true,
                 hasSim  = currentSimState.hasSim == true,
                 number  = currentSimState.number,
+                device  = currentSimState.device == true,
+                profile = currentSimState.profile,
             } or { enabled = false },
         },
     })
@@ -450,10 +454,15 @@ end)
 
 ---Live SIM state push (SIM inserted/ejected/moved). Keeps the local snapshot fresh and, while
 ---the phone is open, swaps the NUI's "No SIM" screen in or out immediately.
----@param state { enabled: boolean, hasSim: boolean, number: string|nil }
+---@param state { enabled: boolean, hasSim: boolean, number: string|nil, device: boolean|nil, profile: string|nil }
 RegisterNetEvent('sd-phone:client:simState', function(state)
     if type(state) ~= 'table' then return end
-    currentSimState = state.enabled and { hasSim = state.hasSim == true, number = state.number } or nil
+    currentSimState = state.enabled and {
+        hasSim  = state.hasSim == true,
+        number  = state.number,
+        device  = state.device == true,
+        profile = state.profile,
+    } or nil
     -- The active SIM'd phone's colour wins: a pending keybind open answered with the owned
     -- colour before the resolve, so correct the frame, the hand prop and the UI rail here.
     if state.color and FRAME_COLORS[state.color] and state.color ~= currentFrameColor then
@@ -474,6 +483,8 @@ RegisterNetEvent('sd-phone:client:simState', function(state)
                 enabled = state.enabled == true,
                 hasSim  = state.hasSim == true,
                 number  = state.number,
+                device  = state.device == true,
+                profile = state.profile,
             },
         })
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -366,17 +366,21 @@ local function OpenPhone()
     -- on screen (the home screen sits behind the lockscreen anyway) and push them in as a
     -- follow-up, so the round-trip never gates the reveal. The NUI paints instantly from its own
     -- fallbacks and reconciles when this lands.
-    CreateThread(function()
-        local installedRes = lib.callback.await('sd-phone:server:apps:list', false)
-        if not phoneState.open then return end
-        SendNUIMessage({
-            action = 'sd-phone:apps',
-            data   = {
-                installedApps = (installedRes and installedRes.success and installedRes.data and installedRes.data.installed) or {},
-                homeLayout    = (installedRes and installedRes.success and installedRes.data and installedRes.data.layout) or nil,
-            },
-        })
-    end)
+    CreateThread(PushInstalledApps)
+end
+
+---Fetches the acting profile's installed apps + home layout and pushes them into the open NUI.
+---Runs as the open follow-up and again after a cloud-backup restore replaces the profile data.
+function PushInstalledApps()
+    local installedRes = lib.callback.await('sd-phone:server:apps:list', false)
+    if not phoneState.open then return end
+    SendNUIMessage({
+        action = 'sd-phone:apps',
+        data   = {
+            installedApps = (installedRes and installedRes.success and installedRes.data and installedRes.data.installed) or {},
+            homeLayout    = (installedRes and installedRes.success and installedRes.data and installedRes.data.layout) or nil,
+        },
+    })
 end
 
 ---Closes the phone NUI, announces the close, releases NUI focus, and drops the pose unless the
@@ -438,14 +442,22 @@ RegisterKeyMapping('+sdphone_look', 'Phone: Hold to look around', 'keyboard', co
 ---@param color string|nil frame colour of the used item variant
 ---@param sim { hasSim: boolean, number: string|nil }|nil SIM snapshot (kept for signature compat; the server now defers and sends nil)
 ---@param simPending boolean|nil true while the server resolves the SIM in the background (unique phones)
-RegisterNetEvent('sd-phone:client:openFromItem', function(color, sim, simPending)
+---@param deviceHint string|nil the used phone's device identity, read synchronously from its
+---item metadata: a DIFFERENT device than the last snapshot seeds the switch at reveal time
+RegisterNetEvent('sd-phone:client:openFromItem', function(color, sim, simPending, deviceHint)
     if color and FRAME_COLORS[color] then currentFrameColor = color end
     if sim then
         currentSimState = { hasSim = sim.hasSim == true, number = sim.number }
     elseif simPending then
-        -- SIM resolve is still running server-side; keep the last snapshot (optimistic
-        -- has-service on a cold start) until the simState push corrects it.
-        currentSimState = currentSimState or { hasSim = true, number = nil }
+        if deviceHint and not (currentSimState and currentSimState.profile == deviceHint) then
+            -- Another phone than last time: seed its profile now so the NUI tears the previous
+            -- one down during the reveal; the deferred simState push still reconciles the rest.
+            currentSimState = { hasSim = true, number = nil, device = true, profile = deviceHint }
+        else
+            -- SIM resolve is still running server-side; keep the last snapshot (optimistic
+            -- has-service on a cold start) until the simState push corrects it.
+            currentSimState = currentSimState or { hasSim = true, number = nil }
+        end
     else
         currentSimState = nil
     end
@@ -465,16 +477,19 @@ RegisterNetEvent('sd-phone:client:simState', function(state)
     } or nil
     -- The active SIM'd phone's colour wins: a pending keybind open answered with the owned
     -- colour before the resolve, so correct the frame, the hand prop and the UI rail here.
-    if state.color and FRAME_COLORS[state.color] and state.color ~= currentFrameColor then
-        currentFrameColor = state.color
-        if shouldHold() then
-            removePhoneProp()
-            attachPhoneProp(PlayerPedId())
-            broadcastHoldState()
+    if state.color and FRAME_COLORS[state.color] then
+        if state.color ~= currentFrameColor then
+            currentFrameColor = state.color
+            if shouldHold() then
+                removePhoneProp()
+                attachPhoneProp(PlayerPedId())
+                broadcastHoldState()
+            end
         end
-        if phoneState.open then
-            SendNUIMessage({ action = 'sd-phone:frameColor', data = { color = state.color } })
-        end
+        -- ALWAYS forwarded (even while closed, even when the client already believed this
+        -- colour): the NUI boots with its own default and has no other pre-open sync point,
+        -- so a skipped forward leaves closed-shell peeks wearing the wrong frame.
+        SendNUIMessage({ action = 'sd-phone:frameColor', data = { color = state.color } })
     end
     if phoneState.open then
         SendNUIMessage({
@@ -488,6 +503,15 @@ RegisterNetEvent('sd-phone:client:simState', function(state)
             },
         })
     end
+end)
+
+---Cloud-backup restore replaced the acting profile's data in place: the NUI drops every cached
+---trace (kept-alive apps, hydrated settings, data stores) and rehydrates. Forwarded even while
+---the phone is closed - the NUI keeps running hidden and would otherwise reopen on stale state.
+---The installed-apps follow-up re-runs too, since the restore changes apps + home layout.
+RegisterNetEvent('sd-phone:client:profileReset', function()
+    SendNUIMessage({ action = 'sd-phone:profileReset' })
+    if phoneState.open then CreateThread(PushInstalledApps) end
 end)
 
 ---Admin wipe (server /wipemyphone): closes the phone and tells the React app to clear its local
@@ -757,9 +781,21 @@ local function pushCharacterLoaded()
     SESSION_START_MS = GetCloudTimeAsInt() * 1000
     SendNUIMessage({ action = 'sd-phone:client:characterLoaded' })
     SendNUIMessage({ action = 'sd-phone:session', data = { startMs = SESSION_START_MS } })
+    -- Unique phones: ask for a SIM snapshot once the inventory has settled, so the active
+    -- phone's frame colour (closed-shell peeks, hand prop) is right before the first open.
+    SetTimeout(2000, function() TriggerServerEvent('sd-phone:server:sim:requestPush') end)
 end
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', pushCharacterLoaded)
 RegisterNetEvent('esx:playerLoaded', pushCharacterLoaded)
+
+---Resource restart with the character already in: the framework load events above won't
+---re-fire, but the freshly reloaded NUI still needs the character signal and a SIM snapshot
+---(closed-shell frame colour before the first open). On a fresh join this fires before any
+---character exists - the server ignores the SIM request then, and the real load event follows.
+AddEventHandler('onClientResourceStart', function(resource)
+    if resource ~= GetCurrentResourceName() then return end
+    SetTimeout(5000, pushCharacterLoaded)
+end)
 
 ---Resource-stop cleanup: releases NUI focus, deletes props, clears the statebag, and stops the
 ---hold anim.

--- a/configs/simcards.lua
+++ b/configs/simcards.lua
@@ -1,12 +1,19 @@
 -- Unique phones + SIM cards (opt-in). When enabled, characters no longer auto-receive a phone
--- number: numbers live on sim_card items, and whichever SIM sits in your phone decides WHOSE
--- phone data you see (messages, call log, contacts, photos, settings - everything). Steal a
--- phone with its SIM and you read the owner's phone from their perspective; the number follows
--- the SIM, and the Cloud Backup section in Settings lets a player carry their data to a new
--- phone + SIM (the number stays behind on the old SIM).
+-- number: numbers live on sim_card items. How the DATA is owned depends on DeviceIdentity below.
 --
--- Without a SIM the phone still opens but shows a "No SIM" screen and every server action is
--- refused - no number, no service, no browsing.
+--   * DeviceIdentity = true  (DEFAULT) - the PHONE owns the data, the SIM only lends a number.
+--     Each phone item carries a persistent identity minted on first use, and that identity keys
+--     everything (messages, contacts, photos, notes, settings, installed apps, games). Popping
+--     a SIM out just drops your number/service: the phone still opens and every non-number app
+--     keeps working. Moving a SIM to another phone hands that phone your NUMBER, not your data.
+--
+--   * DeviceIdentity = false (LEGACY) - the SIM owns the data. Whichever SIM sits in a phone
+--     decides WHOSE phone data you see; steal a phone with its SIM and you read the owner's
+--     phone. Without a SIM the phone opens to a "No SIM" screen with no service and every
+--     server action refused. This is the original unique-phones behaviour, byte-for-byte.
+--
+-- Either way the number follows the SIM, and the Cloud Backup section in Settings lets a player
+-- carry their data to a new phone (the number stays behind on the old SIM).
 --
 -- Backend support: reading/writing per-slot item metadata is required. Supported out of the box:
 --   * ox_inventory              (metadata mode, or the physical SIM-tray container mode below)
@@ -17,6 +24,14 @@ return {
     -- Master switch. Off = sd-phone behaves exactly as before (numbers auto-assigned per
     -- character, phone always has service).
     Enabled = false,
+
+    -- Where the phone DATA lives (see the header above). true (default) = the phone item owns
+    -- its data and a SIM only supplies the number, so a SIM-less phone still opens and works.
+    -- false = LEGACY behaviour where the installed SIM's identity IS the data, and a SIM-less
+    -- phone is a dead "No SIM" screen. Flipping an existing legacy server to true is safe: on
+    -- first use each phone ADOPTS the identity of the SIM currently in it (grandfathering, so no
+    -- data is copied or lost), and only from then on does the number float free of the data.
+    DeviceIdentity = true,
 
     -- Inventory item that carries a phone number in its metadata ({ number = '2075550123' }).
     -- Sell or spawn it anywhere like a normal item: a blank card self-activates on first use.

--- a/configs/simcards.lua
+++ b/configs/simcards.lua
@@ -64,5 +64,9 @@ return {
     -- SIM keeps the old number and the data that was on it.
     Backup = {
         Enabled = true,
+
+        -- How many phones one character can back up at once (each holds a full cloud snapshot).
+        -- Enabling backup on another phone past the cap asks the player to delete one first.
+        MaxProfiles = 3,
     },
 }

--- a/server/admin/actions.lua
+++ b/server/admin/actions.lua
@@ -181,15 +181,19 @@ function actions.overview(source, payload)
 
     -- Unique phones: the character's SIM footprint - every number registered to them (activated
     -- by them or living on their character-bound profile), what they carry right now, and their
-    -- cloud-backup pointer.
+    -- cloud-backup profiles.
     if simState.active then
         local simStore = require 'server.sim.store'
         local sim = { mode = simState.mode, sims = store.simsFor(cid) }
-        local b = simStore.getBackup(cid)
-        sim.backup = b and {
-            identity    = b.identity,
-            enabled     = b.enabled,
-            hasPassword = b.password ~= nil,
+        local profiles = simStore.listProfiles(cid)
+        local enabledAny = false
+        for _, p in ipairs(profiles) do
+            if p.enabled then enabledAny = true break end
+        end
+        sim.backup = #profiles > 0 and {
+            profiles    = #profiles,
+            enabled     = enabledAny,
+            hasPassword = simStore.getBackupPassword(cid) ~= nil,
         } or nil
         local liveSrc = sourceByRealCid(cid)
         if liveSrc then

--- a/server/admin/actions.lua
+++ b/server/admin/actions.lua
@@ -200,11 +200,14 @@ function actions.overview(source, payload)
             local carried = {}
             if s then
                 for _, entry in ipairs(s.sims) do
-                    carried[#carried + 1] = {
-                        number = entry.number,
-                        color  = entry.color,
-                        active = s.active ~= nil and entry.slot == s.active.slot,
-                    }
+                    -- Device mode lists SIM-less phones too; the carried-numbers view skips them.
+                    if entry.number then
+                        carried[#carried + 1] = {
+                            number = entry.number,
+                            color  = entry.color,
+                            active = s.active ~= nil and entry.slot == s.active.slot,
+                        }
+                    end
                 end
             end
             sim.carried = carried

--- a/server/calls/actions.lua
+++ b/server/calls/actions.lua
@@ -252,7 +252,9 @@ function actions.dial(source, payload)
         return fail('Number not in service')
     end
 
-    local targetSrc = player.getSourceByIdentifier(targetCid)
+    -- Any-phone resolver: a call rings the target even when the dialed number sits on the
+    -- OTHER phone in their pocket (unlike UI pushes, which only land on the active phone).
+    local targetSrc = player.getAnySourceByIdentifier(targetCid)
     if not targetSrc then return fail('This number is currently unavailable') end
     if settings.isAirplane(targetCid) then return fail('This number is currently unavailable') end
     if contacts.isBlocked(targetCid, digits(myNumber)) then return fail('This number is currently unavailable') end
@@ -309,7 +311,7 @@ function actions.dialPayphone(source, payload)
     local targetCid = settings.getCitizenByNumber(dialed)
     if not targetCid then return fail('Number not in service') end
 
-    local targetSrc = player.getSourceByIdentifier(targetCid)
+    local targetSrc = player.getAnySourceByIdentifier(targetCid)
     if not targetSrc then return fail('This number is currently unavailable') end
     if settings.isAirplane(targetCid) then return fail('This number is currently unavailable') end
     if callerNumber ~= '' and contacts.isBlocked(targetCid, callerNumber) then return fail('This number is currently unavailable') end

--- a/server/calls/actions.lua
+++ b/server/calls/actions.lua
@@ -214,7 +214,12 @@ function actions.dial(source, payload)
     local muted = moderation.guard(cid, 'calls'); if muted then return muted end
 
     local myNumber = settings.ensurePhoneNumber(cid)
-    if myNumber and digits(myNumber) == dialed then return fail('You can\'t call yourself') end
+    -- Number-dependent: no number in service (device mode with the SIM out) can't place a call.
+    -- In legacy/stock a resolvable caller always has a number, so this never trips.
+    if not myNumber or digits(myNumber) == '' then
+        return fail('No service. Install a SIM card to place calls.')
+    end
+    if digits(myNumber) == dialed then return fail('You can\'t call yourself') end
 
     local targetCid = settings.getCitizenByNumber(dialed)
     if not targetCid then

--- a/server/compat/lbphone/calls.lua
+++ b/server/compat/lbphone/calls.lua
@@ -32,7 +32,7 @@ registerLbExport('CreateCall', function(caller, callee, options)
     local src = tonumber(caller.source)
     if not src then
         local cid = settings.getCitizenByNumber(caller.phoneNumber)
-        src = cid and player.getSourceByIdentifier(cid) or nil
+        src = cid and player.getAnySourceByIdentifier(cid) or nil
     end
     if not src or not GetPlayerName(src) then return nil end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -81,13 +81,22 @@ local simState = require 'server.sim.state'
 local function RegisterPhoneItems()
     for _, entry in ipairs(config.Phone.Items or {}) do
         inv.registerUsable(entry.item, function(source, itemArg, _invArg, slotArg)
+            local deviceHint
             if simState.active then
                 local usedSlot = (type(itemArg) == 'table' and tonumber(itemArg.slot)) or tonumber(slotArg)
                 require('server.sim.session').setActive(source, { slot = usedSlot, color = entry.color })
+                -- Synchronous metadata peek (no DB): hands the client this phone's device
+                -- identity with the open, so switching phones tears the old profile down AT the
+                -- reveal instead of a server round-trip later.
+                if usedSlot then
+                    local row = inv.getSlot(source, usedSlot)
+                    local md = row and row.metadata
+                    deviceHint = type(md) == 'table' and md.deviceId or nil
+                end
             end
             -- Open immediately: the SIM resolve does inventory scans + awaited DB writes, so it
             -- runs AFTER the reveal and reconciles through the live simState push.
-            TriggerClientEvent('sd-phone:client:openFromItem', source, entry.color, nil, simState.active)
+            TriggerClientEvent('sd-phone:client:openFromItem', source, entry.color, nil, simState.active, deviceHint)
             if simState.active then
                 CreateThread(function() require('server.sim.session').push(source) end)
             end

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -25,6 +25,10 @@ local cfg = config.Messages
 ---@type table Actions module; the table returned at end of file.
 local actions = {}
 
+---@type table Notification routing (server.notifications.init): identity-addressed banners
+---incl. the pocketed-phone (carried, not active) transient buzz.
+local notifications = require 'server.notifications.init'
+
 local util = require 'server.util'
 local ok, fail, digits, trim, initialsFor, formatNumber = util.ok, util.fail, util.digits, util.trim, util.initialsFor, util.formatNumber
 
@@ -354,6 +358,25 @@ function actions.list(source)
     })
 end
 
+---@type integer Store-and-forward cap per number; past this the carrier drops new texts silently.
+local MAX_PENDING_PER_NUMBER = 100
+
+---Queues a text for a number that is registered on a SIM but currently out of service (unique
+---phones: the SIM is in no phone). Unregistered numbers still drop silently, like stock.
+---@param target string recipient number digits
+---@param mid string shared logical message id
+---@param senderNumber string
+---@param kind string
+---@param body string
+---@param meta table
+---@param ts number
+local function queueForNumber(target, mid, senderNumber, kind, body, meta, ts)
+    if not require('server.sim.state').active then return end
+    if not require('server.sim.store').get(target) then return end
+    if store.pendingCount(target) >= MAX_PENDING_PER_NUMBER then return end
+    store.queuePending(store.newId(), mid, target, senderNumber, kind, body, meta, ts)
+end
+
 ---Delivers one 1:1 message: the sender's copy is always stored; the recipient's copy + live
 ---push happen only when the number is in service, unblocked, and not in airplane mode.
 ---@param source number
@@ -376,7 +399,9 @@ local function sendDirect(source, cid, myNumber, target, kind, body, meta, ts, m
 
     local targetCid = settings.getCitizenByNumber(target)
     local inId, withheld, targetSrc
-    if targetCid and targetCid ~= cid and not contactsStore.isBlocked(targetCid, myNumber) then
+    if not targetCid then
+        queueForNumber(target, mid, myNumber, kind, body, meta, ts)
+    elseif targetCid ~= cid and not contactsStore.isBlocked(targetCid, myNumber) then
         withheld = settings.isAirplane(targetCid)
         inId = store.newId()
         store.insertMessage(inId, mid, targetCid, myNumber, myNumber, 'incoming', kind, body, meta, false, ts, withheld)
@@ -398,6 +423,17 @@ local function sendDirect(source, cid, myNumber, target, kind, body, meta, ts, m
                 muted        = false,
             })
             notify(targetSrc, participant.name, previewFor(kind, body, meta))
+        elseif not withheld then
+            -- Recipient identity sits on a phone in someone's pocket (carried, not active):
+            -- transient colour-tagged buzz, no thread push - that phone catches up on open.
+            local theirContacts = contactMapFor(targetCid)
+            local participant   = resolveParticipant(myNumber, theirContacts[myNumber])
+            notifications.notifyCid(targetCid, {
+                appId = 'messages',
+                title = participant.name,
+                body  = previewFor(kind, body, meta),
+                time  = 'now',
+            })
         end
     end
 
@@ -530,6 +566,13 @@ function actions.systemText(senderNumber, senderName, targetNumber, body, opts)
             muted        = false,
         })
         notify(targetSrc, participant.name, previewFor(kind, body, meta))
+    elseif not withheld then
+        notifications.notifyCid(targetCid, {
+            appId = 'messages',
+            title = senderName or formatNumber(senderNumber),
+            body  = previewFor(kind, body, meta),
+            time  = 'now',
+        })
     end
 
     -- First-party send announcement (system shape).
@@ -598,6 +641,13 @@ local function sendGroup(source, cid, myNumber, groupId, kind, body, meta, ts, m
                     muted        = false,
                 })
                 notify(targetSrc, group.name, senderName .. ': ' .. previewFor(kind, body, meta))
+            elseif not withheld then
+                notifications.notifyCid(m.citizenid, {
+                    appId = 'messages',
+                    title = group.name,
+                    body  = senderName .. ': ' .. previewFor(kind, body, meta),
+                    time  = 'now',
+                })
             end
         end
     end
@@ -1012,6 +1062,57 @@ function actions.releaseWithheld(source)
 
     local n = #convs
     notify(source, 'Messages', ('You have new messages in %d conversation%s.'):format(n, n == 1 and '' or 's'))
+end
+
+---Delivers every text queued for `number` while it was out of service, into the identity the
+---number just attached to (unique phones: SIM installed / moved). Mirrors releaseWithheld:
+---inserts the copies, pushes each affected thread live, fires one summary banner. Blocked
+---senders are dropped here, since the recipient was unknown at queue time.
+---@param source number player server id holding the phone the number attached to
+---@param cid string data identity the number now belongs to
+---@param number string bare-digit number that came back into service
+function actions.deliverPending(source, cid, number)
+    local rows = store.takePending(number)
+    if #rows == 0 then return end
+
+    local airplane = settings.isAirplane(cid)
+    local convs, seen = {}, {}
+    for _, row in ipairs(rows) do
+        if not contactsStore.isBlocked(cid, row.sender) then
+            local meta = row.meta
+            if type(meta) == 'string' then
+                local okDecode, decoded = pcall(json.decode, meta)
+                meta = okDecode and decoded or nil
+            end
+            store.insertMessage(store.newId(), row.mid, cid, row.sender, row.sender, 'incoming',
+                row.kind, row.body, meta, false, tonumber(row.created_at) or os.time(), airplane)
+            if not seen[row.sender] then
+                seen[row.sender] = true
+                convs[#convs + 1] = row.sender
+            end
+        end
+    end
+    if #convs == 0 then return end
+
+    for _, conversation in ipairs(convs) do
+        store.pruneThread(cid, conversation, cfg.MessagesPerThread)
+    end
+
+    if airplane or not GetPlayerName(source) then
+        badges.push(source)
+        return
+    end
+
+    local myNumber   = digits(settings.getPhoneNumber(cid) or '')
+    local contactMap = contactMapFor(cid)
+    for _, conversation in ipairs(convs) do
+        local threadRows = store.threadMessages(cid, conversation, cfg.MessagesPerThread)
+        TriggerClientEvent('sd-phone:client:messages:incoming', source,
+            buildConversation(cid, myNumber, conversation, threadRows, contactMap))
+    end
+
+    local n = #convs
+    notify(source, 'Messages', ('Delivered while you were out of service: %d conversation%s.'):format(n, n == 1 and '' or 's'))
 end
 
 ---Uploads a recorded voice message to Fivemanage and returns its hosted URL. The payload must

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -646,6 +646,12 @@ function actions.send(source, payload)
 
     local isGroup = conversation:sub(1, 2) == 'g-'
 
+    -- Number-dependent: a phone with no number in service can't send (device mode with the SIM
+    -- out; in legacy/stock a resolvable caller always has a number, so this never trips). Gate
+    -- BEFORE the money branch so a refused text never moves cash.
+    local myNumber = digits(settings.ensurePhoneNumber(cid) or '')
+    if myNumber == '' then return fail('No service. Install a SIM card to send messages.') end
+
     if kind == 'money' then
         if isGroup then return fail('Money can only be sent in a direct message') end
         if not meta.requested then
@@ -660,7 +666,6 @@ function actions.send(source, payload)
         end
     end
 
-    local myNumber = digits(settings.ensurePhoneNumber(cid) or '')
     local ts = os.time()
     local mid = store.newId()
 

--- a/server/messages/init.lua
+++ b/server/messages/init.lua
@@ -7,6 +7,9 @@ local store   = require 'server.messages.store'
 ---@type table Authoritative message handlers (server.messages.actions): validation + delivery fan-out.
 local actions = require 'server.messages.actions'
 
+---@type integer Queued out-of-service texts older than this are dropped at boot (carrier gives up).
+local PENDING_MAX_AGE = 14 * 24 * 60 * 60
+
 ---Boots the message schema; a failure is printed and leaves the module inert.
 CreateThread(function()
     local success, err = pcall(store.ensureSchema)
@@ -14,6 +17,7 @@ CreateThread(function()
         print(('^1[sd-phone:messages]^0 schema bootstrap failed: %s'):format(err))
         return
     end
+    pcall(store.prunePending, PENDING_MAX_AGE)
     print('^2[sd-phone:messages]^0 schema ready')
 end)
 
@@ -34,6 +38,17 @@ lib.callback.register('sd-phone:server:messages:react', function(src, payload) r
 ---@param source number player server id
 AddEventHandler('sd-phone:server:airplane:released', function(source)
     actions.releaseWithheld(source)
+end)
+
+---Delivers texts queued while a number was out of service, when the SIM session attaches the
+---number to an identity (SIM installed or moved). Threaded: the attach fires mid-resolve.
+---@param source number player server id
+---@param cid string data identity the number attached to
+---@param number string bare-digit number
+AddEventHandler('sd-phone:server:sim:numberAttached', function(source, cid, number)
+    CreateThread(function()
+        actions.deliverPending(source, cid, number)
+    end)
 end)
 
 ---Sends a message on a player's behalf from another resource. Mirrors the NUI `send` payload;

--- a/server/messages/store.lua
+++ b/server/messages/store.lua
@@ -137,6 +137,21 @@ function store.ensureSchema()
     if not acol or tonumber(acol.n) == 0 then
         MySQL.query.await('ALTER TABLE phone_message_groups ADD COLUMN avatar VARCHAR(512) NULL')
     end
+
+    MySQL.query.await([[
+        CREATE TABLE IF NOT EXISTS phone_pending_messages (
+            id          VARCHAR(16)  NOT NULL,
+            mid         VARCHAR(16)  NOT NULL,
+            number      VARCHAR(48)  NOT NULL,
+            sender      VARCHAR(32)  NOT NULL,
+            kind        VARCHAR(16)  NOT NULL DEFAULT 'text',
+            body        TEXT         NULL,
+            meta        JSON         NULL,
+            created_at  BIGINT       NOT NULL,
+            PRIMARY KEY (id),
+            INDEX idx_phone_pending_messages_number (number, created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    ]])
 end
 
 ---Lists a player's conversation keys, most-recently-active first, each with the newest message
@@ -262,6 +277,62 @@ function store.releaseWithheld(citizenid)
     MySQL.update.await(
         'UPDATE phone_messages SET withheld = 0 WHERE citizenid = ? AND withheld = 1',
         { citizenid }
+    )
+end
+
+---Queues a message for a registered number that is currently out of service (unique phones:
+---its SIM is in no phone). Delivered by deliverPending when the number attaches again.
+---@param id string
+---@param mid string shared logical message id
+---@param number string target number digits
+---@param sender string sender's number digits
+---@param kind string
+---@param body string|nil
+---@param meta table|nil
+---@param createdAt number unix epoch
+function store.queuePending(id, mid, number, sender, kind, body, meta, createdAt)
+    MySQL.insert.await([[
+        INSERT INTO phone_pending_messages (id, mid, number, sender, kind, body, meta, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ]], { id, mid, number, sender, kind, body, encodeJson(meta), createdAt })
+end
+
+---How many messages are queued for a number. Read-only.
+---@param number string target number digits
+---@return number
+function store.pendingCount(number)
+    local row = MySQL.single.await(
+        'SELECT COUNT(*) AS n FROM phone_pending_messages WHERE number = ?', { number })
+    return row and tonumber(row.n) or 0
+end
+
+---Drains the queue for a number: returns its rows oldest-first and deletes them in one step,
+---so a second concurrent drain gets nothing.
+---@param number string target number digits
+---@return { id: string, mid: string, sender: string, kind: string, body: string|nil, meta: string|nil, created_at: number }[]
+function store.takePending(number)
+    local rows = MySQL.query.await([[
+        SELECT id, mid, sender, kind, body, meta, created_at
+        FROM phone_pending_messages
+        WHERE number = ?
+        ORDER BY created_at ASC
+    ]], { number }) or {}
+    if #rows > 0 then
+        local ids = {}
+        for i = 1, #rows do ids[i] = rows[i].id end
+        local placeholders = ('?,'):rep(#ids):sub(1, -2)
+        MySQL.update.await(
+            'DELETE FROM phone_pending_messages WHERE id IN (' .. placeholders .. ')', ids)
+    end
+    return rows
+end
+
+---Deletes queued messages older than `maxAgeSeconds`; the carrier eventually gives up. Run at boot.
+---@param maxAgeSeconds number
+function store.prunePending(maxAgeSeconds)
+    MySQL.update.await(
+        'DELETE FROM phone_pending_messages WHERE created_at < ?',
+        { os.time() - math.floor(tonumber(maxAgeSeconds) or 0) }
     )
 end
 

--- a/server/notifications/init.lua
+++ b/server/notifications/init.lua
@@ -3,6 +3,9 @@ local player = require 'bridge.server.player'
 ---@type table Settings persistence layer (server.settings.store): phone-number -> citizenid lookups.
 local settingsStore = require 'server.settings.store'
 
+---@type table Notifications module; returned so sibling modules can route identity-addressed banners.
+local notifications = {}
+
 ---Shared relay behind both notification exports: shape-checks the payload, then pushes the
 ---banner. Returns false on a non-number source, non-table data, or missing title.
 ---@param source number player server id
@@ -24,8 +27,48 @@ exports('notify', function(source, data)
     return relay(source, data)
 end)
 
+---Delivers a notification to the player acting as `cid`. When the identity instead sits on a
+---phone in their POCKET (carried, not active - unique phones), a transient "pocket buzz"
+---banner tagged with that phone's colour goes out instead, flagged `otherPhone` so the NUI
+---keeps it off the active phone's lockscreen stack and badges.
+---@param cid string data identity the notification belongs to
+---@param data table notification payload (title required)
+---@return boolean sent
+function notifications.notifyCid(cid, data)
+    if type(cid) ~= 'string' or cid == '' then return false end
+    local src = player.getSourceByIdentifier(cid)
+    if src then return relay(src, data) end
+    if type(data) ~= 'table' or type(data.title) ~= 'string' then return false end
+
+    local anySrc = player.getAnySourceByIdentifier(cid)
+    if not anySrc then return false end
+    local entry
+    local s = require('server.sim.session').resolve(anySrc)
+    if s then
+        for _, e in ipairs(s.sims) do
+            if e.identity == cid then entry = e break end
+        end
+    end
+    local color = entry and entry.color or nil
+    return relay(anySrc, {
+        app        = color and (color:gsub('^%l', string.upper) .. ' Phone') or 'Other Phone',
+        appId      = data.appId,
+        image      = data.image,
+        title      = data.title,
+        body       = data.body,
+        time       = data.time,
+        otherPhone = true,
+        -- The buzzing phone's frame colour (peek shell tint) and its NUI profile key (device
+        -- identity, or the number in legacy mode) so the banner can be parked on THAT phone's
+        -- banked lockscreen stack for its next open.
+        phoneColor = color,
+        profileKey = require('server.sim.state').device and cid or (entry and entry.number) or nil,
+    })
+end
+
 ---Sends the same notification addressed by phone number instead of server id. The number is
----digit-normalised before lookup; an unassigned number or offline owner returns false.
+---digit-normalised before lookup; an unassigned number or offline owner returns false. A
+---number on a pocketed (non-active) phone arrives as a colour-tagged transient buzz.
 ---@param number string phone number in any formatting
 ---@param data table notification payload
 ---@return boolean sent
@@ -34,9 +77,7 @@ exports('notifyNumber', function(number, data)
     if digits == '' then return false end
     local cid = settingsStore.getCitizenByNumber(digits)
     if not cid then return false end
-    local src = player.getSourceByIdentifier(cid)
-    if not src then return false end
-    return relay(src, data)
+    return notifications.notifyCid(cid, data)
 end)
 
 ---/phonenotif-to <playerId> pushes a canned test notification at one player. Ace-restricted;
@@ -58,3 +99,5 @@ RegisterCommand('phonenotif-to', function(src, args)
         appId = 'messages',
     })
 end, true)
+
+return notifications

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -46,6 +46,7 @@ lib.callback.register('sd-phone:server:settings:get', function(source)
     data.airplaneMode            = store.isAirplane(cid)
     data.hour24                  = store.getHour24(cid)
     data.reopenApp               = store.getReopenApp(cid)
+    data.setupDone               = store.getSetupDone(cid)
     data.theme                   = store.getTheme(cid)
     data.darkTheme               = store.getDarkTheme(cid)
     data.lockClock               = store.getLockClock(cid)
@@ -161,6 +162,15 @@ lib.callback.register('sd-phone:server:settings:setHour24', function(source, pay
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
     store.setHour24(cid, payload.on == true)
+    return { success = true }
+end)
+
+---Marks the caller's profile as having completed first-run setup (one-way; the wipe path
+---deletes the whole settings row, which is what un-sets it).
+lib.callback.register('sd-phone:server:settings:setSetupDone', function(source)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    store.setSetupDone(cid)
     return { success = true }
 end)
 

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -378,6 +378,24 @@ function store.setPhoneNumber(citizenid, number)
     ]], { citizenid, clean })
 end
 
+---Clears a phone identity's number mirror (device mode: a phone whose SIM was pulled has no
+---number and must report none). A no-op when the row does not exist.
+---@param citizenid string phone data identity
+function store.clearPhoneNumber(citizenid)
+    if not citizenid or citizenid == '' then return end
+    MySQL.update.await('UPDATE phone_settings SET phone_number = NULL WHERE citizenid = ?', { citizenid })
+end
+
+---True when a phone identity already has a settings row (used by device-mode identity minting to
+---decide whether to ADOPT an existing SIM/character profile instead of opening a blank one).
+---Read-only.
+---@param citizenid string phone data identity
+---@return boolean hasData
+function store.hasData(citizenid)
+    if not citizenid or citizenid == '' then return false end
+    return MySQL.scalar.await('SELECT 1 FROM phone_settings WHERE citizenid = ? LIMIT 1', { citizenid }) ~= nil
+end
+
 ---Returns a player's number, generating and saving a unique one on first access; tries 20
 ---random candidates against numberExists, then accepts an unchecked one. Under unique-phones
 ---mode numbers live on SIM cards (server/sim), so first-access generation is disabled and only

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -100,6 +100,9 @@ function store.ensureSchema()
     if not columnExists('phone_settings', 'reopen_app') then
         MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN reopen_app TINYINT(1) NULL')
     end
+    if not columnExists('phone_settings', 'setup_done') then
+        MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN setup_done TINYINT(1) NULL')
+    end
     for _, col in ipairs({
         { 'card_name',    'VARCHAR(64) NULL'  },
         { 'card_avatar',  'VARCHAR(512) NULL' },
@@ -826,6 +829,26 @@ function store.getHour24(citizenid)
         return row.hour24 == true or tonumber(row.hour24) == 1
     end
     return defaultHour24()
+end
+
+---True once this profile finished the first-run setup. Server-side twin of the client's
+---localStorage flag, so a cleared FiveM cache or another PC never re-runs Hello. Read-only.
+---@param citizenid string framework per-character id
+---@return boolean done
+function store.getSetupDone(citizenid)
+    if not citizenid or citizenid == '' then return false end
+    local row = MySQL.single.await('SELECT setup_done FROM phone_settings WHERE citizenid = ?', { citizenid })
+    return row ~= nil and (row.setup_done == true or tonumber(row.setup_done) == 1)
+end
+
+---Marks this profile's first-run setup as completed (upsert, one-way).
+---@param citizenid string framework per-character id
+function store.setSetupDone(citizenid)
+    if not citizenid or citizenid == '' then return end
+    MySQL.update.await([[
+        INSERT INTO phone_settings (citizenid, setup_done) VALUES (?, 1)
+        ON DUPLICATE KEY UPDATE setup_done = 1
+    ]], { citizenid })
 end
 
 ---Persists a player's 24-hour time preference (upsert), coerced to a strict boolean.

--- a/server/sim/backup.lua
+++ b/server/sim/backup.lua
@@ -113,33 +113,31 @@ local SETTINGS_COLS = {
     'ringtone_volume', 'call_volume', 'locale', 'dark_theme', 'theme',
 }
 
----Restores a phone profile: copies `fromId`'s data onto `toId` (the current SIM identity) and
----moves live group-chat membership over, rewriting the stored member number to the new SIM's.
----The source profile keeps its rows - whoever holds the old SIM keeps what was on it.
----@param fromId string backed-up identity
----@param toId string current SIM identity
----@param toNumber string current SIM bare-digit number
----@return integer rows total rows written
-function backup.restore(fromId, toId, toNumber)
-    local rows = 0
-
-    -- Settings row: overwrite the new profile's preferences with the backup's.
+---Overwrites `toId`'s phone_settings preference columns with `fromId`'s, creating the target
+---row when it doesn't exist yet (a fresh cloud snapshot has none).
+---@param fromId string source identity
+---@param toId string target identity
+---@return integer rows
+local function copySettings(fromId, toId)
+    local rows = run('INSERT IGNORE INTO phone_settings (citizenid) VALUES (?)', { toId })
     local setParts = {}
     for _, col in ipairs(SETTINGS_COLS) do
         setParts[#setParts + 1] = ('a.`%s` = b.`%s`'):format(col, col)
     end
-    rows = rows + run(([[
+    return rows + run(([[
         UPDATE phone_settings a
         JOIN phone_settings b ON b.citizenid = ?
         SET %s WHERE a.citizenid = ?
     ]]):format(table.concat(setParts, ', ')), { fromId, toId })
+end
 
-    for _, t in ipairs(COPY) do
-        rows = rows + copyTable(t[1], t[2], fromId, toId)
-    end
-
-    -- Photo album contents: no identity column; remap both sides of the join like copyTable did.
-    rows = rows + run([[
+---Copies album membership rows across identities, remapping both foreign ids the way
+---copyTable remapped their parents (no identity column of its own).
+---@param fromId string source identity
+---@param toId string target identity
+---@return integer rows
+local function copyAlbumItems(fromId, toId)
+    return run([[
         INSERT IGNORE INTO phone_photo_album_items (album_id, photo_id, added_at)
         SELECT SUBSTRING(MD5(CONCAT(i.album_id, ?)), 1, 16),
                SUBSTRING(MD5(CONCAT(i.photo_id, ?)), 1, 16),
@@ -148,20 +146,75 @@ function backup.restore(fromId, toId, toNumber)
         JOIN phone_photo_albums a ON a.id = i.album_id
         WHERE a.citizenid = ?
     ]], { toId, toId, fromId })
+end
+
+---Deletes every snapshot row a cloud identity holds (profile deletion, and the wipe phase of
+---a sync). The phone_settings row goes too - a dead namespace keeps nothing.
+---@param cloudId string snapshot identity ('cloud:' prefixed)
+function backup.wipe(cloudId)
+    -- Album items go first: their parent album rows are the only link to the cloud identity.
+    run([[
+        DELETE i FROM phone_photo_album_items i
+        JOIN phone_photo_albums a ON a.id = i.album_id
+        WHERE a.citizenid = ?
+    ]], { cloudId })
+    for _, t in ipairs(COPY) do
+        run(('DELETE FROM `%s` WHERE `%s` = ?'):format(t[1], t[2]), { cloudId })
+    end
+    run('DELETE FROM phone_settings WHERE citizenid = ?', { cloudId })
+end
+
+---Snapshot sync: replaces the cloud profile's rows with a fresh copy of the enrolled phone's.
+---Wipe-then-copy (not merge) so deletions and edits on the phone reach the snapshot. Restore
+---side effects (group-membership move, mail-login append) deliberately stay out - the cloud
+---identity is a dead namespace that never acts.
+---@param fromId string enrolled phone identity
+---@param cloudId string snapshot identity ('cloud:' prefixed)
+---@return integer rows total rows written
+function backup.sync(fromId, cloudId)
+    backup.wipe(cloudId)
+
+    local rows = copySettings(fromId, cloudId)
+    for _, t in ipairs(COPY) do
+        rows = rows + copyTable(t[1], t[2], fromId, cloudId)
+    end
+    return rows + copyAlbumItems(fromId, cloudId)
+end
+
+---Restores a phone profile: copies `fromId`'s data onto `toId` (the current SIM identity) and
+---moves live group-chat membership over, rewriting the stored member number to the new SIM's.
+---The source profile keeps its rows - whoever holds the old SIM keeps what was on it. Live
+---room state (groups, mail logins) can't come from a snapshot, so it moves from `liveFromId` -
+---the previously enrolled phone - which for legacy pointer backups IS the backup identity.
+---@param fromId string backed-up identity (cloud snapshot, or a phone identity on legacy rows)
+---@param toId string current SIM identity
+---@param toNumber string current SIM bare-digit number
+---@param liveFromId string|nil previously enrolled phone identity (defaults to fromId)
+---@return integer rows total rows written
+function backup.restore(fromId, toId, toNumber, liveFromId)
+    liveFromId = liveFromId or fromId
+    local rows = copySettings(fromId, toId)
+
+    for _, t in ipairs(COPY) do
+        rows = rows + copyTable(t[1], t[2], fromId, toId)
+    end
+
+    rows = rows + copyAlbumItems(fromId, toId)
 
     -- Group chats fan out by the member rows, so membership MOVES to the restored profile
-    -- (the old SIM drops out) and the stored member number becomes the new SIM's number.
+    -- (the old phone drops out) and the stored member number becomes the new SIM's number.
     rows = rows + run(
         'UPDATE IGNORE phone_message_group_members SET citizenid = ?, number = ? WHERE citizenid = ?',
-        { toId, toNumber, fromId })
+        { toId, toNumber, liveFromId })
     rows = rows + run(
-        'UPDATE phone_message_groups SET owner_cid = ? WHERE owner_cid = ?', { toId, fromId })
+        'UPDATE phone_message_groups SET owner_cid = ? WHERE owner_cid = ?', { toId, liveFromId })
 
-    -- Mailboxes: add the new identity to every account the old identity was signed into.
+    -- Mailboxes: add the new identity to every account the previously enrolled phone was
+    -- signed into (mail logins are live state - the snapshot identity never signs in).
     local ok, mails = pcall(function()
         return MySQL.query.await(
             "SELECT email, logged_in_citizens FROM phone_mail_accounts WHERE JSON_SEARCH(logged_in_citizens, 'one', ?) IS NOT NULL",
-            { fromId })
+            { liveFromId })
     end)
     if ok and type(mails) == 'table' then
         for _, m in ipairs(mails) do

--- a/server/sim/init.lua
+++ b/server/sim/init.lua
@@ -249,7 +249,6 @@ lib.callback.register('sd-phone:server:sim:get', function(source)
     if not realCid then return util.fail('Player not found') end
     session.invalidate(source)
     local s = session.resolve(source)
-    local b = simStore.getBackup(realCid)
     local sims = {}
     if s then
         for _, entry in ipairs(s.sims) do
@@ -263,6 +262,29 @@ lib.callback.register('sd-phone:server:sim:get', function(source)
             end
         end
     end
+
+    -- Backup profiles: one per phone. A profile restores once its snapshot exists (legacy
+    -- pointer rows restore from the live phone identity instead - unless it IS this phone).
+    local myProfile
+    local profiles = {}
+    local restorable = false
+    for _, p in ipairs(simStore.listProfiles(realCid)) do
+        local isCloud = p.identity:sub(1, 6) == 'cloud:'
+        local thisPhone = s ~= nil and s.identity == p.deviceIdentity
+        local canUse = (isCloud and p.syncedAt ~= nil)
+            or (not isCloud and (s == nil or s.identity ~= p.identity))
+        if thisPhone then myProfile = p end
+        profiles[#profiles + 1] = {
+            device     = p.deviceIdentity,
+            color      = p.color,
+            number     = p.number,
+            syncedAt   = p.syncedAt,
+            thisPhone  = thisPhone,
+            restorable = canUse,
+        }
+        if canUse then restorable = true end
+    end
+
     return util.ok({
         mode          = state.mode,
         device        = state.device,
@@ -273,10 +295,16 @@ lib.callback.register('sd-phone:server:sim:get', function(source)
         ejectable     = state.mode == 'metadata' and config.Sim.AllowEject ~= false
                         and s ~= nil and s.hasSim or false,
         backupOn      = config.Sim.Backup and config.Sim.Backup.Enabled ~= false or false,
-        backupEnabled = b ~= nil and b.enabled or false,
+        -- A password only binds while profiles exist (no profiles = enabling may set a new one).
+        hasPassword   = simStore.getBackupPassword(realCid) ~= nil
+                        and #profiles > 0 or false,
+        backupEnabled = myProfile ~= nil and myProfile.enabled or false,
+        autoSync      = myProfile ~= nil and myProfile.autoSync or false,
+        syncedAt      = myProfile and myProfile.syncedAt or nil,
+        profiles      = profiles,
+        maxProfiles   = tonumber(config.Sim.Backup and config.Sim.Backup.MaxProfiles) or 3,
         -- Device mode restores onto the DEVICE identity (no SIM required); legacy needs the SIM.
-        canRestore    = b ~= nil and b.enabled and s ~= nil and s.identity ~= nil
-                        and s.identity ~= b.identity
+        canRestore    = restorable and s ~= nil and s.identity ~= nil
                         and (state.device or s.hasSim) or false,
     })
 end)
@@ -302,9 +330,39 @@ lib.callback.register('sd-phone:server:sim:eject', function(source)
     return util.ok()
 end)
 
----Toggles the caller's cloud backup. Enabling requires a backup password: it protects the
----restore, and a copy is saved into the phone's Passwords app so the player can look it up.
----Backups only ever copy data the caller can already read, never grant new access.
+---True when a backup identity is a snapshot namespace (vs a legacy pointer at a phone).
+---@param identity string|nil
+---@return boolean
+local function isCloudIdentity(identity)
+    return type(identity) == 'string' and identity:sub(1, 6) == 'cloud:'
+end
+
+---Takes a fresh snapshot of `s.identity` into ITS profile, converting a legacy pointer row to
+---a `cloud:` namespace on first use, and stamps the picker labels (colour + number).
+---@param realCid string real (framework) citizenid
+---@param profile table this phone's profile row (simStore.getProfile shape)
+---@param s SimSession resolved session of the syncing phone
+---@return number syncedAt
+local function runProfileSync(realCid, profile, s)
+    local cloudId = profile.identity
+    if not isCloudIdentity(cloudId) then
+        cloudId = 'cloud:' .. util.newId(16)
+        simStore.setProfileIdentity(realCid, profile.deviceIdentity, cloudId)
+    end
+    backup.sync(s.identity, cloudId)
+    local syncedAt = os.time()
+    local entry
+    for _, e in ipairs(s.sims) do
+        if e.identity == s.identity then entry = e break end
+    end
+    simStore.setProfileSynced(realCid, profile.deviceIdentity, syncedAt,
+        entry and entry.color or s.color, entry and entry.number or s.number)
+    return syncedAt
+end
+
+---Toggles cloud backup FOR THIS PHONE (each phone owns its profile, up to MaxProfiles).
+---Enabling requires the character's backup password - set on first use, verified after - and
+---takes the first snapshot immediately. A copy of the password lands in the Passwords app.
 lib.callback.register('sd-phone:server:sim:backup:set', function(source, payload)
     if not (config.Sim.Backup and config.Sim.Backup.Enabled ~= false) then
         return util.fail('Cloud backup is disabled.')
@@ -312,55 +370,176 @@ lib.callback.register('sd-phone:server:sim:backup:set', function(source, payload
     local realCid = player.getRealIdentifier(source)
     if not realCid then return util.fail('Player not found') end
     payload = type(payload) == 'table' and payload or {}
+    local s = session.resolve(source)
+    if not s or not s.identity then return util.fail('Install a SIM card first.') end
 
     if payload.on == true then
-        local s = session.resolve(source)
-        if not s or not s.identity then return util.fail('Install a SIM card first.') end
         local password = type(payload.password) == 'string' and payload.password or ''
         if #password < 4 or #password > 32 then
             return util.fail('Backup password must be 4-32 characters.')
         end
         local accounts = require 'server.accounts.store'
-        simStore.setBackup(realCid, s.identity, true, accounts.hashPassword(password))
+        local existing = simStore.getBackupPassword(realCid)
+        -- With no profiles left there is nothing the password protects: the entered password
+        -- becomes the new one (also the recovery path for a forgotten password).
+        if existing and simStore.profileCount(realCid) > 0 then
+            if accounts.hashPassword(password) ~= existing then
+                return util.fail('Wrong backup password. It\'s saved in the Passwords app of your backed-up phone.')
+            end
+        else
+            simStore.setBackupPassword(realCid, accounts.hashPassword(password))
+        end
+
+        local profile = simStore.getProfile(realCid, s.identity)
+        if not profile then
+            local cap = tonumber(config.Sim.Backup.MaxProfiles) or 3
+            if simStore.profileCount(realCid) >= cap then
+                return util.fail(('You can back up at most %d phones. Delete a backup first.'):format(cap))
+            end
+        end
+        local cloudId = (profile and isCloudIdentity(profile.identity)) and profile.identity
+            or ('cloud:' .. util.newId(16))
+        simStore.upsertProfile(realCid, s.identity, cloudId)
         accounts.saveVaultEntry(s.identity, 'cloud', 'Cloud Backup', password, nil, s.number)
+        profile = simStore.getProfile(realCid, s.identity)
+        if profile then runProfileSync(realCid, profile, s) end
     else
-        local b = simStore.getBackup(realCid)
-        if b then simStore.setBackup(realCid, b.identity, false) end
+        simStore.setProfileEnabled(realCid, s.identity, false)
     end
     return util.ok()
 end)
 
----Restores the caller's cloud backup onto the current SIM profile: the old phone's settings,
----contacts, messages, photos and app data are copied over - the phone NUMBER never is (it lives
----on the old SIM; a lost number is lost). Requires the backup password when one is set.
+---Manual "Back Up Now" for the caller's phone (its own profile only).
+lib.callback.register('sd-phone:server:sim:backup:sync', function(source)
+    if not (config.Sim.Backup and config.Sim.Backup.Enabled ~= false) then
+        return util.fail('Cloud backup is disabled.')
+    end
+    local realCid = player.getRealIdentifier(source)
+    if not realCid then return util.fail('Player not found') end
+    local s = session.resolve(source)
+    if not s or not s.identity then return util.fail('No phone to back up.') end
+    local profile = simStore.getProfile(realCid, s.identity)
+    if not profile or not profile.enabled then
+        return util.fail('Cloud Backup is not enabled on this phone.')
+    end
+
+    local syncedAt = runProfileSync(realCid, profile, s)
+    return util.ok({ syncedAt = syncedAt })
+end)
+
+---Toggles auto-sync (snapshot on holster, throttled) for the caller's phone.
+lib.callback.register('sd-phone:server:sim:backup:setAuto', function(source, payload)
+    local realCid = player.getRealIdentifier(source)
+    if not realCid then return util.fail('Player not found') end
+    local s = session.resolve(source)
+    if not s or not s.identity then return util.fail('No phone.') end
+    if not simStore.getProfile(realCid, s.identity) then
+        return util.fail('Cloud Backup is not enabled on this phone.')
+    end
+    payload = type(payload) == 'table' and payload or {}
+    simStore.setProfileAuto(realCid, s.identity, payload.on == true)
+    return util.ok()
+end)
+
+---Deletes one backup profile AND its snapshot data. Any of the character's profiles may be
+---deleted from any phone (freeing a slot for a new phone).
+lib.callback.register('sd-phone:server:sim:backup:delete', function(source, payload)
+    local realCid = player.getRealIdentifier(source)
+    if not realCid then return util.fail('Player not found') end
+    payload = type(payload) == 'table' and payload or {}
+    local device = type(payload.device) == 'string' and payload.device or ''
+    local profile = simStore.getProfile(realCid, device)
+    if not profile then return util.fail('Backup profile not found.') end
+    if isCloudIdentity(profile.identity) then backup.wipe(profile.identity) end
+    simStore.deleteProfile(realCid, device)
+    return util.ok()
+end)
+
+---@type integer Auto-sync throttle: the enrolled phone re-snapshots at most this often (seconds).
+local AUTO_SYNC_MIN_GAP = 300
+
+---@type table<number, boolean> Per-source auto-sync in progress; drops overlapping attempts.
+local autoSyncBusy = {}
+
+---Auto-sync trigger: holstering the phone is the natural save point. A phone only ever syncs
+---ITS OWN profile, so a lost or stolen phone can never overwrite another phone's backup.
+---Second listener on the share module's open-state event.
+RegisterNetEvent('sd-phone:server:phone:setOpen', function(open)
+    local source = source
+    if open or not state.active then return end
+    if not (config.Sim.Backup and config.Sim.Backup.Enabled ~= false) then return end
+    if autoSyncBusy[source] then return end
+    autoSyncBusy[source] = true
+    CreateThread(function()
+        local okRun, err = pcall(function()
+            local realCid = player.getRealIdentifier(source)
+            if not realCid then return end
+            local s = session.resolve(source)
+            if not s or not s.identity then return end
+            local profile = simStore.getProfile(realCid, s.identity)
+            if not profile or not profile.enabled or not profile.autoSync then return end
+            if (os.time() - (profile.syncedAt or 0)) < AUTO_SYNC_MIN_GAP then return end
+            runProfileSync(realCid, profile, s)
+        end)
+        if not okRun then print(('^1[sd-phone:sim]^0 auto-sync failed for %s: %s'):format(source, err)) end
+        autoSyncBusy[source] = nil
+    end)
+end)
+
+---Restores a chosen backup profile onto the current phone: settings, contacts, messages,
+---photos and app data are copied over - the phone NUMBER never is (it lives on the SIM; a lost
+---number is lost). `payload.device` picks the profile (optional when only one restores).
+---Requires the character's backup password. Restoring does NOT touch the snapshot or move any
+---profile enrollment - the source phone keeps backing itself up.
 lib.callback.register('sd-phone:server:sim:backup:restore', function(source, payload)
     if not (config.Sim.Backup and config.Sim.Backup.Enabled ~= false) then
         return util.fail('Cloud backup is disabled.')
     end
     local realCid = player.getRealIdentifier(source)
     if not realCid then return util.fail('Player not found') end
-    local b = simStore.getBackup(realCid)
-    if not b or not b.enabled then return util.fail('No cloud backup found for this character.') end
+    payload = type(payload) == 'table' and payload or {}
     local s = session.resolve(source)
     -- Device mode restores onto the phone's own identity, no SIM/number required; legacy needs
     -- the installed SIM (its identity + number ARE the phone).
     if not s or not s.identity then return util.fail('Install a SIM card first.') end
     if not state.device and not s.number then return util.fail('Install a SIM card first.') end
-    if s.identity == b.identity then return util.fail('This phone already holds the backed-up data.') end
 
-    if b.password then
-        payload = type(payload) == 'table' and payload or {}
+    local profile
+    if type(payload.device) == 'string' and payload.device ~= '' then
+        profile = simStore.getProfile(realCid, payload.device)
+    else
+        -- No pick: allowed only when exactly one profile can restore here.
+        local candidates = {}
+        for _, p in ipairs(simStore.listProfiles(realCid)) do
+            local isCloud = isCloudIdentity(p.identity)
+            if (isCloud and p.syncedAt ~= nil) or (not isCloud and p.identity ~= s.identity) then
+                candidates[#candidates + 1] = p
+            end
+        end
+        if #candidates > 1 then return util.fail('Pick which backup to restore.') end
+        profile = candidates[1]
+    end
+    if not profile then return util.fail('No cloud backup found for this character.') end
+    local isCloud = isCloudIdentity(profile.identity)
+    if isCloud and profile.syncedAt == nil then return util.fail('That backup has never completed.') end
+    if not isCloud and profile.identity == s.identity then
+        return util.fail('This phone already holds the backed-up data.')
+    end
+
+    local stored = simStore.getBackupPassword(realCid)
+    if stored then
         local given = type(payload.password) == 'string' and payload.password or ''
         local accounts = require 'server.accounts.store'
-        if accounts.hashPassword(given) ~= b.password then
+        if accounts.hashPassword(given) ~= stored then
             return util.fail('Wrong backup password.')
         end
     end
 
-    local rows = backup.restore(b.identity, s.identity, s.number or '')
-    simStore.setBackup(realCid, s.identity, true, nil)
+    -- Snapshot untouched: restore copies OUT of the cloud. Live room state (groups, mail
+    -- logins) moves from the profile's source phone; legacy pointer rows ARE that phone.
+    local rows = backup.restore(profile.identity, s.identity, s.number or '', profile.deviceIdentity)
     print(('^3[sd-phone:sim]^0 restored backup %s -> %s for %s (%d rows)')
-        :format(b.identity, s.identity, realCid, rows))
+        :format(profile.identity, s.identity, realCid, rows))
     -- The restored data replaced the acting profile in place: the client resets the NUI (kept-
     -- alive apps, hydrated settings, caches) so nothing keeps showing pre-restore state.
     TriggerClientEvent('sd-phone:client:profileReset', source)

--- a/server/sim/init.lua
+++ b/server/sim/init.lua
@@ -99,11 +99,12 @@ CreateThread(function()
     end
 
     state.mode   = (config.Sim.UseContainers and siminv.isOx()) and 'container' or 'metadata'
+    state.device = config.Sim.DeviceIdentity ~= false
     state.active = true
     if state.mode == 'container' then siminv.registerContainers() end
     if siminv.isOx() then registerHooks() end
-    print(('^2[sd-phone:sim]^0 unique phones active (%s mode, %s backend)')
-        :format(state.mode, siminv.backendName()))
+    print(('^2[sd-phone:sim]^0 unique phones active (%s mode, %s identity, %s backend)')
+        :format(state.mode, state.device and 'device' or 'sim', siminv.backendName()))
 end)
 
 ---Extracts the used item's slot + SIM number for both usable-item callback shapes (ox passes a
@@ -217,15 +218,19 @@ lib.callback.register('sd-phone:server:sim:get', function(source)
     local sims = {}
     if s then
         for _, entry in ipairs(s.sims) do
-            sims[#sims + 1] = {
-                number = entry.number,
-                color  = entry.color,
-                active = s.active ~= nil and entry.slot == s.active.slot,
-            }
+            -- Device mode carries SIM-less phones too; the SIM list only shows numbered ones.
+            if entry.number then
+                sims[#sims + 1] = {
+                    number = entry.number,
+                    color  = entry.color,
+                    active = s.active ~= nil and entry.slot == s.active.slot,
+                }
+            end
         end
     end
     return util.ok({
         mode          = state.mode,
+        device        = state.device,
         hasSim        = s ~= nil and s.hasSim or false,
         number        = s and s.number or nil,
         color         = s and s.color or nil,
@@ -234,8 +239,10 @@ lib.callback.register('sd-phone:server:sim:get', function(source)
                         and s ~= nil and s.hasSim or false,
         backupOn      = config.Sim.Backup and config.Sim.Backup.Enabled ~= false or false,
         backupEnabled = b ~= nil and b.enabled or false,
-        canRestore    = b ~= nil and b.enabled and s ~= nil and s.hasSim
-                        and s.identity ~= b.identity or false,
+        -- Device mode restores onto the DEVICE identity (no SIM required); legacy needs the SIM.
+        canRestore    = b ~= nil and b.enabled and s ~= nil and s.identity ~= nil
+                        and s.identity ~= b.identity
+                        and (state.device or s.hasSim) or false,
     })
 end)
 
@@ -300,7 +307,10 @@ lib.callback.register('sd-phone:server:sim:backup:restore', function(source, pay
     local b = simStore.getBackup(realCid)
     if not b or not b.enabled then return util.fail('No cloud backup found for this character.') end
     local s = session.resolve(source)
-    if not s or not s.identity or not s.number then return util.fail('Install a SIM card first.') end
+    -- Device mode restores onto the phone's own identity, no SIM/number required; legacy needs
+    -- the installed SIM (its identity + number ARE the phone).
+    if not s or not s.identity then return util.fail('Install a SIM card first.') end
+    if not state.device and not s.number then return util.fail('Install a SIM card first.') end
     if s.identity == b.identity then return util.fail('This phone already holds the backed-up data.') end
 
     if b.password then
@@ -312,7 +322,7 @@ lib.callback.register('sd-phone:server:sim:backup:restore', function(source, pay
         end
     end
 
-    local rows = backup.restore(b.identity, s.identity, s.number)
+    local rows = backup.restore(b.identity, s.identity, s.number or '')
     simStore.setBackup(realCid, s.identity, true, nil)
     print(('^3[sd-phone:sim]^0 restored backup %s -> %s for %s (%d rows)')
         :format(b.identity, s.identity, realCid, rows))

--- a/server/sim/init.lua
+++ b/server/sim/init.lua
@@ -34,15 +34,28 @@ function player.getIdentifier(source)
 end
 
 -- Reachability: a player is "online as" EVERY identity whose SIM they carry, not just the
--- active phone's - calls and messages addressed to any of their numbers reach them. (The
--- acting identity above stays the single active phone.)
+-- active phone's - calls addressed to any of their numbers ring them (a pocketed phone rings).
+local baseGetAnySource = player.getAnySourceByIdentifier
+function player.getAnySourceByIdentifier(citizenid)
+    if not state.active then return baseGetAnySource(citizenid) end
+    if not citizenid or citizenid == '' then return nil end
+    for _, src in ipairs(GetPlayers()) do
+        local s = tonumber(src)
+        if s and session.hasIdentity(s, citizenid) then return s end
+    end
+    return nil
+end
+
+-- Live-UI delivery: every push resolved through this lands only when `citizenid` is the phone
+-- the player is currently acting as. A push for the OTHER phone in their pocket is skipped -
+-- its data is already stored, and that phone surfaces it (threads, badges) on its next open.
 local baseGetSource = player.getSourceByIdentifier
 function player.getSourceByIdentifier(citizenid)
     if not state.active then return baseGetSource(citizenid) end
     if not citizenid or citizenid == '' then return nil end
     for _, src in ipairs(GetPlayers()) do
         local s = tonumber(src)
-        if s and session.hasIdentity(s, citizenid) then return s end
+        if s and session.identity(s) == citizenid then return s end
     end
     return nil
 end
@@ -207,6 +220,28 @@ inv.registerUsable(config.Sim.SimItem, function(source, itemArg, _invArg, slotAr
         or 'SIM installed - your number is %s.'):format(util.formatNumber(number)), 'success')
 end)
 
+---@type table<number, number> Last requestPush per source (GetGameTimer ms); floods are dropped.
+local lastRequestPush = {}
+
+---Client asks for a fresh SIM snapshot (fired once after character load, so the closed-phone
+---frame colour is right before the first open). Cooldown-guarded: push does a full inventory
+---rescan, so a flooding client only gets one every 5s.
+RegisterNetEvent('sd-phone:server:sim:requestPush', function()
+    local source = source
+    if not state.active then return end
+    -- No character yet (a resource-restart probe firing before the multichar pick): stay
+    -- silent and leave the cooldown unarmed, so the real character-load request still lands.
+    if not player.getRealIdentifier(source) then return end
+    local now = GetGameTimer()
+    if lastRequestPush[source] and (now - lastRequestPush[source]) < 5000 then return end
+    lastRequestPush[source] = now
+    session.push(source)
+end)
+
+AddEventHandler('playerDropped', function()
+    lastRequestPush[source] = nil
+end)
+
 ---The player's SIM panel snapshot for Settings -> SIM & Backup. Drops the session cache first
 ---so the panel always reflects the live inventory. Read-only.
 lib.callback.register('sd-phone:server:sim:get', function(source)
@@ -326,6 +361,9 @@ lib.callback.register('sd-phone:server:sim:backup:restore', function(source, pay
     simStore.setBackup(realCid, s.identity, true, nil)
     print(('^3[sd-phone:sim]^0 restored backup %s -> %s for %s (%d rows)')
         :format(b.identity, s.identity, realCid, rows))
+    -- The restored data replaced the acting profile in place: the client resets the NUI (kept-
+    -- alive apps, hydrated settings, caches) so nothing keeps showing pre-restore state.
+    TriggerClientEvent('sd-phone:client:profileReset', source)
     return util.ok({ rows = rows })
 end)
 

--- a/server/sim/inv.lua
+++ b/server/sim/inv.lua
@@ -78,6 +78,38 @@ function inv.getSimNumber(source, phone)
     return digits ~= '' and digits or nil
 end
 
+---The persistent DEVICE identity stamped onto a phone item, plus the first-activator cid that
+---owns it. Both live on the phone item metadata in either attach mode (they describe the PHONE,
+---not the SIM). Read-only; nil fields when never minted.
+---@param phone { metadata: table }
+---@return string|nil deviceId, string|nil ownerCid
+function inv.getDevice(phone)
+    local md = phone.metadata
+    if type(md) ~= 'table' then return nil, nil end
+    local id = md.deviceId
+    if type(id) ~= 'string' or id == '' then id = nil end
+    local owner = md.deviceOwner
+    if type(owner) ~= 'string' or owner == '' then owner = nil end
+    return id, owner
+end
+
+---Stamps the device identity (and, first time, the owning character) onto a phone item's
+---metadata, merging into the existing slot metadata so the SIM number, container id and
+---durability survive. Device-identity mode only.
+---@param source number player server id
+---@param slot number phone item slot
+---@param deviceId string persistent device identity
+---@param ownerCid string|nil first-activator real citizenid (Face Unlock owner gate)
+---@return boolean ok
+function inv.setPhoneDevice(source, slot, deviceId, ownerCid)
+    local row = bridge.getSlot(source, slot)
+    if not row then return false end
+    local metadata = row.metadata
+    metadata.deviceId = deviceId
+    if ownerCid then metadata.deviceOwner = ownerCid end
+    return bridge.setSlotMetadata(source, slot, metadata)
+end
+
 ---Writes (or clears, with nil) the SIM number onto a phone item's metadata - metadata mode
 ---only. Merges into the slot's existing metadata so container ids, durability etc. survive.
 ---@param source number player server id

--- a/server/sim/session.lua
+++ b/server/sim/session.lua
@@ -158,8 +158,14 @@ local function resolveDevice(source, phone, number)
 
     if not identity then
         if number then
+            -- Adoption is a ONE-SHOT grandfathering step: the first phone to carry a legacy SIM
+            -- inherits its profile, but claimAdoption atomically binds the card so a second phone
+            -- that later receives the same SIM mints a fresh device identity (number, not data).
             local simIdentity = simStore.ensureRegistered(number, realCid)
-            if simIdentity and settingsStore.hasData(simIdentity) then identity = simIdentity end
+            if simIdentity and settingsStore.hasData(simIdentity)
+                and simStore.claimAdoption(number, simIdentity) then
+                identity = simIdentity
+            end
         end
         identity = identity or ('device:' .. util.newId(16))
         dirty = true

--- a/server/sim/session.lua
+++ b/server/sim/session.lua
@@ -6,6 +6,8 @@ local simStore      = require 'server.sim.store'
 local siminv        = require 'server.sim.inv'
 ---@type table Settings persistence (server.settings.store): phone_settings number sync.
 local settingsStore = require 'server.settings.store'
+---@type table Shared server helpers (server.util): newId for minting device identities.
+local util          = require 'server.util'
 
 ---@type table Session module; the table returned at end of file. Resolves every SIM each
 ---connected player is carrying (a player can hold several phones with different numbers), which
@@ -25,11 +27,13 @@ function session.setRealResolver(fn) realIdentifier = fn end
 local TTL = 5000
 
 ---@class SimEntry
----@field slot number inventory slot of the phone holding this SIM
+---@field slot number inventory slot of the phone
 ---@field name string phone item name
 ---@field color string phone frame colour
----@field number string bare-digit SIM number
----@field identity string data identity the SIM maps to
+---@field number string|nil bare-digit SIM number (device mode: nil when the phone has no SIM)
+---@field identity string data identity (SIM identity in legacy, device identity in device mode)
+---@field hasSim boolean|nil device mode: whether this phone has a SIM installed
+---@field owner string|nil device mode: the phone's first-activator cid (Face Unlock gate)
 
 ---@class SimSession
 ---@field hasPhone boolean player carries at least one configured phone item
@@ -71,16 +75,40 @@ function session.setActive(source, pref)
     session.invalidate(source)
 end
 
----Scans the player's inventory and binds every SIM found: unknown numbers are registered, the
+---Picks the active entry among `entries` from the player's last-opened hint (slot > number >
+---colour), falling back to the first entry.
+---@param source number player server id
+---@param entries SimEntry[]
+---@return SimEntry|nil
+local function pickActive(source, entries)
+    local active
+    local pref = prefs[source]
+    if pref then
+        for _, entry in ipairs(entries) do
+            if pref.slot and entry.slot == pref.slot then active = entry break end
+        end
+        if not active and pref.number then
+            for _, entry in ipairs(entries) do
+                if entry.number == pref.number then active = entry break end
+            end
+        end
+        if not active and pref.color then
+            for _, entry in ipairs(entries) do
+                if entry.color == pref.color then active = entry break end
+            end
+        end
+    end
+    return active or entries[1]
+end
+
+---LEGACY (SIM-is-identity) resolver. Binds every SIM found: unknown numbers are registered, the
 ---first activator stamped, and each SIM identity's phone_settings row mirrors its number so
 ---every existing "my number" read keeps working. The active phone is the last-opened one
 ---(prefs), else the first SIM'd phone in config order, else the first phone.
 ---@param source number player server id
----@return SimSession|nil s nil when the player carries no phone item
-local function compute(source)
-    local phones = siminv.findPhones(source)
-    if #phones == 0 then return nil end
-
+---@param phones { slot: number, name: string, color: string, metadata: table }[]
+---@return SimSession
+local function computeLegacy(source, phones)
     local sims = {}
     for _, phone in ipairs(phones) do
         local number = siminv.getSimNumber(source, phone)
@@ -101,34 +129,7 @@ local function compute(source)
         end
     end
 
-    local active
-    local pref = prefs[source]
-    if pref then
-        for _, entry in ipairs(sims) do
-            if pref.slot and entry.slot == pref.slot then
-                active = entry
-                break
-            end
-        end
-        if not active and pref.number then
-            for _, entry in ipairs(sims) do
-                if entry.number == pref.number then
-                    active = entry
-                    break
-                end
-            end
-        end
-        if not active and pref.color then
-            for _, entry in ipairs(sims) do
-                if entry.color == pref.color then
-                    active = entry
-                    break
-                end
-            end
-        end
-    end
-    active = active or sims[1]
-
+    local active = pickActive(source, sims)
     return {
         hasPhone = true,
         hasSim   = active ~= nil,
@@ -139,6 +140,92 @@ local function compute(source)
         color    = active and active.color or phones[1].color,
         slot     = active and active.slot or phones[1].slot,
     }
+end
+
+---Resolves a phone's persistent DEVICE identity, minting one into the item metadata on first
+---use. ADOPTS an installed SIM's existing profile (its `sim:<number>` or bound citizenid
+---identity) when that profile already has data, so a legacy server flipping DeviceIdentity on
+---grandfathers every phone in place; a fresh phone gets a `device:<id>` of its own. Also stamps
+---the first-activator cid as the Face Unlock owner.
+---@param source number player server id
+---@param phone { slot: number, metadata: table }
+---@param number string|nil the SIM number currently installed
+---@return string identity, string|nil owner
+local function resolveDevice(source, phone, number)
+    local identity, owner = siminv.getDevice(phone)
+    local realCid = realIdentifier(source)
+    local dirty = false
+
+    if not identity then
+        if number then
+            local simIdentity = simStore.ensureRegistered(number, realCid)
+            if simIdentity and settingsStore.hasData(simIdentity) then identity = simIdentity end
+        end
+        identity = identity or ('device:' .. util.newId(16))
+        dirty = true
+    end
+    if not owner and realCid then
+        owner = realCid
+        dirty = true
+    end
+    if dirty then siminv.setPhoneDevice(source, phone.slot, identity, owner) end
+    return identity, owner
+end
+
+---DEVICE (phone-owns-data) resolver. Every carried phone maps to its own persistent device
+---identity regardless of SIM; a SIM only supplies the number + service. Each SIM'd phone mirrors
+---its number onto its device row (so number lookups resolve to the DEVICE), and a phone whose
+---SIM was pulled has its number mirror cleared (no SIM = no number, but the phone still works).
+---@param source number player server id
+---@param phones { slot: number, name: string, color: string, metadata: table }[]
+---@return SimSession
+local function computeDevice(source, phones)
+    local realCid = realIdentifier(source)
+    local devices = {}
+    for _, phone in ipairs(phones) do
+        local number = siminv.getSimNumber(source, phone)
+        local identity, owner = resolveDevice(source, phone, number)
+        if number then
+            simStore.ensureRegistered(number, realCid)
+            if settingsStore.getPhoneNumber(identity) ~= number then
+                settingsStore.setPhoneNumber(identity, number)
+            end
+        else
+            local existing = settingsStore.getPhoneNumber(identity)
+            if existing and existing ~= '' then settingsStore.clearPhoneNumber(identity) end
+        end
+        devices[#devices + 1] = {
+            slot     = phone.slot,
+            name     = phone.name,
+            color    = phone.color,
+            number   = number,
+            identity = identity,
+            hasSim   = number ~= nil,
+            owner    = owner,
+        }
+    end
+
+    local active = pickActive(source, devices)
+    return {
+        hasPhone = true,
+        hasSim   = active ~= nil and active.hasSim == true,
+        sims     = devices,
+        active   = active,
+        identity = active and active.identity or nil,
+        number   = active and active.number or nil,
+        color    = active and active.color or phones[1].color,
+        slot     = active and active.slot or phones[1].slot,
+    }
+end
+
+---Scans the player's inventory and resolves their SIM/device session for the active mode.
+---@param source number player server id
+---@return SimSession|nil s nil when the player carries no phone item
+local function compute(source)
+    local phones = siminv.findPhones(source)
+    if #phones == 0 then return nil end
+    if state.device then return computeDevice(source, phones) end
+    return computeLegacy(source, phones)
 end
 
 ---The player's current SIM session, cached for TTL ms. Nil when the player carries no phone.
@@ -184,14 +271,20 @@ function session.hasIdentity(source, identity)
     return session.identities(source)[identity] == true
 end
 
----True when the ACTIVE phone "belongs" to the player: its SIM's first activator matches their
----real character. Gates Face Unlock so a stolen phone never face-unlocks for the thief.
+---True when the ACTIVE phone "belongs" to the player: its first activator matches their real
+---character. Gates Face Unlock so a stolen phone never face-unlocks for the thief. Device mode
+---gates on the DEVICE owner (stamped on the phone item, so it holds even with the SIM out);
+---legacy gates on the installed SIM's owner.
 ---@param source number player server id
 ---@return boolean owner
 function session.isOwner(source)
     if not state.active then return true end
     local s = session.resolve(source)
-    if not s or not s.number then return false end
+    if not s then return false end
+    if state.device then
+        return s.active ~= nil and s.active.owner ~= nil and s.active.owner == realIdentifier(source)
+    end
+    if not s.number then return false end
     local row = simStore.get(s.number)
     if not row or not row.owner_cid then return false end
     return row.owner_cid == realIdentifier(source)
@@ -206,9 +299,13 @@ function session.push(source)
     local s = session.resolve(source)
     TriggerClientEvent('sd-phone:client:simState', source, {
         enabled = true,
+        device  = state.device,
         hasSim  = s ~= nil and s.hasSim or false,
         number  = s and s.number or nil,
         color   = s and s.color or nil,
+        -- Device mode: the setup/profile localStorage namespace keys off the DEVICE identity (so
+        -- swapping SIMs on one phone never resets it); legacy keys off the number, client-side.
+        profile = state.device and s and s.identity or nil,
     })
 end
 

--- a/server/sim/session.lua
+++ b/server/sim/session.lua
@@ -117,6 +117,8 @@ local function computeLegacy(source, phones)
             if identity then
                 if settingsStore.getPhoneNumber(identity) ~= number then
                     settingsStore.setPhoneNumber(identity, number)
+                    -- Back in service: store-and-forward listeners deliver anything queued.
+                    TriggerEvent('sd-phone:server:sim:numberAttached', source, identity, number)
                 end
                 sims[#sims + 1] = {
                     slot     = phone.slot,
@@ -195,6 +197,8 @@ local function computeDevice(source, phones)
             simStore.ensureRegistered(number, realCid)
             if settingsStore.getPhoneNumber(identity) ~= number then
                 settingsStore.setPhoneNumber(identity, number)
+                -- Back in service: store-and-forward listeners deliver anything queued.
+                TriggerEvent('sd-phone:server:sim:numberAttached', source, identity, number)
             end
         else
             local existing = settingsStore.getPhoneNumber(identity)

--- a/server/sim/state.lua
+++ b/server/sim/state.lua
@@ -7,4 +7,8 @@ return {
     active = false,
     ---@type 'container'|'metadata'|nil How SIMs attach to phones; nil while inactive.
     mode = nil,
+    ---@type boolean True in DEVICE-identity mode (config.Sim.DeviceIdentity): the phone item
+    ---owns the data and a SIM only lends a number. False = LEGACY, where the SIM is the identity.
+    ---Only meaningful while `active`.
+    device = false,
 }

--- a/server/sim/store.lua
+++ b/server/sim/store.lua
@@ -19,11 +19,19 @@ function store.ensureSchema()
             number     VARCHAR(20) NOT NULL,
             identity   VARCHAR(64) NOT NULL,
             owner_cid  VARCHAR(64) NULL,
+            adopted_by VARCHAR(64) NULL,
             created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (number),
             INDEX idx_phone_sim_identity (identity)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
+    local hasAdoptedBy = MySQL.scalar.await([[
+        SELECT COUNT(*) FROM information_schema.columns
+        WHERE table_schema = DATABASE() AND table_name = 'phone_sim_cards' AND column_name = 'adopted_by'
+    ]])
+    if (tonumber(hasAdoptedBy) or 0) == 0 then
+        MySQL.query.await('ALTER TABLE phone_sim_cards ADD COLUMN adopted_by VARCHAR(64) NULL')
+    end
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_cloud_backups (
             citizenid  VARCHAR(64) NOT NULL,
@@ -146,6 +154,21 @@ function store.ensureRegistered(number, activatorCid)
         row.owner_cid = activatorCid
     end
     return row.identity
+end
+
+---One-shot claim of a SIM's legacy profile for device-mode grandfathering: atomically stamps
+---`adopted_by` on the card, succeeding only for the FIRST phone to adopt it. A second phone that
+---later receives the same SIM sees the claim and gets the number, not the data.
+---@param number string bare-digit SIM number
+---@param identity string data identity being adopted (the card's legacy sim:/citizenid identity)
+---@return boolean claimed true only when THIS call took the (previously unclaimed) card
+function store.claimAdoption(number, identity)
+    local digits = util.digits(number)
+    if digits == '' or not identity or identity == '' then return false end
+    local affected = MySQL.update.await(
+        'UPDATE phone_sim_cards SET adopted_by = ? WHERE number = ? AND adopted_by IS NULL',
+        { identity, digits })
+    return (tonumber(affected) or 0) > 0
 end
 
 ---Reads a character's cloud-backup pointer, or nil when never enabled. Read-only.

--- a/server/sim/store.lua
+++ b/server/sim/store.lua
@@ -50,6 +50,60 @@ function store.ensureSchema()
     if (tonumber(hasPassword) or 0) == 0 then
         MySQL.query.await('ALTER TABLE phone_cloud_backups ADD COLUMN password VARCHAR(64) NULL')
     end
+    local hasDevice = MySQL.scalar.await([[
+        SELECT COUNT(*) FROM information_schema.columns
+        WHERE table_schema = DATABASE() AND table_name = 'phone_cloud_backups' AND column_name = 'device_identity'
+    ]])
+    if (tonumber(hasDevice) or 0) == 0 then
+        MySQL.query.await('ALTER TABLE phone_cloud_backups ADD COLUMN device_identity VARCHAR(64) NULL')
+        MySQL.query.await('ALTER TABLE phone_cloud_backups ADD COLUMN auto_sync TINYINT(1) NOT NULL DEFAULT 1')
+        MySQL.query.await('ALTER TABLE phone_cloud_backups ADD COLUMN synced_at BIGINT NULL')
+    end
+
+    -- Multi-profile backups: one row per (character, phone). The single-slot table above stays
+    -- as the migration source and is otherwise unused.
+    MySQL.query.await([[
+        CREATE TABLE IF NOT EXISTS phone_cloud_profiles (
+            citizenid       VARCHAR(64) NOT NULL,
+            device_identity VARCHAR(64) NOT NULL,
+            identity        VARCHAR(64) NOT NULL,
+            enabled         TINYINT(1)  NOT NULL DEFAULT 1,
+            auto_sync       TINYINT(1)  NOT NULL DEFAULT 1,
+            synced_at       BIGINT      NULL,
+            color           VARCHAR(32) NULL,
+            number          VARCHAR(32) NULL,
+            updated_at      TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
+                ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (citizenid, device_identity)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    ]])
+    MySQL.query.await([[
+        CREATE TABLE IF NOT EXISTS phone_cloud_accounts (
+            citizenid  VARCHAR(64) NOT NULL,
+            password   VARCHAR(64) NULL,
+            updated_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
+                ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (citizenid)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    ]])
+    -- One-shot migration of single-slot rows (a legacy pointer row's device IS its identity).
+    -- Only when the profiles table has never been populated, so deleted profiles stay deleted.
+    local migrated = MySQL.scalar.await('SELECT 1 FROM phone_cloud_profiles LIMIT 1')
+    if not migrated then
+        pcall(function()
+            MySQL.query.await([[
+                INSERT IGNORE INTO phone_cloud_profiles
+                    (citizenid, device_identity, identity, enabled, auto_sync, synced_at)
+                SELECT citizenid, COALESCE(device_identity, identity), identity, enabled,
+                       COALESCE(auto_sync, 1), synced_at
+                FROM phone_cloud_backups
+            ]])
+            MySQL.query.await([[
+                INSERT IGNORE INTO phone_cloud_accounts (citizenid, password)
+                SELECT citizenid, password FROM phone_cloud_backups WHERE password IS NOT NULL
+            ]])
+        end)
+    end
 end
 
 ---True when a number is already claimed - by a registered SIM or by any legacy
@@ -171,33 +225,142 @@ function store.claimAdoption(number, identity)
     return (tonumber(affected) or 0) > 0
 end
 
----Reads a character's cloud-backup pointer, or nil when never enabled. Read-only.
----@param citizenid string real (framework) citizenid
----@return { identity: string, enabled: boolean, password: string|nil }|nil
-function store.getBackup(citizenid)
-    if not citizenid or citizenid == '' then return nil end
-    local row = MySQL.single.await(
-        'SELECT identity, enabled, password FROM phone_cloud_backups WHERE citizenid = ?', { citizenid })
-    if not row then return nil end
-    return { identity = row.identity, enabled = util.truthy(row.enabled), password = row.password }
+---Shapes a phone_cloud_profiles row for callers.
+---@param row table raw DB row
+---@return table profile
+local function shapeProfile(row)
+    return {
+        deviceIdentity = row.device_identity,
+        identity       = row.identity,
+        enabled        = util.truthy(row.enabled),
+        autoSync       = util.truthy(row.auto_sync),
+        syncedAt       = tonumber(row.synced_at),
+        color          = row.color,
+        number         = row.number,
+    }
 end
 
----Upserts a character's cloud-backup pointer: which phone profile is "in the cloud", whether
----backup is currently on, and the (hashed) backup password. A nil passwordHash keeps whatever
----password is already stored.
+---A character's backup profiles, most recently synced first. Read-only.
 ---@param citizenid string real (framework) citizenid
----@param identity string phone profile the backup points at
----@param enabled boolean
----@param passwordHash string|nil hashed backup password
-function store.setBackup(citizenid, identity, enabled, passwordHash)
-    if not citizenid or citizenid == '' or not identity or identity == '' then return end
+---@return table[] profiles
+function store.listProfiles(citizenid)
+    if not citizenid or citizenid == '' then return {} end
+    local rows = MySQL.query.await([[
+        SELECT device_identity, identity, enabled, auto_sync, synced_at, color, number
+        FROM phone_cloud_profiles WHERE citizenid = ?
+        ORDER BY synced_at DESC
+    ]], { citizenid }) or {}
+    local out = {}
+    for i = 1, #rows do out[i] = shapeProfile(rows[i]) end
+    return out
+end
+
+---One phone's backup profile, or nil.
+---@param citizenid string real (framework) citizenid
+---@param deviceIdentity string phone identity
+---@return table|nil profile
+function store.getProfile(citizenid, deviceIdentity)
+    if not citizenid or citizenid == '' or not deviceIdentity or deviceIdentity == '' then return nil end
+    local row = MySQL.single.await([[
+        SELECT device_identity, identity, enabled, auto_sync, synced_at, color, number
+        FROM phone_cloud_profiles WHERE citizenid = ? AND device_identity = ?
+    ]], { citizenid, deviceIdentity })
+    return row and shapeProfile(row) or nil
+end
+
+---Creates or re-enables a phone's backup profile with its snapshot namespace.
+---@param citizenid string real (framework) citizenid
+---@param deviceIdentity string phone identity
+---@param cloudIdentity string snapshot identity
+function store.upsertProfile(citizenid, deviceIdentity, cloudIdentity)
+    if not citizenid or citizenid == '' or not deviceIdentity or deviceIdentity == '' then return end
     MySQL.update.await([[
-        INSERT INTO phone_cloud_backups (citizenid, identity, enabled, password) VALUES (?, ?, ?, ?)
-        ON DUPLICATE KEY UPDATE
-            identity = VALUES(identity),
-            enabled  = VALUES(enabled),
-            password = COALESCE(VALUES(password), password)
-    ]], { citizenid, identity, enabled and 1 or 0, passwordHash })
+        INSERT INTO phone_cloud_profiles (citizenid, device_identity, identity, enabled)
+        VALUES (?, ?, ?, 1)
+        ON DUPLICATE KEY UPDATE enabled = 1, identity = VALUES(identity)
+    ]], { citizenid, deviceIdentity, cloudIdentity })
+end
+
+---Flips one profile's enabled flag.
+---@param citizenid string real (framework) citizenid
+---@param deviceIdentity string phone identity
+---@param on boolean
+function store.setProfileEnabled(citizenid, deviceIdentity, on)
+    MySQL.update.await(
+        'UPDATE phone_cloud_profiles SET enabled = ? WHERE citizenid = ? AND device_identity = ?',
+        { on == true and 1 or 0, citizenid, deviceIdentity })
+end
+
+---Flips one profile's auto-sync flag.
+---@param citizenid string real (framework) citizenid
+---@param deviceIdentity string phone identity
+---@param on boolean
+function store.setProfileAuto(citizenid, deviceIdentity, on)
+    MySQL.update.await(
+        'UPDATE phone_cloud_profiles SET auto_sync = ? WHERE citizenid = ? AND device_identity = ?',
+        { on == true and 1 or 0, citizenid, deviceIdentity })
+end
+
+---Records a completed snapshot sync plus the picker labels (frame colour + number at sync time).
+---@param citizenid string real (framework) citizenid
+---@param deviceIdentity string phone identity
+---@param syncedAt number unix epoch
+---@param color string|nil frame colour
+---@param number string|nil bare-digit number
+function store.setProfileSynced(citizenid, deviceIdentity, syncedAt, color, number)
+    MySQL.update.await([[
+        UPDATE phone_cloud_profiles SET synced_at = ?, color = ?, number = ?
+        WHERE citizenid = ? AND device_identity = ?
+    ]], { syncedAt, color, number, citizenid, deviceIdentity })
+end
+
+---Converts a legacy pointer profile to its minted snapshot namespace.
+---@param citizenid string real (framework) citizenid
+---@param deviceIdentity string phone identity
+---@param identity string new snapshot identity
+function store.setProfileIdentity(citizenid, deviceIdentity, identity)
+    MySQL.update.await(
+        'UPDATE phone_cloud_profiles SET identity = ? WHERE citizenid = ? AND device_identity = ?',
+        { identity, citizenid, deviceIdentity })
+end
+
+---Deletes one profile row (the caller wipes the snapshot data itself).
+---@param citizenid string real (framework) citizenid
+---@param deviceIdentity string phone identity
+function store.deleteProfile(citizenid, deviceIdentity)
+    MySQL.update.await(
+        'DELETE FROM phone_cloud_profiles WHERE citizenid = ? AND device_identity = ?',
+        { citizenid, deviceIdentity })
+end
+
+---How many backup profiles a character holds (enabled or not - disabled ones keep snapshots).
+---@param citizenid string real (framework) citizenid
+---@return number
+function store.profileCount(citizenid)
+    local n = MySQL.scalar.await(
+        'SELECT COUNT(*) FROM phone_cloud_profiles WHERE citizenid = ?', { citizenid })
+    return tonumber(n) or 0
+end
+
+---The character's cloud-account password hash, or nil when never set.
+---@param citizenid string real (framework) citizenid
+---@return string|nil passwordHash
+function store.getBackupPassword(citizenid)
+    if not citizenid or citizenid == '' then return nil end
+    local row = MySQL.single.await(
+        'SELECT password FROM phone_cloud_accounts WHERE citizenid = ?', { citizenid })
+    return row and row.password or nil
+end
+
+---Sets the character-level backup password (upsert; one password guards every profile).
+---@param citizenid string real (framework) citizenid
+---@param passwordHash string
+function store.setBackupPassword(citizenid, passwordHash)
+    if not citizenid or citizenid == '' then return end
+    MySQL.update.await([[
+        INSERT INTO phone_cloud_accounts (citizenid, password) VALUES (?, ?)
+        ON DUPLICATE KEY UPDATE password = VALUES(password)
+    ]], { citizenid, passwordHash })
 end
 
 ---Moves a registered SIM to a different number, keeping its identity, owner and backups intact.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,6 +43,7 @@ import { customToAppDef, installedCustomIds, isCustomApp, setCustomInstalled, us
 import { resolveWallpaper } from '@/shell/wallpapers';
 import { NoSimScreen } from '@/shell/NoSimScreen';
 import { useNoService, useNoSim, useSimStore } from '@/stores/simStore';
+import { resetContacts, syncSimNumber } from '@/stores/contactsStore';
 import { playOnce } from '@/apps/settings/tonePlayer';
 import { resolveTone, toneUrl } from '@/apps/settings/tones';
 import { AlarmRinging, AlarmPeekBanner } from '@/apps/clock/AlarmRinging';
@@ -209,6 +210,12 @@ function AppContent() {
     const downloadTimer = useRef<number>();
 
     const noSim = useNoSim();
+    const simEnabled = useSimStore(s => s.enabled);
+    // Unique phones: setup completion lives in a per-profile localStorage namespace, and the
+    // profile arrives via the deferred SIM resolve - AFTER the reveal on a fresh NUI (rejoin).
+    // Until it lands, the bare namespace reads "not completed", so the Hello screen must wait
+    // for the profile or a set-up phone re-runs setup on every rejoin.
+    const [simProfileReady, setSimProfileReady] = useState(false);
     // Device mode: no SIM means no cellular service, but the phone still opens and works - the
     // status bar shows "No Service" and only number-dependent actions (call/text) are refused
     // server-side. (In legacy mode useNoSim drives the full-screen wall instead.)
@@ -226,6 +233,10 @@ function AppContent() {
     }, [noSim]);
 
     const [setup, setSetup] = useState<SetupSaved>(() => loadSetup());
+    // Server-side twin of the localStorage flag (phone_settings.setup_done): survives a cleared
+    // FiveM cache / another PC. null = this profile's hydrate hasn't answered yet.
+    const serverSetupDone = useThemeStore(s => s.setupDone);
+    const setupCompleted = setup.completed || serverSetupDone === true;
     // Theme and wallpaper are NOT re-applied from the saved setup on launch. Both
     // persist server-side (phone_settings) and hydrate via settings:get on mount;
     // re-applying the localStorage setup value every launch clobbered the player's
@@ -243,6 +254,8 @@ function AppContent() {
         };
         setSetup(next);
         saveSetup(next);
+        useThemeStore.setState({ setupDone: true });
+        if (isFiveM) void fetchNui('sd-phone:settings:setSetupDone').catch(() => {});
         setTheme(result.theme);
         setWallpaper(result.wallpaper);
         setSecurity(result.pin, result.faceUnlock);
@@ -262,6 +275,36 @@ function AppContent() {
     // drop every trace of the previous profile from the UI (kept-alive apps, cached app
     // logins, hydrated settings). The server never leaks across identities; this stops the
     // client's own memory from doing it. Runs on every open AND on live SIM swaps.
+    // Drops every UI trace of the acting profile: kept-alive apps, cached logins, notification
+    // stacks, data caches, hydrated settings. Visuals reset to stock synchronously so the
+    // previous profile's wallpaper/clock never paint while the fresh hydrate is in flight.
+    // Runs on a phone/SIM switch AND when a cloud-backup restore replaces the data in place.
+    const resetProfileUi = useCallback(() => {
+        try {
+            window.localStorage.removeItem('sd-phone:mail:folderOrder');
+            window.localStorage.removeItem('sd-phone:mail:activeAccount');
+        } catch { /* ignore */ }
+        lastOpenAppRef.current = null;
+        resetAuth();
+        useMusicLibrary.getState().reset();
+        useThemeStore.getState().resetProfileVisuals();
+        useThemeStore.getState().hydrate();
+        useLocaleStore.getState().hydrate();
+        resetContacts();
+        setNotifs([]);
+        setLockNotifs([]);
+        setPeekNotif(null);
+        useBadgeStore.getState().setServer({});
+        if (isFiveM) void fetchNui<Record<string, number>>('sd-phone:badges:get').then(m => useBadgeStore.getState().setServer(m ?? {}));
+        setLocked(true);
+        setCurrentApp(null);
+        setRecentApps([]);
+        setRetained([]);
+        setForegroundKeys({});
+        setSwitcherOpen(false);
+        setSwitcherClosing(false);
+    }, []);
+
     const applySimProfile = useCallback((enabled?: boolean, hasSim?: boolean, num?: string, device?: boolean, profile?: string) => {
         // Device mode keys per-phone state off the DEVICE identity (stable across SIM swaps on
         // one phone); legacy keys off the SIM number. Either way a null key means "don't switch".
@@ -269,31 +312,38 @@ function AppContent() {
             ? (device ? (profile || null) : ((hasSim && num) || null))
             : null;
         let switched = false;
+        const prevKey = lastSimNumberRef.current;
         if (key) {
             setSetupProfile(key);
-            if (lastSimNumberRef.current && lastSimNumberRef.current !== key) switched = true;
+            setSimProfileReady(true);
+            if (prevKey && prevKey !== key) switched = true;
             lastSimNumberRef.current = key;
+            if (!prevKey) {
+                // First profile application this NUI session (fresh rejoin): collect banners
+                // parked for this phone by pocket buzzes that arrived before its first open.
+                const parked = lockNotifBankRef.current[key];
+                delete lockNotifBankRef.current[key];
+                if (parked && parked.length > 0) {
+                    setLockNotifs(prev => [...prev, ...parked.filter(p => !prev.some(n => n.id === p.id))].slice(0, 5));
+                }
+            }
         }
         if (enabled) setSetup(loadSetup());
         if (switched) {
-            try {
-                window.localStorage.removeItem('sd-phone:mail:folderOrder');
-                window.localStorage.removeItem('sd-phone:mail:activeAccount');
-            } catch { /* ignore */ }
-            lastOpenAppRef.current = null;
-            resetAuth();
-            useMusicLibrary.getState().reset();
-            useThemeStore.getState().hydrate();
-            useLocaleStore.getState().hydrate();
-            setLocked(true);
-            setCurrentApp(null);
-            setRecentApps([]);
-            setRetained([]);
-            setForegroundKeys({});
-            setSwitcherOpen(false);
-            setSwitcherClosing(false);
+            // Each phone keeps its OWN lockscreen stack: bank the outgoing phone's before the
+            // reset wipes it, and bring back whatever the incoming phone held when we last
+            // switched away from it (move semantics - the bank entry is consumed on return).
+            if (prevKey) lockNotifBankRef.current[prevKey] = lockNotifsRef.current;
+            const banked = key ? lockNotifBankRef.current[key] : undefined;
+            if (key) delete lockNotifBankRef.current[key];
+            resetProfileUi();
+            if (banked && banked.length > 0) setLockNotifs(banked);
         }
-    }, []);
+        // After any reset above: paint this profile's last-known wallpaper in the SAME render
+        // batch as the reveal, so the first open never flashes the stock background while the
+        // authoritative hydrate is still in flight.
+        useThemeStore.getState().applyWallpaperProfile(key);
+    }, [resetProfileUi]);
 
     // The framework loaded a character (first join or a switch): per-player settings become
     // resolvable only now, so restart both hydration pulls with a fresh retry budget.
@@ -308,6 +358,7 @@ function AppContent() {
         if (data.mailDomain) setMailDomain(data.mailDomain);
         useSimStore.getState().apply(data.sim);
         applySimProfile(data.sim?.enabled, data.sim?.hasSim, data.sim?.number, data.sim?.device, data.sim?.profile);
+        syncSimNumber(data.sim);
         const nextView: ViewState = {
             apps:          data.apps,
             dock:          data.dock,
@@ -371,7 +422,15 @@ function AppContent() {
     useNuiEvent('sd-phone:simState', useCallback((data) => {
         useSimStore.getState().apply(data);
         applySimProfile(data?.enabled, data?.hasSim, data?.number, data?.device, data?.profile);
+        syncSimNumber(data);
     }, [applySimProfile]));
+
+    // Cloud-backup restore replaced the acting profile's data in place (same identity, new
+    // contents): the same full reset as a phone switch, so no kept-alive app or hydrated
+    // setting keeps showing pre-restore data.
+    useNuiEvent('sd-phone:profileReset', useCallback(() => {
+        resetProfileUi();
+    }, [resetProfileUi]));
 
     useNuiEvent('sd-phone:close', useCallback(() => {
         setLeaving(true);
@@ -648,8 +707,16 @@ function AppContent() {
 
     const [notifs, setNotifs] = useState<NotificationItem[]>([]);
     const [lockNotifs, setLockNotifs] = useState<NotificationItem[]>([]);
+    const lockNotifsRef = useRef(lockNotifs);
+    lockNotifsRef.current = lockNotifs;
+    // Per-profile lockscreen stacks parked while another phone is active (in-memory, like the
+    // stacks themselves): written on switch-away, consumed on switch-back.
+    const lockNotifBankRef = useRef<Record<string, NotificationItem[]>>({});
     const [peek, setPeek] = useState<'in' | 'out' | null>(null);
     const [peekNotif, setPeekNotif] = useState<NotificationItem | null>(null);
+    // Pocket buzz: the buzzing phone's frame colour, so the closed-shell peek wears THAT
+    // phone's rail instead of the last-opened one's. Null = active phone's colour.
+    const [peekColor, setPeekColor] = useState<string | null>(null);
     const peekTimer = useRef<number | undefined>(undefined);
     const [ringingAlarm, setRingingAlarm] = useState<AlarmDef | null>(null);
     const ringingAlarmRef = useRef(ringingAlarm);
@@ -678,19 +745,31 @@ function AppContent() {
         if (phoneOpenRef.current && !lockedRef.current) {
             setNotifs(prev => [item, ...prev.filter(n => n.id !== item.id)].slice(0, 4));
         }
-        setLockNotifs(prev => [item, ...prev.filter(n => n.id !== item.id)].slice(0, 5));
         if (!phoneOpenRef.current && !ringingAlarmRef.current) {
             setPeekNotif(item);
+            setPeekColor(data.otherPhone ? (data.phoneColor ?? null) : null);
             setPeek('in');
             if (peekTimer.current) window.clearTimeout(peekTimer.current);
             peekTimer.current = window.setTimeout(() => setPeek('out'), 4200);
         }
+        const tones = useThemeStore.getState();
+        playOnce(resolveTone('notification', tones.notificationTone, tones.customNotificationTones).url, tones.ringtoneVol / 100);
+        // A pocket buzz belongs to the OTHER phone: transient banner + tone above, and the
+        // item parks on THAT phone's banked lockscreen stack for its next open - never this
+        // phone's live stack or badges.
+        if (data.otherPhone) {
+            const park = data.profileKey;
+            if (park) {
+                const bank = lockNotifBankRef.current;
+                bank[park] = [item, ...(bank[park] ?? []).filter(n => n.id !== item.id)].slice(0, 5);
+            }
+            return;
+        }
+        setLockNotifs(prev => [item, ...prev.filter(n => n.id !== item.id)].slice(0, 5));
         const badgeTarget = asAppId(target);
         if (badgeTarget && badgeTarget !== currentAppRef.current && !SERVER_BADGE_APPS.has(badgeTarget)) {
             useBadgeStore.getState().bump(badgeTarget);
         }
-        const tones = useThemeStore.getState();
-        playOnce(resolveTone('notification', tones.notificationTone, tones.customNotificationTones).url, tones.ringtoneVol / 100);
     }, []));
     const removeNotif = useCallback((id: string) => setNotifs(prev => prev.filter(n => n.id !== id)), []);
     const toggleFlashlight = useCallback(() => {
@@ -723,7 +802,7 @@ function AppContent() {
     }, []);
     useNuiEvent('sd-phone:launchApp', useCallback((data) => {
         const id = asAppId(data?.id);
-        if (!id || !setup.completed) return;
+        if (!id || !setupCompleted) return;
         if (lockedRef.current) {
             pendingCcApp.current = id;
             pendingLaunchLink.current = data.link;
@@ -732,21 +811,21 @@ function AppContent() {
             applyNotifLink(data.link);
             openAppById(id, { x: 0.5, y: 0.5 });
         }
-    }, [setup.completed, applyNotifLink, openAppById]));
+    }, [setupCompleted, applyNotifLink, openAppById]));
     useEffect(() => {
         if (peek !== 'out') return;
         const t = window.setTimeout(() => setPeek(null), 440);
         return () => window.clearTimeout(t);
     }, [peek]);
     useEffect(() => {
-        if (view) { setPeek(null); setPeekNotif(null); if (peekTimer.current) window.clearTimeout(peekTimer.current); }
+        if (view) { setPeek(null); setPeekNotif(null); setPeekColor(null); if (peekTimer.current) window.clearTimeout(peekTimer.current); }
     }, [view]);
 
     useEffect(() => { hydrateAlarms(); }, []);
     const phoneOpen = !!view;
     useEffect(() => { if (phoneOpen) hydrateAlarms(true); }, [phoneOpen]);
     useAutoContrast(
-        phoneOpen && !locked && setup.completed && currentApp !== 'camera',
+        phoneOpen && !locked && setupCompleted && currentApp !== 'camera',
         `${currentApp ?? ''}|${theme}|${locked}`,
     );
 
@@ -1040,7 +1119,7 @@ function AppContent() {
                 {deckLayer}
                 <div key="shell-closed" className={theme === 'dark' ? 'dark' : undefined} data-dark-theme={darkTheme}>
                 {peek && (
-                    <PhoneShell peek={peek} frameColor={frameColor} radioIsland={radioIsland} alarmIsland={{ ringing: !!ringingAlarm, since: ringingSince }}>
+                    <PhoneShell peek={peek} frameColor={peekColor ?? frameColor} radioIsland={radioIsland} alarmIsland={{ ringing: !!ringingAlarm, since: ringingSince }}>
                         <div className="wallpaper absolute inset-0" style={{ backgroundImage: `url(${peekWall})` }} />
                         <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/30 via-black/5 to-transparent" />
                         <StatusBar
@@ -1079,7 +1158,13 @@ function AppContent() {
 
     const canShowSwitcher = recentApps.length > 0 || !!currentApp;
 
-    const showSetup = !setup.completed;
+    // Hello only renders once the answer is trustworthy: the localStorage flag OR the server
+    // flag says completed -> never; unique phones -> wait for the resolved profile; in-game ->
+    // wait for the profile's settings hydrate (serverSetupDone non-null) so a cleared cache
+    // can't flash setup at a phone whose server flag says done.
+    const showSetup = !setupCompleted
+        && (!simEnabled || simProfileReady)
+        && (!isFiveM || serverSetupDone !== null);
 
     const cameraMode = currentApp === 'camera' && !isClosing && !locked;
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,7 +42,7 @@ import { listInstalledApps, installApp, uninstallApp, loadHomeLayout, saveHomeLa
 import { customToAppDef, installedCustomIds, isCustomApp, setCustomInstalled, useCustomApps, useCustomAppsStore } from '@/stores/customAppsStore';
 import { resolveWallpaper } from '@/shell/wallpapers';
 import { NoSimScreen } from '@/shell/NoSimScreen';
-import { useNoSim, useSimStore } from '@/stores/simStore';
+import { useNoService, useNoSim, useSimStore } from '@/stores/simStore';
 import { playOnce } from '@/apps/settings/tonePlayer';
 import { resolveTone, toneUrl } from '@/apps/settings/tones';
 import { AlarmRinging, AlarmPeekBanner } from '@/apps/clock/AlarmRinging';
@@ -209,6 +209,10 @@ function AppContent() {
     const downloadTimer = useRef<number>();
 
     const noSim = useNoSim();
+    // Device mode: no SIM means no cellular service, but the phone still opens and works - the
+    // status bar shows "No Service" and only number-dependent actions (call/text) are refused
+    // server-side. (In legacy mode useNoSim drives the full-screen wall instead.)
+    const noService = useNoService();
     // A pulled SIM drops the phone straight back to the (blocked) lock state: no app stays
     // foregrounded and the switcher/control-center close.
     useEffect(() => {
@@ -258,13 +262,17 @@ function AppContent() {
     // drop every trace of the previous profile from the UI (kept-alive apps, cached app
     // logins, hydrated settings). The server never leaks across identities; this stops the
     // client's own memory from doing it. Runs on every open AND on live SIM swaps.
-    const applySimProfile = useCallback((enabled?: boolean, hasSim?: boolean, num?: string) => {
-        const simNumber = (enabled && hasSim && num) || null;
+    const applySimProfile = useCallback((enabled?: boolean, hasSim?: boolean, num?: string, device?: boolean, profile?: string) => {
+        // Device mode keys per-phone state off the DEVICE identity (stable across SIM swaps on
+        // one phone); legacy keys off the SIM number. Either way a null key means "don't switch".
+        const key = enabled
+            ? (device ? (profile || null) : ((hasSim && num) || null))
+            : null;
         let switched = false;
-        if (simNumber) {
-            setSetupProfile(simNumber);
-            if (lastSimNumberRef.current && lastSimNumberRef.current !== simNumber) switched = true;
-            lastSimNumberRef.current = simNumber;
+        if (key) {
+            setSetupProfile(key);
+            if (lastSimNumberRef.current && lastSimNumberRef.current !== key) switched = true;
+            lastSimNumberRef.current = key;
         }
         if (enabled) setSetup(loadSetup());
         if (switched) {
@@ -299,7 +307,7 @@ function AppContent() {
         if (data.locale) useLocaleStore.getState().applyServerDefault(data.locale);   // server default, unless the player already picked their own
         if (data.mailDomain) setMailDomain(data.mailDomain);
         useSimStore.getState().apply(data.sim);
-        applySimProfile(data.sim?.enabled, data.sim?.hasSim, data.sim?.number);
+        applySimProfile(data.sim?.enabled, data.sim?.hasSim, data.sim?.number, data.sim?.device, data.sim?.profile);
         const nextView: ViewState = {
             apps:          data.apps,
             dock:          data.dock,
@@ -362,7 +370,7 @@ function AppContent() {
 
     useNuiEvent('sd-phone:simState', useCallback((data) => {
         useSimStore.getState().apply(data);
-        applySimProfile(data?.enabled, data?.hasSim, data?.number);
+        applySimProfile(data?.enabled, data?.hasSim, data?.number, data?.device, data?.profile);
     }, [applySimProfile]));
 
     useNuiEvent('sd-phone:close', useCallback(() => {
@@ -1037,11 +1045,12 @@ function AppContent() {
                         <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/30 via-black/5 to-transparent" />
                         <StatusBar
                             use24h={hour24}
-                            signal={(airplaneMode || noSim) ? 0 : (lv?.signal ?? 4)}
+                            signal={(airplaneMode || noSim || noService) ? 0 : (lv?.signal ?? 4)}
                             showWifi={(airplaneMode || noSim) ? false : ((lv?.showWifi ?? true) && ccWifi)}
                             battery={battery}
                             airplane={airplaneMode}
                             noSim={noSim}
+                            noService={noService}
                             light
                         />
                         {ringingAlarm ? (
@@ -1132,11 +1141,12 @@ function AppContent() {
                 {!(showSetup && setupHello && !noSim) && (
                     <StatusBar
                         use24h={hour24}
-                        signal={(airplaneMode || noSim) ? 0 : view.signal}
+                        signal={(airplaneMode || noSim || noService) ? 0 : view.signal}
                         showWifi={(airplaneMode || noSim) ? false : (view.showWifi && ccWifi)}
                         battery={battery}
                         airplane={airplaneMode}
                         noSim={noSim}
+                        noService={noService}
                         light={noSim ? true : (showSetup ? false : (cameraMode ? true : (statusLightOverride ?? statusBarAutoLight ?? statusLight)))}
                         controlHint={!showSetup && !cameraMode && !ccOpen && !homeEditing && !noSim}
                         editing={homeEditing && onHomescreen}

--- a/web/src/admin/pages/PlayerDetail.tsx
+++ b/web/src/admin/pages/PlayerDetail.tsx
@@ -333,7 +333,7 @@ function SimCard({ ov, toast, reload }: {
                 {sim.backup
                     ? <span className="inline-flex items-center gap-1.5">
                         {sim.backup.enabled ? <Badge tone="green">On</Badge> : <Badge>Off</Badge>}
-                        <span className="font-mono text-[12px] text-zinc-500">{sim.backup.identity}</span>
+                        <span className="font-mono text-[12px] text-zinc-500">{sim.backup.profiles} phone{sim.backup.profiles === 1 ? '' : 's'}</span>
                         {sim.backup.hasPassword && <Badge>password set</Badge>}
                     </span>
                     : 'Never enabled'}

--- a/web/src/admin/types.ts
+++ b/web/src/admin/types.ts
@@ -70,7 +70,7 @@ export interface AdminOverview {
     sim?: {
         mode: 'container' | 'metadata';
         sims: AdminSimRow[];
-        backup?: { identity: string; enabled: boolean; hasPassword: boolean } | null;
+        backup?: { profiles: number; enabled: boolean; hasPassword: boolean } | null;
         /** Only while the player is online. */
         activeNumber?: string | null;
         carried?: { number: string; color: string; active: boolean }[];

--- a/web/src/apps/messages/Messages.tsx
+++ b/web/src/apps/messages/Messages.tsx
@@ -31,7 +31,6 @@ type Draft = Omit<SendInput, 'conversation'>;
 export function Messages({ onClose }: { onClose: () => void }) {
     const [conversations, setConversations] = useState<Conversation[]>([]);
     const [contacts,      setContacts]      = useState<Contact[]>([]);
-    const [myNumber,      setMyNumber]      = useState('');
     const [openId,        setOpenId]        = useSessionState<string | null>('messages:openConvoId', null);
     const [composing,     setComposing]     = useSessionState('messages:composing', false);
     const [sendError,     setSendError]     = useState<string | null>(null);
@@ -42,7 +41,9 @@ export function Messages({ onClose }: { onClose: () => void }) {
     // The saved-contacts book, shared with the Phone app and kept live there (optimistic
     // add/edit/delete + push events). Names are resolved against it at render so a contact
     // change reflects in the conversation list / thread header without a Messages refetch.
-    const { contacts: liveCards } = useContacts('contacts');
+    // myNumber rides along for the same reason: the store refetches on live SIM swaps, so the
+    // own-number guards here never hold a pre-swap number.
+    const { contacts: liveCards, myNumber } = useContacts('contacts', 'myNumber');
     useEffect(() => { void useContactsStore.getState().load(); }, []);
 
     useEffect(() => {
@@ -52,7 +53,6 @@ export function Messages({ onClose }: { onClose: () => void }) {
             if (!active) return;
             setConversations(state.conversations);
             setContacts(state.contacts);
-            setMyNumber(state.myNumber);
 
             if (!pending) return;
             const digits = pending.number.replace(/\D/g, '');

--- a/web/src/apps/phone/contacts/ContactDetail.tsx
+++ b/web/src/apps/phone/contacts/ContactDetail.tsx
@@ -45,6 +45,14 @@ export function ContactDetail({ contact, onBack, backLabel = t('phone.contacts',
         return () => cancelAnimationFrame(id);
     }, [animateIn]);
 
+    // `current` is a local copy so edits/favorites reflect instantly, but the parent re-derives
+    // the prop from the live contacts store (My Card's number changes on a SIM swap mid-view) -
+    // sync when the prop CONTENT changes, keeping locally-toggled fields like favorite.
+    const { name, initials, phone, email, address, avatar } = contact;
+    useEffect(() => {
+        setCurrent(c => ({ ...c, name, initials, phone, email, address, avatar }));
+    }, [name, initials, phone, email, address, avatar]);
+
     useAsyncData(() => isNumberBlockedApi(current.phone), [current.phone], { enabled: !minimal, onData: setBlocked });
 
     function onBlockRow() {

--- a/web/src/apps/settings/sim/SimBackupPage.tsx
+++ b/web/src/apps/settings/sim/SimBackupPage.tsx
@@ -15,6 +15,15 @@ interface SimListEntry {
     active: boolean;
 }
 
+interface BackupProfile {
+    device: string;
+    color?: string | null;
+    number?: string | null;
+    syncedAt?: number;
+    thisPhone: boolean;
+    restorable: boolean;
+}
+
 interface SimInfo {
     mode: 'container' | 'metadata';
     hasSim: boolean;
@@ -23,7 +32,12 @@ interface SimInfo {
     sims: SimListEntry[];
     ejectable: boolean;
     backupOn: boolean;
+    hasPassword: boolean;
     backupEnabled: boolean;
+    autoSync: boolean;
+    syncedAt?: number;
+    profiles: BackupProfile[];
+    maxProfiles: number;
     canRestore: boolean;
 }
 
@@ -35,11 +49,33 @@ const DEV_INFO: SimInfo = {
         { number: '2075550149', color: 'yellow', active: true },
         { number: '3125550188', color: 'black', active: false },
     ],
-    ejectable: true, backupOn: true, backupEnabled: false, canRestore: true,
+    ejectable: true, backupOn: true, hasPassword: true, backupEnabled: true, autoSync: true,
+    syncedAt: Math.floor(Date.now() / 1000) - 4200,
+    profiles: [
+        { device: 'device:aaa', color: 'yellow', number: '2075550149', syncedAt: Math.floor(Date.now() / 1000) - 4200, thisPhone: true, restorable: true },
+        { device: 'device:bbb', color: 'black', number: '3125550188', syncedAt: Math.floor(Date.now() / 1000) - 90000, thisPhone: false, restorable: true },
+    ],
+    maxProfiles: 3, canRestore: true,
 };
 
 function colorLabel(color: string): string {
     return color.charAt(0).toUpperCase() + color.slice(1);
+}
+
+function profileLabel(p: BackupProfile): string {
+    const name = p.color
+        ? t('settings.simColorPhone', '{color} Phone', { color: colorLabel(p.color) })
+        : t('settings.simPhoneGeneric', 'Phone');
+    return p.number ? `${name} · ${formatPhone(p.number)}` : name;
+}
+
+function timeAgo(epochSec: number | undefined): string {
+    if (!epochSec) return t('settings.simBackupNever', 'Never');
+    const s = Math.max(0, Math.floor(Date.now() / 1000) - epochSec);
+    if (s < 60) return t('settings.simBackupJustNow', 'Just now');
+    if (s < 3600) return t('settings.simBackupMinsAgo', '{n}m ago', { n: Math.floor(s / 60) });
+    if (s < 86400) return t('settings.simBackupHoursAgo', '{n}h ago', { n: Math.floor(s / 3600) });
+    return t('settings.simBackupDaysAgo', '{n}d ago', { n: Math.floor(s / 86400) });
 }
 
 /** Settings -> SIM & Backup (unique-phones mode): SIM status, eject, cloud backup + restore. */
@@ -49,6 +85,9 @@ export function SimBackupPage({ onBack }: { onBack: () => void }) {
     const [confirm, setConfirm] = useState<'eject' | null>(null);
     const [prompt,  setPrompt]  = useState<'enable' | 'restore' | null>(null);
     const [notice,  setNotice]  = useState<string | null>(null);
+    const [picking, setPicking] = useState(false);
+    const [restoreDevice, setRestoreDevice] = useState<string | null>(null);
+    const [deleteTarget,  setDeleteTarget]  = useState<BackupProfile | null>(null);
 
     const load = useCallback(async () => {
         if (!isFiveM) { setInfo(DEV_INFO); return; }
@@ -73,16 +112,58 @@ export function SimBackupPage({ onBack }: { onBack: () => void }) {
         const res = await fetchNui<Envelope<never>>('sd-phone:sim:backup:set', { on: true, password }).catch(() => null);
         if (!res?.success) return res?.message ?? t('settings.simBackupFailed', 'Could not enable backup.');
         void load();
-        setNotice(t('settings.simBackupSaved', 'Cloud Backup is on. Your password was saved to the Passwords app.'));
+        setNotice(t('settings.simBackupSaved2', 'Cloud Backup is on and this phone was just backed up. Your password was saved to the Passwords app.'));
         return null;
     }
 
     async function restore(password: string): Promise<string | null> {
-        const res = await fetchNui<Envelope<{ rows: number }>>('sd-phone:sim:backup:restore', { password }).catch(() => null);
+        const res = await fetchNui<Envelope<{ rows: number }>>('sd-phone:sim:backup:restore', { password, device: restoreDevice ?? undefined }).catch(() => null);
         if (!res?.success) return res?.message ?? t('settings.simRestoreFailed', 'Restore failed.');
         void load();
-        setNotice(t('settings.simRestoreDone', 'Backup restored. Reopen your apps to see the data.'));
+        setNotice(t('settings.simRestoreDone2', 'Backup restored onto this phone.'));
         return null;
+    }
+
+    /** Snapshot this phone into its own cloud profile. */
+    async function syncNow() {
+        if (!info || busy) return;
+        setBusy(true);
+        const res = await fetchNui<Envelope<{ syncedAt: number }>>('sd-phone:sim:backup:sync').catch(() => null);
+        setBusy(false);
+        if (res?.success) void load();
+        else if (res?.message) setNotice(res.message);
+    }
+
+    /** Restore entry point: one restorable profile goes straight to the password prompt, more
+     *  than one opens the picker list. */
+    function startRestore() {
+        const restorables = info?.profiles.filter(p => p.restorable) ?? [];
+        if (restorables.length === 0) return;
+        if (restorables.length === 1) {
+            setRestoreDevice(restorables[0].device);
+            setPrompt('restore');
+        } else {
+            setPicking(true);
+        }
+    }
+
+    async function deleteProfile(p: BackupProfile) {
+        if (busy) return;
+        setBusy(true);
+        const res = await fetchNui<Envelope<never>>('sd-phone:sim:backup:delete', { device: p.device }).catch(() => null);
+        setBusy(false);
+        if (!res?.success && res?.message) setNotice(res.message);
+        void load();
+    }
+
+    async function setAutoSync(on: boolean) {
+        if (!info || busy) return;
+        setInfo({ ...info, autoSync: on });
+        const res = await fetchNui<Envelope<never>>('sd-phone:sim:backup:setAuto', { on }).catch(() => null);
+        if (!res?.success) {
+            setInfo(prev => (prev ? { ...prev, autoSync: !on } : prev));
+            if (res?.message) setNotice(res.message);
+        }
     }
 
     async function eject() {
@@ -137,19 +218,69 @@ export function SimBackupPage({ onBack }: { onBack: () => void }) {
                 )}
 
                 {info?.backupOn && (
-                    <ListGroup footer={t('settings.simBackupFooter', 'Cloud Backup belongs to your character, protected by a password kept in your Passwords app. Restoring on a new phone brings back your contacts, messages, photos and settings — never the phone number. A lost number is lost.')}>
+                    <ListGroup footer={t('settings.simBackupFooter3', 'Cloud Backup keeps a snapshot of this phone, protected by one password for all your backups (kept in your Passwords app). Auto Backup refreshes the snapshot when you put the phone away. Up to {max} phones can be backed up. Restoring brings back contacts, messages, photos and settings — never the phone number.', { max: info.maxProfiles })}>
                         <ToggleRow
-                            label={t('settings.simCloudBackup', 'Cloud Backup')}
+                            label={t('settings.simBackupThisPhone', 'Back Up This Phone')}
                             on={info.backupEnabled}
                             onToggle={() => { if (info.backupEnabled) void disableBackup(); else setPrompt('enable'); }}
-                            divider={info.canRestore}
+                            divider={info.backupEnabled || info.canRestore}
                         />
+                        {info.backupEnabled && (
+                            <ListRow
+                                label={t('settings.simBackupNow', 'Back Up Now')}
+                                value={busy ? '…' : timeAgo(info.syncedAt)}
+                                onPress={() => { void syncNow(); }}
+                                divider
+                            />
+                        )}
+                        {info.backupEnabled && (
+                            <ToggleRow
+                                label={t('settings.simAutoBackup', 'Auto Backup')}
+                                on={info.autoSync}
+                                onToggle={() => { void setAutoSync(!info.autoSync); }}
+                                divider={info.canRestore}
+                            />
+                        )}
                         {info.canRestore && (
                             <ListRow
                                 label={t('settings.simRestore', 'Restore from Backup')}
-                                onPress={() => setPrompt('restore')}
+                                onPress={startRestore}
                             />
                         )}
+                    </ListGroup>
+                )}
+
+                {picking && (
+                    <ListGroup header={t('settings.simRestorePick', 'Restore which backup?')}>
+                        {(info?.profiles.filter(p => p.restorable) ?? []).map((p, i, arr) => (
+                            <ListRow
+                                key={p.device}
+                                label={profileLabel(p)}
+                                value={timeAgo(p.syncedAt)}
+                                onPress={() => { setPicking(false); setRestoreDevice(p.device); setPrompt('restore'); }}
+                                divider={i < arr.length}
+                            />
+                        ))}
+                        <ListRow label={t('common.cancel', 'Cancel')} chevron={false} onPress={() => setPicking(false)} />
+                    </ListGroup>
+                )}
+
+                {!picking && (info?.profiles.length ?? 0) > 0 && (
+                    <ListGroup
+                        header={t('settings.simBackedUpPhones', 'Backed-up phones')}
+                        footer={t('settings.simBackedUpPhonesFooter', 'Tap a backup to delete it and free the slot. Deleting erases its cloud snapshot — the phone itself keeps its data.')}
+                    >
+                        {info!.profiles.map((p, i) => (
+                            <ListRow
+                                key={p.device}
+                                label={p.thisPhone
+                                    ? t('settings.simProfileThisPhone', '{label} (This Phone)', { label: profileLabel(p) })
+                                    : profileLabel(p)}
+                                value={timeAgo(p.syncedAt)}
+                                onPress={() => setDeleteTarget(p)}
+                                divider={i < info!.profiles.length - 1}
+                            />
+                        ))}
                     </ListGroup>
                 )}
             </SubPage>
@@ -165,10 +296,23 @@ export function SimBackupPage({ onBack }: { onBack: () => void }) {
                 />
             )}
 
+            {deleteTarget && (
+                <AlertDialog
+                    title={t('settings.simDeleteBackupTitle', 'Delete Backup?')}
+                    message={t('settings.simDeleteBackupMessage', 'The cloud snapshot for {label} is erased and its slot freed. The phone itself keeps its data. This can\'t be undone.', { label: profileLabel(deleteTarget) })}
+                    confirmLabel={t('settings.simDeleteBackupConfirm', 'Delete Backup')}
+                    destructive
+                    onCancel={() => setDeleteTarget(null)}
+                    onConfirm={() => { const p = deleteTarget; setDeleteTarget(null); if (p) void deleteProfile(p); }}
+                />
+            )}
+
             {prompt === 'enable' && (
                 <PromptDialog
                     title={t('settings.simCloudBackup', 'Cloud Backup')}
-                    message={t('settings.simBackupPasswordMsg', 'Set a backup password (4-32 characters). You will need it to restore on a new phone.')}
+                    message={info?.hasPassword
+                        ? t('settings.simBackupPasswordExisting', 'Enter your backup password — the one guarding your other backed-up phones. It\'s saved in their Passwords app.')
+                        : t('settings.simBackupPasswordMsg', 'Set a backup password (4-32 characters). You will need it to restore on a new phone.')}
                     placeholder={t('settings.simBackupPassword', 'Backup password')}
                     maxLength={32}
                     confirmLabel={t('settings.simBackupEnable', 'Turn On')}

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -198,6 +198,7 @@ export type NuiMessage =
     | { action: 'sd-phone:ryde:ratingReceived'; data: { id: string; stars: number; tip?: number } }
     | { action: 'sd-phone:ryde:peerLocation';   data: { tripId: string; role: 'rider' | 'driver'; x: number; y: number; h: number } }
     | { action: 'sd-phone:close' }
+    | { action: 'sd-phone:profileReset' }
     | { action: 'sd-phone:client:characterLoaded' }
     | { action: 'sd-phone:launchApp'; data: { id: string; link?: Record<string, unknown> } }
     | { action: 'sd-phone:battery'; data: number }
@@ -326,7 +327,7 @@ export type NuiMessage =
     | { action: 'wordle:start';        data: { gameId: string; color: string; opponent: string; pot: number } }
     | { action: 'wordle:move';         data: { gameId: string; move: { rows: string[][]; solved: boolean; failed: boolean; tries: number; finishMs: number } } }
     | { action: 'wordle:ended';        data: { reason: string } }
-    | { action: 'sd-phone:notification';       data: { id?: string; app?: string; image?: string; title: string; body?: string; time?: string; appId?: string; quietInApp?: boolean } }
+    | { action: 'sd-phone:notification';       data: { id?: string; app?: string; image?: string; title: string; body?: string; time?: string; appId?: string; quietInApp?: boolean; otherPhone?: boolean; phoneColor?: string; profileKey?: string } }
     | { action: 'sd-phone:badges';             data: Record<string, number> }
     | { action: 'sd-phone:airshare';           data: { id: string; kind: string; fromName: string } }
     | { action: 'sd-phone:maps:friends:update'; data: FriendsUpdatePush }

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -31,6 +31,12 @@ export interface SimStatePush {
     enabled: boolean;
     hasSim?: boolean;
     number?: string;
+    /** DeviceIdentity mode: the phone owns its data and opens without a SIM (no No-SIM wall,
+     *  "No Service" in the status bar instead). Absent/false = legacy SIM-is-identity mode. */
+    device?: boolean;
+    /** Device mode only: the phone's device identity, used to namespace per-phone UI state
+     *  (setup completion, auth cache) so swapping SIMs on one phone never resets it. */
+    profile?: string;
 }
 
 export interface AppDef {

--- a/web/src/shell/Notifications.tsx
+++ b/web/src/shell/Notifications.tsx
@@ -15,6 +15,14 @@ export interface NotificationItem {
     time?:  string;
     appId?: string;
     link?:  Record<string, unknown>;
+    /** Pocket buzz from a carried-but-not-active phone: transient banner only, never this
+     *  phone's lockscreen stack or badges. */
+    otherPhone?: boolean;
+    /** Pocket buzz: the buzzing phone's frame colour, tinting the closed-shell peek. */
+    phoneColor?: string;
+    /** Pocket buzz: the buzzing phone's profile key - the banner parks on that profile's
+     *  banked lockscreen stack so it shows when THAT phone is next opened. */
+    profileKey?: string;
 }
 
 const SHOW_MS = 5000;
@@ -28,10 +36,13 @@ export function NotifIcon({ item, size = 38 }: { item: NotificationItem; size?: 
             </span>
         );
     }
-    if (item.app) {
+    // Pocket buzzes label the SOURCE as "<Color> Phone" in `app`; the glyph must still be the
+    // originating app's, so they resolve via appId first.
+    const icon = item.otherPhone ? (item.appId ?? item.app) : item.app;
+    if (icon) {
         return (
             <span className="squircle shrink-0" style={style}>
-                <AppIconSVG icon={item.app} size={size} />
+                <AppIconSVG icon={icon} size={size} />
             </span>
         );
     }

--- a/web/src/shell/StatusBar.tsx
+++ b/web/src/shell/StatusBar.tsx
@@ -1,4 +1,5 @@
 import { formatClockTime, useClock } from '@/hooks/useClock';
+import { t } from '@/i18n';
 
 export interface StatusBarProps {
     use24h: boolean;
@@ -7,12 +8,13 @@ export interface StatusBarProps {
     battery: number;
     airplane?: boolean;
     noSim?: boolean;
+    noService?: boolean;
     light?: boolean;
     controlHint?: boolean;
     editing?: boolean;
 }
 
-export function StatusBar({ use24h, signal, showWifi, battery, airplane = false, noSim = false, light = true, controlHint = false, editing = false }: StatusBarProps) {
+export function StatusBar({ use24h, signal, showWifi, battery, airplane = false, noSim = false, noService = false, light = true, controlHint = false, editing = false }: StatusBarProps) {
     const time  = formatClockTime(useClock(), use24h);
     const color = light ? '#ffffff' : '#000000';
 
@@ -32,6 +34,8 @@ export function StatusBar({ use24h, signal, showWifi, battery, airplane = false,
                     <Airplane size={23} />
                 ) : noSim ? (
                     <span className="font-sf text-[13px] font-semibold leading-none opacity-80">No SIM</span>
+                ) : noService ? (
+                    <span className="font-sf text-[13px] font-semibold leading-none opacity-80">{t('shell.noService', 'No Service')}</span>
                 ) : (
                     <>
                         {signal > 0 && <Cellular size={21} />}

--- a/web/src/stores/contactsStore.test.ts
+++ b/web/src/stores/contactsStore.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { resetContacts, syncSimNumber, useContactsStore } from './contactsStore';
+
+const MOCK_NUMBER = '2051189847';
+
+function flush(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+    useContactsStore.setState({ contacts: [], recents: [], myNumber: '', myName: '', card: {}, loaded: false });
+});
+
+describe('contactsStore.syncSimNumber', () => {
+    it('does nothing while the store has not loaded', async () => {
+        syncSimNumber({ enabled: true, hasSim: true, number: '5550001111' });
+        await flush();
+        expect(useContactsStore.getState().loaded).toBe(false);
+        expect(useContactsStore.getState().myNumber).toBe('');
+    });
+
+    it('does nothing when the pushed number matches the cached one', async () => {
+        useContactsStore.setState({ loaded: true, myNumber: '5550001111' });
+        syncSimNumber({ enabled: true, hasSim: true, number: '5550001111' });
+        await flush();
+        expect(useContactsStore.getState().myNumber).toBe('5550001111');
+        expect(useContactsStore.getState().contacts).toEqual([]);
+    });
+
+    it('does nothing when the SIM feature is off or the push is absent', async () => {
+        useContactsStore.setState({ loaded: true, myNumber: '5550001111' });
+        syncSimNumber(undefined);
+        syncSimNumber({ enabled: false, hasSim: true, number: '5550009999' });
+        await flush();
+        expect(useContactsStore.getState().myNumber).toBe('5550001111');
+    });
+
+    it('refetches when a different SIM number arrives', async () => {
+        useContactsStore.setState({ loaded: true, myNumber: '5550001111' });
+        syncSimNumber({ enabled: true, hasSim: true, number: '5550009999' });
+        await flush();
+        expect(useContactsStore.getState().myNumber).toBe(MOCK_NUMBER);
+    });
+
+    it('refetches when the SIM is ejected (number gone)', async () => {
+        useContactsStore.setState({ loaded: true, myNumber: '5550001111' });
+        syncSimNumber({ enabled: true, hasSim: false });
+        await flush();
+        expect(useContactsStore.getState().myNumber).toBe(MOCK_NUMBER);
+    });
+});
+
+describe('contactsStore.resetContacts', () => {
+    it('drops the cache and refetches when it was loaded', async () => {
+        useContactsStore.setState({ loaded: true, myNumber: '5550001111', myName: 'Old Name' });
+        resetContacts();
+        await flush();
+        expect(useContactsStore.getState().loaded).toBe(true);
+        expect(useContactsStore.getState().myNumber).toBe(MOCK_NUMBER);
+    });
+
+    it('only clears when nothing had loaded it yet', async () => {
+        useContactsStore.setState({ myNumber: 'stale' });
+        resetContacts();
+        await flush();
+        expect(useContactsStore.getState().loaded).toBe(false);
+        expect(useContactsStore.getState().myNumber).toBe('');
+    });
+});

--- a/web/src/stores/contactsStore.ts
+++ b/web/src/stores/contactsStore.ts
@@ -4,6 +4,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { loadPhoneState, addContactApi } from '@/apps/phone/contactsApi';
 import type { CardOverrides } from '@/apps/phone/contactsApi';
 import type { Contact, RawCall } from '@/apps/phone/data';
+import type { SimStatePush } from '@/core/types';
 import { t } from '@/i18n';
 
 interface ContactsState {
@@ -66,6 +67,26 @@ export function useContacts(...keys: (keyof ContactsState)[]): unknown {
             return out;
         }),
     );
+}
+
+/** Unique phones: the acting profile changed (different phone, or a restore replaced its data)
+ *  - drop the cache so the next load() fetches the new profile's contacts, and refetch NOW when
+ *  something already consumed it (kept-alive Phone/Messages read this store live). */
+export function resetContacts(): void {
+    const wasLoaded = useContactsStore.getState().loaded;
+    useContactsStore.setState({ contacts: [], recents: [], myNumber: '', myName: '', card: {}, loaded: false });
+    if (wasLoaded) void useContactsStore.getState().refresh();
+}
+
+/** Unique phones: a SIM swap/eject changes the phone's number (and in legacy mode the whole
+ *  identity) under this load-once cache, so a loaded store refetches whenever a live SIM push
+ *  carries a number that differs from the cached My Card one. Unloaded stores load lazily. */
+export function syncSimNumber(push: SimStatePush | undefined): void {
+    if (push?.enabled !== true) return;
+    const s = useContactsStore.getState();
+    if (!s.loaded) return;
+    if ((push.number ?? '') === s.myNumber) return;
+    void s.refresh();
 }
 
 /** Canonical add-contact path: guards duplicates/own-number, persists via the

--- a/web/src/stores/simStore.ts
+++ b/web/src/stores/simStore.ts
@@ -11,6 +11,7 @@ interface SimStore {
     enabled: boolean;
     hasSim: boolean;
     number: string | null;
+    device: boolean;
     apply: (push: SimStatePush | undefined) => void;
 }
 
@@ -18,14 +19,28 @@ export const useSimStore = create<SimStore>()(set => ({
     enabled: false,
     hasSim: false,
     number: null,
+    device: false,
     apply: push => set({
         enabled: push?.enabled === true,
         hasSim: push?.hasSim === true,
         number: push?.number ?? null,
+        device: push?.device === true,
     }),
 }));
 
-/** True when the phone should render the "No SIM" lock state. */
+/**
+ * True when the phone should render the full-screen "No SIM" lock state. LEGACY mode only:
+ * in DeviceIdentity mode the phone opens and works without a SIM (see useNoService), so the
+ * wall never shows.
+ */
 export function useNoSim(): boolean {
-    return useSimStore(s => s.enabled && !s.hasSim);
+    return useSimStore(s => s.enabled && !s.device && !s.hasSim);
+}
+
+/**
+ * True when the phone has no cellular service (SIM out) but still opens and works: DeviceIdentity
+ * mode. Surfaces as a "No Service" status-bar label rather than a lock wall.
+ */
+export function useNoService(): boolean {
+    return useSimStore(s => s.enabled && s.device && !s.hasSim);
 }

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -152,10 +152,26 @@ interface ThemeState {
     faceId:      boolean;
     setFaceId:   (on: boolean) => void;
     setSecurity: (pin: string | null, faceId: boolean) => void;
+    /** Server-side first-run-setup flag for the acting profile; null until its hydrate lands. */
+    setupDone: boolean | null;
+    resetProfileVisuals: () => void;
+    applyWallpaperProfile: (key: string | null) => void;
     hydrate: (attempt?: number) => void;
 }
 
 const initialSecurity = isFiveM ? { passcode: null, faceId: false } : loadSecurityLocal();
+
+// In-game last-known-wallpaper cache, keyed per phone profile (unique phones) or bare (stock
+// servers): painted in the same frame as the reveal so the first open never flashes the stock
+// wallpaper while the settings hydrate is in flight. The hydrate stays authoritative.
+const WALLPAPER_CACHE_BASE = 'sd-phone:wallpaperCache:v1';
+let wallpaperProfileKey: string | null = null;
+function wallpaperCacheKey(): string {
+    return wallpaperProfileKey ? `${WALLPAPER_CACHE_BASE}:${wallpaperProfileKey}` : WALLPAPER_CACHE_BASE;
+}
+function cacheWallpaper(value: string): void {
+    try { window.localStorage.setItem(wallpaperCacheKey(), value); } catch { /* ignore */ }
+}
 
 function persistSecurity(pin: string | null, face: boolean) {
     if (isFiveM) void fetchNui('sd-phone:settings:setSecurity', { passcode: pin, faceId: face }).catch(() => {});
@@ -188,6 +204,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     lockClock: isFiveM ? DEFAULT_LOCK_CLOCK : loadLockClockLocal(),
     passcode: initialSecurity.passcode,
     faceId: initialSecurity.faceId,
+    setupDone: null,
 
     setTheme: (next) => {
         if (isFiveM) void fetchNui('sd-phone:settings:setTheme', { theme: next }).catch(() => {});
@@ -205,8 +222,12 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     setWallpaper: (value) => {
         set({ wallpaper: value });
         const key = wallpaperKey(value);
-        if (isFiveM) void fetchNui('sd-phone:settings:setWallpaper', { wallpaper: key }).catch(() => {});
-        else saveWallpaperLocal(key);
+        if (isFiveM) {
+            cacheWallpaper(value);
+            void fetchNui('sd-phone:settings:setWallpaper', { wallpaper: key }).catch(() => {});
+        } else {
+            saveWallpaperLocal(key);
+        }
     },
 
     // Resolves to null on success, or an error message ('' = caller supplies a generic one).
@@ -333,6 +354,28 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
         persistSecurity(pin, finalFace);
     },
 
+    resetProfileVisuals: () => {
+        // Profile switch/restore: paint the stock look NOW, so the previous phone's wallpaper
+        // and clock never show on this one while the async hydrate is still in flight. The
+        // setup flag goes back to "unknown" so Hello waits for THIS profile's answer.
+        set({
+            wallpaper: isFiveM ? lockscreenAsset : (loadWallpaperLocal() ?? devDefaultAsset),
+            lockClock: DEFAULT_LOCK_CLOCK,
+            setupDone: null,
+        });
+    },
+
+    applyWallpaperProfile: (key) => {
+        // Selects the acting profile's wallpaper cache and paints its last-known value NOW
+        // (same render batch as the phone reveal). Dev already persists wallpaper locally.
+        if (!isFiveM) return;
+        wallpaperProfileKey = key;
+        try {
+            const cached = window.localStorage.getItem(wallpaperCacheKey());
+            if (cached) set({ wallpaper: cached });
+        } catch { /* ignore */ }
+    },
+
     hydrate: (attempt = 0) => {
         // In-game only: on first join the character may not be loaded yet, so settings:get returns
         // no data. Reschedule until it does (or we hit the cap). In dev there is no server, so no
@@ -342,12 +385,17 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 window.setTimeout(() => get().hydrate(attempt + 1), HYDRATE_RETRY_MS);
             }
         };
-        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; customWallpapers?: string[]; chatTextScale?: number; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
+        const keyAtRequest = wallpaperProfileKey;
+        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; customWallpapers?: string[]; chatTextScale?: number; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
             .then(res => {
                 if (!res?.data) { retry(); return; }
                 const d = res.data;
                 const patch: Partial<ThemeState> = {};
-                if (typeof d.wallpaper === 'string' && d.wallpaper) patch.wallpaper = wallpaperKey(d.wallpaper);
+                // Always assigned: a profile that never saved one must PAINT the default, not
+                // keep the previous phone's wallpaper (unique phones swap profiles live).
+                patch.wallpaper = (typeof d.wallpaper === 'string' && d.wallpaper)
+                    ? wallpaperKey(d.wallpaper)
+                    : (isFiveM ? lockscreenAsset : (loadWallpaperLocal() ?? devDefaultAsset));
                 if (Array.isArray(d.customWallpapers)) {
                     patch.customWallpapers = d.customWallpapers.filter((u): u is string => typeof u === 'string');
                 }
@@ -356,12 +404,17 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 if (typeof d.airplaneMode === 'boolean') patch.airplaneMode = d.airplaneMode;
                 if (typeof d.hour24 === 'boolean') patch.hour24 = d.hour24;
                 if (typeof d.reopenApp === 'boolean') patch.reopenLastApp = d.reopenApp;
+                // Always assigned (true/false, never left null) - the per-profile answer is
+                // what lets the Hello gate decide, and a stale previous-profile value may not leak.
+                patch.setupDone = d.setupDone === true;
                 if (d.theme === 'light' || d.theme === 'dark') patch.theme = d.theme;
                 if (typeof d.darkTheme === 'string' && (DARK_THEMES as string[]).includes(d.darkTheme)) patch.darkTheme = d.darkTheme as DarkTheme;
                 if (typeof d.chatTextScale === 'number') patch.chatTextScale = clampChatScale(d.chatTextScale);
                 if (typeof d.ringtoneVol === 'number') patch.ringtoneVol = clampVol(d.ringtoneVol);
                 if (typeof d.callVol === 'number') patch.callVol = clampVol(d.callVol);
-                if (d.lockClock && typeof d.lockClock === 'object') patch.lockClock = { ...DEFAULT_LOCK_CLOCK, ...d.lockClock };
+                patch.lockClock = (d.lockClock && typeof d.lockClock === 'object')
+                    ? { ...DEFAULT_LOCK_CLOCK, ...d.lockClock }
+                    : DEFAULT_LOCK_CLOCK;
                 const pin = typeof d.passcode === 'string' && d.passcode ? d.passcode : null;
                 patch.passcode = pin;
                 patch.faceId   = pin !== null && !!d.faceId;
@@ -370,6 +423,11 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 patch.customRingtones         = ring;
                 patch.customNotificationTones = notif;
                 set(patch);
+                // Freshest server answer becomes the profile's cached wallpaper - unless the
+                // acting profile changed while this request was in flight.
+                if (isFiveM && typeof patch.wallpaper === 'string' && keyAtRequest === wallpaperProfileKey) {
+                    cacheWallpaper(patch.wallpaper);
+                }
                 if (isFiveM) void fetchNui('sd-phone:call:setVolume', { volume: get().callVol }).catch(() => {});
                 const ringIsYt  = !!d.ringtone         && ring.some(c => c.id === d.ringtone);
                 const notifIsYt = !!d.notificationTone && notif.some(c => c.id === d.notificationTone);


### PR DESCRIPTION
## Summary

Adds a `DeviceIdentity` mode to unique phones (`configs/simcards.lua`), **on by default**, that inverts who owns the phone's data.

**The model.** In the new default (`DeviceIdentity = true`) the **phone item owns the data** and the SIM only lends a **number**. Each phone mints a persistent identity into its own item metadata on first use (`device:<id>`), and that identity keys everything that used to key off the SIM identity — messages, contacts, photos, notes, settings, installed apps, games (the whole bundle, no per-app splitting). The SIM contributes only the number and `hasSim`/service. Pull the SIM and the phone still opens and every non-number app keeps working; only the number and cellular service drop. Setting `DeviceIdentity = false` restores the **legacy** SIM-is-identity behaviour byte-for-byte (SIM out = dead "No SIM" wall). Stock mode (`Sim.Enabled = false`) is untouched by all of this.

**Adoption migration (in place, automatic, no data copy).** The first time a phone is resolved in device mode, if it has a SIM installed whose registry identity (`sim:<number>` or a bound `citizenid`) already has data, the phone **adopts that identity forever** — so a legacy server that flips the flag grandfathers every phone and loses nothing; the number can later move away while the data stays. Fresh phones mint `device:<id>`.

**Number routing.** A SIM'd phone mirrors its number onto its own device identity (`phone_settings.phone_number`, the existing number↔identity link), so every reverse lookup (`getCitizenByNumber`) resolves a dialled number to the **device currently holding that SIM**, including offline holders. A phone whose SIM was pulled has its mirror cleared, so a number whose SIM sits in no phone lands nowhere — same as an unreachable number today. Install/eject/drag all reconcile through the session resolver.

**Gating split.** Identity-existence guards now succeed without a SIM in device mode (the device identity always exists once a phone is used), so account apps, photos, notes, settings and games all work offline-of-service. Only number-dependent actions are refused, gracefully with "No service. Install a SIM card…" style messages: **sending messages** and **placing calls** are gated on a resolvable own-number; both gates are no-ops in legacy/stock (a resolvable caller there always has a number).

**Face Unlock** now stamps the first activator on the **device** (item metadata) and gates on that, so a thief's face never unlocks a stolen phone even with the SIM out. **Cloud Backup** stays character-bound and restores onto the resolved (device) identity in both modes; in device mode a restore no longer needs a SIM.

**NUI.** In device mode the No-SIM wall never renders — the phone opens normally and the status bar shows **No Service** in place of the cellular icons when `enabled && !hasSim`. The open payload and the live `simState` push gained `device` (mode) and `profile` (device identity, so per-phone UI state namespaces off the device and swapping SIMs on one phone never resets setup/auth). Legacy mode's `NoSimScreen` behaves exactly as before.

`README.md` and the config comments now lead with the new default and describe both modes.

The legacy toggle was the design constraint throughout: every new path collapses to the current behaviour when `DeviceIdentity = false`.

## Type of Change

- [x] New Feature
- [x] Improvement / Refactor

## Related Issues

Related to #

## Testing

Gates run locally (no in-game/multiplayer test available in this environment):

- [x] `luac -p` clean on every changed Lua file (server + client + config)
- [x] `cd web && npx tsc --noEmit` — 0 errors
- [x] `npx eslint src` — 0 errors (29 pre-existing warnings, none added)
- [x] `npx vitest run` — 80 passed
- [x] `npx knip` — exit 0
- [ ] Multiplayer tested

## Breaking Changes

Yes, a default-behaviour change for servers that have `Sim.Enabled = true`. `DeviceIdentity` defaults to `true`, so enabling unique phones now gives device-owns-data semantics. This is designed to be safe: on first use each phone **adopts** the identity of the SIM currently in it (no data is copied or lost), so an existing legacy server flips over transparently. Servers that want the old SIM-is-identity behaviour set `DeviceIdentity = false`. Stock (`Sim.Enabled = false`) servers are unaffected.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
