### PR TITLE
fix(security): close two money-minting holes in stocks and blackjack

### DIFF
--- a/server/games/blackjack.lua
+++ b/server/games/blackjack.lua
@@ -110,14 +110,18 @@ local function statResultFor(outcome)
     return 'loss'
 end
 
----Closes out the caller's hand: optionally plays the dealer, decides the outcome, credits the
----payout, records the result and clears the session.
+---Closes out the caller's hand: claims the session, optionally plays the dealer, decides the
+---outcome, credits the payout and records the result. Nil when the hand was already settled.
 ---@param src integer player server id
 ---@param cid string citizenid
 ---@param playDealer boolean draw the dealer to 17 (false on a player bust / natural)
----@return table result { phase = 'result', player, dealer, outcome, net, chips, bet }
+---@return table|nil result { phase = 'result', player, dealer, outcome, net, chips, bet }
 local function resolve(src, cid, playDealer)
     local s = hands[cid]
+    if not s then return nil end
+    -- Claimed before the first yield: chips.add and stats.record both await, and a second bjStand
+    -- arriving in that window would settle this same hand again off one debited wager.
+    hands[cid] = nil
     if playDealer then
         while dealerShouldHit(s.dealer) do s.dealer[#s.dealer + 1] = draw(s.deck) end
     end
@@ -126,9 +130,7 @@ local function resolve(src, cid, playDealer)
     local bal = s.bal
     if credit > 0 then bal = chips.add(cid, credit) end
     stats.record(cid, 'blackjack', 'cpu', statResultFor(outcome), nameOf(src), net)
-    local result = { phase = 'result', player = s.player, dealer = s.dealer, outcome = outcome, net = net, chips = bal, bet = s.bet }
-    hands[cid] = nil
-    return result
+    return { phase = 'result', player = s.player, dealer = s.dealer, outcome = outcome, net = net, chips = bal, bet = s.bet }
 end
 
 ---Starts a hand: sanitises + debits the wager, deals two cards each, and resolves immediately on a
@@ -184,10 +186,12 @@ function bj.double(src)
     local cid = cidOf(src); if not cid then return nil end
     local s = hands[cid]; if not s then return nil end
     if #s.player ~= 2 or s.doubled then return nil end
-    local bal = chips.remove(cid, s.bet)
-    if not bal then return nil end
-    s.bal     = bal
+    -- Flagged before the yield so a second bjDouble in that window is rejected rather than
+    -- doubling the wager twice; cleared again only when the second stake can't be covered.
     s.doubled = true
+    local bal = chips.remove(cid, s.bet)
+    if not bal then s.doubled = false; return nil end
+    s.bal     = bal
     s.bet     = s.bet * 2
     s.player[#s.player + 1] = draw(s.deck)
     if isBust(s.player) then return resolve(src, cid, false) end

--- a/server/stocks/actions.lua
+++ b/server/stocks/actions.lua
@@ -166,18 +166,23 @@ function actions.buy(src, payload)
         local cash = store.ensureWallet(cid, ST.StartingCash)
         if cash < totalCost then return { success = false, message = 'Insufficient brokerage cash' } end
 
-        local units    = amount / price
         local existing = store.getHolding(cid, symbol)
-        local oldQty   = existing and tonumber(existing.quantity) or 0
-        local oldAvg   = existing and tonumber(existing.avg_cost) or 0
-        local newQty   = oldQty + units
-        local newAvg   = newQty > 0 and (((oldQty * oldAvg) + amount) / newQty) or price
+
+        -- The order moves the market before it fills, so it buys at the price it created, not the
+        -- one it quoted. Filling pre-impact let a buy/sell round trip pocket its own impact.
+        local fill = engine.applyImpact(symbol, amount, true) or price
+        if fill <= 0 then return { success = false, message = 'No price available' } end
+
+        local units  = amount / fill
+        local oldQty = existing and tonumber(existing.quantity) or 0
+        local oldAvg = existing and tonumber(existing.avg_cost) or 0
+        local newQty = oldQty + units
+        local newAvg = newQty > 0 and (((oldQty * oldAvg) + amount) / newQty) or fill
 
         cash = cash - totalCost
         store.setWallet(cid, cash)
         store.upsertHolding(cid, symbol, newQty, newAvg)
 
-        engine.applyImpact(symbol, amount, true)
         broadcastPrices()
 
         return { success = true, data = { cash = cash, units = newQty, avgCost = newAvg } }
@@ -214,7 +219,12 @@ function actions.sell(src, payload)
         end
         if unitsToSell <= 0 then return { success = false, message = 'Nothing to sell' } end
 
-        local gross = unitsToSell * price
+        -- Same rule as the buy: the sale moves the price down before it fills. The order's own
+        -- notional at the quoted price sizes the impact, exactly as it did when applied afterwards.
+        local fill = engine.applyImpact(symbol, unitsToSell * price, false) or price
+        if fill <= 0 then return { success = false, message = 'No price available' } end
+
+        local gross = unitsToSell * fill
         local fee   = math.floor(gross * (ST.Commission or 0) + 0.5)
         local net   = math.floor(gross - fee + 0.5)
 
@@ -229,7 +239,6 @@ function actions.sell(src, payload)
         local cash = store.ensureWallet(cid, ST.StartingCash) + net
         store.setWallet(cid, cash)
 
-        engine.applyImpact(symbol, gross, false)
         broadcastPrices()
 
         return { success = true, data = { cash = cash, units = remaining } }


### PR DESCRIPTION
Found by an adversarially-verified Lua audit of the whole server tree (12 finders, one independent skeptic per finding). These were the only two findings that survived at **critical**: both let a modified client mint value and withdraw it into real framework bank funds.

Scope is deliberately just these two. The rest of the audit backlog is listed at the bottom, not fixed here.

## 1. Stocks fills at the pre-impact price

`actions.buy` and `actions.sell` computed the fill from the price they quoted, then called `engine.applyImpact` afterwards. So an order filled at a price its own impact had not yet moved: a buy filled cheap and *then* raised the price, and the matching sell sold into that raised price.

A zero-hold round trip therefore pocketed its own impact:

```
impact = min(MaxImpact, ImpactScale * order / Liquidity)   -- min(0.5, 0.5 * order / 2e6)
round trip = 1.5 * 0.995 - 1.005 = +48.75%                 -- at any order >= $2M, where impact caps
```

Break-even was ~$40k per order (below that commission wins); above it the gain fraction is fixed and never decays, and the loop is unbounded. Proceeds withdraw to bank via the existing brokerage withdraw path.

Both sides now apply the impact **before** computing the fill. Impact magnitude is unchanged: the sell still sizes it from `unitsToSell * price` (the notional at the quoted price), the exact value it previously passed after the fact.

## 2. Blackjack settles the same hand more than once

`resolve()` read `hands[cid]`, credited the payout through `chips.add` and `stats.record` — both of which `await` — and only cleared the session afterwards:

```lua
local s = hands[cid]
if credit > 0 then bal = chips.add(cid, credit) end   -- MySQL.update.await -> yields
stats.record(...)                                      -- yields
hands[cid] = nil                                       -- too late
```

A second `bjStand` arriving inside that window found the hand still live and settled it again. N concurrent calls paid out N times against one debited wager, and `chips.sell` converts 1:1 via `money.add(src, 'bank', ...)` with no rate limit.

`resolve()` now claims the hand before the first yield and returns nil when it is already gone. `bj.double` sets its `doubled` flag before the `chips.remove` await for the same reason, clearing it only when the second stake cannot be covered.

## Verification

- `luac -p` clean on both files.
- **Round-trip P&L modelled over the real config** (`Liquidity 2e6, ImpactScale 0.5, MaxImpact 0.5, Commission 0.005`):

  | order | before | after |
  |---|---|---|
  | $40,000 | -2 | -798 |
  | $100,000 | **+1,488** | -3,488 |
  | $1,000,000 | **+238,750** | -258,750 |
  | $1,000,000,000 | **+487,500,000** | -507,500,000 |

  Positive (minting) above ~$40k before; negative at every size after.
- **Blackjack race replayed** by driving the real module under a coroutine harness with yielding chip/stat stubs, firing two `bjStand` calls into the await window: `400 trials, 160 paying hands` -> **160 double-settled before, 0 after**.
- No web/frontend files touched, so the tsc/eslint/vitest/knip gates are unaffected by this diff (CI runs them anyway).
- Not runtime-tested in-game: this is server Lua and I can't drive a live FiveM session here. Worth one in-game sanity check that a normal buy/sell and a normal blackjack hand still behave.

## Not fixed here (audit backlog, for follow-up)

Trivial: `syncVaultPassword` UPDATE has no `citizenid` so a planted vault row harvests a victim's new plaintext password; `documents:duplicate` copies `source` but forces `locked = 0`, laundering an issued document; payphone `answer` never compares the answerer's position to `ring.location`.

Also open: invoice-pay balance check across an awaited `markPaid`; `music:share` forwarding a client-chosen `kind`; `sim backup:restore` moving the current holder's group/mail state. Perf: `broadcastPrices` bypasses the watchers set that already exists, mail attachments inline blobs into a whole-mailbox JSON rewrite, per-follower notify fan-out in photogram/birdy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)