### PR TITLE
feat(documents): signable option for issued documents

### DIFF
--- a/server/documents/actions.lua
+++ b/server/documents/actions.lua
@@ -33,6 +33,7 @@ local function serializeDoc(row)
         folderId  = row.folder_id,
         size      = tonumber(row.size) or 0,
         locked    = isTruthy(row.locked),
+        signable  = row.signable == nil or isTruthy(row.signable),
         source    = row.source,
         url       = row.url,
         content   = row.content,
@@ -511,16 +512,17 @@ function actions.createForCid(cid, opts, sourceLabel)
     local folderId, ferr = resolveFolderName(cid, opts.folder)
     if ferr then return nil, ferr end
 
-    local locked = opts.locked == true and 1 or 0
+    local locked   = opts.locked == true and 1 or 0
+    local signable = opts.signable ~= false
     local source = type(sourceLabel) == 'string' and sourceLabel ~= '' and sourceLabel or nil
     local id, ts = newId(), os.time()
     store.createDoc(cid, {
         id = id, folderId = folderId, name = name, kind = kind,
-        content = content, url = url, size = size, locked = locked, source = source, ts = ts,
+        content = content, url = url, size = size, locked = locked, signable = signable, source = source, ts = ts,
     })
     return id, nil, serializeDoc({
         id = id, folder_id = folderId, name = name, kind = kind, content = content, url = url,
-        size = size, locked = locked, source = source, created_at = ts, updated_at = ts,
+        size = size, locked = locked, signable = signable and 1 or 0, source = source, created_at = ts, updated_at = ts,
     })
 end
 
@@ -640,6 +642,7 @@ function actions.sign(src, payload)
     local row = store.getDoc(cid, id)
     if not row then return fail('Document not found') end
     if row.kind ~= 'text' then return fail('Only text documents can be signed') end
+    if row.signable ~= nil and not isTruthy(row.signable) then return fail('This document cannot be signed') end
     if store.hasSigned(id, cid) then return fail('You have already signed this document') end
 
     local image = store.getPersonalSignature(cid)
@@ -683,6 +686,7 @@ function actions.requestShare(src, target, payload)
         url     = row.url,
         size    = tonumber(row.size) or 0,
         source  = row.source,
+        signable = row.signable == nil or isTruthy(row.signable),
         fromName = player.getName(src),
         signatures = sigs,
     })
@@ -721,10 +725,11 @@ function actions.deliverShare(targetSrc, payload)
     end
 
     local source = type(payload.source) == 'string' and payload.source ~= '' and payload.source or nil
+    local signable = payload.signable ~= false
     local id, ts = newId(), os.time()
     store.createDoc(tcid, {
         id = id, folderId = nil, name = name, kind = kind,
-        content = content, url = url, size = size, locked = 0, source = source, ts = ts,
+        content = content, url = url, size = size, locked = 0, signable = signable, source = source, ts = ts,
     })
 
     -- Re-attach the sender's signature rows to the delivered copy; the payload was built
@@ -744,7 +749,7 @@ function actions.deliverShare(targetSrc, payload)
 
     local doc = serializeDoc({
         id = id, folder_id = nil, name = name, kind = kind, content = content, url = url,
-        size = size, locked = 0, source = source, created_at = ts, updated_at = ts,
+        size = size, locked = 0, signable = signable and 1 or 0, source = source, created_at = ts, updated_at = ts,
     })
     if kind == 'text' then attachSignatures(doc, id) end
     local fromName = type(payload.fromName) == 'string' and payload.fromName ~= '' and payload.fromName or 'Someone'

--- a/server/documents/init.lua
+++ b/server/documents/init.lua
@@ -75,7 +75,7 @@ end
 ---Creates a document for a player from another resource. Validates every field and applies the
 ---same caps as the app; on success the owner's open phone is pushed the new document live.
 ---@param source number acting player's server id
----@param opts table { name: string, kind?: 'text'|'image'|'file', content?: string, url?: string, folder?: string, locked?: boolean, notify?: boolean }
+---@param opts table { name: string, kind?: 'text'|'image'|'file', content?: string, url?: string, folder?: string, locked?: boolean, signable?: boolean, notify?: boolean }
 ---@return string|nil docId new document id, nil on failure
 ---@return string? err refusal message when docId is nil
 exports('createDocument', function(source, opts)
@@ -93,7 +93,7 @@ end)
 ---Creates a document addressed by phone number instead of server id. The number is resolved to
 ---its owner; when that owner is online their open phone is pushed the new document live.
 ---@param number string|number phone number in any formatting
----@param opts table { name: string, kind?: 'text'|'image'|'file', content?: string, url?: string, folder?: string, locked?: boolean, notify?: boolean }
+---@param opts table { name: string, kind?: 'text'|'image'|'file', content?: string, url?: string, folder?: string, locked?: boolean, signable?: boolean, notify?: boolean }
 ---@return string|nil docId new document id, nil on failure
 ---@return string? err refusal message when docId is nil
 exports('createDocumentForNumber', function(number, opts)

--- a/server/documents/store.lua
+++ b/server/documents/store.lua
@@ -6,6 +6,20 @@ local store = {}
 ---@type table Shared server helpers (server.util): legacy-table rescue and index bootstrap.
 local util = require 'server.util'
 
+---Returns true if a column already exists on the given table (information_schema probe).
+---@param tbl string table name
+---@param name string column name
+---@return boolean exists
+local function columnExists(tbl, name)
+    local row = MySQL.single.await([[
+        SELECT COUNT(*) AS n FROM information_schema.columns
+        WHERE table_schema = DATABASE()
+          AND table_name = ?
+          AND column_name = ?
+    ]], { tbl, name })
+    return row ~= nil and tonumber(row.n) > 0
+end
+
 ---Creates the phone_documents and phone_document_folders tables idempotently and adds their
 ---secondary indexes. Runs once at boot; an lb-phone-shaped same-named table is moved aside first.
 function store.ensureSchema()
@@ -23,6 +37,7 @@ function store.ensureSchema()
             `url`        VARCHAR(1024) NULL,
             `size`       INT           NOT NULL DEFAULT 0,
             `locked`     TINYINT(1)    NOT NULL DEFAULT 0,
+            `signable`   TINYINT(1)    NOT NULL DEFAULT 1,
             `source`     VARCHAR(64)   NULL,
             `created_at` BIGINT        NOT NULL,
             `updated_at` BIGINT        NOT NULL,
@@ -62,6 +77,10 @@ function store.ensureSchema()
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
+    if not columnExists('phone_documents', 'signable') then
+        MySQL.query.await('ALTER TABLE `phone_documents` ADD COLUMN `signable` TINYINT(1) NOT NULL DEFAULT 1')
+    end
+
     util.ensureIndex('phone_documents', 'idx_phone_documents_folder', '(citizenid, folder_id)')
     util.ensureIndex('phone_documents', 'idx_phone_documents_updated', '(citizenid, updated_at)')
     util.ensureIndex('phone_document_folders', 'idx_phone_document_folders_cid', '(citizenid)')
@@ -83,7 +102,7 @@ end
 ---@return table[] rows {id, folder_id, name, kind, url, size, locked, source, created_at, updated_at}
 function store.listDocs(cid)
     return MySQL.query.await([[
-        SELECT id, folder_id, name, kind, url, size, locked, source, created_at, updated_at
+        SELECT id, folder_id, name, kind, url, size, locked, signable, source, created_at, updated_at
         FROM `phone_documents` WHERE citizenid = ? ORDER BY updated_at DESC
     ]], { cid }) or {}
 end
@@ -96,7 +115,7 @@ end
 function store.getDoc(cid, id)
     if not id or id == '' then return nil end
     return MySQL.single.await([[
-        SELECT id, folder_id, name, kind, content, url, size, locked, source, created_at, updated_at
+        SELECT id, folder_id, name, kind, content, url, size, locked, signable, source, created_at, updated_at
         FROM `phone_documents` WHERE citizenid = ? AND id = ?
     ]], { cid, id })
 end
@@ -150,11 +169,12 @@ end
 function store.createDoc(cid, doc)
     MySQL.insert.await([[
         INSERT INTO `phone_documents`
-            (id, citizenid, folder_id, name, kind, content, url, size, locked, source, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (id, citizenid, folder_id, name, kind, content, url, size, locked, signable, source, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ]], {
         doc.id, cid, doc.folderId, doc.name, doc.kind, doc.content, doc.url,
-        doc.size or 0, doc.locked and 1 or 0, doc.source, doc.ts, doc.ts,
+        doc.size or 0, doc.locked and 1 or 0, doc.signable == false and 0 or 1,
+        doc.source, doc.ts, doc.ts,
     })
 end
 

--- a/web/src/apps/documents/TextEditor.tsx
+++ b/web/src/apps/documents/TextEditor.tsx
@@ -112,7 +112,7 @@ export function TextEditor({ doc, backLabel, onBack, onSave, onSigned, animateIn
                 <span className="text-[13px] text-ios-gray tabular-nums">
                     {t('documents.charCount', '{n} of {max} characters', { n: body.length, max: MAX_TEXT_LENGTH })}
                 </span>
-                {!signed && (
+                {!signed && doc.signable !== false && (
                     <button
                         type="button"
                         onClick={() => setSignOpen(true)}

--- a/web/src/apps/documents/data.ts
+++ b/web/src/apps/documents/data.ts
@@ -26,6 +26,8 @@ export interface DocFile {
     locked:    boolean;
     /** True when the document carries at least one signature (content + name frozen). */
     signed?:   boolean;
+    /** False when the issuing script forbade signing this document (default signable). */
+    signable?: boolean;
     /** Present on full reads only, like content. */
     signatures?: DocSignature[];
     source?:   string | null;
@@ -130,7 +132,7 @@ export const MOCK_DOCS: DocFile[] = [
         locked: false, signed: true, content: RICH_SAMPLE, createdAt: nowSec() - 14400, updatedAt: nowSec() - 14400,
         signatures: [{ id: 's-1', signer: 'Jordan Reyes', image: null, signedAt: nowSec() - 14000 }],
     },
-    { id: 'd-lease',   name: 'Apartment Lease',  kind: 'text',  folderId: 'f-personal', size: byteLength(SAMPLE), locked: true,  source: 'sd-housing', content: SAMPLE, createdAt: nowSec() - 86400, updatedAt: nowSec() - 86400 },
+    { id: 'd-lease',   name: 'Apartment Lease',  kind: 'text',  folderId: 'f-personal', size: byteLength(SAMPLE), locked: true,  signable: false, source: 'sd-housing', content: SAMPLE, createdAt: nowSec() - 86400, updatedAt: nowSec() - 86400 },
     { id: 'd-q3',      name: 'Q3 Summary',       kind: 'text',  folderId: 'f-reports',  size: byteLength(SAMPLE), locked: false, content: SAMPLE, createdAt: nowSec() - 7200,  updatedAt: nowSec() - 7200 },
     { id: 'd-photo',   name: 'Site Photo',       kind: 'image', folderId: 'f-work',     size: 184320,             locked: false, url: 'https://images.unsplash.com/photo-1503387762-592deb58ef4e?w=800', createdAt: nowSec() - 5400, updatedAt: nowSec() - 5400 },
     { id: 'd-receipt', name: 'Receipt.pdf',      kind: 'file',  folderId: null,        size: 51200,              locked: false, source: 'sd-banking', url: 'https://example.com/receipt.pdf', createdAt: nowSec() - 9000, updatedAt: nowSec() - 9000 },

--- a/web/src/apps/documents/documentsApi.ts
+++ b/web/src/apps/documents/documentsApi.ts
@@ -174,7 +174,7 @@ export async function apiSetSignature(image: string): Promise<boolean> {
 export async function apiSignDoc(id: string): Promise<DocFile | null> {
     if (!isFiveM) {
         const doc = devDocs.find(d => d.id === id);
-        if (!doc || doc.kind !== 'text' || doc.signed || !devSignature) return null;
+        if (!doc || doc.kind !== 'text' || doc.signed || doc.signable === false || !devSignature) return null;
         const sig: DocSignature = { id: newId('s'), signer: 'You', image: devSignature, signedAt: nowSec() };
         doc.signed = true;
         doc.signatures = [...(doc.signatures ?? []), sig];


### PR DESCRIPTION
## Summary
Follow-up to the signature system (#93/#94): every text document was signable, but a signature makes no sense on a citation, report or license. `createDocument` / `createDocumentForNumber` gain `signable = false` (default unchanged - signable):

- **Server-enforced**: the `sign` action refuses unsignable documents ("This document cannot be signed"), so the restriction holds even against a hand-crafted NUI call; the UI hides the Sign button
- **Storage**: `phone_documents.signable` column, `DEFAULT 1` with create + backfill - every existing document stays signable, old installs migrate on boot
- **AirShare carries the restriction**; player-created documents and duplicates are always signable - the flag is pure issuer control
- sd-phonetest gained `/doctest signable` + `/doctest unsignable` A/B presets (identical documents differing only in the flag) and the citation preset now issues `signable = false`

## Testing
- `luac -p` clean, vitest / eslint 0 errors / knip / build green
- In-game A/B: `/doctest signable` shows the Sign button, `/doctest unsignable` hides it and the server refuses regardless