### PR TITLE
feat(apps): Files ships as a base app

### DIFF
--- a/configs/homescreen.lua
+++ b/configs/homescreen.lua
@@ -33,7 +33,7 @@ return {
         { id = 'voicememos', label = 'Voice Memos', icon = 'voicememos', route = '/voicememos', accent = '#ff3b30', base = true },
         { id = 'bank',      label = 'Bank',      icon = 'bank',      route = '/bank',      accent = '#00b894', base = true },
         { id = 'health',    label = 'Health',    icon = 'health',    route = '/health',    accent = '#ff2d55', base = true },
-        { id = 'documents', label = 'Files',     icon = 'documents', route = '/documents', accent = '#3478F6' },
+        { id = 'documents', label = 'Files',     icon = 'documents', route = '/documents', accent = '#3478F6', base = true },
         { id = 'groups',    label = 'Groups',    icon = 'groups',    route = '/groups',    accent = '#6C63FF' },
         { id = 'birdy',     label = 'Birdy',     icon = 'birdy',     route = '/birdy',     accent = '#1d9bf0' },
         { id = 'services',  label = 'Services',  icon = 'services',  route = '/services',  accent = '#16B8A6' },

--- a/web/src/core/dev.ts
+++ b/web/src/core/dev.ts
@@ -31,7 +31,7 @@ export function devInjectMockData(): () => void {
             { id: 'voicememos', label: 'Voice Memos', icon: 'voicememos', route: '/voicememos', accent: '#ff3b30', base: true },
             { id: 'bank',     label: 'Bank',      icon: 'bank',     route: '/bank',     accent: '#00b894', base: true },
             { id: 'health',   label: 'Health',    icon: 'health',   route: '/health',   accent: '#ff2d55', base: true },
-            { id: 'documents', label: 'Files',    icon: 'documents', route: '/documents', accent: '#3478F6' },
+            { id: 'documents', label: 'Files',    icon: 'documents', route: '/documents', accent: '#3478F6', base: true },
             { id: 'groups',   label: 'Groups',    icon: 'groups',   route: '/groups',   accent: '#6C63FF' },
             { id: 'birdy',    label: 'Birdy',     icon: 'birdy',    route: '/birdy',    accent: '#1d9bf0' },
             { id: 'services', label: 'Services',  icon: 'services', route: '/services', accent: '#16B8A6' },


### PR DESCRIPTION
## Summary
Files is core functionality now that script-issued documents and signatures land in it - a player without the app installed would receive citations/contracts they cannot open until they find it in the App Store. `base = true` in both catalogs (configs/homescreen.lua + the dev catalog):

- preinstalled on every phone, present on the default first home page
- cannot be uninstalled (the generic base-app handling all 15 existing base apps use)
- App Store lists it as **Open** instead of **Get**
- players who already installed it keep a redundant `installed_apps` entry - harmless
- the Wallpaper page's home-screen preview already depicted Files in the default first page; it is now exactly faithful

## Testing
- `luac -p` clean, vitest/eslint/build green
- In-game: fresh character sees Files on the home screen; no Remove option in edit mode