### PR TITLE
perf: audit quick wins across stocks, friends, settings, darkchat and games

### DIFF
--- a/bridge/server/version.lua
+++ b/bridge/server/version.lua
@@ -44,6 +44,9 @@ local LATEST_TTL = 3600
 ---@type { value: string|nil, at: number }|nil
 local latestCache
 
+---@type table|nil In-flight lookup, shared by every caller that arrives before it resolves.
+local latestInFlight
+
 ---Resolves the latest non-prerelease GitHub release of `repo` as bare x.y.z, cached for
 ---LATEST_TTL. Yields; nil when the lookup fails.
 ---@param repo string GitHub repo in `owner/name` form.
@@ -52,7 +55,11 @@ function version.latest(repo)
     if latestCache and (os.time() - latestCache.at) < LATEST_TTL then
         return latestCache.value
     end
+    -- Callers arriving while a lookup is in flight join it instead of each firing their own
+    -- request: the cache is only written once the await returns.
+    if latestInFlight then return Citizen.Await(latestInFlight) end
     local p = promise.new()
+    latestInFlight = p
     PerformHttpRequest(('https://api.github.com/repos/%s/releases/latest'):format(repo), function(status, response)
         if status ~= 200 then return p:resolve(nil) end
         local ok, data = pcall(json.decode, response or '')
@@ -60,7 +67,8 @@ function version.latest(repo)
         p:resolve(type(data.tag_name) == 'string' and data.tag_name:match('%d+%.%d+%.%d+') or nil)
     end, 'GET', '', { ['User-Agent'] = 'sd-phone' })
     local latest = Citizen.Await(p)
-    latestCache = { value = latest, at = os.time() }
+    latestCache    = { value = latest, at = os.time() }
+    latestInFlight = nil
     return latest
 end
 

--- a/server/cherry/store.lua
+++ b/server/cherry/store.lua
@@ -1,3 +1,6 @@
+---@type table Shared server helpers (server.util): ensureIndex.
+local util = require 'server.util'
+
 ---@type table Store module; the table returned at end of file.
 local store = {}
 
@@ -102,6 +105,10 @@ function store.ensureSchema()
             INDEX idx_cherry_msgs_thread (match_id, created_at)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
+
+    -- uq_cherry_pair leads on `a`, so matchesFor's `WHERE a = ? OR b = ?` had no index for the
+    -- `b` half and fell back to a full scan on every Cherry open.
+    util.ensureIndex('phone_cherry_matches', 'idx_cherry_match_b', '(b)')
 end
 
 ---A profile row by username (nil if none).

--- a/server/darkchat/actions.lua
+++ b/server/darkchat/actions.lua
@@ -142,9 +142,12 @@ end
 ---@param cid string viewer citizenid
 ---@return table[] messages oldest-first client message rows
 local function buildMessages(roomId, cid)
-    local reactions = store.reactionsForRoom(roomId, cid)
+    local rows = store.recentMessages(roomId, DC.HistoryLimit)
+    local ids = {}
+    for i = 1, #rows do ids[i] = rows[i].id end
+    local reactions = store.reactionsForMessages(ids, cid)
     local out = {}
-    for _, m in ipairs(store.recentMessages(roomId, DC.HistoryLimit)) do
+    for _, m in ipairs(rows) do
         local msg = {
             id = tostring(m.id), author = m.author, body = m.body, at = fmtTime(m.created_at),
             mine = m.citizenid == cid, kind = m.kind or 'text',

--- a/server/darkchat/store.lua
+++ b/server/darkchat/store.lua
@@ -297,23 +297,27 @@ function store.reactionsFor(messageId, cid)
     return out
 end
 
----Every message's reactions in a room, from `cid`'s viewpoint, keyed by message id AS A STRING to
+---Reactions for specific messages, from `cid`'s viewpoint, keyed by message id AS A STRING to
 ---match the string ids client messages carry: { [messageId] = { {emoji, count, mine}, ... } }.
----One grouped query for the whole room, so buildMessages attaches per-message sets without an N+1.
----Same anonymity posture as reactionsFor. Read-only.
----@param roomId string room id
+---Scoped by id, not by room: the ids come from the room's own history window, so decorating the
+---newest messages no longer aggregates a room's entire (never-pruned) reaction history. One
+---grouped query, so buildMessages attaches per-message sets without an N+1. Same anonymity
+---posture as reactionsFor. Read-only.
+---@param ids integer[] message ids from the room's history window
 ---@param cid string viewer citizenid
 ---@return table<string, table[]> reactions per-message reaction lists
-function store.reactionsForRoom(roomId, cid)
-    local rows = MySQL.query.await([[
+function store.reactionsForMessages(ids, cid)
+    local out = {}
+    if type(ids) ~= 'table' or #ids == 0 then return out end
+    local ph, args = {}, { cid }
+    for i = 1, #ids do ph[i] = '?'; args[#args + 1] = ids[i] end
+    local rows = MySQL.query.await(([[
         SELECT r.message_id AS message_id, r.emoji AS emoji, COUNT(*) AS cnt, MAX(r.citizenid = ?) AS mine
         FROM `darkchat_reactions` r
-        JOIN `darkchat_messages` m ON m.id = r.message_id
-        WHERE m.room_id = ?
+        WHERE r.message_id IN (%s)
         GROUP BY r.message_id, r.emoji
         ORDER BY MIN(r.created_at)
-    ]], { cid, roomId }) or {}
-    local out = {}
+    ]]):format(table.concat(ph, ',')), args) or {}
     for _, r in ipairs(rows) do
         local key = tostring(r.message_id)
         out[key] = out[key] or {}

--- a/server/documents/store.lua
+++ b/server/documents/store.lua
@@ -86,9 +86,13 @@ function store.ensureSchema()
     end
 
     -- Repair: createDoc used to coerce a numeric locked = 0 to 1 (0 is truthy in Lua), so every
-    -- player-created document landed locked. Player rows never carry a source; issued rows
-    -- always name their invoking resource - so this unlock is safe to run every boot.
-    MySQL.query.await('UPDATE `phone_documents` SET locked = 0 WHERE locked = 1 AND source IS NULL')
+    -- player-created document landed locked. Player rows never carry a source; issued rows always
+    -- name their invoking resource. Run once: the predicate is unindexed, so repeating it every
+    -- boot scanned the whole table to match nothing.
+    util.runOnce('documents_unlock_player_rows', function()
+        local n = MySQL.update.await('UPDATE `phone_documents` SET locked = 0 WHERE locked = 1 AND source IS NULL')
+        return { repaired = tonumber(n) or 0 }
+    end)
 
     util.ensureIndex('phone_documents', 'idx_phone_documents_folder', '(citizenid, folder_id)')
     util.ensureIndex('phone_documents', 'idx_phone_documents_updated', '(citizenid, updated_at)')

--- a/server/friends/actions.lua
+++ b/server/friends/actions.lua
@@ -57,14 +57,33 @@ end
 ---@param onlineCids? table<string, number> shared citizenid->src map; the tick loop builds it once
 ---and passes it to every watcher, nil = build it here (for one-off callback use)
 ---@return table[] roster entries
-function actions.snapshot(src, onlineCids)
-    local owner = cidOf(src)
-    if not owner then return {} end
+---@type integer Seconds a roster stays cached across live-push ticks. Only positions and online
+---state change tick-to-tick; the roster itself only changes on a mutation, which drops the entry.
+local ROSTER_TTL = 15
+---@type integer Cached rosters kept before the cache is dropped wholesale (keys are server-resolved
+---citizenids, so this only bounds growth over a long uptime).
+local ROSTER_KEYS_MAX = 256
 
-    local contacts = contactInfo(owner)
-    local sharers  = store.sharersOf(owner)
-    onlineCids     = onlineCids or player.onlineCidMap()
-    local nowMs    = os.time() * 1000
+local rosterCache, rosterKeys = {}, 0
+
+---Drops cached rosters so the next read rebuilds them. Every edge mutation invalidates BOTH
+---sides: one player's share flag or pending request is visible in the other's roster.
+---@param ... string|nil citizenids to invalidate
+local function invalidateRoster(...)
+    for i = 1, select('#', ...) do
+        local cid = select(i, ...)
+        if cid and rosterCache[cid] then rosterCache[cid] = nil; rosterKeys = rosterKeys - 1 end
+    end
+end
+
+---The query-backed half of a snapshot: contact cards, share flags, pending requests, friend edges
+---and their phone numbers. Cached, because the 3s push loop re-ran all five queries per watcher
+---per tick just to refresh coordinates.
+---@param owner string owner citizenid
+---@return table parts { contacts, sharers, requests, friends, numbers }
+local function rosterParts(owner)
+    local hit = rosterCache[owner]
+    if hit and (os.time() - hit.at) < ROSTER_TTL then return hit end
 
     local requests = store.requestsFor(owner)
     local friends  = store.friendsOf(owner)
@@ -72,7 +91,35 @@ function actions.snapshot(src, onlineCids)
     local cids = {}
     for i = 1, #requests do cids[#cids + 1] = requests[i] end
     for i = 1, #friends do cids[#cids + 1] = friends[i].friend end
-    local numbers = settings.numbersFor(cids)
+
+    if not hit then
+        if rosterKeys >= ROSTER_KEYS_MAX then rosterCache, rosterKeys = {}, 0 end
+        rosterKeys = rosterKeys + 1
+    end
+    local parts = {
+        at       = os.time(),
+        contacts = contactInfo(owner),
+        sharers  = store.sharersOf(owner),
+        requests = requests,
+        friends  = friends,
+        numbers  = settings.numbersFor(cids),
+    }
+    rosterCache[owner] = parts
+    return parts
+end
+
+function actions.snapshot(src, onlineCids)
+    local owner = cidOf(src)
+    if not owner then return {} end
+
+    local parts    = rosterParts(owner)
+    local contacts = parts.contacts
+    local sharers  = parts.sharers
+    local requests = parts.requests
+    local friends  = parts.friends
+    local numbers  = parts.numbers
+    onlineCids     = onlineCids or player.onlineCidMap()
+    local nowMs    = os.time() * 1000
 
     local out, inRoster = {}, {}
 
@@ -164,6 +211,7 @@ function actions.add(src, phone)
     end
 
     store.add(owner, fcid, os.date('!%Y-%m-%dT%H:%M:%S.000Z'), true)
+    invalidateRoster(owner, fcid)
 
     messages.appMessage(src, number, 'locrequest', 'Location sharing request',
         { requested = true, requestStatus = 'pending' })
@@ -193,8 +241,10 @@ function actions.respond(src, msgId, phone, accept)
 
     if accept then
         store.accept(rcid, owner, os.date('!%Y-%m-%dT%H:%M:%S.000Z'))
+        invalidateRoster(owner, rcid)
     else
         store.remove(rcid, owner)
+        invalidateRoster(owner, rcid)
     end
 
     local copyId = (type(msgId) == 'string' and msgId ~= '') and msgId
@@ -259,6 +309,7 @@ function actions.remove(src, id)
     local owner = cidOf(src)
     if not owner or type(id) ~= 'string' or id == '' then return { success = false } end
     store.remove(owner, id)
+    invalidateRoster(owner, id)
     return { success = true, data = actions.snapshot(src) }
 end
 
@@ -272,6 +323,7 @@ function actions.setShare(src, id, enabled)
     local owner = cidOf(src)
     if not owner or type(id) ~= 'string' or id == '' then return { success = false } end
     store.setShare(owner, id, enabled == true)
+    invalidateRoster(owner, id)
     return { success = true, data = actions.snapshot(src) }
 end
 

--- a/server/games/stats.lua
+++ b/server/games/stats.lua
@@ -1,3 +1,6 @@
+---@type table Shared server helpers (server.util): ensureIndex.
+local util = require 'server.util'
+
 ---@type table Stats module; the table returned at end of file. Unified per-character game stats
 ---(W/L/D, split vs-Computer / Online, cumulative chip amounts, and a single-player high score)
 ---shared by every game (chess, connectfour, blackjack, blocks, flappy, ...). One row per
@@ -46,6 +49,12 @@ function stats.ensureSchema()
             FROM phone_chess_stats
         ]])
     end
+    -- `game` is the SECOND primary-key column, so every board's `WHERE game = ?` had no usable
+    -- index and scanned the whole table.
+    util.ensureIndex('phone_game_stats', 'idx_game_stats_game_high',   '(game, high_score)')
+    util.ensureIndex('phone_game_stats', 'idx_game_stats_game_cpu',    '(game, cpu_wins)')
+    util.ensureIndex('phone_game_stats', 'idx_game_stats_game_online', '(game, online_wins)')
+    util.ensureIndex('phone_game_stats', 'idx_game_stats_game_chips',  '(game, chips_won)')
 end
 
 ---Reads a player's stats for one game: { cpu = {wins,losses,draws}, online = {...}, won, lost,
@@ -142,27 +151,55 @@ end
 ---chips (won - lost). A non-string game id returns the empty shape. Read-only.
 ---@param game any game id (client-supplied)
 ---@return table boards { cpu, online, winners, losers }
+---@type integer Seconds a computed board stays warm. The boards are cosmetic, and the callback
+---behind them is ungated, so a short cache also bounds how often a client can force the queries.
+local BOARD_TTL = 30
+---@type integer Cache entries kept before the whole cache is dropped. The game id comes from the
+---client, so the key space is attacker-chosen and must not grow without bound.
+local BOARD_KEYS_MAX = 64
+
+local boardCache, boardKeys = {}, 0
+
+---Returns a cached board, building and storing it when the entry is missing or stale.
+---@param key string cache key
+---@param build fun(): any board builder
+---@return any board
+local function cachedBoard(key, build)
+    local now = os.time()
+    local hit = boardCache[key]
+    if hit and (now - hit.at) < BOARD_TTL then return hit.data end
+    if not hit then
+        if boardKeys >= BOARD_KEYS_MAX then boardCache, boardKeys = {}, 0 end
+        boardKeys = boardKeys + 1
+    end
+    local data = build()
+    boardCache[key] = { at = now, data = data }
+    return data
+end
+
 function stats.leaderboard(game)
     if type(game) ~= 'string' then return { cpu = {}, online = {}, winners = {}, losers = {} } end
-    local function wlBoard(winCol, lossCol)
-        return MySQL.query.await((
-            'SELECT name, %s AS wins, %s AS losses FROM phone_game_stats ' ..
-            'WHERE game = ? AND (%s + %s) > 0 ORDER BY %s DESC, %s ASC LIMIT 20'
-        ):format(winCol, lossCol, winCol, lossCol, winCol, lossCol), { game }) or {}
-    end
-    local function chipBoard(cmp, order)
-        return MySQL.query.await((
-            'SELECT name, chips_won AS won, chips_lost AS lost, (chips_won - chips_lost) AS net ' ..
-            'FROM phone_game_stats WHERE game = ? AND (chips_won - chips_lost) %s 0 ' ..
-            'ORDER BY net %s LIMIT 20'
-        ):format(cmp, order), { game }) or {}
-    end
-    return {
-        cpu     = wlBoard('cpu_wins', 'cpu_losses'),
-        online  = wlBoard('online_wins', 'online_losses'),
-        winners = chipBoard('>', 'DESC'),
-        losers  = chipBoard('<', 'ASC'),
-    }
+    return cachedBoard('lb:' .. game, function()
+        local function wlBoard(winCol, lossCol)
+            return MySQL.query.await((
+                'SELECT name, %s AS wins, %s AS losses FROM phone_game_stats ' ..
+                'WHERE game = ? AND (%s + %s) > 0 ORDER BY %s DESC, %s ASC LIMIT 20'
+            ):format(winCol, lossCol, winCol, lossCol, winCol, lossCol), { game }) or {}
+        end
+        local function chipBoard(cmp, order)
+            return MySQL.query.await((
+                'SELECT name, chips_won AS won, chips_lost AS lost, (chips_won - chips_lost) AS net ' ..
+                'FROM phone_game_stats WHERE game = ? AND (chips_won - chips_lost) %s 0 ' ..
+                'ORDER BY net %s LIMIT 20'
+            ):format(cmp, order), { game }) or {}
+        end
+        return {
+            cpu     = wlBoard('cpu_wins', 'cpu_losses'),
+            online  = wlBoard('online_wins', 'online_losses'),
+            winners = chipBoard('>', 'DESC'),
+            losers  = chipBoard('<', 'ASC'),
+        }
+    end)
 end
 
 ---Global high-score board for a game: top 20 players by high score. A non-string game id returns
@@ -171,11 +208,13 @@ end
 ---@return { name: string, score: integer }[]
 function stats.scoreboard(game)
     if type(game) ~= 'string' then return {} end
-    return MySQL.query.await([[
-        SELECT name, high_score AS score FROM phone_game_stats
-        WHERE game = ? AND high_score > 0
-        ORDER BY high_score DESC LIMIT 20
-    ]], { game }) or {}
+    return cachedBoard('sb:' .. game, function()
+        return MySQL.query.await([[
+            SELECT name, high_score AS score FROM phone_game_stats
+            WHERE game = ? AND high_score > 0
+            ORDER BY high_score DESC LIMIT 20
+        ]], { game }) or {}
+    end)
 end
 
 return stats

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -46,34 +46,13 @@ end)
 lib.callback.register('sd-phone:server:settings:get', function(source)
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
-    local data = store.getTones(cid)
+    -- One row read, not one per field: this used to issue 16 single-column PK lookups.
+    local data = store.snapshot(cid)
     data.customRingtones         = store.listCustomTones(cid, 'ringtone')
     data.customNotificationTones = store.listCustomTones(cid, 'notification')
-    data.airplaneMode            = store.isAirplane(cid)
-    data.hour24                  = store.getHour24(cid)
-    data.reopenApp               = store.getReopenApp(cid)
-    data.setupDone               = store.getSetupDone(cid)
-    data.theme                   = store.getTheme(cid)
-    data.darkTheme               = store.getDarkTheme(cid)
-    data.lockClock               = store.getLockClock(cid)
-    local walls = store.getWallpapers(cid)
-    data.wallpaper               = walls.lock
-    data.wallpaperHome           = walls.home
-    data.blurLock                = walls.blurLock
-    data.blurHome                = walls.blurHome
-    data.customWallpapers        = store.getCustomWallpapers(cid)
-    data.chatTextScale           = store.getChatTextScale(cid)
-    data.phoneScale              = store.getPhoneScale(cid)
-    data.phoneAlign              = store.getPhoneAlign(cid)
-    local vols = store.getVolumes(cid)
-    data.ringtoneVol             = vols.ringtone
-    data.callVol                 = vols.call
-    data.locale                  = store.getLocale(cid)
-    local sec = store.getSecurity(cid)
-    data.passcode                = sec.passcode
     -- Face Unlock only works for the SIM's first activator - a stolen phone still asks the
     -- thief for the passcode (a no-op outside unique-phones mode).
-    data.faceId                  = sec.faceId and require('server.sim.session').isOwner(source)
+    data.faceId                  = data.faceId and require('server.sim.session').isOwner(source)
     return { success = true, data = data }
 end)
 

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -212,6 +212,18 @@ function store.ensureSchema()
             PRIMARY KEY (citizenid, app)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
+
+    -- setPhoneNumber has always written bare digits; only rows imported from another phone
+    -- resource can still carry separators. Normalising them once lets the number lookups compare
+    -- the bare column, so idx_phone_settings_number can be SEEKED instead of scanned through a
+    -- REPLACE() wrapper that made the predicate non-sargable.
+    util.runOnce('settings_phone_number_bare_digits', function()
+        local n = MySQL.update.await((
+            'UPDATE phone_settings SET phone_number = %s ' ..
+            'WHERE phone_number IS NOT NULL AND phone_number <> %s'
+        ):format(stripCol('phone_number'), stripCol('phone_number')))
+        return { normalized = tonumber(n) or 0 }
+    end)
 end
 
 ---Clamps an app id to a lowercase slug capped at 32 chars; nil for empty/invalid input.
@@ -375,7 +387,7 @@ function store.getCitizenByNumber(number)
     local digits = (tostring(number or ''):gsub('%D', ''))
     if digits == '' then return nil end
     local row = MySQL.single.await(
-        ('SELECT citizenid FROM phone_settings WHERE %s = ? LIMIT 1'):format(stripCol('phone_number')),
+        'SELECT citizenid FROM phone_settings WHERE phone_number = ? LIMIT 1',
         { digits }
     )
     return row and row.citizenid or nil
@@ -387,7 +399,7 @@ end
 function store.numberExists(number)
     local digits = (tostring(number or ''):gsub('%D', ''))
     local row = MySQL.single.await(
-        ('SELECT 1 AS hit FROM phone_settings WHERE %s = ? LIMIT 1'):format(stripCol('phone_number')),
+        'SELECT 1 AS hit FROM phone_settings WHERE phone_number = ? LIMIT 1',
         { digits }
     )
     return row ~= nil
@@ -1133,6 +1145,66 @@ function store.removeCustomTone(citizenid, id)
         'DELETE FROM phone_custom_ringtones WHERE citizenid = ? AND id = ?',
         { citizenid, id }
     )
+end
+
+---Decodes a JSON settings column, falling back to `fallback` on an empty or unparseable value.
+---@param raw any stored column value
+---@param fallback any value to return when the column can't be decoded
+---@return any
+local function decodeColumn(raw, fallback)
+    if not raw or raw == '' then return fallback end
+    local ok, decoded = pcall(json.decode, raw)
+    if not ok or type(decoded) ~= 'table' then return fallback end
+    return decoded
+end
+
+---The caller's whole settings row in ONE query, derived exactly as the individual getters do.
+---The per-field getters each ran their own single-column PK lookup, so building the snapshot the
+---settings screen wants cost 16 round trips per hydrate. Custom tones and their own table stay
+---separate. Read-only apart from warming the airplane cache.
+---@param citizenid string framework per-character id
+---@return table snapshot the settings:get payload shape
+function store.snapshot(citizenid)
+    if not citizenid or citizenid == '' then return {} end
+    local row = MySQL.single.await('SELECT * FROM phone_settings WHERE citizenid = ?', { citizenid })
+
+    local airplane = airplaneCache[citizenid]
+    if airplane == nil then
+        airplane = row ~= nil and isTruthy(row.airplane_mode) or false
+        airplaneCache[citizenid] = airplane
+    end
+
+    local pin = row and sanitizePin(row.passcode) or nil
+    local hour24 = (row and row.hour24 ~= nil)
+        and (row.hour24 == true or tonumber(row.hour24) == 1)
+        or defaultHour24()
+    local dark = row and row.dark_theme
+    if dark ~= 'graphite' and dark ~= 'black' and dark ~= 'warm' then dark = 'graphite' end
+
+    return {
+        ringtone         = row and row.ringtone or nil,
+        notificationTone = row and row.notification_tone or nil,
+        airplaneMode     = airplane,
+        hour24           = hour24,
+        reopenApp        = row ~= nil and (row.reopen_app == true or tonumber(row.reopen_app) == 1),
+        setupDone        = row ~= nil and (row.setup_done == true or tonumber(row.setup_done) == 1),
+        theme            = (row and row.theme == 'dark') and 'dark' or 'light',
+        darkTheme        = dark,
+        lockClock        = row and decodeColumn(row.lock_clock, nil) or nil,
+        wallpaper        = (row and row.wallpaper ~= '') and row.wallpaper or nil,
+        wallpaperHome    = (row and row.wallpaper_home ~= '') and row.wallpaper_home or nil,
+        blurLock         = row ~= nil and isTruthy(row.blur_lock),
+        blurHome         = row ~= nil and isTruthy(row.blur_home),
+        customWallpapers = row and decodeColumn(row.custom_wallpapers, {}) or {},
+        chatTextScale    = (row and row.chat_text_scale ~= nil) and tonumber(row.chat_text_scale) or nil,
+        phoneScale       = (row and row.phone_scale ~= nil) and tonumber(row.phone_scale) or nil,
+        phoneAlign       = (row and row.phone_align ~= '') and row.phone_align or nil,
+        ringtoneVol      = (row and row.ringtone_volume ~= nil) and tonumber(row.ringtone_volume) or nil,
+        callVol          = (row and row.call_volume ~= nil) and tonumber(row.call_volume) or nil,
+        locale           = (row and row.locale ~= '') and row.locale or nil,
+        passcode         = pin,
+        faceId           = pin ~= nil and row ~= nil and isTruthy(row.face_id),
+    }
 end
 
 return store

--- a/server/sim/backup.lua
+++ b/server/sim/backup.lua
@@ -12,11 +12,19 @@ local function run(sql, params)
     return ok and (tonumber(res) or 0) or 0
 end
 
+---@type table<string, table> Memoised describe() results. A table's shape can't change while the
+---resource is up, and one sync probed information_schema once per copied table. Callers only read
+---these, never mutate them. A failed probe is not cached.
+local shapeCache = {}
+
 ---Column metadata for a table: names in ordinal order, the auto-increment column (skipped on
 ---copy so fresh ids are allocated), and the primary-key column set.
 ---@param tbl string table name
 ---@return string[] cols, table<string, boolean> autoinc, table<string, boolean> pk
 local function describe(tbl)
+    local hit = shapeCache[tbl]
+    if hit then return hit[1], hit[2], hit[3] end
+
     local cols, autoinc, pk = {}, {}, {}
     local ok, rows = pcall(function()
         return MySQL.query.await([[
@@ -32,6 +40,7 @@ local function describe(tbl)
         if tostring(r.extra or ''):find('auto_increment') then autoinc[r.name] = true end
         if r.ckey == 'PRI' then pk[r.name] = true end
     end
+    shapeCache[tbl] = { cols, autoinc, pk }
     return cols, autoinc, pk
 end
 

--- a/server/sim/init.lua
+++ b/server/sim/init.lua
@@ -434,6 +434,17 @@ lib.callback.register('sd-phone:server:sim:backup:set', function(source, payload
     return util.ok()
 end)
 
+---@type integer Auto-sync throttle: the enrolled phone re-snapshots at most this often (seconds).
+local AUTO_SYNC_MIN_GAP = 300
+
+---@type integer Manual "Back Up Now" throttle. Shorter than the auto gap so the button stays
+---responsive, but enough that the ~88-statement run can't be looped at will.
+local MANUAL_SYNC_MIN_GAP = 30
+
+---@type table<number, boolean> Per-source sync in progress; drops overlapping attempts on both
+---the manual and the automatic path.
+local syncBusy = {}
+
 ---Manual "Back Up Now" for the caller's phone (its own profile only).
 lib.callback.register('sd-phone:server:sim:backup:sync', function(source)
     if not (config.Sim.Backup and config.Sim.Backup.Enabled ~= false) then
@@ -448,7 +459,16 @@ lib.callback.register('sd-phone:server:sim:backup:sync', function(source)
         return util.fail('Cloud Backup is not enabled on this phone.')
     end
 
-    local syncedAt = runProfileSync(realCid, profile, s)
+    if syncBusy[source] then return util.fail('A backup is already running.') end
+    local since = os.time() - (profile.syncedAt or 0)
+    if since < MANUAL_SYNC_MIN_GAP then
+        return util.fail(('Backed up moments ago. Try again in %ds.'):format(MANUAL_SYNC_MIN_GAP - since))
+    end
+
+    syncBusy[source] = true
+    local okRun, syncedAt = pcall(runProfileSync, realCid, profile, s)
+    syncBusy[source] = nil
+    if not okRun then error(syncedAt, 0) end
     return util.ok({ syncedAt = syncedAt })
 end)
 
@@ -480,12 +500,6 @@ lib.callback.register('sd-phone:server:sim:backup:delete', function(source, payl
     return util.ok()
 end)
 
----@type integer Auto-sync throttle: the enrolled phone re-snapshots at most this often (seconds).
-local AUTO_SYNC_MIN_GAP = 300
-
----@type table<number, boolean> Per-source auto-sync in progress; drops overlapping attempts.
-local autoSyncBusy = {}
-
 ---Auto-sync trigger: holstering the phone is the natural save point. A phone only ever syncs
 ---ITS OWN profile, so a lost or stolen phone can never overwrite another phone's backup.
 ---Second listener on the share module's open-state event.
@@ -493,8 +507,8 @@ RegisterNetEvent('sd-phone:server:phone:setOpen', function(open)
     local source = source
     if open or not state.active then return end
     if not (config.Sim.Backup and config.Sim.Backup.Enabled ~= false) then return end
-    if autoSyncBusy[source] then return end
-    autoSyncBusy[source] = true
+    if syncBusy[source] then return end
+    syncBusy[source] = true
     CreateThread(function()
         local okRun, err = pcall(function()
             local realCid = player.getRealIdentifier(source)
@@ -507,7 +521,7 @@ RegisterNetEvent('sd-phone:server:phone:setOpen', function(open)
             runProfileSync(realCid, profile, s)
         end)
         if not okRun then print(('^1[sd-phone:sim]^0 auto-sync failed for %s: %s'):format(source, err)) end
-        autoSyncBusy[source] = nil
+        syncBusy[source] = nil
     end)
 end)
 

--- a/server/stocks/actions.lua
+++ b/server/stocks/actions.lua
@@ -8,6 +8,8 @@ local engine = require 'server.stocks.engine'
 local bank   = require 'bridge.server.banking'
 ---@type table Player bridge (bridge.server.player): citizenid lookups from a server id.
 local player = require 'bridge.server.player'
+---@type table Watcher registry (server.stocks.watchers): players with the app open.
+local watchers = require 'server.stocks.watchers'
 
 ---@type table Stocks config (config.Stocks): fees, trade bounds, market knobs, asset list.
 local ST = config.Stocks
@@ -44,13 +46,11 @@ local function withTradeGate(cid, fn)
     return result
 end
 
----Pushes a fresh price snapshot to every online player. Ticks carry symbol/price/% change only.
+---Pushes a fresh price snapshot to the players with Stocks open. Ticks carry symbol/price/%
+---change only. Scoped to watchers: a trade used to wake every client on the server.
 local function broadcastPrices()
-    local ticks = engine.ticks()
-    local players = GetPlayers()
-    for i = 1, #players do
-        TriggerClientEvent('sd-phone:client:stocks:prices', players[i], { assets = ticks })
-    end
+    if not watchers.any() then return end
+    watchers.push('sd-phone:client:stocks:prices', { assets = engine.ticks() })
 end
 
 ---Full market + the caller's positions + brokerage cash, for the app's main screen. Creates the

--- a/server/stocks/init.lua
+++ b/server/stocks/init.lua
@@ -6,6 +6,8 @@ local store   = require 'server.stocks.store'
 local engine  = require 'server.stocks.engine'
 ---@type table Authoritative trade handlers (server.stocks.actions): validation + money movement.
 local actions = require 'server.stocks.actions'
+---@type table Watcher registry (server.stocks.watchers): shared with the per-trade broadcast.
+local watchers = require 'server.stocks.watchers'
 
 ---@type table Stocks config (config.Stocks): tick + save cadence.
 local ST = config.Stocks
@@ -18,21 +20,18 @@ lib.callback.register('sd-phone:server:stocks:buy',      function(src, payload) 
 lib.callback.register('sd-phone:server:stocks:sell',     function(src, payload) return actions.sell(src, payload)      end)
 lib.callback.register('sd-phone:server:stocks:holders',  function(src, payload) return actions.holders(src, payload)   end)
 
----@type table<number, boolean> Players with the Stocks app open (live price-push targets), by src.
-local watchers = {}
-
 ---Subscribes or unsubscribes the caller to the per-tick price push while the app is open.
 ---@param src number
 ---@param payload table { on: boolean }
 lib.callback.register('sd-phone:server:stocks:watch', function(src, payload)
     payload = type(payload) == 'table' and payload or {}
-    if payload.on == true then watchers[src] = true else watchers[src] = nil end
+    watchers.watch(src, payload.on == true)
     return { success = true }
 end)
 
 ---Drops a departing watcher's entry.
 AddEventHandler('playerDropped', function()
-    watchers[source] = nil
+    watchers.drop(source)
 end)
 
 -- Boot then heartbeat: creates the schema, seeds prices, then ticks the market every
@@ -49,15 +48,8 @@ CreateThread(function()
     while true do
         Wait((ST.TickSeconds or 5) * 1000)
         engine.tick()
-        if next(watchers) then
-            local ticks = engine.ticks()
-            for src in pairs(watchers) do
-                if GetPlayerName(src) then
-                    TriggerClientEvent('sd-phone:client:stocks:prices', src, { assets = ticks })
-                else
-                    watchers[src] = nil
-                end
-            end
+        if watchers.any() then
+            watchers.push('sd-phone:client:stocks:prices', { assets = engine.ticks() })
         end
     end
 end)

--- a/server/stocks/watchers.lua
+++ b/server/stocks/watchers.lua
@@ -1,0 +1,33 @@
+---@type table<number, boolean> Players with the Stocks app open, by src. Shared by the tick loop
+---and the per-trade broadcast so neither has to push prices to the whole server.
+local watchers = {}
+
+---@type table Watcher registry; the table returned at end of file.
+local M = {}
+
+---Subscribes or unsubscribes a player to the price push.
+---@param src number player server id
+---@param on boolean true to subscribe
+function M.watch(src, on) watchers[src] = on and true or nil end
+
+---Drops a player's subscription (disconnect, or a stale entry found while pushing).
+---@param src number player server id
+function M.drop(src) watchers[src] = nil end
+
+---@return boolean any true when at least one player has Stocks open
+function M.any() return next(watchers) ~= nil end
+
+---Pushes an event to every live watcher, clearing entries whose player has gone.
+---@param event string client event name
+---@param payload table event payload
+function M.push(event, payload)
+    for src in pairs(watchers) do
+        if GetPlayerName(src) then
+            TriggerClientEvent(event, src, payload)
+        else
+            watchers[src] = nil
+        end
+    end
+end
+
+return M

--- a/server/util.lua
+++ b/server/util.lua
@@ -117,6 +117,32 @@ function util.ensureIndex(tableName, indexName, columnsDDL)
     end
 end
 
+---Runs a one-shot repair or backfill exactly once per database, recording it in phone_migrations
+---so later boots skip it. Use for work whose predicate can't be indexed and would otherwise
+---re-scan a whole table every start to match nothing.
+---@param name string unique migration name
+---@param fn fun(): table|nil the work; may return stats to stamp on the marker row
+---@return boolean ran true when the work executed on this call
+function util.runOnce(name, fn)
+    MySQL.query.await([[
+        CREATE TABLE IF NOT EXISTS phone_migrations (
+            name       VARCHAR(64) NOT NULL,
+            applied_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            stats      JSON        NULL,
+            PRIMARY KEY (name)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    ]])
+    if MySQL.scalar.await('SELECT 1 FROM phone_migrations WHERE name = ? LIMIT 1', { name }) ~= nil then
+        return false
+    end
+    local stats = fn()
+    MySQL.query.await(
+        'INSERT IGNORE INTO phone_migrations (name, stats) VALUES (?, ?)',
+        { name, json.encode(stats or {}) }
+    )
+    return true
+end
+
 ---Rescues a same-named table left behind by another phone resource (lb-phone shares several
 ---table names with sd-phone): when `tbl` exists but is missing the sd-phone marker column, it
 ---is renamed to `<tbl>_lb` so the following CREATE TABLE builds the real sd-phone table. The

--- a/web/src/apps/compass/Compass.tsx
+++ b/web/src/apps/compass/Compass.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { fetchNui, isFiveM } from '@/core/nui';
 import { t } from '@/i18n';
+import { useDeckActive } from '@/shell/deckActive';
 import { useTheme } from '@/stores/themeStore';
 
 const SB_H = 54;
@@ -56,7 +57,12 @@ export function Compass({ onClose: _onClose }: { onClose: () => void }) {
     const { theme } = useTheme('theme');
     const dark = theme === 'dark';
 
+    // Compass is retained in the app switcher, so without this gate its 250ms poll kept running
+    // (4 NUI round-trips a second) while the app sat suspended in the hidden deck layer.
+    const deckActive = useDeckActive();
+
     useEffect(() => {
+        if (!deckActive) return;
         if (!isFiveM) {
             const t = window.setInterval(() => {
                 if (!dragging.current) setRot(r => r + (Math.random() - 0.5) * 0.5);
@@ -85,7 +91,7 @@ export function Compass({ onClose: _onClose }: { onClose: () => void }) {
         poll();
         const t = window.setInterval(poll, 250);
         return () => { alive = false; window.clearInterval(t); };
-    }, []);
+    }, [deckActive]);
 
     const heading = ((-rot % 360) + 360) % 360;
 

--- a/web/src/apps/maps/Maps.tsx
+++ b/web/src/apps/maps/Maps.tsx
@@ -16,7 +16,7 @@ import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { useSessionState } from '@/hooks/useSessionState';
 import { mapsConfig } from './config';
 import { MapView, usePinStyle } from './MapView';
-import { LiveDot } from './LiveDot';
+import { LiveDot, useSelfLocation } from './LiveDot';
 import type { MapViewHandle } from './MapView';
 import {
     COLOR_SWATCHES, getDefaultMarkers, ICON_KEYS, loadMarkers, newId, saveMarkers,
@@ -107,17 +107,10 @@ export function Maps({ onClose }: { onClose: () => void }) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const [me, setMe] = useState<{ x: number; y: number; h: number } | null>(
-        isFiveM ? null : { x: -1037, y: -2738, h: 0 },
-    );
-    useNuiEvent('sd-phone:maps:location', useCallback((d) => {
-        if (d) setMe({ x: d.x, y: d.y, h: d.h });
-    }, []));
-    useEffect(() => {
-        if (!isFiveM) return;
-        void fetchNui('sd-phone:maps:watch', { on: true });
-        return () => { void fetchNui('sd-phone:maps:watch', { on: false }); };
-    }, []);
+    // Shared with the ryde consumers: useSelfLocation refcounts the native stream and gates it on
+    // useDeckActive. Maps used to duplicate this inline without either, so a backgrounded Maps kept
+    // the stream running, and its ungated on/off fought the refcount other consumers rely on.
+    const me = useSelfLocation();
 
     useNuiEvent('sd-phone:maps:pinAdded', useCallback((m) => {
         if (!m || typeof m.id !== 'string') return;


### PR DESCRIPTION
Eleven independently-verified findings from the Lua audit, picked because each is small and self-contained. Sibling of #115 (not stacked); the two touch `server/stocks/actions.lua` in different functions.

No data shapes change. The only schema touches are additive indexes and one backfill.

## Broadcast scoping

**`broadcastPrices` fanned all 30 assets to every connected player on every trade** via `GetPlayers()`. Commission rounds to zero at `MinTrade`, so a free $1 buy/sell loop drove roughly 2.5-6.4k outbound net events/sec on a 64-slot server, waking every client's Lua and NUI.

The `watchers` set the 5s tick loop already uses lived in `init.lua`, and `init` requires `actions`, so `actions.lua` could not reach it. It moves to a shared `server.stocks.watchers` module and both paths iterate it.

## Query counts

| | before | after |
|---|---|---|
| `settings:get` | 16 single-column PK lookups on one row | 1 `SELECT *` + the 2 custom-tone queries |
| friends push (per watcher, per 3s tick) | 5 queries | 0 while the roster is warm |
| `darkchat.reactionsForRoom` | joins a room's entire never-pruned reaction history | grouped query over the 60 ids `recentMessages` already returned |
| `sim` backup `describe()` | ~27 information_schema probes per sync | memoised for the resource lifetime |

The friends roster cache is the only one with a staleness window (15s), so it drops on **both sides** of every edge mutation (`add`, `respond`, `remove`, `setShare`). An accepted friend request still shows up immediately; only the periodic refresh is served from cache. Coordinates come from natives and are recomputed every tick as before.

`store.snapshot()` derives every field with the same coercions as the individual getters (including the `airplaneCache` warm-up); the per-field getters stay for their other callers.

## Indexes and access paths

- **`phone_game_stats` has `game` as its SECOND primary-key column**, so all four leaderboard boards plus the scoreboard scanned the table, on a callback that ignores `_src` and had no rate limit. Adds `(game, high_score)` / `(game, cpu_wins)` / `(game, online_wins)` / `(game, chips_won)` and a 30s board cache. The cache is key-capped because the game id is client-supplied and would otherwise be an attacker-chosen key space.
- **`phone_cherry_matches` only indexed `(a, b)`**, so `matchesFor`'s `WHERE a = ? OR b = ?` had nothing for the `b` branch and full-scanned on every Cherry open. Adds `(b)`.
- **`getCitizenByNumber` / `numberExists` wrapped `phone_number` in six nested `REPLACE()` calls** - non-sargable, so `idx_phone_settings_number` could only be scanned. This sits on every message send, dial, transfer and friend-add. `setPhoneNumber` has always written bare digits, so only rows imported from another phone resource can carry separators: a one-shot backfill normalises those and both lookups now compare the bare column.

## Boot and rate limiting

- `documents.ensureSchema` ran an unindexed full-table `UPDATE` **every boot** that matched zero rows after the first run. New `util.runOnce()` records it in the existing `phone_migrations` table (same DDL the lb-phone importer already creates).
- `sim backup:sync` (manual "Back Up Now") had neither the in-flight guard nor the gap the automatic path has, so its ~88 statements could be looped at will. Adds the shared busy guard and a **30s** manual gap rather than the auto path's 300s, so the button stays responsive.
- `version.latest` wrote its cache only after awaiting, so concurrent callers each fired their own GitHub request. The in-flight promise is now shared.

## Frontend

- **Compass** never consumed `useDeckActive`, so its 250ms poll (4 NUI round-trips/sec) kept running while the app sat suspended in the retained deck layer.
- **Maps** duplicated `useSelfLocation`'s logic inline *without* the `useDeckActive` gate or the shared `selfWatchers` refcount. Beyond the wasted stream, its ungated `maps:watch {on:false}` on unmount fought the refcount the ryde consumers depend on. It now uses the shared hook.

## Verification

- `luac -p` on all 15 Lua files.
- `tsc` clean; `eslint` **0 errors**, warning count unchanged from main (29, none in the touched files); `vitest` **122/122**; `knip` clean; `vite build` succeeds.
- **Playwright** against the dev server:
  - Maps renders and mounts its `LiveDot` through the shared hook (`liveDotPresent: true`).
  - Compass dial **animates while foregrounded** (`-35.187` -> `-35.727`), **freezes while backgrounded** (`-34.1176` -> `-34.1176` over 1.5s, still mounted in the deck), and **resumes on re-foreground** (`-34.164` -> `-34.272`).
- Not runtime-tested in-game: this is mostly server Lua and I can't drive a live FiveM session here. The index additions and the two backfills run on next resource start, so a boot log check is the natural first look.

## Not included

The larger findings stay out by design: photogram/birdy/services per-recipient fan-out rewrites, the mail attachment-by-reference change, and the mail badge junction table. Those change data shapes and deserve their own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)