### PR TITLE
fix(mail): keep the detail action bar visible while the page slides in

### DIFF
--- a/web/src/apps/mail/MailDetail.tsx
+++ b/web/src/apps/mail/MailDetail.tsx
@@ -22,7 +22,7 @@ interface Props {
 }
 
 export function MailDetail({ msg, backLabel, prevId, nextId, onBack, onOpenSibling, onToggleFlag, onDelete, onMove, onReply }: Props) {
-    const { goBack, pageStyle } = useIosPush(onBack);
+    const { goBack, pageStyle, animating } = useIosPush(onBack);
     const [confirmDelete, setConfirmDelete] = useState(false);
     const [confirmSpam, setConfirmSpam] = useState(false);
     const [detailsOpen, setDetailsOpen] = useState(false);
@@ -147,7 +147,7 @@ export function MailDetail({ msg, backLabel, prevId, nextId, onBack, onOpenSibli
                 )}
             </div>
 
-            <div className="absolute inset-x-0 bottom-0 flex items-center justify-around border-t border-black/10 bg-[#f7f7f7]/95 px-4 pb-9 pt-2.5 backdrop-blur-xl dark:border-white/10 dark:bg-base/80">
+            <div className={`absolute inset-x-0 bottom-0 flex items-center justify-around border-t border-black/10 px-4 pb-9 pt-2.5 dark:border-white/10 ${animating ? 'bg-[#f7f7f7] dark:bg-base' : 'bg-[#f7f7f7]/95 backdrop-blur-xl dark:bg-base/80'}`}>
                 <ActionBtn
                     label={t('mail.flag', 'Flag')}
                     icon={Flag}

--- a/web/src/hooks/useIosPush.ts
+++ b/web/src/hooks/useIosPush.ts
@@ -35,5 +35,9 @@ export function useIosPush(onBack: () => void, animateIn = true) {
             : enter ? 'ios-push 0.34s cubic-bezier(0.32,0.72,0,1) forwards' : undefined,
     };
 
-    return { goBack, pageStyle };
+    // True while the page is sliding; backdrop-filter children don't composite under a
+    // transform-animated ancestor in CEF, so frosted bars should render solid until this clears.
+    const animating = enter || leaving;
+
+    return { goBack, pageStyle, animating };
 }


### PR DESCRIPTION
## What
- Opening an email left the bottom action bar (Flag / Move to Spam / Bin / Reply) invisible until the push animation finished, then it popped in - in CEF a backdrop-filtered element does not composite while an ancestor runs a transform animation
- useIosPush now also returns an animating flag (true during the ios-push slide-in and ios-pop slide-out), synced to the exact moment the hook drops the animation from pageStyle
- MailDetail renders the bar with a solid background while animating and switches to the frosted translucent look once the page is at rest - content only scrolls under the bar after arrival, so the swap is invisible

## Testing
- vitest / eslint 0 errors / build all green
- CEF-specific compositing behavior; verified visually in-game