### PR TITLE
perf(fanout): resolve recipient sources once per fan-out, batch birdy notifications

### DIFF
--- a/bridge/server/player.lua
+++ b/bridge/server/player.lua
@@ -231,6 +231,17 @@ function player.onlineRealCidMap()
     return buildCidMap()
 end
 
+---`{ [citizenid] = source }` for the identity each player is CURRENTLY ACTING AS. The batch
+---equivalent of getSourceByIdentifier: a fan-out builds this once and indexes it per recipient
+---instead of resolving each one separately. Kept distinct from the SIM-aware onlineCidMap
+---override because that one maps every carried SIM, so live-UI pushes would reach a phone sitting
+---in a player's pocket. In this base module the acting identity IS the framework identifier, so
+---both share one memoised table. Read-only.
+---@return table<string, number>
+function player.activeCidMap()
+    return buildCidMap()
+end
+
 ---A `{ [citizenid] = source }` lookup of every currently-connected player. Read-only.
 ---@return table<string, number>
 function player.onlineCidMap()

--- a/server/birdy/actions.lua
+++ b/server/birdy/actions.lua
@@ -511,10 +511,22 @@ function actions.create(source, payload)
     -- The TriggerEvent above is server-local; this is what reaches players.
     TriggerClientEvent('sd-phone:client:birdy:feedChanged', -1, {})
 
-    local preview = body ~= '' and body:sub(1, 80) or 'shared a photo'
-    for _, cid in ipairs(store.followerCids(prof.citizenid)) do
-        store.insertNotification(store.newId(), cid, 'post', prof.citizenid, id)
-        local src = player.getSourceByIdentifier(cid)
+    local preview   = body ~= '' and body:sub(1, 80) or 'shared a photo'
+    local followers = store.followerCids(prof.citizenid)
+
+    if #followers == 0 then return ok({ post = serializePost(store.getPost(id, prof.citizenid)) }) end
+
+    local notifs = {}
+    for i = 1, #followers do
+        notifs[i] = { id = store.newId(), recipient = followers[i], kind = 'post', actor = prof.citizenid, postId = id }
+    end
+    store.insertNotifications(notifs)
+
+    -- One pass over the connected players for the whole fan-out; this resolved each follower
+    -- separately, and every resolution re-scanned every player on the server.
+    local activeSrcs = player.activeCidMap()
+    for _, cid in ipairs(followers) do
+        local src = activeSrcs[cid]
         if src then
             TriggerClientEvent('sd-phone:client:birdy:notification', src, {})
             TriggerClientEvent('sd-phone:client:notify', src, {

--- a/server/birdy/store.lua
+++ b/server/birdy/store.lua
@@ -829,6 +829,29 @@ function store.insertNotification(id, recipientCid, kind, actorCid, postId)
     ]], { id, recipientCid, kind, actorCid, postId })
 end
 
+---Inserts many notifications in one statement. The post fan-out wrote one row per follower, so
+---a 100-follower post cost 100 sequential round trips. A nil/empty list is a no-op.
+---Every field must be non-nil: the args are positional, and a nil would shift every following
+---row's values. Notification kinds with no post (follow) use insertNotification instead.
+---@param rows { id: string, recipient: string, kind: string, actor: string, postId: string }[]
+function store.insertNotifications(rows)
+    if type(rows) ~= 'table' or #rows == 0 then return end
+    local ph, args, n = {}, {}, 0
+    for i = 1, #rows do
+        local r = rows[i]
+        if r.id and r.recipient and r.kind and r.actor and r.postId then
+            ph[#ph + 1] = '(?, ?, ?, ?, ?)'
+            args[n + 1], args[n + 2], args[n + 3], args[n + 4], args[n + 5] =
+                r.id, r.recipient, r.kind, r.actor, r.postId
+            n = n + 5
+        end
+    end
+    if n == 0 then return end
+    MySQL.insert.await((
+        'INSERT INTO phone_birdy_notifications (id, recipient_cid, kind, actor_cid, post_id) VALUES %s'
+    ):format(table.concat(ph, ',')), args)
+end
+
 ---@param recipientCid string
 ---@param limit number
 ---@return table[] rows with `created_ms` added

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -508,12 +508,15 @@ function actions.setRequestStatus(citizenid, copyId, status)
     local mid = store.midForCopy(copyId, citizenid)
     if not mid then return false end
 
+    -- One pass over the connected players for the whole fan-out; resolving per copy re-scanned
+    -- every player on the server each time.
+    local activeSrcs = player.activeCidMap()
     for _, copy in ipairs(store.siblingCopies(mid)) do
         local meta = store.decodeJson(store.messageMeta(copy.id))
         meta.requestStatus = status
         store.updateMeta(copy.id, meta)
 
-        local tgt = player.getSourceByIdentifier(copy.citizenid)
+        local tgt = activeSrcs[copy.citizenid]
         if tgt then
             TriggerClientEvent('sd-phone:client:messages:meta', tgt, {
                 conversation  = copy.conversation,
@@ -618,6 +621,8 @@ local function sendGroup(source, cid, myNumber, groupId, kind, body, meta, ts, m
     local members    = store.groupMembers(groupId)
     local outId
 
+    -- One pass over the connected players for the whole fan-out.
+    local activeSrcs = player.activeCidMap()
     for _, m in ipairs(members) do
         local isMe = m.citizenid == cid
         local withheld = (not isMe) and settings.isAirplane(m.citizenid)
@@ -628,7 +633,7 @@ local function sendGroup(source, cid, myNumber, groupId, kind, body, meta, ts, m
         if isMe then
             outId = id
         else
-            local targetSrc = player.getSourceByIdentifier(m.citizenid)
+            local targetSrc = activeSrcs[m.citizenid]
             if targetSrc and not withheld then
                 local theirContacts = contactMapFor(m.citizenid)
                 local msg = buildMessage(id, myNumber, kind, body, meta, ts, false, digits(m.number))
@@ -747,9 +752,11 @@ function actions.react(source, payload)
 
     local rows = store.reactionsFor(mid)
 
+    -- One pass over the connected players for the whole fan-out.
+    local activeSrcs = player.activeCidMap()
     for _, copy in ipairs(store.siblingCopies(mid)) do
         if copy.citizenid ~= cid then
-            local tgt = player.getSourceByIdentifier(copy.citizenid)
+            local tgt = activeSrcs[copy.citizenid]
             if tgt then
                 TriggerClientEvent('sd-phone:client:messages:reaction', tgt, {
                     conversation = copy.conversation,
@@ -803,8 +810,10 @@ function actions.createGroup(source, payload)
     end
 
     store.addGroupMember(groupId, cid, myNumber, player.getName(source))
+    -- One pass over the connected players, shared by both loops below.
+    local activeSrcs = player.activeCidMap()
     for _, m in ipairs(resolved) do
-        local msrc  = player.getSourceByIdentifier(m.cid)
+        local msrc  = activeSrcs[m.cid]
         local mname = msrc and player.getName(msrc) or formatNumber(m.number)
         store.addGroupMember(groupId, m.cid, m.number, mname)
     end
@@ -812,7 +821,7 @@ function actions.createGroup(source, payload)
     local key = 'g-' .. groupId
 
     for _, m in ipairs(resolved) do
-        local msrc = player.getSourceByIdentifier(m.cid)
+        local msrc = activeSrcs[m.cid]
         if msrc then
             local theirContacts = contactMapFor(m.cid)
             TriggerClientEvent('sd-phone:client:messages:incoming', msrc, {
@@ -868,8 +877,10 @@ function actions.addGroupMember(source, payload)
         return fail(('Groups are capped at %d members'):format(cfg.MaxGroupMembers))
     end
 
+    -- One pass over the connected players, shared by both loops below.
+    local activeSrcs = player.activeCidMap()
     for _, m in ipairs(resolved) do
-        local msrc  = player.getSourceByIdentifier(m.cid)
+        local msrc  = activeSrcs[m.cid]
         local mname = msrc and player.getName(msrc) or formatNumber(m.number)
         store.addGroupMember(groupId, m.cid, m.number, mname)
     end
@@ -877,7 +888,7 @@ function actions.addGroupMember(source, payload)
     local groupName = (store.getGroup(groupId) or {}).name or 'Group'
     local roster = store.groupMembers(groupId)
     for _, m in ipairs(roster) do
-        local msrc = m.citizenid ~= cid and player.getSourceByIdentifier(m.citizenid)
+        local msrc = m.citizenid ~= cid and activeSrcs[m.citizenid]
         if msrc then
             TriggerClientEvent('sd-phone:client:messages:incoming', msrc, {
                 id           = key,
@@ -924,9 +935,11 @@ function actions.updateGroup(source, payload)
 
     local myNumber = digits(settings.ensurePhoneNumber(cid) or '')
 
+    -- One pass over the connected players for the whole fan-out.
+    local activeSrcs = player.activeCidMap()
     local roster = store.groupMembers(groupId)
     for _, m in ipairs(roster) do
-        local msrc = m.citizenid ~= cid and player.getSourceByIdentifier(m.citizenid)
+        local msrc = m.citizenid ~= cid and activeSrcs[m.citizenid]
         if msrc then
             TriggerClientEvent('sd-phone:client:messages:incoming', msrc, {
                 id           = key,
@@ -971,14 +984,17 @@ function actions.removeGroupMember(source, payload)
 
     store.removeGroupMember(groupId, mcid)
 
-    local removedSrc = player.getSourceByIdentifier(mcid)
+    -- One pass over the connected players, covering the removed member and the fan-out below.
+    local activeSrcs = player.activeCidMap()
+
+    local removedSrc = activeSrcs[mcid]
     if removedSrc then
         TriggerClientEvent('sd-phone:client:messages:removed', removedSrc, { conversation = key })
     end
 
     local roster = store.groupMembers(groupId)
     for _, m in ipairs(roster) do
-        local msrc = m.citizenid ~= cid and player.getSourceByIdentifier(m.citizenid)
+        local msrc = m.citizenid ~= cid and activeSrcs[m.citizenid]
         if msrc then
             TriggerClientEvent('sd-phone:client:messages:incoming', msrc, {
                 id           = key,

--- a/server/photogram/actions.lua
+++ b/server/photogram/actions.lua
@@ -49,12 +49,16 @@ end
 ---Online sources signed into `username`'s photogram account.
 ---@param username string photogram handle
 ---@return integer[] sources
-local function sourcesFor(username)
+---@param activeSrcs table<string, number>|nil prebuilt citizenid -> source map for a fan-out
+local function sourcesFor(username, activeSrcs)
     local acc = acctStore.getAccount('photogram', username)
     if not acc then return {} end
     local out = {}
     for _, cid in ipairs(acctStore.sessionCitizens('photogram', acc.id)) do
-        local src = player.getSourceByIdentifier(cid)
+        -- Indexing a prebuilt map is the same lookup getSourceByIdentifier does, minus the
+        -- rescan of every connected player that it costs once per recipient.
+        local src = activeSrcs and activeSrcs[cid] or nil
+        if not activeSrcs then src = player.getSourceByIdentifier(cid) end
         if src then out[#out + 1] = src end
     end
     return out
@@ -243,15 +247,23 @@ end
 ---@param actor string acting handle
 ---@param postId string|nil related post id
 ---@param preview string|nil comment preview (already capped by the caller)
-local function notify(recipient, kind, actor, postId, preview)
+---@param ctx { activeSrcs: table<string, number>, actorName: string, thumb: string|nil }|nil
+---per-fan-out context; without it the actor profile, post thumb and player scan are resolved
+---here, which a loop over recipients pays once per recipient for invariant values
+local function notify(recipient, kind, actor, postId, preview, ctx)
     if recipient == actor or recipient == '' then return end
     store.insertNotification(store.newId(), recipient, kind, actor, postId, preview, os.time())
 
-    local sources = sourcesFor(recipient)
+    local sources = sourcesFor(recipient, ctx and ctx.activeSrcs or nil)
     if #sources == 0 then return end
-    local actorRow  = store.getProfile(actor)
-    local actorName = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or actor
-    local thumb     = postId and store.postThumb(postId) or nil
+    local actorName, thumb
+    if ctx then
+        actorName, thumb = ctx.actorName, ctx.thumb
+    else
+        local actorRow = store.getProfile(actor)
+        actorName = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or actor
+        thumb     = postId and store.postThumb(postId) or nil
+    end
     for _, src in ipairs(sources) do
         TriggerClientEvent('sd-phone:client:photogram:notification', src, {})
         TriggerClientEvent('sd-phone:client:notify', src, {
@@ -460,15 +472,31 @@ function actions.create(src, payload)
     local id = store.newId()
     store.insertPost(id, acc.username, images, caption, location, os.time())
 
+    local mentions  = mentionsIn(caption, acc.username)
+    local followers = store.followerUsernames(acc.username)
+
+    -- Fan-out context resolved once, and only when there is someone to notify: the actor profile
+    -- and post thumb are the same for every recipient, and the source map replaces a
+    -- per-recipient rescan of every connected player.
+    local ctx
+    if #mentions > 0 or #followers > 0 then
+        local actorRow = store.getProfile(acc.username)
+        ctx = {
+            activeSrcs = player.activeCidMap(),
+            actorName  = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or acc.username,
+            thumb      = store.postThumb(id),
+        }
+    end
+
     local mentioned = {}
-    for _, m in ipairs(mentionsIn(caption, acc.username)) do
+    for _, m in ipairs(mentions) do
         if canView(m, me) then
             mentioned[m] = true
-            notify(m, 'mention', acc.username, id, nil)
+            notify(m, 'mention', acc.username, id, nil, ctx)
         end
     end
-    for _, f in ipairs(store.followerUsernames(acc.username)) do
-        if not mentioned[f] then notify(f, 'post', acc.username, id, nil) end
+    for _, f in ipairs(followers) do
+        if not mentioned[f] then notify(f, 'post', acc.username, id, nil, ctx) end
     end
     broadcast('feedChanged', {})
     -- First-party hook: one server-local event per created post.

--- a/server/sim/init.lua
+++ b/server/sim/init.lua
@@ -60,6 +60,22 @@ function player.getSourceByIdentifier(citizenid)
     return nil
 end
 
+-- Batch form of getSourceByIdentifier above, and it must track it: ACTIVE identity only, so a
+-- fan-out that indexes this map still skips the other phone in a player's pocket.
+local baseActiveCidMap = player.activeCidMap
+function player.activeCidMap()
+    if not state.active then return baseActiveCidMap() end
+    local out = {}
+    for _, src in ipairs(GetPlayers()) do
+        local s = tonumber(src)
+        if s then
+            local id = session.identity(s)
+            if id then out[id] = s end
+        end
+    end
+    return out
+end
+
 local baseCidMap = player.onlineCidMap
 function player.onlineCidMap()
     if not state.active then return baseCidMap() end

--- a/server/vibez/actions.lua
+++ b/server/vibez/actions.lua
@@ -44,12 +44,16 @@ end
 ---Online sources signed into `username`'s vibez account.
 ---@param username string vibez handle
 ---@return integer[] sources
-local function sourcesFor(username)
+---@param activeSrcs table<string, number>|nil prebuilt citizenid -> source map for a fan-out
+local function sourcesFor(username, activeSrcs)
     local acc = acctStore.getAccount('vibez', username)
     if not acc then return {} end
     local out = {}
     for _, cid in ipairs(acctStore.sessionCitizens('vibez', acc.id)) do
-        local src = player.getSourceByIdentifier(cid)
+        -- Indexing a prebuilt map is the same lookup getSourceByIdentifier does, minus the
+        -- rescan of every connected player that it costs once per recipient.
+        local src = activeSrcs and activeSrcs[cid] or nil
+        if not activeSrcs then src = player.getSourceByIdentifier(cid) end
         if src then out[#out + 1] = src end
     end
     return out
@@ -167,15 +171,23 @@ end
 ---@param actor string acting handle
 ---@param postId string|nil related post id
 ---@param preview string|nil comment preview (already capped by the caller)
-local function notify(recipient, kind, actor, postId, preview)
+---@param ctx { activeSrcs: table<string, number>, actorName: string, thumb: string|nil }|nil
+---per-fan-out context; without it the actor profile, post thumb and player scan are resolved
+---here, which a loop over recipients pays once per recipient for invariant values
+local function notify(recipient, kind, actor, postId, preview, ctx)
     if recipient == actor or recipient == '' then return end
     store.insertNotification(store.newId(), recipient, kind, actor, postId, preview, os.time())
 
-    local sources = sourcesFor(recipient)
+    local sources = sourcesFor(recipient, ctx and ctx.activeSrcs or nil)
     if #sources == 0 then return end
-    local actorRow  = store.getProfile(actor)
-    local actorName = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or actor
-    local thumb     = postId and store.thumbsFor({ postId })[postId] or nil
+    local actorName, thumb
+    if ctx then
+        actorName, thumb = ctx.actorName, ctx.thumb
+    else
+        local actorRow = store.getProfile(actor)
+        actorName = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or actor
+        thumb     = postId and store.thumbsFor({ postId })[postId] or nil
+    end
     for _, src in ipairs(sources) do
         TriggerClientEvent('sd-phone:client:vibez:notification', src, {})
         TriggerClientEvent('sd-phone:client:notify', src, {
@@ -304,13 +316,29 @@ function actions.create(src, payload)
     local id = store.newId()
     store.insertPost(id, acc.username, video, thumb, caption, sound, os.time())
 
-    local mentioned = {}
-    for _, m in ipairs(mentionsIn(caption, acc.username)) do
-        mentioned[m] = true
-        notify(m, 'mention', acc.username, id, nil)
+    local mentions  = mentionsIn(caption, acc.username)
+    local followers = store.followerUsernames(acc.username)
+
+    -- Fan-out context resolved once, and only when there is someone to notify: the actor profile
+    -- and post thumb are the same for every recipient, and the source map replaces a
+    -- per-recipient rescan of every connected player.
+    local ctx
+    if #mentions > 0 or #followers > 0 then
+        local actorRow = store.getProfile(acc.username)
+        ctx = {
+            activeSrcs = player.activeCidMap(),
+            actorName  = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or acc.username,
+            thumb      = store.thumbsFor({ id })[id],
+        }
     end
-    for _, f in ipairs(store.followerUsernames(acc.username)) do
-        if not mentioned[f] then notify(f, 'post', acc.username, id, nil) end
+
+    local mentioned = {}
+    for _, m in ipairs(mentions) do
+        mentioned[m] = true
+        notify(m, 'mention', acc.username, id, nil, ctx)
+    end
+    for _, f in ipairs(followers) do
+        if not mentioned[f] then notify(f, 'post', acc.username, id, nil, ctx) end
     end
     broadcast('feedChanged', {})
     return ok({ post = serializePost(store.getPost(acc.username, id)) })


### PR DESCRIPTION
Third sibling off `main` (independent of #115 and #116). This is the remaining hot spot the audit turned up: not a scattered list, one structural problem.

## The problem

`player.getSourceByIdentifier(cid)` answers *"who is holding this citizenid?"* by scanning every connected player and calling the framework's `GetPlayer` on each (`bridge/server/player.lua:104`). Fine once. But **nine call sites invoke it from inside a per-recipient loop**, so the cost is `O(recipients x players)` to answer something a map answers in `O(1)`.

Measured on a 64-slot server, one post to 50 followers (40 online):

| | framework `GetPlayer` calls |
|---|---|
| before | **1,460** |
| after | **64** |

## `activeCidMap`, and why not `onlineCidMap`

The batch primitive had to match `getSourceByIdentifier`'s semantics *exactly*, and the obvious candidate does not:

- `onlineCidMap()` under unique-phones maps **every carried SIM** to a source - that is the `getAnySourceByIdentifier` ("a pocketed phone still rings") semantics.
- `getSourceByIdentifier` matches only the **active** identity. `server/sim/init.lua:50` is explicit about why: *"A push for the OTHER phone in their pocket is skipped - its data is already stored, and that phone surfaces it on its next open."*

Indexing `onlineCidMap` would therefore have pushed live UI to pocketed phones under SIM mode. So `player.activeCidMap()` is new, and `server/sim/init.lua` overrides it in parallel with `getSourceByIdentifier`, resolving `session.identity(s)` only.

## What changed

**Hoisted (9 sites)** - `messages`: `setRequestStatus`, the group send fan-out, `react`, `createGroup` (two loops, one map), `addGroupMember` (two loops, one map), `updateGroup`, `removeGroupMember`; `photogram` and `vibez` `sourcesFor`. The three remaining single lookups (`list`, `systemText`) are untouched - they are not in a loop.

**`notify()` gained an optional context** in photogram and vibez. Without it behaviour is byte-identical, so the seven other `notify` call sites are unchanged. With it, `create()` resolves the actor profile, the post thumb and the source map **once** instead of once per recipient. The context is only built when there is at least one recipient, so a post nobody follows costs nothing extra.

**Batched inserts** - birdy `create` wrote one notification row per follower; `store.insertNotifications` makes it a single multi-VALUES statement. It drops rows with a nil field rather than letting positional args shift, and kinds with no post (`follow`) keep using the single-row insert.

## Verification

- `luac -p` on all seven files.
- **Bytecode scan** for `GETTABUP _ENV "activeSrcs"` across every changed file: none. Every hoisted local resolves as a local, not an accidental global - `luac -p` would *not* have caught that, since a stray global is valid syntax that fails at runtime.
- **Equivalence harness** loading the real `bridge/server/player.lua` with a stubbed framework: `activeCidMap` and `getSourceByIdentifier` return identical answers across 11 probes - hits, misses, the empty string, and a connected-but-unloaded source. Call count for the same probes: 53 -> 8.
- **Fan-out harness**: 64 slots, 50 followers, 40 online -> 1,460 -> 64 `GetPlayer` calls (23x).
- **Batch-insert harness**: 4 rows -> 4 placeholders / 20 args, aligned; row values in order; a nil-field row dropped without shifting its neighbours; empty list issues no query.
- Not runtime-tested in-game: server Lua, no live FiveM session here. The SIM-mode path (`configs/uniqueandsim.lua` `Enabled`, default false) is the one worth a deliberate look if you run unique phones - specifically that a notification still reaches the active phone and still skips a pocketed one.

## Still open (deliberately)

`badges.push` recomputes all seven counts per recipient, and inside it `mailStore.unreadCount` is a `JSON_SEARCH` full scan of `phone_mail_accounts` plus a full JSON decode of every mailbox. That is the other half of the fan-out cost, but fixing it means either a targeted single-count push (badge-correctness risk) or the mail junction-table migration (schema change). Both want their own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
