### PR TITLE
perf(badges): push only the app whose count changed

### DIFF
--- a/client/apps/notifications.lua
+++ b/client/apps/notifications.lua
@@ -24,6 +24,12 @@ RegisterNetEvent('sd-phone:client:badges', function(snap)
     SendNUIMessage({ action = 'sd-phone:badges', data = snap })
 end)
 
+---Server push: one app's count changed; relay it as a patch the store merges over the rest.
+---@param patch table single-entry { [appId] = count }
+RegisterNetEvent('sd-phone:client:badgePatch', function(patch)
+    SendNUIMessage({ action = 'sd-phone:badges:patch', data = patch })
+end)
+
 ---React to server: badge snapshot fetched on phone open, with a zeroed fallback.
 RegisterNUICallback('sd-phone:badges:get', function(_, cb)
     local snap = lib.callback.await('sd-phone:server:badges:get', false)

--- a/server/badges/init.lua
+++ b/server/badges/init.lua
@@ -40,20 +40,27 @@ local function vibezCount(cid)
     return vibezStore.unseenNotificationCount(acc.username)
 end
 
+---@type table<string, fun(cid: string): number> One count resolver per home-screen app id. The
+---single source of truth for both the full snapshot and a single-app push, so the two can never
+---disagree about which apps carry a badge.
+local counters = {
+    messages  = function(cid) return messageStore.unreadCount(cid) end,
+    phone     = function(cid) return contactStore.unreadMissedCount(cid) end,
+    mail      = function(cid) return mailStore.unreadCount(cid) end,
+    groups    = function(cid) return groupStore.pendingInviteCount(cid) end,
+    photogram = photogramCount,
+    vibez     = vibezCount,
+    birdy     = function(cid) return birdyStore.unseenNotificationCount(cid) end,
+}
+
 ---Per-app unread counts for one character, keyed by home-screen app id, computed straight from
 ---the database on every call.
 ---@param cid string framework per-character id
 ---@return { messages: number, phone: number, mail: number, groups: number, photogram: number, vibez: number, birdy: number }
 function badges.snapshot(cid)
-    return {
-        messages  = messageStore.unreadCount(cid),
-        phone     = contactStore.unreadMissedCount(cid),
-        mail      = mailStore.unreadCount(cid),
-        groups    = groupStore.pendingInviteCount(cid),
-        photogram = photogramCount(cid),
-        vibez     = vibezCount(cid),
-        birdy     = birdyStore.unseenNotificationCount(cid),
-    }
+    local out = {}
+    for app, count in pairs(counters) do out[app] = count(cid) end
+    return out
 end
 
 ---Recomputes a player's badge counts from the DB and pushes the exact numbers to their phone.
@@ -64,6 +71,20 @@ function badges.push(source)
     local cid = player.getIdentifier(source)
     if not cid then return end
     TriggerClientEvent('sd-phone:client:badges', source, badges.snapshot(cid))
+end
+
+---Recomputes ONE app's badge and pushes just that number, merged into whatever the phone already
+---shows. A content fan-out only ever changes its own app's count, and a full snapshot costs seven
+---store reads (one of them an unindexed mail scan) - paid per recipient.
+---@param source number player server id
+---@param app string home-screen app id; an unknown id is a no-op
+function badges.pushApp(source, app)
+    if not source or source <= 0 then return end
+    local count = counters[app]
+    if not count then return end
+    local cid = player.getIdentifier(source)
+    if not cid then return end
+    TriggerClientEvent('sd-phone:client:badgePatch', source, { [app] = count(cid) })
 end
 
 ---Fetched once by the React app on phone open. An unresolvable caller gets all-zero counts.

--- a/server/birdy/actions.lua
+++ b/server/birdy/actions.lua
@@ -522,7 +522,7 @@ function actions.create(source, payload)
                 body = ('%s posted: %s'):format(prof.displayName, preview),
                 time = 'now', quietInApp = true,
             })
-            badges.push(src)
+            badges.pushApp(src, 'birdy')
         end
     end
 
@@ -739,7 +739,7 @@ function actions.notifications(source)
     end
 
     store.markNotificationsSeen(prof.citizenid)
-    badges.push(source)
+    badges.pushApp(source, 'birdy')
 
     return ok({ notifications = items })
 end

--- a/server/photogram/actions.lua
+++ b/server/photogram/actions.lua
@@ -264,14 +264,14 @@ local function notify(recipient, kind, actor, postId, preview)
                 ['photogram:viewHandle'] = false, ['photogram:detail'] = false, ['photogram:follows'] = false,
             },
         })
-        badges.push(src)
+        badges.pushApp(src, 'photogram')
     end
 end
 
 ---Refreshes the badge for a user's online sources.
 ---@param username string handle
 local function bumpBadge(username)
-    for _, src in ipairs(sourcesFor(username)) do badges.push(src) end
+    for _, src in ipairs(sourcesFor(username)) do badges.pushApp(src, 'photogram') end
 end
 
 ---Pings a recipient to refetch Activity without adding a notification.
@@ -279,7 +279,7 @@ end
 local function pingActivity(recipient)
     for _, src in ipairs(sourcesFor(recipient)) do
         TriggerClientEvent('sd-phone:client:photogram:notification', src, {})
-        badges.push(src)
+        badges.pushApp(src, 'photogram')
     end
 end
 

--- a/server/vibez/actions.lua
+++ b/server/vibez/actions.lua
@@ -184,14 +184,14 @@ local function notify(recipient, kind, actor, postId, preview)
             time = 'now', quietInApp = true,
             link = { ['vibez:tab'] = 'inbox' },
         })
-        badges.push(src)
+        badges.pushApp(src, 'vibez')
     end
 end
 
 ---Refreshes the badge for a user's online sources.
 ---@param username string handle
 local function bumpBadge(username)
-    for _, src in ipairs(sourcesFor(username)) do badges.push(src) end
+    for _, src in ipairs(sourcesFor(username)) do badges.pushApp(src, 'vibez') end
 end
 
 ---One http(s) URL clamped to the column width, or nil.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -737,6 +737,9 @@ function AppContent() {
     useNuiEvent('sd-phone:badges', useCallback((data) => {
         useBadgeStore.getState().setServer(data ?? {});
     }, []));
+    useNuiEvent('sd-phone:badges:patch', useCallback((data) => {
+        useBadgeStore.getState().patchServer(data ?? {});
+    }, []));
     useEffect(() => {
         if (currentApp === 'phone') void fetchNui('sd-phone:calls:seen');
     }, [currentApp]);

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -336,6 +336,7 @@ export type NuiMessage =
     | { action: 'wordle:ended';        data: { reason: string } }
     | { action: 'sd-phone:notification';       data: { id?: string; app?: string; image?: string; title: string; body?: string; time?: string; appId?: string; quietInApp?: boolean; otherPhone?: boolean; phoneColor?: string; profileKey?: string } }
     | { action: 'sd-phone:badges';             data: Record<string, number> }
+    | { action: 'sd-phone:badges:patch';       data: Record<string, number> }
     | { action: 'sd-phone:airshare';           data: { id: string; kind: string; fromName: string } }
     | { action: 'sd-phone:maps:friends:update'; data: FriendsUpdatePush }
     | { action: 'sd-phone:maps:location';       data: { x: number; y: number; h: number } }

--- a/web/src/stores/badgeStore.test.ts
+++ b/web/src/stores/badgeStore.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useBadgeStore } from './badgeStore';
+
+// Mirrors what useBadges() renders (server counts over local bumps) without needing a React
+// renderer; these tests are about the store's state transitions.
+function badges() {
+    const { local, server } = useBadgeStore.getState();
+    return { ...local, ...server };
+}
+
+beforeEach(() => {
+    useBadgeStore.setState({ local: {}, server: {} });
+});
+
+describe('badgeStore server counts', () => {
+    it('setServer replaces the whole map, as a full snapshot should', () => {
+        useBadgeStore.getState().setServer({ messages: 2, mail: 5 });
+        useBadgeStore.getState().setServer({ groups: 1 });
+        expect(badges()).toEqual({ groups: 1 });
+    });
+
+    it('patchServer merges one app over the rest', () => {
+        useBadgeStore.getState().setServer({ messages: 2, phone: 3, mail: 5, groups: 1 });
+        useBadgeStore.getState().patchServer({ birdy: 7 });
+        expect(badges()).toEqual({ messages: 2, phone: 3, mail: 5, groups: 1, birdy: 7 });
+    });
+
+    it('a patch clearing one app to zero leaves the others untouched', () => {
+        useBadgeStore.getState().setServer({ messages: 2, mail: 5 });
+        useBadgeStore.getState().patchServer({ birdy: 7 });
+        useBadgeStore.getState().patchServer({ birdy: 0 });
+        expect(badges()).toEqual({ messages: 2, mail: 5, birdy: 0 });
+    });
+
+    it('a patch overwrites only its own key', () => {
+        useBadgeStore.getState().setServer({ messages: 2, mail: 5 });
+        useBadgeStore.getState().patchServer({ mail: 9 });
+        expect(badges()).toEqual({ messages: 2, mail: 9 });
+    });
+
+    it('an empty or missing patch is a no-op', () => {
+        useBadgeStore.getState().setServer({ messages: 2 });
+        useBadgeStore.getState().patchServer({});
+        expect(badges()).toEqual({ messages: 2 });
+    });
+
+    it('server counts still win over local bumps', () => {
+        useBadgeStore.getState().bump('birdy');
+        useBadgeStore.getState().patchServer({ birdy: 4 });
+        expect(badges().birdy).toBe(4);
+    });
+});

--- a/web/src/stores/badgeStore.ts
+++ b/web/src/stores/badgeStore.ts
@@ -4,9 +4,10 @@ import { create } from 'zustand';
 interface BadgeState {
     local:  Record<string, number>;
     server: Record<string, number>;
-    bump:      (id: string) => void;
-    setServer: (map: Record<string, number>) => void;
-    clear:     (id: string) => void;
+    bump:        (id: string) => void;
+    setServer:   (map: Record<string, number>) => void;
+    patchServer: (map: Record<string, number>) => void;
+    clear:       (id: string) => void;
 }
 
 export const useBadgeStore = create<BadgeState>((set) => ({
@@ -14,6 +15,9 @@ export const useBadgeStore = create<BadgeState>((set) => ({
     server: {},
     bump:      (id) => set(s => ({ local: { ...s.local, [id]: (s.local[id] ?? 0) + 1 } })),
     setServer: (map) => set({ server: map ?? {} }),
+    // A single app's recount, merged over the rest: the server sends one key rather than
+    // recomputing all seven counts for every recipient of a fan-out.
+    patchServer: (map) => set(s => ({ server: { ...s.server, ...(map ?? {}) } })),
     clear:     (id) => set(s => (s.local[id] ? { local: { ...s.local, [id]: 0 } } : s)),
 }));
 


### PR DESCRIPTION
Fourth sibling off `main` (independent of #115, #116, #117). First half of the badge work I flagged as the dominant remaining cost at high player counts.

## The problem

`badges.push` recomputes **all seven counts** and sends the whole map. A content fan-out calls it **once per online recipient**:

```
birdy post -> 40 online followers -> 280 store reads
```

And 40 of those are `mailStore.unreadCount`, which is a `JSON_SEARCH` over `phone_mail_accounts` (unindexable) plus a full JSON decode of every mailbox the player is signed into.

A new Birdy post cannot change anyone's mail count. It was being recomputed 40 times anyway.

## The change

`badges.pushApp(source, app)` recomputes one app and sends a single-key patch that the store **merges** over what the phone already shows.

- **7 store reads per recipient -> 1.**
- The unindexed mail scan leaves the fan-out path **entirely**.

The per-app resolvers now live in one `counters` table that both `snapshot()` and `pushApp()` read, so the full snapshot and a targeted push can't drift about which apps carry a badge.

## Scope of the conversion

Only sites whose action provably moves exactly one app's count: birdy `create` fan-out + `markNotificationsSeen`, photogram `notify`/`bumpBadge`/`pingActivity`, vibez `notify`/`bumpBadge`.

**Every other `badges.push` call site is untouched.** Anything that can move more than one count still sends a full snapshot, as does the on-open fetch. That is the conservative half of this change and it is deliberate.

## Wire

`sd-phone:client:badgePatch` -> `sd-phone:badges:patch` NUI message -> `badgeStore.patchServer`, which merges. `setServer` keeps replacing, which is correct for a full snapshot.

## Verification

- `luac -p` on the five Lua files; `tsc` clean; `eslint` 0 errors, warnings unchanged from main (29); `knip` clean; `vite build` succeeds.
- **Six new `badgeStore` unit tests** on the property that matters - a patch must merge, not replace: patch adds a key; patch overwrites only its own key; clearing one app to zero leaves the others; empty patch is a no-op; `setServer` still replaces; server counts still beat local bumps. Suite now **128 passing** (was 122).
- **Playwright** against the dev server, whole wire end to end: full snapshot renders `mail=5`; a `mail` patch re-renders `9`; a `birdy` patch leaves mail at `9`.
- Not runtime-tested in-game.

## Next

The other half - the mail junction table to kill the `JSON_SEARCH` outright - is now a **much smaller win** than when I proposed it, because this change removes that scan from the per-recipient path. It still runs on the full snapshot (phone open, cross-app pushes), so it is worth doing eventually, but it is a schema migration for a cost that is no longer multiplied by recipient count. I would rather land the player-registry work first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
