### PR TITLE
fix(client): stop scroll wheel reaching radio and weapon cycling

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -234,6 +234,19 @@ local function startMovementThread()
                 DisableControlAction(0, 106, true)
                 DisableControlAction(0, 245, true)
                 DisableControlAction(0, 246, true)
+                -- Scroll-wheel fall-throughs under keep-input: the phone owns the wheel, so
+                -- vehicle radio cycling, the radio wheel and weapon cycling must not react.
+                DisableControlAction(0, 14, true)
+                DisableControlAction(0, 15, true)
+                DisableControlAction(0, 16, true)
+                DisableControlAction(0, 17, true)
+                DisableControlAction(0, 81, true)
+                DisableControlAction(0, 82, true)
+                DisableControlAction(0, 83, true)
+                DisableControlAction(0, 84, true)
+                DisableControlAction(0, 85, true)
+                DisableControlAction(0, 99, true)
+                DisableControlAction(0, 100, true)
             end
             Wait(0)
         end


### PR DESCRIPTION
## Summary
With the phone open under keep-input (`AllowMovement`), the mouse wheel reached both the phone AND the game - scrolling a list while driving cycled radio stations, and on foot the wheel could cycle weapons.

The movement-suppression thread (which already disables combat/mouse-look/chat controls per frame) now also disables the wheel-driven controls:

| Controls | What they did |
|---|---|
| 81 / 82 | vehicle radio next / previous station |
| 83 / 84 | radio track skip |
| 85 | radio wheel |
| 14 / 15 / 16 / 17 | weapon wheel + weapon next / previous |
| 99 / 100 | vehicle weapon select |

Scrolling inside the phone is unaffected - CEF receives wheel input independently of game controls, so this locks the wheel *to* the phone exactly. The disables sit in the existing per-open thread, so they only run while the phone is open, skip typing/camera states (which drop keep-input anyway), and stop with the thread on close.

## Testing
- `luac -p` clean; no web changes
- Needs the usual in-game check: phone open in a vehicle -> scroll a list -> station stays put