### PR TITLE
Add physical keyboard support to digit keypads.

### DIFF
--- a/web/src/apps/phone/keypad/KeypadTab.tsx
+++ b/web/src/apps/phone/keypad/KeypadTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Delete, Phone, Plus } from 'lucide-react';
 
+import { useKeypadInput } from '@/hooks/useKeypadInput';
 import { useSessionState } from '@/hooks/useSessionState';
 import { AddContact } from '../contacts/AddContact';
 import { playDtmf } from './dtmf';
@@ -25,6 +26,18 @@ export function KeypadTab({ onAddContact, onCall }: {
         setDigits(prev => (prev.length >= 24 ? prev : prev + d));
         playDtmf(d);
     }
+
+    function del() {
+        setDigits(prev => prev.slice(0, -1));
+    }
+
+    useKeypadInput({
+        onPress: press,
+        onDelete: del,
+        canDelete: digits.length > 0,
+        enabled: !adding,
+        extraKeys: ['*', '#'],
+    });
 
     const size = digits.length > 15 ? 'text-[29px]' : digits.length > 11 ? 'text-[36px]' : 'text-[44px]';
     const shown = /^\d{10}$/.test(digits) ? formatPhone(digits) : digits;
@@ -72,7 +85,7 @@ export function KeypadTab({ onAddContact, onCall }: {
                     <button
                         type="button"
                         aria-label={t('phone.delete','Delete')}
-                        onClick={() => setDigits(prev => prev.slice(0, -1))}
+                        onClick={del}
                         className="flex h-[88px] w-[88px] items-center justify-center text-black/70 active:opacity-50 dark:text-white/70"
                     >
                         <Delete className="h-[37px] w-[37px]" strokeWidth={1.8} />

--- a/web/src/apps/settings/security/FaceUnlockPage.tsx
+++ b/web/src/apps/settings/security/FaceUnlockPage.tsx
@@ -3,6 +3,7 @@ import { Delete } from 'lucide-react';
 
 import { t } from '@/i18n';
 import { useIosPush } from '@/hooks/useIosPush';
+import { useKeypadInput } from '@/hooks/useKeypadInput';
 import { useTheme } from '@/stores/themeStore';
 import { ListGroup } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
@@ -157,6 +158,12 @@ function PinFlow({
     }
 
     function del() { setPin(p => p.slice(0, -1)); setError(''); }
+
+    useKeypadInput({
+        onPress: press,
+        onDelete: del,
+        canDelete: pin.length > 0,
+    });
 
     function advance(entered: string) {
         if (step === 'old') {

--- a/web/src/hooks/useKeypadInput.ts
+++ b/web/src/hooks/useKeypadInput.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+
+import { useKeyboardCapture } from '@/hooks/useKeyboardCapture';
+
+/**
+ * Physical keyboard support for on-screen digit pads: number keys, optional extras
+ * (`.` / `*` / `#`), and Backspace/Delete. Also claims the keyboard from game binds
+ * while enabled (same path as Wordle), since keep-input would otherwise let 1–9 fire
+ * weapon-slot / inventory mappings.
+ */
+export function useKeypadInput({
+    onPress,
+    onDelete,
+    canDelete = true,
+    enabled = true,
+    extraKeys = [],
+    capture = true,
+}: {
+    onPress:     (key: string) => void;
+    onDelete?:   () => void;
+    canDelete?:  boolean;
+    enabled?:    boolean;
+    extraKeys?:  string[];
+    capture?:    boolean;
+}): void {
+    useKeyboardCapture(capture && enabled);
+
+    const onPressRef   = useRef(onPress);
+    const onDeleteRef  = useRef(onDelete);
+    const canDeleteRef = useRef(canDelete);
+    const extrasRef    = useRef(extraKeys);
+    onPressRef.current   = onPress;
+    onDeleteRef.current  = onDelete;
+    canDeleteRef.current = canDelete;
+    extrasRef.current    = extraKeys;
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        function onKey(e: KeyboardEvent) {
+            if (e.ctrlKey || e.metaKey || e.altKey) return;
+            const tgt = e.target as HTMLElement | null;
+            if (tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable)) {
+                return;
+            }
+
+            if (e.key === 'Backspace' || e.key === 'Delete') {
+                if (!onDeleteRef.current || !canDeleteRef.current) return;
+                e.preventDefault();
+                onDeleteRef.current();
+                return;
+            }
+
+            if (/^[0-9]$/.test(e.key)) {
+                e.preventDefault();
+                onPressRef.current(e.key);
+                return;
+            }
+
+            if (extrasRef.current.includes(e.key)) {
+                e.preventDefault();
+                onPressRef.current(e.key);
+            }
+        }
+
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [enabled]);
+}

--- a/web/src/payphone/PayphoneUI.tsx
+++ b/web/src/payphone/PayphoneUI.tsx
@@ -4,6 +4,7 @@ import { Coins, Delete, Hash, Phone, PhoneOff, RotateCcw, X } from 'lucide-react
 
 import { t } from '@/i18n';
 import { fetchNui, isFiveM } from '@/core/nui';
+import { useKeypadInput } from '@/hooks/useKeypadInput';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { playDtmf } from '@/apps/phone/keypad/dtmf';
 import { formatPhone } from '@/lib/phone';
@@ -336,6 +337,19 @@ export function PayphoneUI() {
         playDtmf(k);
     }
 
+    function delDigit() {
+        if (phaseRef.current !== 'idle') return;
+        setDigits(prev => prev.slice(0, -1));
+    }
+
+    useKeypadInput({
+        onPress: press,
+        onDelete: delDigit,
+        canDelete: digits.length > 0,
+        enabled: open && phase === 'idle',
+        extraKeys: ['*', '#'],
+    });
+
     /** Feed the slot: charge server-side, then run the coin-drop and unlock. */
     async function insertCoin() {
         if (!coinRef.current.enabled || creditRef.current || coinBusy.current || phaseRef.current !== 'idle') return;
@@ -615,7 +629,7 @@ export function PayphoneUI() {
                                 <div className="flex gap-1.5">
                                     <button
                                         type="button"
-                                        onClick={() => { if (phase === 'idle') setDigits(prev => prev.slice(0, -1)); }}
+                                        onClick={delDigit}
                                         aria-label={t('payphone.clear', 'Clear')}
                                         title={t('payphone.clear', 'Clear')}
                                         className="flex h-[42px] w-[42px] items-center justify-center rounded-[7px] text-[#2a2c30] active:translate-y-[1px] active:brightness-90"

--- a/web/src/shell/Lockscreen.tsx
+++ b/web/src/shell/Lockscreen.tsx
@@ -3,6 +3,7 @@ import type { PointerEvent as ReactPointerEvent, MouseEvent as ReactMouseEvent, 
 import { Camera, Check, Delete, Flashlight, Lock, ScanFace } from 'lucide-react';
 
 import { formatClockTime, formatLongDate, useClock } from '@/hooks/useClock';
+import { useKeypadInput } from '@/hooks/useKeypadInput';
 import { fetchNui, isFiveM } from '@/core/nui';
 import { resolveWallpaper } from './wallpapers';
 import { useTheme } from '@/stores/themeStore';
@@ -290,6 +291,13 @@ function PasscodeEntry({ wallpaper, expected, onSuccess, onCancel }: {
         }
     }
     function del() { setPin(p => p.slice(0, -1)); }
+
+    useKeypadInput({
+        onPress: press,
+        onDelete: del,
+        canDelete: pin.length > 0 && !shake && !exiting,
+        enabled: !exiting,
+    });
 
     return (
         <div className={`absolute inset-0 z-[80] ${exiting ? 'animate-passcode-out' : 'animate-passcode-in'}`}>

--- a/web/src/ui/Keypad.tsx
+++ b/web/src/ui/Keypad.tsx
@@ -1,5 +1,6 @@
 import { Delete } from 'lucide-react';
 
+import { useKeypadInput } from '@/hooks/useKeypadInput';
 import { t } from '@/i18n';
 
 
@@ -22,6 +23,13 @@ export function Keypad({ variant = 'pin', onPress, onDelete, canDelete = true, c
 }) {
     const showLetters = variant === 'phone' || variant === 'pin';
     const zeroSub     = variant === 'phone' ? '+' : '';
+
+    useKeypadInput({
+        onPress,
+        onDelete,
+        canDelete,
+        extraKeys: variant === 'decimal' ? ['.'] : [],
+    });
 
     return (
         <div className={`grid grid-cols-3 gap-x-3 gap-y-2.5 ${className}`}>


### PR DESCRIPTION
Number keys and Backspace work on dialer, PIN, lockscreen, and payphone pads.

## Summary

- Physical number keys + Backspace work on all digit keypads (dialer, PIN, lockscreen, banking/stocks/radio, payphone)
- Shared via new useKeypadInput hook; on-screen buttons unchanged

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

no related issues

## Testing

Describe how this was tested.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [x] Tested with latest ox_lib
- [x] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

Does this introduce any breaking changes?

no breaking changes

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.