### PR TITLE
chore(ci): dependabot config (npm + actions, monthly, grouped)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Frontend npm tree (web/package.json + lockfile). Monthly, one grouped PR
+  # instead of a PR per package.
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  # Marketplace actions used by ci.yml and release.yml.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds .github/dependabot.yml:

- npm ecosystem at /web, monthly, all bumps grouped into a single PR (limit 5 open)
- github-actions at /, monthly, grouped

Repo-side Dependabot alerts and automated security fixes were enabled via the API alongside this. Security PRs arrive as needed; version PRs at most monthly per ecosystem.