### PR TITLE
ui(settings): sub-page hero cards use the house card grey

### DIFF
--- a/web/src/apps/settings/general/AboutPage.tsx
+++ b/web/src/apps/settings/general/AboutPage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { t } from '@/i18n';
 import { formatPhone } from '@/lib/phone';
 import { useContacts } from '@/stores/contactsStore';
-import { ListGroup, ListRow } from '@/ui/ListGroup';
+import { GroupCard, ListGroup, ListRow } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
 import { useVersionInfo } from './useVersionInfo';
 
@@ -47,12 +47,12 @@ export function AboutPage({ onBack }: { onBack: () => void }) {
 function LegalPage({ onBack }: { onBack: () => void }) {
     return (
         <SubPage title={t('settings.aboutLegalRegulatory', 'Legal & Regulatory')} backLabel={t('settings.about', 'About')} onBack={onBack}>
-            <div className="mx-4 flex flex-col gap-4 rounded-[10px] bg-white px-4 py-4 text-[13px] leading-relaxed text-ios-gray dark:bg-surface">
+            <GroupCard className="mx-4 flex flex-col gap-4 px-4 py-4 text-[13px] leading-relaxed text-ios-gray">
                 <p>{t('settings.legalIntro', 'This device and its software are provided as part of your service agreement with LifeInvader Wireless.')}</p>
                 <p>{t('settings.legalWarranty', 'Hardware is covered by a one-year limited warranty. Unauthorized modification of the operating system voids all warranty coverage.')}</p>
                 <p>{t('settings.legalRf', 'This equipment complies with San Andreas RF exposure limits for portable devices. FCC ID: SA-SP2024.')}</p>
                 <p>{t('settings.legalTrademarks', 'All product names, logos and brands are property of their respective owners in the state of San Andreas.')}</p>
-            </div>
+            </GroupCard>
         </SubPage>
     );
 }

--- a/web/src/apps/settings/general/BatteryPage.tsx
+++ b/web/src/apps/settings/general/BatteryPage.tsx
@@ -2,7 +2,7 @@ import { BatteryCharging } from 'lucide-react';
 
 import { t } from '@/i18n';
 import { useBatteryStore } from '@/stores/batteryStore';
-import { ListGroup, ListRow, ToggleRow } from '@/ui/ListGroup';
+import { GroupCard, ListGroup, ListRow, ToggleRow } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
 
 export function BatteryPage({ onBack }: { onBack: () => void }) {
@@ -11,10 +11,10 @@ export function BatteryPage({ onBack }: { onBack: () => void }) {
 
     return (
         <SubPage title={t('settings.battery', 'Battery')} backLabel={t('settings.settings', 'Settings')} onBack={onBack}>
-            <div className="mx-4 overflow-hidden rounded-[10px] bg-white px-4 py-4 dark:bg-surface">
+            <GroupCard className="mx-4 px-4 py-4">
                 <div className="flex items-center justify-between">
                     <span className="text-[15px] font-semibold text-black dark:text-white">{t('settings.batteryLevel', 'Battery Level')}</span>
-                    <span className="text-[15px] font-semibold tabular-nums" style={{ color: low ? '#ff3b30' : undefined }}>
+                    <span className="text-[15px] font-semibold tabular-nums text-black dark:text-white" style={{ color: low ? '#ff3b30' : undefined }}>
                         {level}%
                     </span>
                 </div>
@@ -28,7 +28,7 @@ export function BatteryPage({ onBack }: { onBack: () => void }) {
                     <BatteryCharging className="h-[14px] w-[14px]" strokeWidth={2} />
                     {t('settings.batteryDrainNote', 'Battery drains while the phone is in use and recharges automatically over time.')}
                 </div>
-            </div>
+            </GroupCard>
 
             <ListGroup footer={t('settings.lowPowerFooter', 'Low Power Mode reduces background activity until your phone recharges.')}>
                 <ToggleRow label={t('settings.lowPowerMode', 'Low Power Mode')} />

--- a/web/src/apps/settings/general/DateTimePage.tsx
+++ b/web/src/apps/settings/general/DateTimePage.tsx
@@ -1,5 +1,5 @@
 import { t } from '@/i18n';
-import { ListGroup, ListRow, ToggleRow } from '@/ui/ListGroup';
+import { GroupCard, ListGroup, ListRow, ToggleRow } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
 import { useTheme } from '@/stores/themeStore';
 import { formatClockTime, formatLongDate, useClock } from '@/hooks/useClock';
@@ -19,12 +19,12 @@ export function DateTimePage({ onBack }: { onBack: () => void }) {
                 <ListRow label={t('settings.dateTimeZone', 'Time Zone')} value="Los Santos (UTC−8)" />
             </ListGroup>
 
-            <div className="mx-4 overflow-hidden rounded-[10px] bg-white px-4 py-5 text-center dark:bg-surface">
+            <GroupCard className="mx-4 px-4 py-5 text-center">
                 <div className="text-[42px] font-thin tracking-tight text-black dark:text-white">{formatClockTime(now, hour24)}</div>
                 <div className="mt-1 text-[15px] font-normal text-ios-gray">
                     {formatLongDate(now)}
                 </div>
-            </div>
+            </GroupCard>
         </SubPage>
     );
 }

--- a/web/src/apps/settings/general/PhoneStoragePage.tsx
+++ b/web/src/apps/settings/general/PhoneStoragePage.tsx
@@ -1,5 +1,5 @@
 import { t } from '@/i18n';
-import { ListGroup, ListRow } from '@/ui/ListGroup';
+import { GroupCard, ListGroup, ListRow } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
 
 const USED_GB  = 154.2;
@@ -19,7 +19,7 @@ const APPS = [
 export function PhoneStoragePage({ onBack }: { onBack: () => void }) {
     return (
         <SubPage title={t('settings.phoneStorage', 'Phone Storage')} onBack={onBack}>
-            <div className="mx-4 overflow-hidden rounded-[10px] bg-white px-4 py-4 dark:bg-surface">
+            <GroupCard className="mx-4 px-4 py-4">
                 <div className="mb-1 text-[13px] font-normal text-ios-gray">
                     {t('settings.storageCapacity', '{gb} GB Capacity', { gb: TOTAL_GB })}
                 </div>
@@ -33,7 +33,7 @@ export function PhoneStoragePage({ onBack }: { onBack: () => void }) {
                     <span>{t('settings.storageUsed', '{gb} GB Used', { gb: USED_GB })}</span>
                     <span>{t('settings.storageAvailable', '{gb} GB Available', { gb: FREE_GB })}</span>
                 </div>
-            </div>
+            </GroupCard>
 
             <ListGroup header={t('settings.storageByCategory', 'Storage by category')}>
                 {APPS.map((app, i) => (

--- a/web/src/apps/settings/general/SoftwareUpdatePage.tsx
+++ b/web/src/apps/settings/general/SoftwareUpdatePage.tsx
@@ -1,6 +1,7 @@
 import { Smartphone } from 'lucide-react';
 
 import { t } from '@/i18n';
+import { GroupCard } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
 import { useVersionInfo } from './useVersionInfo';
 
@@ -15,7 +16,7 @@ export function SoftwareUpdatePage({ onBack }: { onBack: () => void }) {
 
     return (
         <SubPage title={t('settings.softwareUpdate', 'Software Update')} onBack={onBack}>
-            <div className="mx-4 flex flex-col items-center gap-3 overflow-hidden rounded-[10px] bg-white px-4 py-6 dark:bg-surface">
+            <GroupCard className="mx-4 flex flex-col items-center gap-3 px-4 py-6">
                 <div className="flex h-[64px] w-[64px] items-center justify-center rounded-[14px] bg-ios-blue shadow-md">
                     <Smartphone className="h-9 w-9 text-white" strokeWidth={1.75} />
                 </div>
@@ -25,10 +26,10 @@ export function SoftwareUpdatePage({ onBack }: { onBack: () => void }) {
                     </div>
                     <div className="mt-0.5 text-[13px] text-ios-gray">{status}</div>
                 </div>
-            </div>
+            </GroupCard>
 
             {info?.updateAvailable && info.latest && (
-                <div className="mx-4 overflow-hidden rounded-[10px] bg-white dark:bg-surface">
+                <GroupCard className="mx-4">
                     <div className="flex items-start gap-3 px-4 py-3.5">
                         <span className="mt-[7px] h-[8px] w-[8px] shrink-0 rounded-full bg-ios-red" />
                         <div className="min-w-0">
@@ -40,7 +41,7 @@ export function SoftwareUpdatePage({ onBack }: { onBack: () => void }) {
                             </div>
                         </div>
                     </div>
-                </div>
+                </GroupCard>
             )}
         </SubPage>
     );


### PR DESCRIPTION
## Summary
Follow-up polish to #89. Six content cards across the settings sub-pages used `bg-white`, which glares next to the `#e5e5e5` grey every other card (`GroupCard`) uses on the grey page background:

- Software Update: version card + update-available banner
- Battery: battery-level card
- Phone Storage: capacity gauge card
- Date & Time: live clock card
- About > Legal & Regulatory: text card

Rather than hand-patching colors, all six are now `GroupCard` (which already encodes the card look: `rounded-[10px] bg-[#e5e5e5] dark:bg-surface`), so the settings card style has exactly one definition. Dark mode is visually unchanged - both variants already used `dark:bg-surface`.

Bonus fix surfaced by the change: the Battery Level percentage had no text color class, so it rendered white-on-white (invisible) on the old card. It now gets `text-black dark:text-white`, with the low-battery red override unchanged.

## Testing
- Full gates: vitest 103/103, eslint 0 errors, knip clean, `tsc --noEmit` + vite build pass
- Verified rendered UI via dev server + Playwright screenshots: Software Update and Battery cards now match neighboring ListGroup cards; battery percentage legible in light mode