### PR TITLE
feat(birdy): the bird lands - user-drawn mark replaces the feather

### DIFF
--- a/web/src/apps/birdy/BirdyBird.tsx
+++ b/web/src/apps/birdy/BirdyBird.tsx
@@ -1,8 +1,10 @@
 // The Birdy bird mark (user-drawn), bare glyph for headers, empty states and splash spots.
 // Sized and coloured the Lucide way: className drives dimensions, currentColor the fill.
+// The viewBox hugs the artwork's bounding box (it sits low in its authored 100x100 frame),
+// so the bird renders centered and full-size in whatever box the call site gives it.
 export function BirdyBird({ className }: { className?: string }) {
     return (
-        <svg viewBox="0 0 100 100" className={className} fill="currentColor" aria-hidden>
+        <svg viewBox="6 17 88 79" className={className} fill="currentColor" aria-hidden>
             <path d="M91 27 C87 31 82 33 78 35 C81 41 82 48 80 54 C76 76 60 94 37 95 C27 96 16 93 7 88 C16 86 24 83 31 78 C24 78 17 73 14 66 C18 67 22 67 26 65 C17 62 11 56 10 47 C13 49 17 51 21 51 C14 45 11 37 13 28 C20 38 30 43 41 44 C42 36 46 29 52 25 C57 20 65 19 70 22 C75 24 79 25 82 26 C85 26 88 26 91 27 Z" />
         </svg>
     );

--- a/web/src/apps/birdy/BirdyBird.tsx
+++ b/web/src/apps/birdy/BirdyBird.tsx
@@ -1,0 +1,9 @@
+// The Birdy bird mark (user-drawn), bare glyph for headers, empty states and splash spots.
+// Sized and coloured the Lucide way: className drives dimensions, currentColor the fill.
+export function BirdyBird({ className }: { className?: string }) {
+    return (
+        <svg viewBox="0 0 100 100" className={className} fill="currentColor" aria-hidden>
+            <path d="M91 27 C87 31 82 33 78 35 C81 41 82 48 80 54 C76 76 60 94 37 95 C27 96 16 93 7 88 C16 86 24 83 31 78 C24 78 17 73 14 66 C18 67 22 67 26 65 C17 62 11 56 10 47 C13 49 17 51 21 51 C14 45 11 37 13 28 C20 38 30 43 41 44 C42 36 46 29 52 25 C57 20 65 19 70 22 C75 24 79 25 82 26 C85 26 88 26 91 27 Z" />
+        </svg>
+    );
+}

--- a/web/src/apps/birdy/discover/Search.tsx
+++ b/web/src/apps/birdy/discover/Search.tsx
@@ -5,7 +5,7 @@ import { useSessionState } from '@/hooks/useSessionState';
 import { SearchBar } from '@/ui/SearchBar';
 import { apiSearch } from '../birdyApi';
 import { BG, BLUE, META, PILL, type BirdyAuthor } from '../data';
-import { Feather } from 'lucide-react';
+import { BirdyBird } from '../BirdyBird';
 
 import { Avatar, VerifiedBadge } from '../ui';
 
@@ -82,7 +82,7 @@ export function Search({ onOpenProfile }: { onOpenProfile: (handle?: string) => 
                 ) : (
                     <div>
                         <div className="relative flex h-[200px] w-full items-center justify-center overflow-hidden pb-6" style={{ background: BLUE }}>
-                            <Feather className="h-28 w-28 text-white" strokeWidth={1.5} />
+                            <BirdyBird className="h-28 w-28 text-white" />
                             <span className="absolute bottom-4 left-4 text-[17px] font-bold text-white">{t('birdy.startSearching', 'Start searching to explore Birdy')}</span>
                         </div>
 

--- a/web/src/apps/birdy/feed/Feed.tsx
+++ b/web/src/apps/birdy/feed/Feed.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { ArrowUp, Feather, Loader2 } from 'lucide-react';
+import { ArrowUp, Loader2 } from 'lucide-react';
+
+import { BirdyBird } from '../BirdyBird';
 
 import { t } from '@/i18n';
 import { EmptyState } from '@/ui/EmptyState';
@@ -54,7 +56,7 @@ export function Feed({ posts, me, feed, onFeedChange, onRefresh, onToggleLike, o
                 <div className="flex items-center px-4 py-2">
                     <button type="button" onClick={onOpenProfile} aria-label={t('birdy.yourProfile', 'Your profile')}><Avatar size={44} src={me.avatar} /></button>
                     <div className="flex flex-1 justify-center">
-                        <Feather className="h-8 w-8 text-[#1d9bf0]" strokeWidth={2.1} />
+                        <BirdyBird className="h-8 w-8 text-[#1d9bf0]" />
                     </div>
                     <div className="w-11" aria-hidden />
                 </div>
@@ -111,7 +113,7 @@ export function Feed({ posts, me, feed, onFeedChange, onRefresh, onToggleLike, o
                     ) : shown.length === 0 ? (
                         <EmptyState
                             center
-                            icon={<Feather className="h-8 w-8" strokeWidth={1.8} />}
+                            icon={<BirdyBird className="h-8 w-8" />}
                             circleClassName="bg-black/[0.06] text-black/35"
                             title={feed === 'following'
                                 ? t('birdy.nothingHereYet', 'Nothing here yet')

--- a/web/src/apps/birdy/feed/Feed.tsx
+++ b/web/src/apps/birdy/feed/Feed.tsx
@@ -56,7 +56,7 @@ export function Feed({ posts, me, feed, onFeedChange, onRefresh, onToggleLike, o
                 <div className="flex items-center px-4 py-2">
                     <button type="button" onClick={onOpenProfile} aria-label={t('birdy.yourProfile', 'Your profile')}><Avatar size={44} src={me.avatar} /></button>
                     <div className="flex flex-1 justify-center">
-                        <BirdyBird className="h-8 w-8 text-[#1d9bf0]" />
+                        <BirdyBird className="h-9 w-9 text-[#1d9bf0]" />
                     </div>
                     <div className="w-11" aria-hidden />
                 </div>

--- a/web/src/apps/birdy/profile/Profile.tsx
+++ b/web/src/apps/birdy/profile/Profile.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, CalendarDays, Feather, Heart, Image as ImageIcon, Lock, Mail, MessageCircle } from 'lucide-react';
+import { ArrowLeft, CalendarDays, Heart, Image as ImageIcon, Lock, Mail, MessageCircle } from 'lucide-react';
+
+import { BirdyBird } from '../BirdyBird';
 
 import { t } from '@/i18n';
 import { useAsyncData } from '@/hooks/useAsyncData';
@@ -23,7 +25,7 @@ function tabLabels(): Record<Tab, string> {
 
 function tabEmptyStates(): Record<Tab, { icon: React.ReactNode; title: string; subtitle: string }> {
     return {
-        posts:   { icon: <Feather className="h-7 w-7" strokeWidth={1.8} />,       title: t('birdy.noPostsYet', 'No posts yet'),   subtitle: t('birdy.postsEmptySubtitle', 'Posts will show up here.') },
+        posts:   { icon: <BirdyBird className="h-7 w-7" />,       title: t('birdy.noPostsYet', 'No posts yet'),   subtitle: t('birdy.postsEmptySubtitle', 'Posts will show up here.') },
         replies: { icon: <MessageCircle className="h-7 w-7" strokeWidth={1.8} />, title: t('birdy.noRepliesYet', 'No replies yet'), subtitle: t('birdy.repliesEmptySubtitle', 'Replies will show up here.') },
         media:   { icon: <ImageIcon className="h-7 w-7" strokeWidth={1.8} />,     title: t('birdy.noMediaYet', 'No media yet'),   subtitle: t('birdy.mediaEmptySubtitle', 'Photos and videos will show up here.') },
         likes:   { icon: <Heart className="h-7 w-7" strokeWidth={1.8} />,         title: t('birdy.noLikesYet', 'No likes yet'),   subtitle: t('birdy.likesEmptySubtitle', 'Liked posts will show up here.') },

--- a/web/src/shell/AppIconSVG.tsx
+++ b/web/src/shell/AppIconSVG.tsx
@@ -690,27 +690,25 @@ function CalculatorIcon() {
 }
 
 function BirdyIcon() {
-    // A quill on the sky: Lucide's Feather vane filled solid, with the shaft and barb masked
-    // OUT so the tile gradient shows through the cuts (true cutouts, not painted-on lines).
+    // The user-drawn Birdy bird on its own diagonal blue (Downloads/BirdyIcon.jsx); the bare
+    // glyph twin lives in apps/birdy/BirdyBird for in-app branding.
     return (
         <svg viewBox={`0 0 ${S} ${S}`} width={S} height={S}>
             <defs>
-                <LinearGrad id="bdy" top="#6BC1FF" mid="#3D9EF8" bot="#1D7BE8" />
-                <mask id="bdyfcut">
-                    <rect x="0" y="0" width="24" height="24" fill="white" />
-                    <g fill="none" stroke="black" strokeWidth="1.9" strokeLinecap="round">
-                        <path d="M16 8 2 22" />
-                        <path d="M17.5 15H9" />
-                    </g>
-                </mask>
+                <linearGradient id="bdy" x1="0.15" y1="0" x2="0.85" y2="1">
+                    <stop offset="0" stopColor="#4aa8e8" />
+                    <stop offset="0.55" stopColor="#2f7fdc" />
+                    <stop offset="1" stopColor="#2560c9" />
+                </linearGradient>
             </defs>
             <rect width={S} height={S} fill="url(#bdy)" />
-            <svg x="9" y="9" width="42" height="42" viewBox="0 0 24 24">
-                <path
-                    d="M12.67 19a2 2 0 0 0 1.416-.588l6.154-6.172a6 6 0 0 0-8.49-8.49L5.586 9.914A2 2 0 0 0 5 11.328V18a1 1 0 0 0 1 1z"
-                    fill="#fff"
-                    mask="url(#bdyfcut)"
-                />
+            <svg x="0" y="0" width={S} height={S} viewBox="0 0 512 512">
+                <g transform="translate(102,102) scale(3.08)">
+                    <path
+                        d="M91 27 C87 31 82 33 78 35 C81 41 82 48 80 54 C76 76 60 94 37 95 C27 96 16 93 7 88 C16 86 24 83 31 78 C24 78 17 73 14 66 C18 67 22 67 26 65 C17 62 11 56 10 47 C13 49 17 51 21 51 C14 45 11 37 13 28 C20 38 30 43 41 44 C42 36 46 29 52 25 C57 20 65 19 70 22 C75 24 79 25 82 26 C85 26 88 26 91 27 Z"
+                        fill="#fff"
+                    />
+                </g>
             </svg>
         </svg>
     );


### PR DESCRIPTION
## Summary
Birdy gets its bird. The hand-drawn mark (Twitter-family silhouette) replaces the placeholder feather everywhere the brand appears:

- **App tile** (`AppIconSVG`): the bird on its own diagonal blue gradient (#4aa8e8 -> #2f7fdc -> #2560c9)
- **New `apps/birdy/BirdyBird`**: the bare glyph, adapted to the codebase's Lucide conventions (className sizing, `currentColor` fill) so every call site colours it with existing text classes
- **In-app brand spots**: feed header (Birdy blue), feed + profile empty states, Discover hero - all swapped from Lucide's `Feather`

## Testing
- vitest / eslint 0 errors / knip / build green
- Verified in dev via Playwright: the tile renders on the App Store detail page and the feed header shows the glyph in brand blue