### PR TITLE
chore(ci): dependabot npm updates limited to minor and patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    # Majors (React, Tailwind, Vite...) are migration projects, not routine
+    # bumps; they stay manual.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Marketplace actions used by ci.yml and release.yml.
   - package-ecosystem: github-actions


### PR DESCRIPTION
Grouped npm PR #108 bundled six major upgrades (React 19, Tailwind 4, Vite 8, TS 7, lucide 1.x, plugin-react 6) and failed CI in 13s. Majors are migration projects, not routine bumps - this ignores semver-major for the npm group so scheduled PRs stay mergeable. Actions majors remain allowed (drop-in there, and #107 validated its own bump in CI).