### PR TITLE
fix(settings): persist phone frame scale across restarts

### DIFF
--- a/client/apps/settings.lua
+++ b/client/apps/settings.lua
@@ -19,6 +19,7 @@ proxyCallback('sd-phone:settings:setWallpaper', 'sd-phone:server:settings:setWal
 proxyCallback('sd-phone:settings:wallpapers:add',    'sd-phone:server:settings:wallpapers:add')
 proxyCallback('sd-phone:settings:wallpapers:remove', 'sd-phone:server:settings:wallpapers:remove')
 proxyCallback('sd-phone:settings:setChatTextScale', 'sd-phone:server:settings:setChatTextScale')
+proxyCallback('sd-phone:settings:setPhoneScale',    'sd-phone:server:settings:setPhoneScale')
 proxyCallback('sd-phone:settings:setVolumes',       'sd-phone:server:settings:setVolumes')
 proxyCallback('sd-phone:settings:setLocale',        'sd-phone:server:settings:setLocale')
 proxyCallback('sd-phone:settings:getNotifPref', 'sd-phone:server:settings:getNotifPref')

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -53,6 +53,7 @@ lib.callback.register('sd-phone:server:settings:get', function(source)
     data.wallpaper               = store.getWallpaper(cid)
     data.customWallpapers        = store.getCustomWallpapers(cid)
     data.chatTextScale           = store.getChatTextScale(cid)
+    data.phoneScale              = store.getPhoneScale(cid)
     local vols = store.getVolumes(cid)
     data.ringtoneVol             = vols.ringtone
     data.callVol                 = vols.call
@@ -124,6 +125,15 @@ lib.callback.register('sd-phone:server:settings:setChatTextScale', function(sour
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
     store.setChatTextScale(cid, payload.scale)
+    return { success = true }
+end)
+
+---Persists the caller's phone frame scale (slider value 0-100).
+lib.callback.register('sd-phone:server:settings:setPhoneScale', function(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    payload = type(payload) == 'table' and payload or {}
+    store.setPhoneScale(cid, payload.scale)
     return { success = true }
 end)
 

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -80,6 +80,7 @@ function store.ensureSchema()
             passcode           VARCHAR(8)   NULL,
             face_id            TINYINT(1)   NOT NULL DEFAULT 0,
             chat_text_scale    DECIMAL(3,2) NULL,
+            phone_scale        TINYINT UNSIGNED NULL,
             hour24             TINYINT(1)   NULL,
             reopen_app         TINYINT(1)   NULL,
             ringtone_volume    TINYINT UNSIGNED NULL,
@@ -148,6 +149,9 @@ function store.ensureSchema()
     end
     if not columnExists('phone_settings', 'chat_text_scale') then
         MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN chat_text_scale DECIMAL(3,2) NULL')
+    end
+    if not columnExists('phone_settings', 'phone_scale') then
+        MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN phone_scale TINYINT UNSIGNED NULL')
     end
     if not columnExists('phone_settings', 'ringtone_volume') then
         MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN ringtone_volume TINYINT UNSIGNED NULL')
@@ -652,6 +656,43 @@ function store.setChatTextScale(citizenid, scale)
     MySQL.update.await([[
         INSERT INTO phone_settings (citizenid, chat_text_scale) VALUES (?, ?)
         ON DUPLICATE KEY UPDATE chat_text_scale = VALUES(chat_text_scale)
+    ]], { citizenid, clean })
+end
+
+---Clamps the phone frame scale to an integer 0-100; nil for non-numbers and NaN, out-of-range
+---values fall to the nearest bound.
+---@param v any client-supplied scale
+---@return number|nil scale integer 0-100, nil if unusable
+local function clampPhoneScale(v)
+    local n = tonumber(v)
+    if not n or n ~= n then return nil end
+    n = math.floor(n + 0.5)
+    if n < 0 then n = 0 elseif n > 100 then n = 100 end
+    return n
+end
+
+---Reads a player's phone frame scale (slider value 0-100), tonumber-coerced, or nil if unset.
+---Read-only.
+---@param citizenid string framework per-character id
+---@return number|nil scale saved slider value
+function store.getPhoneScale(citizenid)
+    if not citizenid or citizenid == '' then return nil end
+    local row = MySQL.single.await('SELECT phone_scale FROM phone_settings WHERE citizenid = ?', { citizenid })
+    if not row or row.phone_scale == nil then return nil end
+    return tonumber(row.phone_scale)
+end
+
+---Persists a player's phone frame scale, leaving other settings intact. An out-of-range /
+---non-numeric value is ignored.
+---@param citizenid string framework per-character id
+---@param scale number slider value (clamped to 0-100)
+function store.setPhoneScale(citizenid, scale)
+    if not citizenid or citizenid == '' then return end
+    local clean = clampPhoneScale(scale)
+    if not clean then return end
+    MySQL.update.await([[
+        INSERT INTO phone_settings (citizenid, phone_scale) VALUES (?, ?)
+        ON DUPLICATE KEY UPDATE phone_scale = VALUES(phone_scale)
     ]], { citizenid, clean })
 end
 

--- a/server/sim/backup.lua
+++ b/server/sim/backup.lua
@@ -126,8 +126,8 @@ local COPY = {
 local SETTINGS_COLS = {
     'active_group_id', 'ringtone', 'notification_tone', 'card_name', 'card_avatar',
     'card_email', 'card_address', 'installed_apps', 'home_layout', 'lock_clock',
-    'wallpaper', 'custom_wallpapers', 'passcode', 'face_id', 'chat_text_scale', 'hour24',
-    'ringtone_volume', 'call_volume', 'locale', 'dark_theme', 'theme',
+    'wallpaper', 'custom_wallpapers', 'passcode', 'face_id', 'chat_text_scale', 'phone_scale',
+    'hour24', 'ringtone_volume', 'call_volume', 'locale', 'dark_theme', 'theme',
 }
 
 ---Overwrites `toId`'s phone_settings preference columns with `fromId`'s, creating the target

--- a/web/src/stores/themeStore.test.ts
+++ b/web/src/stores/themeStore.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PHONE_SCALE_KEY = 'sd-phone:phoneScale';
+
+function fakeLocalStorage() {
+    const map = new Map<string, string>();
+    return {
+        getItem:    (k: string) => map.get(k) ?? null,
+        setItem:    (k: string, v: string) => { map.set(k, String(v)); },
+        removeItem: (k: string) => { map.delete(k); },
+        clear:      () => { map.clear(); },
+    };
+}
+
+let storage: ReturnType<typeof fakeLocalStorage>;
+
+beforeEach(() => {
+    storage = fakeLocalStorage();
+    vi.stubGlobal('window', { localStorage: storage, setTimeout, clearTimeout });
+    vi.resetModules();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.doUnmock('@/core/nui');
+});
+
+async function importStore() {
+    const mod = await import('./themeStore');
+    return mod.useThemeStore;
+}
+
+describe('themeStore phone scale persistence (dev)', () => {
+    it('saves the scale to localStorage when set', async () => {
+        const store = await importStore();
+        store.getState().setPhoneScale(72);
+        expect(store.getState().phoneScale).toBe(72);
+        expect(storage.getItem(PHONE_SCALE_KEY)).toBe('72');
+    });
+
+    it('clamps out-of-range values before storing them', async () => {
+        const store = await importStore();
+        store.getState().setPhoneScale(500);
+        expect(store.getState().phoneScale).toBe(100);
+        expect(storage.getItem(PHONE_SCALE_KEY)).toBe('100');
+        store.getState().setPhoneScale(-20);
+        expect(store.getState().phoneScale).toBe(0);
+        expect(storage.getItem(PHONE_SCALE_KEY)).toBe('0');
+    });
+
+    it('seeds the initial scale from localStorage', async () => {
+        storage.setItem(PHONE_SCALE_KEY, '80');
+        const store = await importStore();
+        expect(store.getState().phoneScale).toBe(80);
+    });
+
+    it('falls back to the default when the stored value is garbage', async () => {
+        storage.setItem(PHONE_SCALE_KEY, 'not-a-number');
+        const store = await importStore();
+        expect(store.getState().phoneScale).toBe(50);
+    });
+});
+
+describe('themeStore phone scale persistence (in-game)', () => {
+    it('persists the scale through the settings NUI callback', async () => {
+        const fetchNui = vi.fn().mockResolvedValue({ success: true });
+        vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
+        const store = await importStore();
+        store.getState().setPhoneScale(35);
+        expect(fetchNui).toHaveBeenCalledWith('sd-phone:settings:setPhoneScale', { scale: 35 });
+    });
+
+    it('applies the server-saved scale on hydrate', async () => {
+        const fetchNui = vi.fn().mockImplementation((event: string) => {
+            if (event === 'sd-phone:settings:get') {
+                return Promise.resolve({ data: { phoneScale: 30 } });
+            }
+            return Promise.resolve({ success: true });
+        });
+        vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
+        const store = await importStore();
+        store.getState().hydrate();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(store.getState().phoneScale).toBe(30);
+    });
+});

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -95,6 +95,18 @@ function saveChatScaleLocal(v: number) {
     try { window.localStorage.setItem(CHAT_SCALE_KEY, String(v)); } catch { /* ignore */ }
 }
 
+const PHONE_SCALE_KEY = 'sd-phone:phoneScale';
+const clampPhoneScale = (n: number) => Math.min(100, Math.max(0, Math.round(n)));
+function loadPhoneScaleLocal(): number {
+    try {
+        const n = parseFloat(window.localStorage.getItem(PHONE_SCALE_KEY) ?? '');
+        return Number.isFinite(n) ? clampPhoneScale(n) : 50;
+    } catch { return 50; }
+}
+function savePhoneScaleLocal(v: number) {
+    try { window.localStorage.setItem(PHONE_SCALE_KEY, String(v)); } catch { /* ignore */ }
+}
+
 export type PhoneAlign =
     | 'top-left'    | 'top-center'    | 'top-right'
     | 'middle-left' | 'middle-center' | 'middle-right'
@@ -185,7 +197,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     customWallpapers: isFiveM ? [] : loadCustomWallpapersLocal(),
     blurHomescreen: false,
     brightness: 100,
-    phoneScale: 50,
+    phoneScale: isFiveM ? 50 : loadPhoneScaleLocal(),
     chatTextScale: isFiveM ? 1 : loadChatScaleLocal(),
     phoneAlign: 'bottom-right',
     ringtoneVol: 40,
@@ -261,8 +273,14 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
 
     setBlurHomescreen: (v) => set({ blurHomescreen: v }),
     setBrightness:     (v) => set({ brightness: v }),
-    setPhoneScale:     (v) => set({ phoneScale: v }),
     setPhoneAlign:     (v) => set({ phoneAlign: v }),
+
+    setPhoneScale: (v) => {
+        const next = clampPhoneScale(v);
+        set({ phoneScale: next });
+        if (isFiveM) void fetchNui('sd-phone:settings:setPhoneScale', { scale: next }).catch(() => {});
+        else savePhoneScaleLocal(next);
+    },
 
     setRingtoneVol: (v) => {
         set({ ringtoneVol: v });
@@ -386,7 +404,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
             }
         };
         const keyAtRequest = wallpaperProfileKey;
-        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; customWallpapers?: string[]; chatTextScale?: number; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
+        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
             .then(res => {
                 if (!res?.data) { retry(); return; }
                 const d = res.data;
@@ -410,6 +428,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 if (d.theme === 'light' || d.theme === 'dark') patch.theme = d.theme;
                 if (typeof d.darkTheme === 'string' && (DARK_THEMES as string[]).includes(d.darkTheme)) patch.darkTheme = d.darkTheme as DarkTheme;
                 if (typeof d.chatTextScale === 'number') patch.chatTextScale = clampChatScale(d.chatTextScale);
+                if (typeof d.phoneScale === 'number') patch.phoneScale = clampPhoneScale(d.phoneScale);
                 if (typeof d.ringtoneVol === 'number') patch.ringtoneVol = clampVol(d.ringtoneVol);
                 if (typeof d.callVol === 'number') patch.callVol = clampVol(d.callVol);
                 patch.lockClock = (d.lockClock && typeof d.lockClock === 'object')


### PR DESCRIPTION
## Summary
Fixes #84 - the Phone Scale slider (Settings > Display & Brightness) only updated in-memory state, so the value reset to default on every disconnect, resource restart or reconnect.

This wires phone scale through the same persistence pipeline every other setting uses (mirroring `chatTextScale`):

- **DB**: new `phone_scale TINYINT UNSIGNED NULL` column on `phone_settings` (in the CREATE TABLE for fresh installs + a `columnExists` backfill for existing ones), with `store.getPhoneScale`/`store.setPhoneScale` clamping to an integer 0-100
- **Server**: `sd-phone:server:settings:setPhoneScale` callback, and the `settings:get` snapshot now includes `phoneScale`
- **Client**: NUI proxy for the new callback
- **Frontend**: `setPhoneScale` persists (fetchNui in-game, localStorage in dev) and `hydrate()` applies the saved value with clamping
- **SIM backup**: `phone_scale` joined the `SETTINGS_COLS` whitelist so the scale also survives unique-phones backup/restore

Out-of-range/garbage values are clamped or ignored at both ends, matching the store's existing sanitizer conventions.

Note: the Phone Position (alignment) picker on the same page has the identical gap - left out of this PR to keep it scoped to the issue, happy to follow up.

## Testing
- New `web/src/stores/themeStore.test.ts` (written failing-first): dev localStorage save/seed/clamp, in-game NUI persist call, and hydrate applying the server value - 6 tests
- Full gates: vitest 97/97, eslint 0 errors, knip clean, `tsc --noEmit` + vite build pass, `luac -p` parse-checks all four edited Lua files