### PR TITLE
fix(settings): persist phone position across restarts

### DIFF
--- a/client/apps/settings.lua
+++ b/client/apps/settings.lua
@@ -20,6 +20,7 @@ proxyCallback('sd-phone:settings:wallpapers:add',    'sd-phone:server:settings:w
 proxyCallback('sd-phone:settings:wallpapers:remove', 'sd-phone:server:settings:wallpapers:remove')
 proxyCallback('sd-phone:settings:setChatTextScale', 'sd-phone:server:settings:setChatTextScale')
 proxyCallback('sd-phone:settings:setPhoneScale',    'sd-phone:server:settings:setPhoneScale')
+proxyCallback('sd-phone:settings:setPhoneAlign',    'sd-phone:server:settings:setPhoneAlign')
 proxyCallback('sd-phone:settings:setVolumes',       'sd-phone:server:settings:setVolumes')
 proxyCallback('sd-phone:settings:setLocale',        'sd-phone:server:settings:setLocale')
 proxyCallback('sd-phone:settings:getNotifPref', 'sd-phone:server:settings:getNotifPref')

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -54,6 +54,7 @@ lib.callback.register('sd-phone:server:settings:get', function(source)
     data.customWallpapers        = store.getCustomWallpapers(cid)
     data.chatTextScale           = store.getChatTextScale(cid)
     data.phoneScale              = store.getPhoneScale(cid)
+    data.phoneAlign              = store.getPhoneAlign(cid)
     local vols = store.getVolumes(cid)
     data.ringtoneVol             = vols.ringtone
     data.callVol                 = vols.call
@@ -134,6 +135,15 @@ lib.callback.register('sd-phone:server:settings:setPhoneScale', function(source,
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
     store.setPhoneScale(cid, payload.scale)
+    return { success = true }
+end)
+
+---Persists the caller's phone anchor position (whitelisted).
+lib.callback.register('sd-phone:server:settings:setPhoneAlign', function(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    payload = type(payload) == 'table' and payload or {}
+    store.setPhoneAlign(cid, payload.align)
     return { success = true }
 end)
 

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -81,6 +81,7 @@ function store.ensureSchema()
             face_id            TINYINT(1)   NOT NULL DEFAULT 0,
             chat_text_scale    DECIMAL(3,2) NULL,
             phone_scale        TINYINT UNSIGNED NULL,
+            phone_align        VARCHAR(16) NULL,
             hour24             TINYINT(1)   NULL,
             reopen_app         TINYINT(1)   NULL,
             ringtone_volume    TINYINT UNSIGNED NULL,
@@ -152,6 +153,9 @@ function store.ensureSchema()
     end
     if not columnExists('phone_settings', 'phone_scale') then
         MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN phone_scale TINYINT UNSIGNED NULL')
+    end
+    if not columnExists('phone_settings', 'phone_align') then
+        MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN phone_align VARCHAR(16) NULL')
     end
     if not columnExists('phone_settings', 'ringtone_volume') then
         MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN ringtone_volume TINYINT UNSIGNED NULL')
@@ -694,6 +698,36 @@ function store.setPhoneScale(citizenid, scale)
         INSERT INTO phone_settings (citizenid, phone_scale) VALUES (?, ?)
         ON DUPLICATE KEY UPDATE phone_scale = VALUES(phone_scale)
     ]], { citizenid, clean })
+end
+
+-- Mirrors the PhoneAlign union in web/src/stores/themeStore.tsx.
+---@type table<string, boolean> Whitelist of storable phone anchor positions.
+local PHONE_ALIGNS = {
+    ['top-left'] = true,    ['top-center'] = true,    ['top-right'] = true,
+    ['middle-left'] = true, ['middle-center'] = true, ['middle-right'] = true,
+    ['bottom-left'] = true, ['bottom-center'] = true, ['bottom-right'] = true,
+}
+
+---Reads a player's phone anchor position, or nil if unset. Read-only.
+---@param citizenid string framework per-character id
+---@return string|nil align saved anchor position
+function store.getPhoneAlign(citizenid)
+    if not citizenid or citizenid == '' then return nil end
+    local row = MySQL.single.await('SELECT phone_align FROM phone_settings WHERE citizenid = ?', { citizenid })
+    if not row or not row.phone_align or row.phone_align == '' then return nil end
+    return row.phone_align
+end
+
+---Persists a player's phone anchor position, whitelist-checked against PHONE_ALIGNS.
+---@param citizenid string framework per-character id
+---@param align any client-supplied anchor position
+function store.setPhoneAlign(citizenid, align)
+    if not citizenid or citizenid == '' then return end
+    if type(align) ~= 'string' or not PHONE_ALIGNS[align] then return end
+    MySQL.update.await([[
+        INSERT INTO phone_settings (citizenid, phone_align) VALUES (?, ?)
+        ON DUPLICATE KEY UPDATE phone_align = VALUES(phone_align)
+    ]], { citizenid, align })
 end
 
 ---Clamps a volume to an integer 0-100; nil for non-numbers and NaN, out-of-range values fall to

--- a/server/sim/backup.lua
+++ b/server/sim/backup.lua
@@ -127,7 +127,7 @@ local SETTINGS_COLS = {
     'active_group_id', 'ringtone', 'notification_tone', 'card_name', 'card_avatar',
     'card_email', 'card_address', 'installed_apps', 'home_layout', 'lock_clock',
     'wallpaper', 'custom_wallpapers', 'passcode', 'face_id', 'chat_text_scale', 'phone_scale',
-    'hour24', 'ringtone_volume', 'call_volume', 'locale', 'dark_theme', 'theme',
+    'phone_align', 'hour24', 'ringtone_volume', 'call_volume', 'locale', 'dark_theme', 'theme',
 }
 
 ---Overwrites `toId`'s phone_settings preference columns with `fromId`'s, creating the target

--- a/web/src/stores/themeStore.test.ts
+++ b/web/src/stores/themeStore.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const PHONE_SCALE_KEY = 'sd-phone:phoneScale';
+const PHONE_ALIGN_KEY = 'sd-phone:phoneAlign';
 
 function fakeLocalStorage() {
     const map = new Map<string, string>();
@@ -82,5 +83,60 @@ describe('themeStore phone scale persistence (in-game)', () => {
         store.getState().hydrate();
         await new Promise(resolve => setTimeout(resolve, 0));
         expect(store.getState().phoneScale).toBe(30);
+    });
+});
+
+describe('themeStore phone align persistence (dev)', () => {
+    it('saves the anchor to localStorage when set', async () => {
+        const store = await importStore();
+        store.getState().setPhoneAlign('top-left');
+        expect(store.getState().phoneAlign).toBe('top-left');
+        expect(storage.getItem(PHONE_ALIGN_KEY)).toBe('top-left');
+    });
+
+    it('seeds the initial anchor from localStorage', async () => {
+        storage.setItem(PHONE_ALIGN_KEY, 'middle-center');
+        const store = await importStore();
+        expect(store.getState().phoneAlign).toBe('middle-center');
+    });
+
+    it('falls back to the default when the stored value is garbage', async () => {
+        storage.setItem(PHONE_ALIGN_KEY, 'under-the-sofa');
+        const store = await importStore();
+        expect(store.getState().phoneAlign).toBe('bottom-right');
+    });
+});
+
+describe('themeStore phone align persistence (in-game)', () => {
+    it('persists the anchor through the settings NUI callback', async () => {
+        const fetchNui = vi.fn().mockResolvedValue({ success: true });
+        vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
+        const store = await importStore();
+        store.getState().setPhoneAlign('bottom-left');
+        expect(fetchNui).toHaveBeenCalledWith('sd-phone:settings:setPhoneAlign', { align: 'bottom-left' });
+    });
+
+    it('applies the server-saved anchor on hydrate and drops unknown values', async () => {
+        const fetchNui = vi.fn().mockImplementation((event: string) => {
+            if (event === 'sd-phone:settings:get') {
+                return Promise.resolve({ data: { phoneAlign: 'top-right' } });
+            }
+            return Promise.resolve({ success: true });
+        });
+        vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
+        const store = await importStore();
+        store.getState().hydrate();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(store.getState().phoneAlign).toBe('top-right');
+
+        fetchNui.mockImplementation((event: string) => {
+            if (event === 'sd-phone:settings:get') {
+                return Promise.resolve({ data: { phoneAlign: 'sideways' } });
+            }
+            return Promise.resolve({ success: true });
+        });
+        store.getState().hydrate();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(store.getState().phoneAlign).toBe('top-right');
     });
 });

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -112,6 +112,22 @@ export type PhoneAlign =
     | 'middle-left' | 'middle-center' | 'middle-right'
     | 'bottom-left' | 'bottom-center' | 'bottom-right';
 
+const PHONE_ALIGN_KEY = 'sd-phone:phoneAlign';
+const PHONE_ALIGNS: PhoneAlign[] = [
+    'top-left',    'top-center',    'top-right',
+    'middle-left', 'middle-center', 'middle-right',
+    'bottom-left', 'bottom-center', 'bottom-right',
+];
+function loadPhoneAlignLocal(): PhoneAlign {
+    try {
+        const v = window.localStorage.getItem(PHONE_ALIGN_KEY) as PhoneAlign | null;
+        return v && PHONE_ALIGNS.includes(v) ? v : 'bottom-right';
+    } catch { return 'bottom-right'; }
+}
+function savePhoneAlignLocal(v: PhoneAlign) {
+    try { window.localStorage.setItem(PHONE_ALIGN_KEY, v); } catch { /* ignore */ }
+}
+
 interface ThemeState {
     theme:             Theme;
     setTheme:          (t: Theme) => void;
@@ -199,7 +215,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     brightness: 100,
     phoneScale: isFiveM ? 50 : loadPhoneScaleLocal(),
     chatTextScale: isFiveM ? 1 : loadChatScaleLocal(),
-    phoneAlign: 'bottom-right',
+    phoneAlign: isFiveM ? 'bottom-right' : loadPhoneAlignLocal(),
     ringtoneVol: 40,
     callVol: 60,
     airplaneMode: false,
@@ -273,7 +289,12 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
 
     setBlurHomescreen: (v) => set({ blurHomescreen: v }),
     setBrightness:     (v) => set({ brightness: v }),
-    setPhoneAlign:     (v) => set({ phoneAlign: v }),
+
+    setPhoneAlign: (v) => {
+        set({ phoneAlign: v });
+        if (isFiveM) void fetchNui('sd-phone:settings:setPhoneAlign', { align: v }).catch(() => {});
+        else savePhoneAlignLocal(v);
+    },
 
     setPhoneScale: (v) => {
         const next = clampPhoneScale(v);
@@ -404,7 +425,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
             }
         };
         const keyAtRequest = wallpaperProfileKey;
-        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
+        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
             .then(res => {
                 if (!res?.data) { retry(); return; }
                 const d = res.data;
@@ -429,6 +450,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 if (typeof d.darkTheme === 'string' && (DARK_THEMES as string[]).includes(d.darkTheme)) patch.darkTheme = d.darkTheme as DarkTheme;
                 if (typeof d.chatTextScale === 'number') patch.chatTextScale = clampChatScale(d.chatTextScale);
                 if (typeof d.phoneScale === 'number') patch.phoneScale = clampPhoneScale(d.phoneScale);
+                if (typeof d.phoneAlign === 'string' && (PHONE_ALIGNS as string[]).includes(d.phoneAlign)) patch.phoneAlign = d.phoneAlign as PhoneAlign;
                 if (typeof d.ringtoneVol === 'number') patch.ringtoneVol = clampVol(d.ringtoneVol);
                 if (typeof d.callVol === 'number') patch.callVol = clampVol(d.callVol);
                 patch.lockClock = (d.lockClock && typeof d.lockClock === 'object')


### PR DESCRIPTION
## Summary
Follow-up to #85 (supersedes #86, which was auto-closed when the stacked base branch was deleted) - the Phone Position picker (Settings > Display & Brightness) had the identical persistence gap as the phone scale slider: the anchor only updated in-memory state and snapped back to `bottom-right` on every disconnect, resource restart or reconnect.

Same pipeline treatment, with whitelist validation instead of clamping since the value is a string enum:

- **DB**: new `phone_align VARCHAR(16) NULL` column on `phone_settings` (CREATE TABLE + `columnExists` backfill), with `store.getPhoneAlign`/`store.setPhoneAlign` whitelist-checked against the nine anchor positions (mirrors the `PhoneAlign` union in `themeStore.tsx`)
- **Server**: `sd-phone:server:settings:setPhoneAlign` callback, and the `settings:get` snapshot now includes `phoneAlign`
- **Client**: NUI proxy for the new callback
- **Frontend**: `setPhoneAlign` persists (fetchNui in-game, localStorage in dev) and `hydrate()` applies the saved anchor, dropping unknown values
- **SIM backup**: `phone_align` joined the `SETTINGS_COLS` whitelist so the anchor survives unique-phones backup/restore

## Testing
- 5 new cases in `web/src/stores/themeStore.test.ts` (written failing-first): dev localStorage save/seed/garbage-fallback, in-game NUI persist call, and hydrate applying valid + dropping unknown anchors
- Full gates: vitest 102/102, eslint 0 errors, knip clean, `tsc --noEmit` + vite build pass, `luac -p` parse-checks all four edited Lua files