### PR TITLE
perf(settings): debounce slider persists to one write per gesture

### DIFF
--- a/web/src/stores/themeStore.test.ts
+++ b/web/src/stores/themeStore.test.ts
@@ -17,11 +17,18 @@ let storage: ReturnType<typeof fakeLocalStorage>;
 
 beforeEach(() => {
     storage = fakeLocalStorage();
-    vi.stubGlobal('window', { localStorage: storage, setTimeout, clearTimeout });
+    // Forward timer calls at invocation time so vi.useFakeTimers() (installed after this
+    // stub is created) still intercepts the store's window.setTimeout.
+    vi.stubGlobal('window', {
+        localStorage: storage,
+        setTimeout: (...args: Parameters<typeof setTimeout>) => setTimeout(...args),
+        clearTimeout: (...args: Parameters<typeof clearTimeout>) => clearTimeout(...args),
+    });
     vi.resetModules();
 });
 
 afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.doUnmock('@/core/nui');
 });
@@ -63,12 +70,36 @@ describe('themeStore phone scale persistence (dev)', () => {
 });
 
 describe('themeStore phone scale persistence (in-game)', () => {
-    it('persists the scale through the settings NUI callback', async () => {
+    it('debounces a drag gesture into one NUI persist with the final value', async () => {
+        vi.useFakeTimers();
         const fetchNui = vi.fn().mockResolvedValue({ success: true });
         vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
         const store = await importStore();
+        store.getState().setPhoneScale(31);
+        store.getState().setPhoneScale(33);
         store.getState().setPhoneScale(35);
+        expect(store.getState().phoneScale).toBe(35);
+        expect(fetchNui).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(300);
+        expect(fetchNui).toHaveBeenCalledTimes(1);
         expect(fetchNui).toHaveBeenCalledWith('sd-phone:settings:setPhoneScale', { scale: 35 });
+    });
+
+    it('merges rapid volume changes into one settings write, keeping live call volume immediate', async () => {
+        vi.useFakeTimers();
+        const fetchNui = vi.fn().mockResolvedValue({ success: true });
+        vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
+        const store = await importStore();
+        store.getState().setRingtoneVol(10);
+        store.getState().setRingtoneVol(55);
+        store.getState().setCallVol(80);
+        const writesBefore = fetchNui.mock.calls.filter(c => c[0] === 'sd-phone:settings:setVolumes');
+        expect(writesBefore).toHaveLength(0);
+        expect(fetchNui).toHaveBeenCalledWith('sd-phone:call:setVolume', { volume: 80 });
+        vi.advanceTimersByTime(300);
+        const writes = fetchNui.mock.calls.filter(c => c[0] === 'sd-phone:settings:setVolumes');
+        expect(writes).toHaveLength(1);
+        expect(writes[0][1]).toEqual({ ringtone: 55, call: 80 });
     });
 
     it('applies the server-saved scale on hydrate', async () => {

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -206,6 +206,17 @@ function persistSecurity(pin: string | null, face: boolean) {
     else saveSecurityLocal({ passcode: pin, faceId: face });
 }
 
+// Range sliders fire a persist per drag tick; store state must follow every tick, but one
+// server write per gesture is enough. Trailing timer, keyed per setting so concurrent
+// sliders never cancel each other's writes. The NUI document survives phone close/holster,
+// so a pending timer still fires - only a resource restart inside the window can drop one.
+const PERSIST_DEBOUNCE_MS = 300;
+const persistTimers: Record<string, number> = {};
+function persistDebounced(key: string, send: () => void) {
+    window.clearTimeout(persistTimers[key]);
+    persistTimers[key] = window.setTimeout(send, PERSIST_DEBOUNCE_MS);
+}
+
 export const useThemeStore = create<ThemeState>((set, get) => ({
     theme: isFiveM ? 'light' : loadThemeLocal(),
     darkTheme: isFiveM ? 'graphite' : loadDarkThemeLocal(),
@@ -299,18 +310,19 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     setPhoneScale: (v) => {
         const next = clampPhoneScale(v);
         set({ phoneScale: next });
-        if (isFiveM) void fetchNui('sd-phone:settings:setPhoneScale', { scale: next }).catch(() => {});
+        if (isFiveM) persistDebounced('phoneScale', () => { void fetchNui('sd-phone:settings:setPhoneScale', { scale: get().phoneScale }).catch(() => {}); });
         else savePhoneScaleLocal(next);
     },
 
     setRingtoneVol: (v) => {
         set({ ringtoneVol: v });
-        if (isFiveM) void fetchNui('sd-phone:settings:setVolumes', { ringtone: v, call: get().callVol }).catch(() => {});
+        if (isFiveM) persistDebounced('volumes', () => { void fetchNui('sd-phone:settings:setVolumes', { ringtone: get().ringtoneVol, call: get().callVol }).catch(() => {}); });
     },
     setCallVol: (v) => {
         set({ callVol: v });
         if (isFiveM) {
-            void fetchNui('sd-phone:settings:setVolumes', { ringtone: get().ringtoneVol, call: v }).catch(() => {});
+            persistDebounced('volumes', () => { void fetchNui('sd-phone:settings:setVolumes', { ringtone: get().ringtoneVol, call: get().callVol }).catch(() => {}); });
+            // Live in-call volume must track the drag in real time - never debounced.
             void fetchNui('sd-phone:call:setVolume', { volume: v }).catch(() => {});
         }
     },
@@ -318,7 +330,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     setChatTextScale: (v) => {
         const next = clampChatScale(v);
         set({ chatTextScale: next });
-        if (isFiveM) void fetchNui('sd-phone:settings:setChatTextScale', { scale: next }).catch(() => {});
+        if (isFiveM) persistDebounced('chatTextScale', () => { void fetchNui('sd-phone:settings:setChatTextScale', { scale: get().chatTextScale }).catch(() => {}); });
         else saveChatScaleLocal(next);
     },
 


### PR DESCRIPTION
## Summary
Follow-up to #85/#87, prompted by the KVP discussion on #86: the write chatter from settings sliders is real, but the fix belongs at the source of the chatter, not in the storage layer.

Range sliders fire `onChange` per drag tick, so phone scale, chat text scale and both volume sliders each pushed a full NUI -> client -> server -> `phone_settings` upsert per tick - a single drag produced ~30 identical round trips where only the last value matters.

This adds a trailing **300ms debounce, keyed per setting**, around the persist call only:

- Store state still updates every tick, so the UI tracks the finger with zero added latency
- The NUI/DB write fires **once per gesture** with the final value
- `setRingtoneVol`/`setCallVol` share one key since they persist through the same `setVolumes` callback - cross-slider fiddling lands as a single write carrying both values
- `call:setVolume` stays immediate: it drives live in-call audio, not persistence
- Dev-mode localStorage writes stay immediate (synchronous and free)

Debounced closures read the store at fire time, so the write always carries the freshest state and racing per-tick callbacks can no longer land out of order. The NUI document survives phone close/holster, so a pending timer still fires; only a resource restart inside the 300ms window can drop a write, which is negligible for cosmetic preferences.

## Testing
- Updated `themeStore.test.ts` (failing-first with fake timers): a 3-tick drag produces zero writes until 300ms idle, then exactly one with the final value; rapid ringtone+call volume changes merge into one `setVolumes` write while the live call-volume call fires immediately
- Full gates: vitest 103/103, eslint 0 errors, knip clean, `tsc --noEmit` + vite build pass