### PR TITLE
feat(documents): typed signature styles + min-ink guard + isDocumentSigned

### DIFF
--- a/server/documents/actions.lua
+++ b/server/documents/actions.lua
@@ -575,6 +575,18 @@ function actions.deleteForCid(cid, docId)
     return true
 end
 
+---True when a citizenid's document carries at least one signature. Read-only; false when the
+---document doesn't exist or belong to the player.
+---@param cid string acting citizenid
+---@param docId any document id
+---@return boolean signed
+function actions.isSignedForCid(cid, docId)
+    if type(cid) ~= 'string' or cid == '' then return false end
+    if type(docId) ~= 'string' or docId == '' then return false end
+    if not store.getDoc(cid, docId) then return false end
+    return store.hasSignatures(docId)
+end
+
 ---A document's signatures for a citizenid, for other resources. Read-only; an empty array when
 ---the document doesn't exist or belong to the player.
 ---@param cid string acting citizenid

--- a/server/documents/init.lua
+++ b/server/documents/init.lua
@@ -157,3 +157,15 @@ exports('getDocumentSignatures', function(source, docId)
     if not cid then return {} end
     return actions.listSignaturesForCid(cid, docId)
 end)
+
+---True when one of a player's documents carries at least one signature - the quick boolean
+---twin of getDocumentSignatures for scripts that only need a yes/no gate.
+---@param source number acting player's server id
+---@param docId string document id
+---@return boolean signed
+exports('isDocumentSigned', function(source, docId)
+    if type(source) ~= 'number' then return false end
+    local cid = player.getIdentifier(source)
+    if not cid then return false end
+    return actions.isSignedForCid(cid, docId)
+end)

--- a/web/src/apps/documents/SignaturePad.tsx
+++ b/web/src/apps/documents/SignaturePad.tsx
@@ -23,6 +23,9 @@ function ancestorZoom(el: HTMLElement | null): number {
 
 const INK = '#1d1d1f';
 const INK_WIDTH = 2.5;
+// A stray tap must not count as a signature: the pad only reports ink once the total drawn
+// path passes this length (CSS px).
+const MIN_INK_LENGTH = 24;
 
 export const SignaturePad = forwardRef<SignaturePadHandle, { onInkChange?: (hasInk: boolean) => void }>(
     function SignaturePad({ onInkChange }, ref) {
@@ -30,6 +33,7 @@ export const SignaturePad = forwardRef<SignaturePadHandle, { onInkChange?: (hasI
         const strokesRef = useRef<Point[][]>([]);
         const drawingRef = useRef(false);
         const dprRef     = useRef(1);
+        const lengthRef  = useRef(0);
         const [hasInk, setHasInk] = useState(false);
 
         useEffect(() => {
@@ -70,7 +74,6 @@ export const SignaturePad = forwardRef<SignaturePadHandle, { onInkChange?: (hasI
             try { (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId); } catch { /* capture unsupported */ }
             drawingRef.current = true;
             strokesRef.current.push([point(e)]);
-            markInk(true);
         }
 
         function onMove(e: React.PointerEvent) {
@@ -85,14 +88,21 @@ export const SignaturePad = forwardRef<SignaturePadHandle, { onInkChange?: (hasI
             c.moveTo(prev.x, prev.y);
             c.lineTo(p.x, p.y);
             c.stroke();
+            lengthRef.current += Math.hypot(p.x - prev.x, p.y - prev.y);
+            if (!hasInk && lengthRef.current >= MIN_INK_LENGTH) markInk(true);
         }
 
-        function onUp() { drawingRef.current = false; }
+        function onUp() {
+            drawingRef.current = false;
+            // A tap without movement leaves a pointless one-point stroke - drop it.
+            const last = strokesRef.current[strokesRef.current.length - 1];
+            if (last && last.length < 2) strokesRef.current.pop();
+        }
 
         useImperativeHandle(ref, () => ({
             toImage() {
                 const canvas = canvasRef.current;
-                if (!canvas || strokesRef.current.length === 0) return null;
+                if (!canvas || strokesRef.current.length === 0 || lengthRef.current < MIN_INK_LENGTH) return null;
                 const out = document.createElement('canvas');
                 out.width  = canvas.width;
                 out.height = canvas.height;
@@ -113,6 +123,7 @@ export const SignaturePad = forwardRef<SignaturePadHandle, { onInkChange?: (hasI
                 c.restore();
                 strokesRef.current = [];
                 drawingRef.current = false;
+                lengthRef.current = 0;
                 markInk(false);
             },
         }));
@@ -138,3 +149,62 @@ export const SignaturePad = forwardRef<SignaturePadHandle, { onInkChange?: (hasI
         );
     },
 );
+
+
+export interface SignatureStyle {
+    id:         string;
+    label:      string;
+    fontFamily: string;
+    fontWeight: number;
+    fontStyle?: string;
+    fontSize:   number;
+}
+
+// Great Vibes ships in the bundle (main.tsx); the rest fall back through fonts CEF/Windows
+// carries. Each style renders the typed name onto the same PNG pipeline drawn signatures use.
+export const SIGNATURE_STYLES: SignatureStyle[] = [
+    { id: 'elegant', label: 'Elegant',    fontFamily: '"Great Vibes", "Snell Roundhand", cursive',                 fontWeight: 400, fontSize: 64 },
+    { id: 'script',  label: 'Script',     fontFamily: '"Segoe Script", "Snell Roundhand", "Bradley Hand", cursive', fontWeight: 400, fontSize: 44 },
+    { id: 'formal',  label: 'Formal',     fontFamily: 'Georgia, "Times New Roman", serif',                          fontWeight: 600, fontStyle: 'italic', fontSize: 52 },
+    { id: 'typed',   label: 'Typewriter', fontFamily: '"Courier New", Courier, monospace',                          fontWeight: 700, fontSize: 42 },
+];
+
+function fontOf(style: SignatureStyle): string {
+    return `${style.fontStyle ? style.fontStyle + ' ' : ''}${style.fontWeight} ${style.fontSize}px ${style.fontFamily}`;
+}
+
+/** Renders a typed name in a signature style to the same white-paper PNG a drawn signature
+ *  produces, shrinking long names to fit. Null for an effectively empty name. */
+export async function renderTypedSignature(text: string, style: SignatureStyle): Promise<string | null> {
+    const clean = text.trim();
+    if (clean.length < 2) return null;
+    try { await document.fonts.load(fontOf(style), clean); } catch { /* system-only font */ }
+
+    const measure = document.createElement('canvas').getContext('2d');
+    if (!measure) return null;
+    measure.font = fontOf(style);
+    const pad = 30;
+    const textWidth = measure.measureText(clean).width;
+    const w = Math.min(680, Math.max(260, Math.ceil(textWidth) + pad * 2));
+    const h = Math.ceil(style.fontSize * 1.9);
+
+    const canvas = document.createElement('canvas');
+    canvas.width  = w;
+    canvas.height = h;
+    const c = canvas.getContext('2d');
+    if (!c) return null;
+    c.fillStyle = '#ffffff';
+    c.fillRect(0, 0, w, h);
+    c.fillStyle = INK;
+    c.font = fontOf(style);
+    c.textAlign = 'center';
+    c.textBaseline = 'middle';
+    if (textWidth > w - pad * 2) {
+        const scale = (w - pad * 2) / textWidth;
+        c.setTransform(scale, 0, 0, scale, w / 2, h / 2);
+        c.fillText(clean, 0, 0);
+    } else {
+        c.fillText(clean, w / 2, h / 2);
+    }
+    return canvas.toDataURL('image/png');
+}

--- a/web/src/apps/documents/TextEditor.tsx
+++ b/web/src/apps/documents/TextEditor.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { BadgeCheck, ChevronLeft, Lock, PenLine } from 'lucide-react';
 
 import { useIosPush } from '@/hooks/useIosPush';
 import { t } from '@/i18n';
 import { useContacts } from '@/stores/contactsStore';
+import { AlertDialog } from '@/ui/AlertDialog';
 import { Sheet } from '@/ui/Sheet';
 import { apiGetSignature, apiSetSignature, apiSignDoc } from './documentsApi';
 import { SIGNATURE_STYLES, SignaturePad, renderTypedSignature, type SignaturePadHandle } from './SignaturePad';
@@ -126,6 +127,7 @@ export function TextEditor({ doc, backLabel, onBack, onSave, onSigned, animateIn
             {signOpen && (
                 <SignSheet
                     docId={doc.id}
+                    docName={doc.name}
                     onClose={() => setSignOpen(false)}
                     onSigned={updated => {
                         setSignOpen(false);
@@ -218,8 +220,34 @@ function SignatureBlock({ sig }: { sig: DocSignature }) {
 
 type SignMode = 'saved' | 'draw' | 'type';
 
-function SignSheet({ docId, onClose, onSigned }: {
+// The sheet is bottom-anchored, so animating this wrapper's height makes mode switches grow
+// and shrink upward smoothly instead of snapping. Content height is tracked live (fonts and
+// the saved-signature image settle async), driven by CSS - no rAF (starved in CEF in-game).
+function AnimatedHeight({ children }: { children: React.ReactNode }) {
+    const innerRef = useRef<HTMLDivElement>(null);
+    const [height, setHeight] = useState<number | null>(null);
+    useLayoutEffect(() => {
+        const el = innerRef.current;
+        if (!el) return;
+        const measure = () => setHeight(el.offsetHeight);
+        measure();
+        const ro = new ResizeObserver(measure);
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, []);
+    return (
+        <div
+            className="overflow-hidden"
+            style={{ height: height ?? undefined, transition: 'height 0.32s cubic-bezier(0.32, 0.72, 0, 1)' }}
+        >
+            <div ref={innerRef}>{children}</div>
+        </div>
+    );
+}
+
+function SignSheet({ docId, docName, onClose, onSigned }: {
     docId:    string;
+    docName:  string;
     onClose:  () => void;
     onSigned: (doc: DocFile) => void;
 }) {
@@ -233,6 +261,7 @@ function SignSheet({ docId, onClose, onSigned }: {
     const [styleId, setStyleId] = useState(SIGNATURE_STYLES[0].id);
     const [busy,    setBusy]    = useState(false);
     const [error,   setError]   = useState<string | null>(null);
+    const [confirming, setConfirming] = useState(false);
 
     useEffect(() => { void load(); }, [load]);
     useEffect(() => {
@@ -298,51 +327,55 @@ function SignSheet({ docId, onClose, onSigned }: {
                         </div>
                     )}
 
-                    {loading ? (
-                        <div className="h-[150px]" />
-                    ) : mode === 'saved' ? (
-                        <div className="flex items-center justify-center rounded-[12px] border border-black/10 bg-white px-4 py-5">
-                            <img src={saved ?? undefined} alt="" className="h-[84px] max-w-full object-contain" draggable={false} />
+                    <AnimatedHeight>
+                        <div className="flex flex-col gap-3">
+                            {loading ? (
+                                <div className="h-[150px]" />
+                            ) : mode === 'saved' ? (
+                                <div className="flex items-center justify-center rounded-[12px] border border-black/10 bg-white px-4 py-5">
+                                    <img src={saved ?? undefined} alt="" className="h-[84px] max-w-full object-contain" draggable={false} />
+                                </div>
+                            ) : mode === 'draw' ? (
+                                <SignaturePad ref={padRef} onInkChange={setHasInk} />
+                            ) : (
+                                <>
+                                    <input
+                                        value={typed}
+                                        onChange={e => setTyped(e.target.value)}
+                                        maxLength={40}
+                                        placeholder={t('documents.typeYourName', 'Type your name')}
+                                        className="rounded-[12px] border border-black/10 bg-white px-4 py-3 text-[17px] text-black outline-none placeholder:text-ios-gray3 focus:border-ios-blue"
+                                    />
+                                    <div className="flex flex-col gap-2">
+                                        {SIGNATURE_STYLES.map(s => (
+                                            <button
+                                                key={s.id}
+                                                type="button"
+                                                onClick={() => setStyleId(s.id)}
+                                                className={`flex h-[58px] items-center justify-between rounded-[12px] border bg-white px-4 text-left ${
+                                                    styleId === s.id ? 'border-ios-blue ring-1 ring-ios-blue' : 'border-black/10'
+                                                }`}
+                                            >
+                                                <span
+                                                    className="min-w-0 flex-1 truncate text-[#1d1d1f]"
+                                                    style={{
+                                                        fontFamily: s.fontFamily,
+                                                        fontWeight: s.fontWeight,
+                                                        fontStyle:  s.fontStyle,
+                                                        fontSize:   Math.round(s.fontSize * 0.55),
+                                                        lineHeight: 1.5,
+                                                    }}
+                                                >
+                                                    {typed.trim() || t('documents.typeYourName', 'Type your name')}
+                                                </span>
+                                                <span className="ml-3 shrink-0 text-[12px] text-ios-gray">{s.label}</span>
+                                            </button>
+                                        ))}
+                                    </div>
+                                </>
+                            )}
                         </div>
-                    ) : mode === 'draw' ? (
-                        <SignaturePad ref={padRef} onInkChange={setHasInk} />
-                    ) : (
-                        <>
-                            <input
-                                value={typed}
-                                onChange={e => setTyped(e.target.value)}
-                                maxLength={40}
-                                placeholder={t('documents.typeYourName', 'Type your name')}
-                                className="rounded-[12px] border border-black/10 bg-white px-4 py-3 text-[17px] text-black outline-none placeholder:text-ios-gray3 focus:border-ios-blue"
-                            />
-                            <div className="flex flex-col gap-2">
-                                {SIGNATURE_STYLES.map(s => (
-                                    <button
-                                        key={s.id}
-                                        type="button"
-                                        onClick={() => setStyleId(s.id)}
-                                        className={`flex items-center justify-between rounded-[12px] border bg-white px-4 py-2 text-left ${
-                                            styleId === s.id ? 'border-ios-blue ring-1 ring-ios-blue' : 'border-black/10'
-                                        }`}
-                                    >
-                                        <span
-                                            className="min-w-0 flex-1 truncate text-[#1d1d1f]"
-                                            style={{
-                                                fontFamily: s.fontFamily,
-                                                fontWeight: s.fontWeight,
-                                                fontStyle:  s.fontStyle,
-                                                fontSize:   Math.round(s.fontSize * 0.55),
-                                                lineHeight: 1.4,
-                                            }}
-                                        >
-                                            {typed.trim() || t('documents.typeYourName', 'Type your name')}
-                                        </span>
-                                        <span className="ml-3 shrink-0 text-[12px] text-ios-gray">{s.label}</span>
-                                    </button>
-                                ))}
-                            </div>
-                        </>
-                    )}
+                    </AnimatedHeight>
 
                     <p className="text-center text-[13px] leading-snug text-ios-gray">
                         {t('documents.signLockHint', 'Signing adds your name and locks this document from further edits.')}
@@ -353,11 +386,21 @@ function SignSheet({ docId, onClose, onSigned }: {
                     <button
                         type="button"
                         disabled={!canSign}
-                        onClick={() => void sign()}
+                        onClick={() => setConfirming(true)}
                         className="rounded-[12px] bg-ios-blue py-3 text-[16px] font-semibold text-white active:opacity-80 disabled:opacity-40"
                     >
                         {t('documents.signDocument', 'Sign Document')}
                     </button>
+
+                    {confirming && (
+                        <AlertDialog
+                            title={t('documents.confirmSignTitle', 'Sign Document?')}
+                            message={t('documents.confirmSignBody', 'You are about to sign "{name}". This locks the document from further edits and cannot be undone.', { name: docName })}
+                            confirmLabel={t('documents.sign', 'Sign')}
+                            onCancel={() => setConfirming(false)}
+                            onConfirm={() => { setConfirming(false); void sign(); }}
+                        />
+                    )}
 
                     {mode === 'saved' ? (
                         <button

--- a/web/src/apps/documents/TextEditor.tsx
+++ b/web/src/apps/documents/TextEditor.tsx
@@ -3,9 +3,10 @@ import { BadgeCheck, ChevronLeft, Lock, PenLine } from 'lucide-react';
 
 import { useIosPush } from '@/hooks/useIosPush';
 import { t } from '@/i18n';
+import { useContacts } from '@/stores/contactsStore';
 import { Sheet } from '@/ui/Sheet';
 import { apiGetSignature, apiSetSignature, apiSignDoc } from './documentsApi';
-import { SignaturePad, type SignaturePadHandle } from './SignaturePad';
+import { SIGNATURE_STYLES, SignaturePad, renderTypedSignature, type SignaturePadHandle } from './SignaturePad';
 import { MAX_TEXT_LENGTH, formatDocDate, type DocFile, type DocSignature } from './data';
 
 interface Props {
@@ -215,36 +216,54 @@ function SignatureBlock({ sig }: { sig: DocSignature }) {
 }
 
 
+type SignMode = 'saved' | 'draw' | 'type';
+
 function SignSheet({ docId, onClose, onSigned }: {
     docId:    string;
     onClose:  () => void;
     onSigned: (doc: DocFile) => void;
 }) {
     const padRef = useRef<SignaturePadHandle>(null);
+    const { myName, load } = useContacts('myName', 'load');
     const [saved,   setSaved]   = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
-    const [drawing, setDrawing] = useState(false);
+    const [mode,    setMode]    = useState<SignMode>('draw');
     const [hasInk,  setHasInk]  = useState(false);
+    const [typed,   setTyped]   = useState('');
+    const [styleId, setStyleId] = useState(SIGNATURE_STYLES[0].id);
     const [busy,    setBusy]    = useState(false);
     const [error,   setError]   = useState<string | null>(null);
 
+    useEffect(() => { void load(); }, [load]);
     useEffect(() => {
         let alive = true;
         void apiGetSignature().then(image => {
             if (!alive) return;
             setSaved(image);
-            setDrawing(!image);
+            setMode(image ? 'saved' : 'draw');
             setLoading(false);
         });
         return () => { alive = false; };
     }, []);
 
+    // The typed name defaults to the character once contacts resolve; a name the player
+    // already typed is never overwritten.
+    useEffect(() => {
+        if (myName) setTyped(prev => (prev === '' ? myName : prev));
+    }, [myName]);
+
+    const typedOk = typed.trim().length >= 2;
+    const canSign = !loading && !busy
+        && (mode === 'saved' || (mode === 'draw' && hasInk) || (mode === 'type' && typedOk));
+
     async function sign() {
-        if (busy) return;
+        if (!canSign) return;
         setBusy(true);
         setError(null);
-        if (drawing) {
-            const image = padRef.current?.toImage();
+        if (mode !== 'saved') {
+            const image = mode === 'draw'
+                ? padRef.current?.toImage()
+                : await renderTypedSignature(typed, SIGNATURE_STYLES.find(s => s.id === styleId) ?? SIGNATURE_STYLES[0]);
             if (!image) { setBusy(false); return; }
             const stored = await apiSetSignature(image);
             if (!stored) {
@@ -262,18 +281,67 @@ function SignSheet({ docId, onClose, onSigned }: {
         onSigned(updated);
     }
 
+    function switchMode(next: SignMode) {
+        setMode(next);
+        setHasInk(false);
+        setError(null);
+    }
+
     return (
         <Sheet onClose={onClose} fit="content" title={t('documents.signDocument', 'Sign Document')} className="bg-[#ececec] dark:bg-surface">
             {() => (
                 <div className="flex flex-col gap-3 px-5 pb-8 pt-1">
+                    {mode !== 'saved' && !loading && (
+                        <div className="flex rounded-[10px] bg-black/[0.06] p-[3px] dark:bg-white/[0.08]">
+                            <ModeTab label={t('documents.signModeDraw', 'Draw')} active={mode === 'draw'} onPress={() => switchMode('draw')} />
+                            <ModeTab label={t('documents.signModeType', 'Type')} active={mode === 'type'} onPress={() => switchMode('type')} />
+                        </div>
+                    )}
+
                     {loading ? (
                         <div className="h-[150px]" />
-                    ) : drawing ? (
-                        <SignaturePad ref={padRef} onInkChange={setHasInk} />
-                    ) : (
+                    ) : mode === 'saved' ? (
                         <div className="flex items-center justify-center rounded-[12px] border border-black/10 bg-white px-4 py-5">
                             <img src={saved ?? undefined} alt="" className="h-[84px] max-w-full object-contain" draggable={false} />
                         </div>
+                    ) : mode === 'draw' ? (
+                        <SignaturePad ref={padRef} onInkChange={setHasInk} />
+                    ) : (
+                        <>
+                            <input
+                                value={typed}
+                                onChange={e => setTyped(e.target.value)}
+                                maxLength={40}
+                                placeholder={t('documents.typeYourName', 'Type your name')}
+                                className="rounded-[12px] border border-black/10 bg-white px-4 py-3 text-[17px] text-black outline-none placeholder:text-ios-gray3 focus:border-ios-blue"
+                            />
+                            <div className="flex flex-col gap-2">
+                                {SIGNATURE_STYLES.map(s => (
+                                    <button
+                                        key={s.id}
+                                        type="button"
+                                        onClick={() => setStyleId(s.id)}
+                                        className={`flex items-center justify-between rounded-[12px] border bg-white px-4 py-2 text-left ${
+                                            styleId === s.id ? 'border-ios-blue ring-1 ring-ios-blue' : 'border-black/10'
+                                        }`}
+                                    >
+                                        <span
+                                            className="min-w-0 flex-1 truncate text-[#1d1d1f]"
+                                            style={{
+                                                fontFamily: s.fontFamily,
+                                                fontWeight: s.fontWeight,
+                                                fontStyle:  s.fontStyle,
+                                                fontSize:   Math.round(s.fontSize * 0.55),
+                                                lineHeight: 1.4,
+                                            }}
+                                        >
+                                            {typed.trim() || t('documents.typeYourName', 'Type your name')}
+                                        </span>
+                                        <span className="ml-3 shrink-0 text-[12px] text-ios-gray">{s.label}</span>
+                                    </button>
+                                ))}
+                            </div>
+                        </>
                     )}
 
                     <p className="text-center text-[13px] leading-snug text-ios-gray">
@@ -284,43 +352,59 @@ function SignSheet({ docId, onClose, onSigned }: {
 
                     <button
                         type="button"
-                        disabled={busy || loading || (drawing && !hasInk)}
+                        disabled={!canSign}
                         onClick={() => void sign()}
                         className="rounded-[12px] bg-ios-blue py-3 text-[16px] font-semibold text-white active:opacity-80 disabled:opacity-40"
                     >
                         {t('documents.signDocument', 'Sign Document')}
                     </button>
 
-                    {drawing ? (
+                    {mode === 'saved' ? (
+                        <button
+                            type="button"
+                            onClick={() => switchMode('draw')}
+                            className="text-[15px] text-ios-blue active:opacity-60"
+                        >
+                            {t('documents.redrawSignature', 'Replace Signature')}
+                        </button>
+                    ) : (
                         <div className="flex items-center justify-center gap-6">
-                            <button
-                                type="button"
-                                onClick={() => { padRef.current?.clear(); }}
-                                className="text-[15px] text-ios-blue active:opacity-60"
-                            >
-                                {t('documents.clearSignature', 'Clear')}
-                            </button>
+                            {mode === 'draw' && (
+                                <button
+                                    type="button"
+                                    onClick={() => { padRef.current?.clear(); }}
+                                    className="text-[15px] text-ios-blue active:opacity-60"
+                                >
+                                    {t('documents.clearSignature', 'Clear')}
+                                </button>
+                            )}
                             {saved && (
                                 <button
                                     type="button"
-                                    onClick={() => { setDrawing(false); setHasInk(false); }}
+                                    onClick={() => switchMode('saved')}
                                     className="text-[15px] text-ios-blue active:opacity-60"
                                 >
                                     {t('documents.useSavedSignature', 'Use Saved Signature')}
                                 </button>
                             )}
                         </div>
-                    ) : (
-                        <button
-                            type="button"
-                            onClick={() => setDrawing(true)}
-                            className="text-[15px] text-ios-blue active:opacity-60"
-                        >
-                            {t('documents.redrawSignature', 'Redraw Signature')}
-                        </button>
                     )}
                 </div>
             )}
         </Sheet>
+    );
+}
+
+function ModeTab({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onPress}
+            className={`flex-1 rounded-[8px] py-1.5 text-[14px] font-semibold transition-colors ${
+                active ? 'bg-white text-black shadow-sm dark:bg-elevated dark:text-white' : 'text-ios-gray'
+            }`}
+        >
+            {label}
+        </button>
     );
 }


### PR DESCRIPTION
## Summary
Follow-ups to #93 from in-game testing:

### Min-ink guard
A stray tap on the signature pad registered a stroke and enabled Sign Document with a blank canvas. The pad now only reports ink once the drawn path passes a minimum length (24 CSS px), drops tap-only one-point strokes, and `toImage()` refuses below the same threshold - so an empty signature can no longer be saved or used, at both the button and the export layer.

### Typed signature styles
The sign sheet gains a **Draw / Type** toggle. Type mode: the player's name (prefilled from their character, editable) renders live in four styles - **Elegant** (Great Vibes, already bundled for the lock clock so zero new assets), **Script** (Segoe Script stack), **Formal** (Georgia italic) and **Typewriter** (Courier). Signing renders the chosen style onto the same white-paper PNG data-URL pipeline drawn signatures use, so the server/validation/storage side is completely untouched - a typed signature is just another image snapshot.

### isDocumentSigned export
`isDocumentSigned(source, docId)` -> `boolean` - the quick gate for scripts that don't need the full `getDocumentSignatures` list. Same ownership check, same false-on-missing semantics.

## Testing
- Full gates: vitest, eslint 0 errors, knip, tsc + vite build, `luac -p`
- Playwright: tap-only on the pad leaves Sign Document disabled (asserted `isDisabled()`); Type mode prefills the character name, renders all four style previews live, and signing produced the Elegant-style signature block on the document