### PR TITLE
feat(documents): server-verified signatures (phase 1)

### DIFF
--- a/client/apps/documents.lua
+++ b/client/apps/documents.lua
@@ -15,6 +15,9 @@ proxy('sd-phone:documents:delete',       'sd-phone:server:documents:delete')
 proxy('sd-phone:documents:deleteFolder', 'sd-phone:server:documents:deleteFolder')
 proxy('sd-phone:documents:duplicate',    'sd-phone:server:documents:duplicate')
 proxy('sd-phone:documents:importImage',  'sd-phone:server:documents:importImage')
+proxy('sd-phone:documents:signature:get', 'sd-phone:server:documents:signature:get')
+proxy('sd-phone:documents:signature:set', 'sd-phone:server:documents:signature:set')
+proxy('sd-phone:documents:sign',          'sd-phone:server:documents:sign')
 proxy('sd-phone:documents:share',        'sd-phone:server:documents:share')
 
 ---Server push: a document was created for us elsewhere (an export or another resource); relays

--- a/configs/documents.lua
+++ b/configs/documents.lua
@@ -8,4 +8,5 @@ return {
     MaxNameLength   = 60,     -- max length of a document or folder name
     MaxFolderDepth  = 5,      -- deepest nesting allowed in the folder tree
     AllowShare      = true,    -- whether AirShare to a nearby phone is offered
+    MaxSignatureLength = 150000, -- characters of a drawn-signature image data-URL
 }

--- a/server/documents/actions.lua
+++ b/server/documents/actions.lua
@@ -48,6 +48,35 @@ local function serializeFolder(row)
     return { id = row.id, name = row.name, parentId = row.parent_id }
 end
 
+---Reshapes a stored signature row into the React shape. The signer's citizenid stays
+---server-side; the client only needs the frozen display name.
+---@param row table stored signature row
+---@return table
+local function serializeSig(row)
+    return { id = row.id, signer = row.signer, image = row.image, signedAt = tonumber(row.created_at) or 0 }
+end
+
+---Attaches the signature list and signed flag to a serialized text document.
+---@param doc table serialized document (mutated)
+---@param docId string document id
+---@return table doc
+local function attachSignatures(doc, docId)
+    local sigs = {}
+    for _, row in ipairs(store.listSignatures(docId)) do sigs[#sigs + 1] = serializeSig(row) end
+    doc.signed     = #sigs > 0
+    doc.signatures = sigs
+    return doc
+end
+
+---Validates a client-supplied signature image: a PNG data-URL within the configured length.
+---@param v any client-supplied image
+---@return string|nil image verbatim data-URL, nil if unusable
+local function sanitizeSignatureImage(v)
+    if type(v) ~= 'string' or #v > cfg.MaxSignatureLength then return nil end
+    if not v:match('^data:image/png;base64,[A-Za-z0-9+/=]+$') then return nil end
+    return v
+end
+
 ---Resolves a client-supplied target folder id: nil/empty means root, otherwise the id must
 ---belong to the caller. Returns (nil) for root, (id) when valid, or (nil, err) when missing.
 ---@param cid string acting citizenid
@@ -121,8 +150,13 @@ function actions.list(src)
     local folders = {}
     for _, row in ipairs(store.listFolders(cid)) do folders[#folders + 1] = serializeFolder(row) end
 
+    local signed = store.listSignedDocIds(cid)
     local docs = {}
-    for _, row in ipairs(store.listDocs(cid)) do docs[#docs + 1] = serializeDoc(row) end
+    for _, row in ipairs(store.listDocs(cid)) do
+        local doc = serializeDoc(row)
+        doc.signed = signed[row.id] == true
+        docs[#docs + 1] = doc
+    end
 
     return ok({ folders = folders, docs = docs })
 end
@@ -139,7 +173,9 @@ function actions.get(src, payload)
     local id = type(payload.id) == 'string' and payload.id or ''
     local row = store.getDoc(cid, id)
     if not row then return fail('Document not found') end
-    return ok({ doc = serializeDoc(row) })
+    local doc = serializeDoc(row)
+    if row.kind == 'text' then attachSignatures(doc, id) end
+    return ok({ doc = doc })
 end
 
 ---Creates a folder for the caller. The name is required, the folder cap applies, and the new
@@ -226,6 +262,7 @@ function actions.save(src, payload)
     local row = store.getDoc(cid, id)
     if not row then return fail('Document not found') end
     if isTruthy(row.locked) then return fail('This document is locked') end
+    if store.hasSignatures(id) then return fail('This document has been signed and can no longer be edited') end
 
     local ts, size = os.time(), #content
     if store.updateContent(cid, id, content, size, ts) == 0 then return fail('Could not save document') end
@@ -249,6 +286,7 @@ function actions.rename(src, payload)
     local row = store.getDoc(cid, id)
     if not row then return fail('Document not found') end
     if isTruthy(row.locked) then return fail('This document is locked') end
+    if store.hasSignatures(id) then return fail('This document has been signed and can no longer be renamed') end
 
     if store.renameDoc(cid, id, name, os.time()) == 0 then return fail('Could not rename document') end
     return ok({})
@@ -311,6 +349,7 @@ function actions.delete(src, payload)
     if isTruthy(row.locked) then return fail('This document is locked') end
 
     if store.deleteDoc(cid, id) == 0 then return fail('Could not delete document') end
+    store.deleteSignaturesForDocs({ id })
     return ok({})
 end
 
@@ -348,16 +387,18 @@ function actions.deleteFolder(src, payload)
         end
     end
 
-    local removedDocs = 0
+    local removedDocs, removedIds = 0, {}
     for _, row in ipairs(store.listDocs(cid)) do
         if row.folder_id and inSet[row.folder_id] and not isTruthy(row.locked) then
             removedDocs = removedDocs + 1
+            removedIds[#removedIds + 1] = row.id
         end
     end
 
     store.reparentLockedToRoot(cid, idList)
     store.deleteDocsInFolders(cid, idList)
     store.deleteFolders(cid, idList)
+    store.deleteSignaturesForDocs(removedIds)
     return ok({ removedDocs = removedDocs })
 end
 
@@ -529,7 +570,74 @@ end
 function actions.deleteForCid(cid, docId)
     if type(cid) ~= 'string' or cid == '' then return false end
     if type(docId) ~= 'string' or docId == '' then return false end
-    return store.deleteDoc(cid, docId) > 0
+    if store.deleteDoc(cid, docId) == 0 then return false end
+    store.deleteSignaturesForDocs({ docId })
+    return true
+end
+
+---A document's signatures for a citizenid, for other resources. Read-only; an empty array when
+---the document doesn't exist or belong to the player.
+---@param cid string acting citizenid
+---@param docId any document id
+---@return table[] signatures
+function actions.listSignaturesForCid(cid, docId)
+    if type(cid) ~= 'string' or cid == '' then return {} end
+    if type(docId) ~= 'string' or docId == '' then return {} end
+    if not store.getDoc(cid, docId) then return {} end
+    local out = {}
+    for _, row in ipairs(store.listSignatures(docId)) do out[#out + 1] = serializeSig(row) end
+    return out
+end
+
+---The caller's saved personal signature image, or nil when never drawn.
+---@param src integer player server id
+---@return table result envelope with { image }
+function actions.getSignature(src)
+    local cid = player.getIdentifier(src)
+    if not cid then return fail('Player not found') end
+    return ok({ image = store.getPersonalSignature(cid) })
+end
+
+---Saves the caller's personal signature image (a PNG data-URL within the configured length).
+---@param src integer player server id
+---@param payload { image?: string }
+---@return table result envelope
+function actions.setSignature(src, payload)
+    if type(payload) ~= 'table' then payload = {} end
+    local cid = player.getIdentifier(src)
+    if not cid then return fail('Player not found') end
+
+    local image = sanitizeSignatureImage(payload.image)
+    if not image then return fail('That signature could not be saved') end
+    store.setPersonalSignature(cid, image, os.time())
+    return ok({})
+end
+
+---Signs one of the caller's text documents with their saved personal signature. The image is
+---snapshotted onto the signature row, so redrawing the personal signature later never rewrites
+---history; the presence of any signature freezes the document's content and name.
+---@param src integer player server id
+---@param payload { id?: string }
+---@return table result envelope with { doc }
+function actions.sign(src, payload)
+    if type(payload) ~= 'table' then payload = {} end
+    local cid = player.getIdentifier(src)
+    if not cid then return fail('Player not found') end
+
+    local id = type(payload.id) == 'string' and payload.id or ''
+    local row = store.getDoc(cid, id)
+    if not row then return fail('Document not found') end
+    if row.kind ~= 'text' then return fail('Only text documents can be signed') end
+    if store.hasSigned(id, cid) then return fail('You have already signed this document') end
+
+    local image = store.getPersonalSignature(cid)
+    if not image then return fail('Draw your signature first') end
+
+    store.addSignature({
+        id = newId(), docId = id, citizenid = cid,
+        signer = player.getName(src) or 'Unknown', image = image, ts = os.time(),
+    })
+    return ok({ doc = attachSignatures(serializeDoc(row), id) })
 end
 
 ---Opens an AirShare request offering one of the caller's documents to a nearby player. The
@@ -549,6 +657,13 @@ function actions.requestShare(src, target, payload)
     if not row then return fail('Document not found') end
     if isTruthy(row.locked) then return fail('This document cannot be shared') end
 
+    -- Signatures travel with the copy (read server-side here, re-inserted server-side on
+    -- delivery), so a signed contract stays verifiably signed on the recipient's phone.
+    local sigs = {}
+    for _, s in ipairs(store.listSignatures(id)) do
+        sigs[#sigs + 1] = { citizenid = s.citizenid, signer = s.signer, image = s.image, created_at = s.created_at }
+    end
+
     local okSent, msg = share.request(src, target, 'document', {
         name    = row.name,
         kind    = row.kind,
@@ -557,6 +672,7 @@ function actions.requestShare(src, target, payload)
         size    = tonumber(row.size) or 0,
         source  = row.source,
         fromName = player.getName(src),
+        signatures = sigs,
     })
     if not okSent then return fail(msg or 'Could not send request') end
     return ok({})
@@ -599,10 +715,26 @@ function actions.deliverShare(targetSrc, payload)
         content = content, url = url, size = size, locked = 0, source = source, ts = ts,
     })
 
+    -- Re-attach the sender's signature rows to the delivered copy; the payload was built
+    -- server-side in requestShare, so the rows stay authentic.
+    if kind == 'text' and type(payload.signatures) == 'table' then
+        for _, s in ipairs(payload.signatures) do
+            if type(s) == 'table' and type(s.citizenid) == 'string' and s.citizenid ~= '' then
+                store.addSignature({
+                    id = newId(), docId = id, citizenid = s.citizenid,
+                    signer = type(s.signer) == 'string' and s.signer:sub(1, 64) or 'Unknown',
+                    image = sanitizeSignatureImage(s.image),
+                    ts = tonumber(s.created_at) or ts,
+                })
+            end
+        end
+    end
+
     local doc = serializeDoc({
         id = id, folder_id = nil, name = name, kind = kind, content = content, url = url,
         size = size, locked = 0, source = source, created_at = ts, updated_at = ts,
     })
+    if kind == 'text' then attachSignatures(doc, id) end
     local fromName = type(payload.fromName) == 'string' and payload.fromName ~= '' and payload.fromName or 'Someone'
     TriggerClientEvent('sd-phone:client:documents:receive', targetSrc, { doc = doc, fromName = fromName })
     TriggerClientEvent('sd-phone:client:notify', targetSrc, {

--- a/server/documents/init.lua
+++ b/server/documents/init.lua
@@ -40,6 +40,9 @@ lib.callback.register('sd-phone:server:documents:delete', function(src, payload)
 lib.callback.register('sd-phone:server:documents:deleteFolder', function(src, payload) return actions.deleteFolder(src, payload) end)
 lib.callback.register('sd-phone:server:documents:duplicate', function(src, payload) return actions.duplicate(src, payload) end)
 lib.callback.register('sd-phone:server:documents:importImage', function(src, payload) return actions.importImage(src, payload) end)
+lib.callback.register('sd-phone:server:documents:signature:get', function(src) return actions.getSignature(src) end)
+lib.callback.register('sd-phone:server:documents:signature:set', function(src, payload) return actions.setSignature(src, payload) end)
+lib.callback.register('sd-phone:server:documents:sign', function(src, payload) return actions.sign(src, payload) end)
 
 ---AirShares a document to a nearby player; the payload carries both the recipient and the id.
 lib.callback.register('sd-phone:server:documents:share', function(src, payload)
@@ -140,4 +143,17 @@ exports('deleteDocumentById', function(source, docId)
     local cid = player.getIdentifier(source)
     if not cid then return false end
     return actions.deleteForCid(cid, docId)
+end)
+
+---Reads a document's signatures for a player, for other resources: each entry carries the
+---frozen signer name, the epoch signing time and the signature image. Read-only; always an
+---array, empty when the document doesn't exist or belong to the player.
+---@param source number acting player's server id
+---@param docId string document id
+---@return table[] signatures { id, signer, image, signedAt }
+exports('getDocumentSignatures', function(source, docId)
+    if type(source) ~= 'number' then return {} end
+    local cid = player.getIdentifier(source)
+    if not cid then return {} end
+    return actions.listSignaturesForCid(cid, docId)
 end)

--- a/server/documents/store.lua
+++ b/server/documents/store.lua
@@ -41,9 +41,31 @@ function store.ensureSchema()
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
+    MySQL.query.await([[
+        CREATE TABLE IF NOT EXISTS `phone_document_signatures` (
+            `id`         VARCHAR(16) NOT NULL,
+            `doc_id`     VARCHAR(16) NOT NULL,
+            `citizenid`  VARCHAR(64) NOT NULL,
+            `signer`     VARCHAR(64) NOT NULL,
+            `image`      MEDIUMTEXT  NULL,
+            `created_at` BIGINT      NOT NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    ]])
+
+    MySQL.query.await([[
+        CREATE TABLE IF NOT EXISTS `phone_signatures` (
+            `citizenid`  VARCHAR(64) NOT NULL,
+            `image`      MEDIUMTEXT  NOT NULL,
+            `updated_at` BIGINT      NOT NULL,
+            PRIMARY KEY (`citizenid`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    ]])
+
     util.ensureIndex('phone_documents', 'idx_phone_documents_folder', '(citizenid, folder_id)')
     util.ensureIndex('phone_documents', 'idx_phone_documents_updated', '(citizenid, updated_at)')
     util.ensureIndex('phone_document_folders', 'idx_phone_document_folders_cid', '(citizenid)')
+    util.ensureIndex('phone_document_signatures', 'idx_phone_document_signatures_doc', '(doc_id)')
 end
 
 ---All of a player's folders. Read-only.
@@ -225,6 +247,92 @@ function store.reparentLockedToRoot(cid, idList)
             :format(table.concat(placeholders, ', ')),
         params
     )
+end
+
+---A document's signatures, oldest first. Ownership of the parent document is the caller's
+---responsibility (check getDoc first). Read-only.
+---@param docId string document id
+---@return table[] rows {id, citizenid, signer, image, created_at}
+function store.listSignatures(docId)
+    if not docId or docId == '' then return {} end
+    return MySQL.query.await([[
+        SELECT id, citizenid, signer, image, created_at
+        FROM `phone_document_signatures` WHERE doc_id = ? ORDER BY created_at ASC
+    ]], { docId }) or {}
+end
+
+---The ids of a player's documents that carry at least one signature, as a set. Read-only.
+---@param cid string owner citizenid
+---@return table<string, boolean> signed
+function store.listSignedDocIds(cid)
+    local rows = MySQL.query.await([[
+        SELECT DISTINCT s.doc_id FROM `phone_document_signatures` s
+        JOIN `phone_documents` d ON d.id = s.doc_id
+        WHERE d.citizenid = ?
+    ]], { cid }) or {}
+    local set = {}
+    for i = 1, #rows do set[rows[i].doc_id] = true end
+    return set
+end
+
+---True when this signer already has a signature on the document. Read-only.
+---@param docId string document id
+---@param cid string signer citizenid
+---@return boolean signed
+function store.hasSigned(docId, cid)
+    return MySQL.scalar.await(
+        'SELECT 1 FROM `phone_document_signatures` WHERE doc_id = ? AND citizenid = ? LIMIT 1',
+        { docId, cid }) ~= nil
+end
+
+---True when the document carries any signature (drives the content-freeze guards). Read-only.
+---@param docId string document id
+---@return boolean signed
+function store.hasSignatures(docId)
+    return MySQL.scalar.await(
+        'SELECT 1 FROM `phone_document_signatures` WHERE doc_id = ? LIMIT 1', { docId }) ~= nil
+end
+
+---Inserts a signature row.
+---@param sig { id: string, docId: string, citizenid: string, signer: string, image: string|nil, ts: number }
+function store.addSignature(sig)
+    MySQL.insert.await([[
+        INSERT INTO `phone_document_signatures` (id, doc_id, citizenid, signer, image, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+    ]], { sig.id, sig.docId, sig.citizenid, sig.signer, sig.image, sig.ts })
+end
+
+---Removes every signature on a set of documents, in one parameterized IN statement. A no-op on
+---an empty list.
+---@param docIds string[] document ids
+function store.deleteSignaturesForDocs(docIds)
+    if not docIds or #docIds == 0 then return end
+    local placeholders = {}
+    for i = 1, #docIds do placeholders[i] = '?' end
+    MySQL.update.await(
+        ('DELETE FROM `phone_document_signatures` WHERE doc_id IN (%s)')
+            :format(table.concat(placeholders, ', ')),
+        docIds
+    )
+end
+
+---A player's saved personal signature image, or nil when never drawn. Read-only.
+---@param cid string owner citizenid
+---@return string|nil image PNG data-URL
+function store.getPersonalSignature(cid)
+    if not cid or cid == '' then return nil end
+    return MySQL.scalar.await('SELECT image FROM `phone_signatures` WHERE citizenid = ?', { cid })
+end
+
+---Saves a player's personal signature image (upsert).
+---@param cid string owner citizenid
+---@param image string PNG data-URL
+---@param ts number epoch-seconds save time
+function store.setPersonalSignature(cid, image, ts)
+    MySQL.update.await([[
+        INSERT INTO `phone_signatures` (citizenid, image, updated_at) VALUES (?, ?, ?)
+        ON DUPLICATE KEY UPDATE image = VALUES(image), updated_at = VALUES(updated_at)
+    ]], { cid, image, ts })
 end
 
 ---Counts a player's documents (drives the per-player cap). Read-only.

--- a/server/sim/backup.lua
+++ b/server/sim/backup.lua
@@ -119,6 +119,7 @@ local COPY = {
     { 'phone_app_sessions',      'citizenid' },
     { 'phone_documents',         'citizenid' },
     { 'phone_document_folders',  'citizenid' },
+    { 'phone_signatures',        'citizenid' },
 }
 
 ---@type string[] phone_settings columns carried by a restore. The number, citizenid and
@@ -149,6 +150,24 @@ local function copySettings(fromId, toId)
     ]]):format(table.concat(setParts, ', ')), { fromId, toId })
 end
 
+---Copies document signature rows across identities, remapping their own id and the doc_id FK
+---the way copyTable remapped phone_documents. The signer's citizenid copies VERBATIM: it names
+---who signed (possibly another character), not who owns the document.
+---@param fromId string source identity
+---@param toId string target identity
+---@return integer rows
+local function copyDocSignatures(fromId, toId)
+    return run([[
+        INSERT IGNORE INTO phone_document_signatures (id, doc_id, citizenid, signer, image, created_at)
+        SELECT SUBSTRING(MD5(CONCAT(s.id, ?)), 1, 16),
+               SUBSTRING(MD5(CONCAT(s.doc_id, ?)), 1, 16),
+               s.citizenid, s.signer, s.image, s.created_at
+        FROM phone_document_signatures s
+        JOIN phone_documents d ON d.id = s.doc_id
+        WHERE d.citizenid = ?
+    ]], { toId, toId, fromId })
+end
+
 ---Copies album membership rows across identities, remapping both foreign ids the way
 ---copyTable remapped their parents (no identity column of its own).
 ---@param fromId string source identity
@@ -170,11 +189,16 @@ end
 ---a sync). The phone_settings row goes too - a dead namespace keeps nothing.
 ---@param cloudId string snapshot identity ('cloud:' prefixed)
 function backup.wipe(cloudId)
-    -- Album items go first: their parent album rows are the only link to the cloud identity.
+    -- Join-keyed children go first: their parent rows are the only link to the cloud identity.
     run([[
         DELETE i FROM phone_photo_album_items i
         JOIN phone_photo_albums a ON a.id = i.album_id
         WHERE a.citizenid = ?
+    ]], { cloudId })
+    run([[
+        DELETE s FROM phone_document_signatures s
+        JOIN phone_documents d ON d.id = s.doc_id
+        WHERE d.citizenid = ?
     ]], { cloudId })
     for _, t in ipairs(COPY) do
         run(('DELETE FROM `%s` WHERE `%s` = ?'):format(t[1], t[2]), { cloudId })
@@ -196,6 +220,7 @@ function backup.sync(fromId, cloudId)
     for _, t in ipairs(COPY) do
         rows = rows + copyTable(t[1], t[2], fromId, cloudId)
     end
+    rows = rows + copyDocSignatures(fromId, cloudId)
     return rows + copyAlbumItems(fromId, cloudId)
 end
 
@@ -217,6 +242,7 @@ function backup.restore(fromId, toId, toNumber, liveFromId)
         rows = rows + copyTable(t[1], t[2], fromId, toId)
     end
 
+    rows = rows + copyDocSignatures(fromId, toId)
     rows = rows + copyAlbumItems(fromId, toId)
 
     -- Group chats fan out by the member rows, so membership MOVES to the restored profile

--- a/web/src/apps/documents/DocRow.tsx
+++ b/web/src/apps/documents/DocRow.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, File as FileIcon, FileText, Folder, Image as ImageIcon, Lock, MoreHorizontal } from 'lucide-react';
+import { BadgeCheck, ChevronRight, File as FileIcon, FileText, Folder, Image as ImageIcon, Lock, MoreHorizontal } from 'lucide-react';
 
 import { t } from '@/i18n';
 import { ListRow } from '@/ui/ListGroup';
@@ -94,6 +94,7 @@ export function FileRow({ doc, onOpen, onMore, divider }: {
                 }
                 right={
                     <span className="flex items-center gap-1">
+                        {doc.signed && <BadgeCheck className="h-[15px] w-[15px] shrink-0 text-ios-blue" strokeWidth={2.2} />}
                         {doc.locked && <Lock className="h-[14px] w-[14px] shrink-0 text-ios-gray" strokeWidth={2.4} />}
                         <MoreGlyph onMore={onMore} />
                     </span>

--- a/web/src/apps/documents/Documents.tsx
+++ b/web/src/apps/documents/Documents.tsx
@@ -157,7 +157,7 @@ export function Documents({ onClose: _onClose }: { onClose: () => void }) {
     }
 
     const docActions = moreDoc ? [
-        ...(moreDoc.locked ? [] : [{
+        ...(moreDoc.locked || moreDoc.signed ? [] : [{
             label: t('documents.rename', 'Rename'),
             onClick: () => setRenaming({ kind: 'doc', id: moreDoc.id, name: moreDoc.name }),
         }]),
@@ -212,6 +212,10 @@ export function Documents({ onClose: _onClose }: { onClose: () => void }) {
                     animateIn={animateNav}
                     onBack={() => setOpenText(null)}
                     onSave={content => void saveText(openText.id, content)}
+                    onSigned={updated => {
+                        patchDoc(updated.id, d => ({ ...d, signed: true }));
+                        setOpenText(prev => (prev && prev.id === updated.id ? { ...prev, ...updated } : prev));
+                    }}
                 />
             )}
 

--- a/web/src/apps/documents/SignaturePad.tsx
+++ b/web/src/apps/documents/SignaturePad.tsx
@@ -1,0 +1,140 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+
+import { t } from '@/i18n';
+
+interface Point { x: number; y: number }
+
+export interface SignaturePadHandle {
+    /** Composited PNG data-URL (white paper background), or null with no ink. */
+    toImage(): string | null;
+    clear(): void;
+}
+
+// Coordinate correction under the phone's fractional CSS zoom, mirroring
+// notes/SketchCanvas: clientX/Y are zoom-scaled while rect.left/top are not.
+function ancestorZoom(el: HTMLElement | null): number {
+    let z = 1;
+    for (let n: HTMLElement | null = el; n; n = n.parentElement) {
+        const cz = parseFloat(getComputedStyle(n).getPropertyValue('zoom'));
+        if (cz > 0 && cz !== 1) z *= cz;
+    }
+    return z || 1;
+}
+
+const INK = '#1d1d1f';
+const INK_WIDTH = 2.5;
+
+export const SignaturePad = forwardRef<SignaturePadHandle, { onInkChange?: (hasInk: boolean) => void }>(
+    function SignaturePad({ onInkChange }, ref) {
+        const canvasRef  = useRef<HTMLCanvasElement>(null);
+        const strokesRef = useRef<Point[][]>([]);
+        const drawingRef = useRef(false);
+        const dprRef     = useRef(1);
+        const [hasInk, setHasInk] = useState(false);
+
+        useEffect(() => {
+            const canvas = canvasRef.current;
+            if (!canvas) return;
+            const dpr = window.devicePixelRatio || 1;
+            dprRef.current = dpr;
+            canvas.width  = Math.max(1, Math.round(canvas.offsetWidth  * dpr));
+            canvas.height = Math.max(1, Math.round(canvas.offsetHeight * dpr));
+            const c = canvas.getContext('2d');
+            if (!c) return;
+            c.scale(dpr, dpr);
+            c.lineCap  = 'round';
+            c.lineJoin = 'round';
+            c.strokeStyle = INK;
+            c.lineWidth   = INK_WIDTH;
+        }, []);
+
+        function point(e: React.PointerEvent): Point {
+            const canvas = canvasRef.current!;
+            const rect = canvas.getBoundingClientRect();
+            const ow = canvas.offsetWidth, oh = canvas.offsetHeight;
+            if (rect.width === 0 || rect.height === 0 || ow === 0 || oh === 0) return { x: 0, y: 0 };
+            const z  = ancestorZoom(canvas);
+            const sx = (rect.width  / ow) / z;
+            const sy = (rect.height / oh) / z;
+            return { x: e.clientX * sx - rect.left, y: e.clientY * sy - rect.top };
+        }
+
+        function markInk(v: boolean) {
+            setHasInk(v);
+            onInkChange?.(v);
+        }
+
+        function onDown(e: React.PointerEvent) {
+            const c = canvasRef.current?.getContext('2d');
+            if (!c) return;
+            try { (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId); } catch { /* capture unsupported */ }
+            drawingRef.current = true;
+            strokesRef.current.push([point(e)]);
+            markInk(true);
+        }
+
+        function onMove(e: React.PointerEvent) {
+            if (!drawingRef.current) return;
+            const c = canvasRef.current?.getContext('2d');
+            const stroke = strokesRef.current[strokesRef.current.length - 1];
+            if (!c || !stroke) return;
+            const p = point(e);
+            const prev = stroke[stroke.length - 1];
+            stroke.push(p);
+            c.beginPath();
+            c.moveTo(prev.x, prev.y);
+            c.lineTo(p.x, p.y);
+            c.stroke();
+        }
+
+        function onUp() { drawingRef.current = false; }
+
+        useImperativeHandle(ref, () => ({
+            toImage() {
+                const canvas = canvasRef.current;
+                if (!canvas || strokesRef.current.length === 0) return null;
+                const out = document.createElement('canvas');
+                out.width  = canvas.width;
+                out.height = canvas.height;
+                const c = out.getContext('2d');
+                if (!c) return null;
+                c.fillStyle = '#ffffff';
+                c.fillRect(0, 0, out.width, out.height);
+                c.drawImage(canvas, 0, 0);
+                return out.toDataURL('image/png');
+            },
+            clear() {
+                const canvas = canvasRef.current;
+                const c = canvas?.getContext('2d');
+                if (!canvas || !c) return;
+                c.save();
+                c.setTransform(1, 0, 0, 1, 0, 0);
+                c.clearRect(0, 0, canvas.width, canvas.height);
+                c.restore();
+                strokesRef.current = [];
+                drawingRef.current = false;
+                markInk(false);
+            },
+        }));
+
+        return (
+            <div className="relative overflow-hidden rounded-[12px] border border-black/10 bg-white">
+                <canvas
+                    ref={canvasRef}
+                    className="block h-[150px] w-full touch-none"
+                    onPointerDown={onDown}
+                    onPointerMove={onMove}
+                    onPointerUp={onUp}
+                    onPointerCancel={onUp}
+                    onPointerLeave={onUp}
+                />
+                {!hasInk && (
+                    <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[15px] text-ios-gray3">
+                        {t('documents.signHere', 'Sign here')}
+                    </span>
+                )}
+                <div className="pointer-events-none absolute inset-x-6 bottom-7 border-b border-dashed border-black/15" />
+            </div>
+        );
+    },
+);

--- a/web/src/apps/documents/TextEditor.tsx
+++ b/web/src/apps/documents/TextEditor.tsx
@@ -1,48 +1,55 @@
 import { useEffect, useRef, useState } from 'react';
-import { ChevronLeft, Lock } from 'lucide-react';
+import { BadgeCheck, ChevronLeft, Lock, PenLine } from 'lucide-react';
 
 import { useIosPush } from '@/hooks/useIosPush';
 import { t } from '@/i18n';
-import { MAX_TEXT_LENGTH, type DocFile } from './data';
+import { Sheet } from '@/ui/Sheet';
+import { apiGetSignature, apiSetSignature, apiSignDoc } from './documentsApi';
+import { SignaturePad, type SignaturePadHandle } from './SignaturePad';
+import { MAX_TEXT_LENGTH, formatDocDate, type DocFile, type DocSignature } from './data';
 
 interface Props {
     doc:       DocFile;
     backLabel: string;
     onBack:    () => void;
     onSave:    (content: string) => void;
+    onSigned?: (doc: DocFile) => void;
     animateIn?: boolean;
 }
 
-export function TextEditor({ doc, backLabel, onBack, onSave, animateIn = true }: Props) {
+export function TextEditor({ doc, backLabel, onBack, onSave, onSigned, animateIn = true }: Props) {
     const { goBack, pageStyle } = useIosPush(onBack, animateIn);
 
     const [body, setBody] = useState(doc.content ?? '');
-    const locked = doc.locked;
+    const signed   = doc.signed === true;
+    const readOnly = doc.locked || signed;
+    const [signOpen, setSignOpen] = useState(false);
 
     const lastSaved = useRef(doc.content ?? '');
     const onSaveRef = useRef(onSave);
     onSaveRef.current = onSave;
 
     useEffect(() => {
-        if (locked) return;
+        if (readOnly) return;
         const handle = window.setTimeout(() => {
             if (body === lastSaved.current) return;
             lastSaved.current = body;
             onSaveRef.current(body);
         }, 800);
         return () => window.clearTimeout(handle);
-    }, [body, locked]);
+    }, [body, readOnly]);
 
     // Flush on unmount (covers back before the debounce fires). Refs hold latest.
     const live = useRef(body);
     live.current = body;
+    const roRef = useRef(readOnly);
+    roRef.current = readOnly;
     useEffect(() => () => {
-        if (locked) return;
+        if (roRef.current) return;
         if (live.current !== lastSaved.current) {
             lastSaved.current = live.current;
             onSaveRef.current(live.current);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return (
@@ -63,33 +70,198 @@ export function TextEditor({ doc, backLabel, onBack, onSave, animateIn = true }:
                 </button>
                 <span className="min-w-0 flex-1 truncate text-center text-[17px] font-semibold">{doc.name}</span>
                 <span className="flex w-[68px] shrink-0 items-center justify-end pr-1.5">
-                    {locked && (
+                    {signed ? (
+                        <span className="flex items-center gap-1 text-[13px] text-ios-blue">
+                            <BadgeCheck className="h-[15px] w-[15px]" strokeWidth={2.2} />
+                            {t('documents.signed', 'Signed')}
+                        </span>
+                    ) : doc.locked ? (
                         <span className="flex items-center gap-1 text-[13px] text-ios-gray">
                             <Lock className="h-[14px] w-[14px]" strokeWidth={2.4} />
                             {t('documents.readOnly', 'Read Only')}
                         </span>
-                    )}
+                    ) : null}
                 </span>
             </div>
 
             <div className="flex-1 overflow-y-auto no-scrollbar px-4">
                 <textarea
                     value={body}
-                    readOnly={locked}
+                    readOnly={readOnly}
                     maxLength={MAX_TEXT_LENGTH}
                     onChange={e => setBody(e.target.value)}
                     placeholder={t('documents.startWriting', 'Start writing…')}
                     className="mt-4 w-full resize-none bg-transparent text-[17px] leading-snug outline-none placeholder:text-ios-gray"
-                    style={{ minHeight: 320 }}
+                    style={{ minHeight: signed ? 180 : 320 }}
                     aria-label={t('documents.documentBody', 'Document body')}
                 />
+
+                {(doc.signatures?.length ?? 0) > 0 && (
+                    <div className="mb-4 mt-2 flex flex-col gap-2.5">
+                        {doc.signatures!.map(sig => <SignatureBlock key={sig.id} sig={sig} />)}
+                    </div>
+                )}
             </div>
 
-            <div className="flex shrink-0 items-center justify-center px-4 pb-12 pt-2">
+            <div className="flex shrink-0 items-center justify-between px-4 pb-12 pt-2">
                 <span className="text-[13px] text-ios-gray tabular-nums">
                     {t('documents.charCount', '{n} of {max} characters', { n: body.length, max: MAX_TEXT_LENGTH })}
                 </span>
+                {!signed && (
+                    <button
+                        type="button"
+                        onClick={() => setSignOpen(true)}
+                        className="flex items-center gap-1.5 text-[15px] font-semibold text-ios-blue active:opacity-60"
+                    >
+                        <PenLine className="h-[16px] w-[16px]" strokeWidth={2.3} />
+                        {t('documents.sign', 'Sign')}
+                    </button>
+                )}
+            </div>
+
+            {signOpen && (
+                <SignSheet
+                    docId={doc.id}
+                    onClose={() => setSignOpen(false)}
+                    onSigned={updated => {
+                        setSignOpen(false);
+                        onSigned?.(updated);
+                    }}
+                />
+            )}
+        </div>
+    );
+}
+
+
+function SignatureBlock({ sig }: { sig: DocSignature }) {
+    return (
+        <div className="rounded-[12px] border border-black/[0.08] bg-white px-4 py-3 shadow-sm dark:border-white/[0.1]">
+            {sig.image ? (
+                <img src={sig.image} alt="" className="h-[64px] max-w-full object-contain" draggable={false} />
+            ) : (
+                <span className="block py-2 font-serif text-[26px] italic leading-none text-[#1d1d1f]">
+                    {sig.signer}
+                </span>
+            )}
+            <div className="mt-2 flex items-center justify-between border-t border-black/[0.06] pt-2">
+                <span className="text-[13px] font-semibold text-black">{sig.signer}</span>
+                <span className="flex items-center gap-1 text-[12px] text-ios-blue">
+                    <BadgeCheck className="h-[13px] w-[13px]" strokeWidth={2.2} />
+                    {t('documents.signedOn', 'Signed {date}', { date: formatDocDate(sig.signedAt) })}
+                </span>
             </div>
         </div>
+    );
+}
+
+
+function SignSheet({ docId, onClose, onSigned }: {
+    docId:    string;
+    onClose:  () => void;
+    onSigned: (doc: DocFile) => void;
+}) {
+    const padRef = useRef<SignaturePadHandle>(null);
+    const [saved,   setSaved]   = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [drawing, setDrawing] = useState(false);
+    const [hasInk,  setHasInk]  = useState(false);
+    const [busy,    setBusy]    = useState(false);
+    const [error,   setError]   = useState<string | null>(null);
+
+    useEffect(() => {
+        let alive = true;
+        void apiGetSignature().then(image => {
+            if (!alive) return;
+            setSaved(image);
+            setDrawing(!image);
+            setLoading(false);
+        });
+        return () => { alive = false; };
+    }, []);
+
+    async function sign() {
+        if (busy) return;
+        setBusy(true);
+        setError(null);
+        if (drawing) {
+            const image = padRef.current?.toImage();
+            if (!image) { setBusy(false); return; }
+            const stored = await apiSetSignature(image);
+            if (!stored) {
+                setError(t('documents.signatureSaveFailed', 'Your signature could not be saved.'));
+                setBusy(false);
+                return;
+            }
+        }
+        const updated = await apiSignDoc(docId);
+        if (!updated) {
+            setError(t('documents.signFailed', 'The document could not be signed.'));
+            setBusy(false);
+            return;
+        }
+        onSigned(updated);
+    }
+
+    return (
+        <Sheet onClose={onClose} fit="content" title={t('documents.signDocument', 'Sign Document')} className="bg-[#ececec] dark:bg-surface">
+            {() => (
+                <div className="flex flex-col gap-3 px-5 pb-8 pt-1">
+                    {loading ? (
+                        <div className="h-[150px]" />
+                    ) : drawing ? (
+                        <SignaturePad ref={padRef} onInkChange={setHasInk} />
+                    ) : (
+                        <div className="flex items-center justify-center rounded-[12px] border border-black/10 bg-white px-4 py-5">
+                            <img src={saved ?? undefined} alt="" className="h-[84px] max-w-full object-contain" draggable={false} />
+                        </div>
+                    )}
+
+                    <p className="text-center text-[13px] leading-snug text-ios-gray">
+                        {t('documents.signLockHint', 'Signing adds your name and locks this document from further edits.')}
+                    </p>
+
+                    {error && <p className="text-center text-[13px] text-ios-red">{error}</p>}
+
+                    <button
+                        type="button"
+                        disabled={busy || loading || (drawing && !hasInk)}
+                        onClick={() => void sign()}
+                        className="rounded-[12px] bg-ios-blue py-3 text-[16px] font-semibold text-white active:opacity-80 disabled:opacity-40"
+                    >
+                        {t('documents.signDocument', 'Sign Document')}
+                    </button>
+
+                    {drawing ? (
+                        <div className="flex items-center justify-center gap-6">
+                            <button
+                                type="button"
+                                onClick={() => { padRef.current?.clear(); }}
+                                className="text-[15px] text-ios-blue active:opacity-60"
+                            >
+                                {t('documents.clearSignature', 'Clear')}
+                            </button>
+                            {saved && (
+                                <button
+                                    type="button"
+                                    onClick={() => { setDrawing(false); setHasInk(false); }}
+                                    className="text-[15px] text-ios-blue active:opacity-60"
+                                >
+                                    {t('documents.useSavedSignature', 'Use Saved Signature')}
+                                </button>
+                            )}
+                        </div>
+                    ) : (
+                        <button
+                            type="button"
+                            onClick={() => setDrawing(true)}
+                            className="text-[15px] text-ios-blue active:opacity-60"
+                        >
+                            {t('documents.redrawSignature', 'Redraw Signature')}
+                        </button>
+                    )}
+                </div>
+            )}
+        </Sheet>
     );
 }

--- a/web/src/apps/documents/TextEditor.tsx
+++ b/web/src/apps/documents/TextEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { BadgeCheck, ChevronLeft, Lock, PenLine } from 'lucide-react';
 
 import { useIosPush } from '@/hooks/useIosPush';
@@ -85,16 +85,19 @@ export function TextEditor({ doc, backLabel, onBack, onSave, onSigned, animateIn
             </div>
 
             <div className="flex-1 overflow-y-auto no-scrollbar px-4">
-                <textarea
-                    value={body}
-                    readOnly={readOnly}
-                    maxLength={MAX_TEXT_LENGTH}
-                    onChange={e => setBody(e.target.value)}
-                    placeholder={t('documents.startWriting', 'Start writing…')}
-                    className="mt-4 w-full resize-none bg-transparent text-[17px] leading-snug outline-none placeholder:text-ios-gray"
-                    style={{ minHeight: signed ? 180 : 320 }}
-                    aria-label={t('documents.documentBody', 'Document body')}
-                />
+                {readOnly ? (
+                    <RichBody content={body} />
+                ) : (
+                    <textarea
+                        value={body}
+                        maxLength={MAX_TEXT_LENGTH}
+                        onChange={e => setBody(e.target.value)}
+                        placeholder={t('documents.startWriting', 'Start writing…')}
+                        className="mt-4 w-full resize-none bg-transparent text-[17px] leading-snug outline-none placeholder:text-ios-gray"
+                        style={{ minHeight: 320 }}
+                        aria-label={t('documents.documentBody', 'Document body')}
+                    />
+                )}
 
                 {(doc.signatures?.length ?? 0) > 0 && (
                     <div className="mb-4 mt-2 flex flex-col gap-2.5">
@@ -130,6 +133,62 @@ export function TextEditor({ doc, backLabel, onBack, onSave, onSigned, animateIn
                 />
             )}
         </div>
+    );
+}
+
+
+type RichBlock = { kind: 'text' | 'image'; value: string };
+
+// A line that is exactly one http(s) URL becomes an inline image in the read view; everything
+// else stays running text. Script-issued documents (citations, dossiers, contracts) use this
+// to mix paragraphs and pictures in a single document.
+function parseBlocks(content: string): RichBlock[] {
+    const blocks: RichBlock[] = [];
+    let run: string[] = [];
+    const flush = () => {
+        const text = run.join('\n');
+        if (text.trim() !== '') blocks.push({ kind: 'text', value: text });
+        run = [];
+    };
+    for (const line of content.split('\n')) {
+        if (/^https?:\/\/\S+$/.test(line.trim())) {
+            flush();
+            blocks.push({ kind: 'image', value: line.trim() });
+        } else {
+            run.push(line);
+        }
+    }
+    flush();
+    return blocks;
+}
+
+function RichBody({ content }: { content: string }) {
+    const blocks = useMemo(() => parseBlocks(content), [content]);
+    return (
+        <div className="mb-2 mt-4 flex flex-col gap-3">
+            {blocks.map((b, i) => (
+                b.kind === 'image'
+                    ? <RichImage key={i} url={b.value} />
+                    : <p key={i} className="whitespace-pre-wrap text-[17px] leading-snug">{b.value}</p>
+            ))}
+        </div>
+    );
+}
+
+function RichImage({ url }: { url: string }) {
+    const [failed, setFailed] = useState(false);
+    if (failed) {
+        return <p className="break-all text-[15px] text-ios-blue">{url}</p>;
+    }
+    return (
+        <img
+            src={url}
+            alt=""
+            draggable={false}
+            onError={() => setFailed(true)}
+            className="max-h-[340px] w-full rounded-[12px] object-cover"
+            style={{ border: '0.5px solid rgba(0,0,0,0.12)' }}
+        />
     );
 }
 

--- a/web/src/apps/documents/data.ts
+++ b/web/src/apps/documents/data.ts
@@ -106,6 +106,17 @@ export function orderedFolders(folders: DocFolder[]): { folder: DocFolder; depth
 
 const SAMPLE = 'This is a sample document. In dev mode the Files app runs entirely off local mocks so every screen is navigable without the game.';
 
+// Read-only docs render URL-only lines as inline images; this mock demos the mixed layout.
+const RICH_SAMPLE = [
+    'VEHICLE SALES CONTRACT',
+    '',
+    'The seller transfers one (1) used Blista, VIN 1D4HR48N73F526809, to the buyer for the agreed sum of $12,500, payable on delivery.',
+    'https://picsum.photos/seed/sdphone-car/640/360',
+    'Condition at handover is documented above. The buyer acknowledges existing wear on the front bumper and both front seats.',
+    'https://picsum.photos/seed/sdphone-int/640/360',
+    'This agreement is binding once signed. Signatures below are recorded and verified by the phone.',
+].join('\n');
+
 export const MOCK_FOLDERS: DocFolder[] = [
     { id: 'f-work',     name: 'Work',     parentId: null },
     { id: 'f-personal', name: 'Personal', parentId: null },
@@ -115,8 +126,8 @@ export const MOCK_FOLDERS: DocFolder[] = [
 export const MOCK_DOCS: DocFile[] = [
     { id: 'd-todo',    name: 'To-do',            kind: 'text',  folderId: null,        size: byteLength(SAMPLE), locked: false, content: SAMPLE, createdAt: nowSec() - 3600,  updatedAt: nowSec() - 600 },
     {
-        id: 'd-contract', name: 'Sales Contract', kind: 'text', folderId: null, size: byteLength(SAMPLE),
-        locked: false, signed: true, content: SAMPLE, createdAt: nowSec() - 14400, updatedAt: nowSec() - 14400,
+        id: 'd-contract', name: 'Sales Contract', kind: 'text', folderId: null, size: byteLength(RICH_SAMPLE),
+        locked: false, signed: true, content: RICH_SAMPLE, createdAt: nowSec() - 14400, updatedAt: nowSec() - 14400,
         signatures: [{ id: 's-1', signer: 'Jordan Reyes', image: null, signedAt: nowSec() - 14000 }],
     },
     { id: 'd-lease',   name: 'Apartment Lease',  kind: 'text',  folderId: 'f-personal', size: byteLength(SAMPLE), locked: true,  source: 'sd-housing', content: SAMPLE, createdAt: nowSec() - 86400, updatedAt: nowSec() - 86400 },

--- a/web/src/apps/documents/data.ts
+++ b/web/src/apps/documents/data.ts
@@ -8,6 +8,15 @@ export interface DocFolder {
     parentId: string | null;
 }
 
+export interface DocSignature {
+    id:       string;
+    /** Signer display name, frozen at signing time server-side. */
+    signer:   string;
+    /** PNG data-URL of the drawn signature; null renders the cursive-name fallback. */
+    image?:   string | null;
+    signedAt: number;
+}
+
 export interface DocFile {
     id:        string;
     name:      string;
@@ -15,6 +24,10 @@ export interface DocFile {
     folderId:  string | null;
     size:      number;
     locked:    boolean;
+    /** True when the document carries at least one signature (content + name frozen). */
+    signed?:   boolean;
+    /** Present on full reads only, like content. */
+    signatures?: DocSignature[];
     source?:   string | null;
     url?:      string | null;
     content?:  string;
@@ -101,6 +114,11 @@ export const MOCK_FOLDERS: DocFolder[] = [
 
 export const MOCK_DOCS: DocFile[] = [
     { id: 'd-todo',    name: 'To-do',            kind: 'text',  folderId: null,        size: byteLength(SAMPLE), locked: false, content: SAMPLE, createdAt: nowSec() - 3600,  updatedAt: nowSec() - 600 },
+    {
+        id: 'd-contract', name: 'Sales Contract', kind: 'text', folderId: null, size: byteLength(SAMPLE),
+        locked: false, signed: true, content: SAMPLE, createdAt: nowSec() - 14400, updatedAt: nowSec() - 14400,
+        signatures: [{ id: 's-1', signer: 'Jordan Reyes', image: null, signedAt: nowSec() - 14000 }],
+    },
     { id: 'd-lease',   name: 'Apartment Lease',  kind: 'text',  folderId: 'f-personal', size: byteLength(SAMPLE), locked: true,  source: 'sd-housing', content: SAMPLE, createdAt: nowSec() - 86400, updatedAt: nowSec() - 86400 },
     { id: 'd-q3',      name: 'Q3 Summary',       kind: 'text',  folderId: 'f-reports',  size: byteLength(SAMPLE), locked: false, content: SAMPLE, createdAt: nowSec() - 7200,  updatedAt: nowSec() - 7200 },
     { id: 'd-photo',   name: 'Site Photo',       kind: 'image', folderId: 'f-work',     size: 184320,             locked: false, url: 'https://images.unsplash.com/photo-1503387762-592deb58ef4e?w=800', createdAt: nowSec() - 5400, updatedAt: nowSec() - 5400 },

--- a/web/src/apps/documents/documentsApi.ts
+++ b/web/src/apps/documents/documentsApi.ts
@@ -3,13 +3,14 @@ import { apiCall, apiData } from '@/core/api';
 import { newId } from '@/lib/format';
 import {
     MOCK_DOCS, MOCK_FOLDERS, byteLength, nowSec,
-    type DocFile, type DocFolder, type DocList,
+    type DocFile, type DocFolder, type DocList, type DocSignature,
 } from './data';
 
 // Dev store: a mutable in-memory mirror so isFiveM=false is fully navigable
 // (create / rename / move / duplicate / delete all persist for the session).
 const devFolders: DocFolder[] = MOCK_FOLDERS.map(f => ({ ...f }));
 const devDocs:    DocFile[]   = MOCK_DOCS.map(d => ({ ...d }));
+let devSignature: string | null = null;
 
 function strip(d: DocFile): DocFile {
     const { content: _content, ...rest } = d;
@@ -155,4 +156,29 @@ export async function apiDeleteFolder(id: string): Promise<number | null> {
 export async function shareDocumentApi(target: number, id: string): Promise<boolean> {
     if (!isFiveM) return true;
     return (await apiCall('sd-phone:documents:share', { target, id })).success;
+}
+
+export async function apiGetSignature(): Promise<string | null> {
+    if (!isFiveM) return devSignature;
+    return (await apiData<{ image?: string | null }>('sd-phone:documents:signature:get'))?.image ?? null;
+}
+
+export async function apiSetSignature(image: string): Promise<boolean> {
+    if (!isFiveM) {
+        devSignature = image;
+        return true;
+    }
+    return (await apiCall('sd-phone:documents:signature:set', { image })).success;
+}
+
+export async function apiSignDoc(id: string): Promise<DocFile | null> {
+    if (!isFiveM) {
+        const doc = devDocs.find(d => d.id === id);
+        if (!doc || doc.kind !== 'text' || doc.signed || !devSignature) return null;
+        const sig: DocSignature = { id: newId('s'), signer: 'You', image: devSignature, signedAt: nowSec() };
+        doc.signed = true;
+        doc.signatures = [...(doc.signatures ?? []), sig];
+        return { ...doc };
+    }
+    return (await apiData<{ doc: DocFile }>('sd-phone:documents:sign', { id }))?.doc ?? null;
 }


### PR DESCRIPTION
## Summary
Community-requested (relayed from #86's suggester): a signature/authentication system for the Files app. This is phase 1 of the design discussed - personal signatures with server-side verification.

**Player flow**: open a text document -> Sign -> draw your signature once on the new `SignaturePad` (zoom-safe pointer math borrowed from the Notes sketchboard) -> it's saved as *your* signature for one-tap signing from then on. The document gains an iOS-style signature block (drawn image, signer name, verified timestamp) and freezes.

**Why it can't be forged**: signatures are rows in `phone_document_signatures`, written only by the server when that character actually signs - carrying the signer's citizenid, their display name frozen at signing time, an image *snapshot* (redrawing your personal signature later never rewrites history) and the timestamp. The verified badge renders from those rows, never from anything typed into the document.

**Freeze semantics**: a signature freezes content + name server-side (save/rename refuse). Deliberately **not** the `locked` flag - locked also blocks delete, which would trap the owner's copy forever. Signed docs can still be deleted, moved, duplicated (copies are unsigned) and shared.

**Sharing**: AirShare carries the signature rows onto the delivered copy (read server-side in `requestShare`, re-inserted server-side in `deliverShare`), so a signed contract stays verifiably signed on the recipient's phone.

**Ecosystem**: new `getDocumentSignatures(source, docId)` export so third-party scripts can verify who signed a document - pairs with the existing `createDocument` exports (a dealership can issue a locked contract and check for the customer's signature). Signing locked (script-issued) documents is allowed on purpose: it adds rows without touching content.

**SIM backup**: `phone_signatures` (personal signatures) joins the COPY list; document signature rows copy via a doc-join with `id`/`doc_id` MD5-remapped like their parent documents while the signer citizenid copies verbatim (it names who signed, possibly another character).

Phases 2 (job-gated official seals) and 3 (signature requests between players + sign events for scripts) build on this schema - the signatures table already supports multiple signers per document.

## Testing
- Full gates: vitest green, eslint 0 errors (29 pre-existing warnings), knip clean, `tsc --noEmit` + vite build, `luac -p` on all six touched Lua files
- Playwright end-to-end in dev: installed Files from the App Store, opened the mock signed contract (cursive-fallback signature block + verified line + Signed chip, no Sign button), then signed an unsigned doc - drew on the pad, Sign Document, and the doc rendered the drawn signature with the verified timestamp and went read-only