### PR TITLE
chore(release): bump version to 0.9.3

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 'yes'
 
 name 'sd-phone'
 author 'Samuel#0008'
-version '0.9.2'
+version '0.9.3'
 description 'iOS-themed in-game phone — lockscreen, homepage, NUI bridge'
 
 -- Both sides load ox_lib first (require / callback machinery), then the shared


### PR DESCRIPTION
Version bump for the v0.9.3 release - keeps the Software Update page comparing equal against the latest GitHub release tag.