### PR TITLE
feat(client): numeric typing tier keeps movement on digit pads

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -114,6 +114,9 @@ local flashlightOn = false
 local cameraActive = false
 ---@type boolean True while a UI text field is focused.
 local typingInPhone = false
+---@type boolean True while the focused field is digit-only (PIN pads, dialers): keep-input
+---stays on so the player can move, and the digit weapon binds are suppressed instead.
+local typingNumeric = false
 ---@type boolean True while the hold-to-look keybind has released the cursor for camera control.
 local lookMode = false
 
@@ -215,7 +218,7 @@ local function startMovementThread()
         while phoneState.open do
             if IsPauseMenuActive() then
                 if ClosePhone then ClosePhone() end
-            elseif not typingInPhone and not cameraActive then
+            elseif (not typingInPhone or typingNumeric) and not cameraActive then
                 DisablePlayerFiring(PlayerId(), true)
                 if not lookMode then
                     DisableControlAction(0, 1, true)
@@ -247,6 +250,12 @@ local function startMovementThread()
                 DisableControlAction(0, 85, true)
                 DisableControlAction(0, 99, true)
                 DisableControlAction(0, 100, true)
+                if typingNumeric then
+                    -- Digit pad up: the number row must not fire GTA weapon-slot binds.
+                    for control = 157, 166 do
+                        DisableControlAction(0, control, true)
+                    end
+                end
             end
             Wait(0)
         end
@@ -258,7 +267,7 @@ end
 ---AllowMovement on.
 local function syncKeepInput()
     if phoneState.open and config.Phone.AllowMovement then
-        SetNuiFocusKeepInput(not typingInPhone and not cameraActive)
+        SetNuiFocusKeepInput((not typingInPhone or typingNumeric) and not cameraActive)
     end
 end
 
@@ -335,6 +344,7 @@ local function OpenPhone()
     SetNuiFocus(true, true)
     if config.Phone.AllowMovement then
         typingInPhone = false
+        typingNumeric = false
         SetNuiFocusKeepInput(true)
         startMovementThread()
     end
@@ -407,6 +417,7 @@ function ClosePhone()
     TriggerServerEvent('sd-phone:server:phone:setOpen', false)
     SetNuiFocus(false, false)
     typingInPhone = false
+    typingNumeric = false
     lookMode = false
     SendNUIMessage({ action = 'sd-phone:close' })
 
@@ -556,12 +567,14 @@ RegisterNUICallback('sd-phone:unlock', function(_, cb)
     cb({ ok = true })
 end)
 
----React to Lua: a text field gained or lost focus. Updates the typing flag and re-syncs
----keep-input; payload nil-guarded and coerced to a strict boolean.
----@param data table|nil { typing: boolean }
+---React to Lua: a text field gained or lost focus. Full typing releases keep-input so keys
+---reach only the field; numeric typing (PIN pads, dialers) keeps it so the player can still
+---move, with the digit weapon binds suppressed by the movement thread instead.
+---@param data table|nil { typing: boolean, numeric: boolean }
 ---@param cb fun(result: table) NUI response
 RegisterNUICallback('sd-phone:typing', function(data, cb)
     typingInPhone = data and data.typing and true or false
+    typingNumeric = typingInPhone and data and data.numeric and true or false
     syncKeepInput()
     cb({ ok = true })
 end)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1040,7 +1040,14 @@ function AppContent() {
             const t = el as HTMLElement | null;
             return !!t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
         };
-        const onFocus = (e: FocusEvent) => { if (isText(e.target)) void fetchNui('sd-phone:typing', { typing: true }); };
+        // Digit-only inputs take the numeric typing tier: the player keeps moving while the
+        // field is focused (client/main.lua suppresses the digit weapon binds instead).
+        const isNumeric = (el: EventTarget | null) => {
+            const t = el as HTMLInputElement | null;
+            return !!t && t.tagName === 'INPUT'
+                && (['numeric', 'tel', 'decimal'].includes(t.inputMode) || ['number', 'tel'].includes(t.type));
+        };
+        const onFocus = (e: FocusEvent) => { if (isText(e.target)) void fetchNui('sd-phone:typing', { typing: true, numeric: isNumeric(e.target) }); };
         const onBlur  = (e: FocusEvent) => { if (isText(e.target)) void fetchNui('sd-phone:typing', { typing: false }); };
         document.addEventListener('focusin', onFocus);
         document.addEventListener('focusout', onBlur);

--- a/web/src/hooks/useKeyboardCapture.ts
+++ b/web/src/hooks/useKeyboardCapture.ts
@@ -20,39 +20,50 @@ import { useDeckActive } from '@/shell/deckActive';
 //
 // Refcounted, since two capturing views can briefly overlap during a transition and
 // the last one to unmount must not release a claim the other still holds.
-let holders = 0;
+// Two claim tiers. A FULL claim (letter-typing apps - the word games) releases keep-input
+// entirely: every key must reach only the phone, and movement freezes. A NUMERIC claim
+// (digit pads - lockscreen PIN, dialer) keeps keep-input on so the player can still move;
+// the client suppresses the GTA digit weapon binds per frame instead. A full claim anywhere
+// outranks any number of numeric ones.
+let fullHolders = 0;
+let numericHolders = 0;
 
-function setTyping(typing: boolean): void {
+function sync(): void {
     if (!isFiveM) return;
-    void fetchNui('sd-phone:typing', { typing });
+    const typing  = fullHolders > 0 || numericHolders > 0;
+    const numeric = fullHolders === 0 && numericHolders > 0;
+    void fetchNui('sd-phone:typing', { typing, numeric });
 }
 
-function acquire(): void {
-    holders += 1;
-    if (holders === 1) setTyping(true);
+function acquire(numeric: boolean): void {
+    if (numeric) numericHolders += 1;
+    else fullHolders += 1;
+    sync();
 }
 
-function release(): void {
-    holders = Math.max(0, holders - 1);
-    if (holders === 0) setTyping(false);
+function release(numeric: boolean): void {
+    if (numeric) numericHolders = Math.max(0, numericHolders - 1);
+    else fullHolders = Math.max(0, fullHolders - 1);
+    sync();
 }
 
 /** True while some app holds the keyboard, so shell-level hotkeys can stand down too. */
 export function isKeyboardCaptured(): boolean {
-    return holders > 0;
+    return fullHolders + numericHolders > 0;
 }
 
 /**
  * Keeps game keybinds from firing while a keyboard-driven app is the foreground app.
  * @param enabled pass false to hold the claim off (e.g. the game is over / a sheet is up)
+ * @param numeric digit-pad tier: the player keeps moving while the pad is active
  */
-export function useKeyboardCapture(enabled = true): void {
+export function useKeyboardCapture(enabled = true, numeric = false): void {
     const deckActive = useDeckActive();
     const on = enabled && deckActive;
 
     useEffect(() => {
         if (!on) return;
-        acquire();
-        return release;
-    }, [on]);
+        acquire(numeric);
+        return () => release(numeric);
+    }, [on, numeric]);
 }

--- a/web/src/hooks/useKeypadInput.ts
+++ b/web/src/hooks/useKeypadInput.ts
@@ -31,7 +31,9 @@ export function useKeypadInput({
 }): void {
     const deckActive = useDeckActive();
     const listening = enabled && deckActive;
-    useKeyboardCapture(capture && listening);
+    // Numeric tier: the player keeps moving while a digit pad is up (a PIN entry must not
+    // freeze WASD); the client disables the GTA digit weapon binds per frame instead.
+    useKeyboardCapture(capture && listening, true);
 
     const onPressRef   = useRef(onPress);
     const onDeleteRef  = useRef(onDelete);


### PR DESCRIPTION
## Summary
Typing anywhere used to drop keep-input entirely, freezing movement. Correct for text fields (WASD must type, not walk) - pointless for digit pads: entering the lockscreen PIN or dialing rooted the player in place.

The typing claim now has **two tiers**:

- **Full** (text fields, textareas, contentEditable, letter-typing apps like Wordle): unchanged - keep-input off, keys reach only the phone.
- **Numeric** (every `useKeypadInput` pad: lockscreen PIN, keypad dialer, payphone, Face Unlock - plus any focused `<input>` with `inputMode` numeric/tel/decimal or `type` number/tel): keep-input stays on, so **WASD keeps working while you type digits**. The movement-suppression thread disables the GTA digit weapon-slot controls (157-166) per frame while a pad is up, and a full claim anywhere outranks any number of numeric claims.

Implementation: `useKeyboardCapture` becomes a two-tier refcount reporting `{ typing, numeric }`; `client/main.lua` tracks `typingNumeric`, feeds it into `syncKeepInput` and the suppression thread, and resets it on open/close.

## Known trade-off
Physical digit key presses can still reach other resources' `RegisterKeyMapping` binds (e.g. an inventory hotbar on 1-5) - keymaps of other resources cannot be suppressed from outside, which is exactly why pads previously took the full lock. On-screen keypad taps leak nothing. Worth one in-game check against your inventory binds; if hotbar firing during PIN entry turns out worse than the frozen movement, the pads can trivially revert to the full tier while keeping the numeric tier for amount fields.

## Testing
- `luac -p` clean; vitest, eslint 0 errors, knip, tsc + vite build all green
- Needs in-game confirmation: lockscreen PIN entry -> WASD moves; Messages compose -> movement still locks as before