### PR TITLE
ui(birdy): legibility pass, iOS-native edit profile, pushed New Message screen

### DIFF
--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -480,7 +480,7 @@ function NavButton({ active, onClick, children, badge = 0 }: { active: boolean; 
                 {children}
                 {badge > 0 && (
                     <span
-                        className="absolute -top-1.5 -right-2.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1 text-[11px] font-bold leading-none text-white"
+                        className="absolute -right-2 -top-2 flex h-[22px] min-w-[22px] items-center justify-center rounded-full px-1.5 text-[13px] font-bold leading-none text-white"
                         style={{ background: BLUE, boxShadow: `0 0 0 2px ${BG}` }}
                     >
                         {badge > 99 ? '99+' : badge}

--- a/web/src/apps/birdy/data.ts
+++ b/web/src/apps/birdy/data.ts
@@ -2,6 +2,10 @@
 import { t } from '@/i18n';
 import { formatClockTime, formatMediumDate, relTimeCompact } from '@/lib/time';
 import type { MsgKind, Reaction } from '@/shared/chat/data';
+import seedPhoto1 from '@/assets/photos/background7.webp';
+import seedPhoto2 from '@/assets/photos/background12.webp';
+import seedPhoto3 from '@/assets/photos/background15.webp';
+import seedPhoto4 from '@/assets/photos/background20.webp';
 
 export interface BirdyAuthor {
     name:     string;
@@ -110,6 +114,30 @@ export const SEED_POSTS: BirdyPost[] = [
         likes:     0,
         liked:     false,
         views:     3,
+    },
+    {
+        id:        'seed-4',
+        author:    TOMMY,
+        body:      'sunset over the pier tonight, no filter needed',
+        createdAt: Date.now() - 7 * HOUR,
+        replies:   0,
+        reposts:   1,
+        likes:     7,
+        liked:     false,
+        views:     19,
+        images:    [seedPhoto1],
+    },
+    {
+        id:        'seed-5',
+        author:    MARCUS,
+        body:      'little road trip up the coast, camera roll is full',
+        createdAt: Date.now() - 9 * HOUR,
+        replies:   0,
+        reposts:   0,
+        likes:     3,
+        liked:     true,
+        views:     11,
+        images:    [seedPhoto2, seedPhoto3, seedPhoto4],
     },
 ];
 

--- a/web/src/apps/birdy/discover/Search.tsx
+++ b/web/src/apps/birdy/discover/Search.tsx
@@ -115,15 +115,15 @@ export function Search({ me, onOpenProfile, onOpenPost, onToggleLike, onToggleRe
                                 key={u.handle}
                                 type="button"
                                 onClick={() => onOpenProfile(u.handle)}
-                                className="flex w-full items-center gap-3.5 px-4 py-3 text-left transition-colors active:bg-black/[0.04]"
+                                className="flex w-full items-center gap-3.5 px-4 py-3.5 text-left transition-colors active:bg-black/[0.04]"
                             >
-                                <Avatar size={48} src={u.avatar} />
+                                <Avatar size={54} src={u.avatar} />
                                 <div className="min-w-0">
                                     <div className="flex items-center gap-1">
-                                        <span className="truncate text-[17px] font-bold text-black">{u.name}</span>
-                                        {u.verified && <VerifiedBadge size={16} />}
+                                        <span className="truncate text-[18px] font-bold text-black">{u.name}</span>
+                                        {u.verified && <VerifiedBadge size={18} />}
                                     </div>
-                                    <div className="truncate text-[15px]" style={{ color: META }}>@{u.handle}</div>
+                                    <div className="truncate text-[16px]" style={{ color: META }}>@{u.handle}</div>
                                 </div>
                             </button>
                         ))

--- a/web/src/apps/birdy/dms/Messages.tsx
+++ b/web/src/apps/birdy/dms/Messages.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Mail, PenSquare, Search as SearchIcon } from 'lucide-react';
 
 import { t } from '@/i18n';
 import { useAsyncData } from '@/hooks/useAsyncData';
+import { useIosPush } from '@/hooks/useIosPush';
 import { SearchBar } from '@/ui/SearchBar';
 import { EmptyState } from '@/ui/EmptyState';
 import { apiSearch } from '../birdyApi';
@@ -33,10 +34,6 @@ export function MessagesList({ conversations, onOpen, onOpenProfile, onCompose }
     const filtered = q
         ? conversations.filter(c => c.user.name.toLowerCase().includes(q) || c.user.handle.toLowerCase().includes(q))
         : conversations;
-
-    if (composing && onCompose) {
-        return <NewDm onSelect={h => { setComposing(false); onCompose(h); }} onBack={() => setComposing(false)} />;
-    }
 
     return (
         <div className="flex h-full flex-col" style={{ background: BG }}>
@@ -116,19 +113,24 @@ export function MessagesList({ conversations, onOpen, onOpenProfile, onCompose }
                     </div>
                 )}
             </div>
+
+            {composing && onCompose && (
+                <NewDm onSelect={h => { setComposing(false); onCompose(h); }} onBack={() => setComposing(false)} />
+            )}
         </div>
     );
 }
 
 function NewDm({ onSelect, onBack }: { onSelect: (handle: string) => void; onBack: () => void }) {
+    const { goBack, pageStyle } = useIosPush(onBack);
     const [query, setQuery] = useState('');
     const { data } = useAsyncData<BirdyAuthor[]>(() => apiSearch(query), [query]);
     const users = data ?? [];
 
     return (
-        <div className="flex h-full flex-col" style={{ background: BG }}>
+        <div className="absolute inset-0 z-20 flex flex-col" style={{ background: BG, ...pageStyle }}>
             <header className="flex shrink-0 items-center px-2 py-2">
-                <button type="button" onClick={onBack} aria-label={t('birdy.back', 'Back')} className="flex h-11 w-11 items-center justify-center text-black active:opacity-60">
+                <button type="button" onClick={goBack} aria-label={t('birdy.back', 'Back')} className="flex h-11 w-11 items-center justify-center text-black active:opacity-60">
                     <ArrowLeft className="h-6 w-6" strokeWidth={2.2} />
                 </button>
                 <h1 className="flex-1 text-center text-[22px] font-extrabold text-black">{t('birdy.newMessage', 'New message')}</h1>

--- a/web/src/apps/birdy/feed/PostCard.tsx
+++ b/web/src/apps/birdy/feed/PostCard.tsx
@@ -31,17 +31,17 @@ export function PostCard({ post, isOwn, onToggleLike, onToggleRepost, onOpen, on
         <>
         <article
             onClick={onOpen}
-            className={`flex gap-3.5 border-b border-black/10 px-4 py-4 ${onOpen ? 'cursor-pointer transition-colors hover:bg-black/[0.04]' : ''}`}
+            className={`flex gap-4 border-b border-black/10 px-4 py-[18px] ${onOpen ? 'cursor-pointer transition-colors hover:bg-black/[0.04]' : ''}`}
         >
             <button type="button" onClick={openAuthor} className="h-fit shrink-0">
-                <Avatar size={56} src={post.author.avatar} />
+                <Avatar size={60} src={post.author.avatar} />
             </button>
 
             <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1 text-[18px] leading-tight">
+                <div className="flex items-center gap-1 text-[19px] leading-tight">
                     <button type="button" onClick={openAuthor} className="flex min-w-0 items-center gap-1 text-left">
                         <span className="font-bold text-black">{post.author.name}</span>
-                        {post.author.verified && <VerifiedBadge size={19} />}
+                        {post.author.verified && <VerifiedBadge size={20} />}
                         <span className="truncate" style={{ color: META }}>@{post.author.handle}</span>
                     </button>
                     <span style={{ color: META }}>· {relativeTime(post.createdAt)}</span>
@@ -53,29 +53,29 @@ export function PostCard({ post, isOwn, onToggleLike, onToggleRepost, onOpen, on
                             aria-label={t('birdy.more', 'More')}
                             style={{ color: META }}
                         >
-                            <MoreHorizontal className="h-[21px] w-[21px]" />
+                            <MoreHorizontal className="h-[22px] w-[22px]" />
                         </button>
                     )}
                 </div>
 
                 {post.body && (
-                    <p className="mt-1 whitespace-pre-wrap break-words text-[18px] leading-snug text-black">
+                    <p className="mt-1 whitespace-pre-wrap break-words text-[19px] leading-snug text-black">
                         <RichText text={post.body} />
                     </p>
                 )}
 
                 <PostImages images={post.images} />
 
-                <div className="mt-3.5 flex max-w-[20rem] items-center justify-between">
+                <div className="mt-4 flex max-w-[21rem] items-center justify-between">
                     <ActionButton
                         tone="comment"
-                        icon={<MessageCircle className="h-[25px] w-[25px]" strokeWidth={1.9} />}
+                        icon={<MessageCircle className="h-[27px] w-[27px]" strokeWidth={1.9} />}
                         count={post.replies}
                         onClick={onOpen}
                     />
                     <ActionButton
                         tone="repost"
-                        icon={<Repeat2 className="h-[27px] w-[27px]" strokeWidth={1.9} />}
+                        icon={<Repeat2 className="h-[29px] w-[29px]" strokeWidth={1.9} />}
                         count={repostCount}
                         color={reposted ? REPOST : undefined}
                         onClick={() => setConfirmRepost(true)}
@@ -85,7 +85,7 @@ export function PostCard({ post, isOwn, onToggleLike, onToggleRepost, onOpen, on
                         icon={
                             <HeartBurst liked={post.liked === true}>
                                 <Heart
-                                    className="h-[25px] w-[25px]"
+                                    className="h-[27px] w-[27px]"
                                     strokeWidth={1.9}
                                     fill={post.liked ? LIKE : 'none'}
                                     color={post.liked ? LIKE : 'currentColor'}
@@ -137,10 +137,10 @@ function ActionButton({ icon, count, color, tone, onClick }: {
             className={`group flex items-center gap-1 transition-transform active:scale-90 ${active ? '' : `text-[#657786] ${t.text}`}`}
             style={active ? { color } : undefined}
         >
-            <span className={`-m-1.5 flex h-9 w-9 items-center justify-center rounded-full transition-colors ${t.bg}`}>
+            <span className={`-m-1.5 flex h-10 w-10 items-center justify-center rounded-full transition-colors ${t.bg}`}>
                 {icon}
             </span>
-            <span className="min-w-[1.5rem] text-left text-[15px] tabular-nums">{compactCount(count)}</span>
+            <span className="min-w-[1.5rem] text-left text-[16px] tabular-nums">{compactCount(count)}</span>
         </button>
     );
 }

--- a/web/src/apps/birdy/feed/PostDetail.tsx
+++ b/web/src/apps/birdy/feed/PostDetail.tsx
@@ -52,13 +52,13 @@ export function PostDetail({ post, me, onBack, onToggleLike, onToggleRepost, onT
             <div className="min-h-0 flex-1 overflow-y-auto no-scrollbar">
                 <div className="px-4 pt-3">
                     <button type="button" onClick={openAuthor} className="flex items-center gap-3 text-left">
-                        <Avatar size={42} src={post.author.avatar} />
+                        <Avatar size={52} src={post.author.avatar} />
                         <div className="min-w-0 leading-tight">
                             <div className="flex items-center gap-1">
-                                <span className="text-[15px] font-bold text-black">{post.author.name}</span>
-                                {post.author.verified && <VerifiedBadge size={15} />}
+                                <span className="text-[18px] font-bold text-black">{post.author.name}</span>
+                                {post.author.verified && <VerifiedBadge size={18} />}
                             </div>
-                            <div className="text-[14px]" style={{ color: META }}>@{post.author.handle}</div>
+                            <div className="text-[16px]" style={{ color: META }}>@{post.author.handle}</div>
                         </div>
                     </button>
 
@@ -70,42 +70,39 @@ export function PostDetail({ post, me, onBack, onToggleLike, onToggleRepost, onT
 
                     <PostImages images={post.images} />
 
-                    <div className="mt-3 text-[14px]" style={{ color: META }}>
+                    <div className="mt-3 text-[16px]" style={{ color: META }}>
                         {absoluteTime(post.createdAt)} · <span className="font-semibold text-black">{compactCount(post.views ?? 0)}</span> {t('birdy.views', 'views')}
                     </div>
                 </div>
 
-                <div className="mx-4 mt-3 border-t border-black/10 py-3 text-[14px]" style={{ color: META }}>
+                <div className="mx-4 mt-4 text-[16px]" style={{ color: META }}>
                     <span className="font-bold text-black">{compactCount(post.reposts)}</span> {t('birdy.reposts', 'Reposts')}
                     <span className="ml-5 font-bold text-black">{compactCount(post.likes)}</span> {t('birdy.likes', 'Likes')}
                 </div>
 
-                <div className="mx-4 flex items-center justify-around border-y border-black/10 py-2.5" style={{ color: META }}>
-                    <button type="button" aria-label={t('birdy.reply', 'Reply')} onClick={() => inputRef.current?.focus()} className="transition-transform active:scale-90"><MessageCircle className="h-[22px] w-[22px]" strokeWidth={1.8} /></button>
-                    <button type="button" aria-label={t('birdy.repost', 'Repost')} onClick={onToggleRepost} className="transition-transform active:scale-90" style={post.reposted ? { color: REPOST } : undefined}><Repeat2 className="h-[22px] w-[22px]" strokeWidth={1.8} /></button>
+                <div className="mx-4 flex items-center justify-around py-4" style={{ color: META }}>
+                    <button type="button" aria-label={t('birdy.reply', 'Reply')} onClick={() => inputRef.current?.focus()} className="transition-transform active:scale-90"><MessageCircle className="h-[25px] w-[25px]" strokeWidth={1.8} /></button>
+                    <button type="button" aria-label={t('birdy.repost', 'Repost')} onClick={onToggleRepost} className="transition-transform active:scale-90" style={post.reposted ? { color: REPOST } : undefined}><Repeat2 className="h-[25px] w-[25px]" strokeWidth={1.8} /></button>
                     <button type="button" aria-label={t('birdy.like', 'Like')} onClick={onToggleLike} className="transition-transform active:scale-90" style={post.liked ? { color: LIKE } : undefined}>
                         <HeartBurst liked={post.liked === true}>
-                            <Heart className="h-[22px] w-[22px]" strokeWidth={1.8} fill={post.liked ? LIKE : 'none'} color={post.liked ? LIKE : 'currentColor'} />
+                            <Heart className="h-[25px] w-[25px]" strokeWidth={1.8} fill={post.liked ? LIKE : 'none'} color={post.liked ? LIKE : 'currentColor'} />
                         </HeartBurst>
                     </button>
                 </div>
 
                 {(post.thread?.length ?? 0) > 0 && (
-                    <p className="px-4 pt-3 text-[13px] font-semibold uppercase tracking-wide" style={{ color: META }}>
+                    <p className="border-t border-black/10 px-4 pt-3 text-[14px] font-semibold uppercase tracking-wide" style={{ color: META }}>
                         {t('birdy.replies', 'Replies')}
                     </p>
                 )}
                 {post.thread?.map(r => (
-                    <div key={r.id} className="relative">
-                        {/* Thread rail: ties each reply back to the focal post, Twitter-style. */}
-                        <span aria-hidden className="absolute bottom-0 left-[43px] top-0 w-[2px] rounded bg-black/[0.08]" />
-                        <PostCard
-                            post={r}
-                            isOwn={r.author.handle === me.handle}
-                            onToggleLike={() => onToggleReplyLike(r.id)}
-                            onOpenAuthor={onOpenAuthor}
-                        />
-                    </div>
+                    <PostCard
+                        key={r.id}
+                        post={r}
+                        isOwn={r.author.handle === me.handle}
+                        onToggleLike={() => onToggleReplyLike(r.id)}
+                        onOpenAuthor={onOpenAuthor}
+                    />
                 ))}
             </div>
 
@@ -115,7 +112,7 @@ export function PostDetail({ post, me, onBack, onToggleLike, onToggleRepost, onT
                         <div className="flex gap-2 px-3 pt-2">
                             {media.map((url, i) => (
                                 <div key={`${url}-${i}`} className="relative">
-                                    <img src={url} alt="" draggable={false} className="h-14 w-14 rounded-[10px] object-cover" />
+                                    <img src={url} alt="" draggable={false} className="h-16 w-16 rounded-[10px] object-cover" />
                                     <button
                                         type="button"
                                         onClick={() => setMedia(prev => prev.filter((_, idx) => idx !== i))}
@@ -128,24 +125,24 @@ export function PostDetail({ post, me, onBack, onToggleLike, onToggleRepost, onT
                             ))}
                         </div>
                     )}
-                    <div className="flex items-center gap-1 px-3 py-2">
+                    <div className="flex items-center gap-1.5 px-3 py-2.5">
                         <button
                             type="button"
                             aria-label={t('birdy.addImage', 'Add image')}
                             disabled={media.length >= MAX_REPLY_IMAGES}
                             onClick={() => setPicking('photo')}
-                            className="flex h-9 w-8 shrink-0 items-center justify-center rounded-full active:bg-black/5 disabled:opacity-40"
+                            className="flex h-10 w-9 shrink-0 items-center justify-center rounded-full active:bg-black/5 disabled:opacity-40"
                         >
-                            <ImageIcon className="h-[21px] w-[21px]" style={{ color: BLUE }} strokeWidth={2} />
+                            <ImageIcon className="h-[24px] w-[24px]" style={{ color: BLUE }} strokeWidth={2} />
                         </button>
                         <button
                             type="button"
                             aria-label={t('birdy.addGif', 'Add GIF')}
                             disabled={media.length >= MAX_REPLY_IMAGES}
                             onClick={() => setPicking('gif')}
-                            className="mr-1 flex h-9 w-8 shrink-0 items-center justify-center rounded-full active:bg-black/5 disabled:opacity-40"
+                            className="mr-1 flex h-10 w-9 shrink-0 items-center justify-center rounded-full active:bg-black/5 disabled:opacity-40"
                         >
-                            <span className="rounded-[5px] border-[1.5px] px-[3px] py-[1.5px] text-[10px] font-extrabold leading-none" style={{ borderColor: BLUE, color: BLUE }}>GIF</span>
+                            <span className="rounded-[6px] border-[1.5px] px-[4px] py-[2px] text-[12px] font-extrabold leading-none" style={{ borderColor: BLUE, color: BLUE }}>GIF</span>
                         </button>
                         <input
                             ref={inputRef}
@@ -154,14 +151,14 @@ export function PostDetail({ post, me, onBack, onToggleLike, onToggleRepost, onT
                             onKeyDown={e => { if (e.key === 'Enter') sendReply(); }}
                             maxLength={MAX_POST_LENGTH}
                             placeholder={t('birdy.postYourReply', 'Post your reply')}
-                            className="min-w-0 flex-1 rounded-full px-4 py-2 text-[15px] text-black outline-none placeholder:text-[#657786]"
+                            className="min-w-0 flex-1 rounded-full px-4 py-2.5 text-[17px] text-black outline-none placeholder:text-[#657786]"
                             style={{ background: PILL, caretColor: BLUE }}
                         />
                         <button
                             type="button"
                             onClick={sendReply}
                             disabled={!canSend}
-                            className="shrink-0 rounded-full px-4 py-2 text-[14px] font-bold text-white disabled:opacity-50"
+                            className="shrink-0 rounded-full px-5 py-2.5 text-[16px] font-bold text-white disabled:opacity-50"
                             style={{ background: BLUE }}
                         >
                             {t('birdy.reply', 'Reply')}

--- a/web/src/apps/birdy/profile/EditProfile.tsx
+++ b/web/src/apps/birdy/profile/EditProfile.tsx
@@ -8,9 +8,9 @@ import { Toggle } from '@/ui/Toggle';
 import { apiDeleteAccount, apiLogout, apiUpdateProfile } from '../birdyApi';
 import { accountsForgetPassword } from '@/core/accountsApi';
 import { ChangePasswordPage } from '@/shared/ChangePasswordPage';
-import { BLUE, META, type BirdyProfile } from '../data';
+import { BG, BLUE, type BirdyProfile } from '../data';
 
-const RED = '#f4212e';
+const RED = '#ff3b30';
 
 export function EditProfile({ profile, onCancel, onSaved, onSignOut, onDeleted }: {
     profile:   BirdyProfile;
@@ -58,8 +58,9 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onDeleted }
 
     return (
         <div
-            className="absolute inset-0 z-40 flex flex-col bg-[#f2f3f5] text-black"
+            className="absolute inset-0 z-40 flex flex-col text-black"
             style={{
+                background: BG,
                 animation: closing
                     ? 'ios-sheet-down 0.34s cubic-bezier(0.4,0,1,1) forwards'
                     : 'ios-sheet-up 0.42s cubic-bezier(0.19,1,0.22,1)',
@@ -68,38 +69,39 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onDeleted }
         >
             <div className="h-[54px] shrink-0" aria-hidden />
             <header className="flex items-center justify-between px-4 py-2.5">
-                <button type="button" onClick={() => dismiss(onCancel)} className="text-[15px]" style={{ color: META }}>{t('birdy.cancel', 'Cancel')}</button>
+                <button type="button" onClick={() => dismiss(onCancel)} className="text-[17px]" style={{ color: BLUE }}>{t('birdy.cancel', 'Cancel')}</button>
                 <div className="text-[18px] font-bold">{t('birdy.editProfile', 'Edit profile')}</div>
-                <button type="button" onClick={save} disabled={busy} className="text-[15px] font-bold disabled:opacity-50" style={{ color: BLUE }}>{t('birdy.save', 'Save')}</button>
+                <button type="button" onClick={save} disabled={busy} className="text-[17px] font-bold disabled:opacity-50" style={{ color: BLUE }}>{t('birdy.save', 'Save')}</button>
             </header>
 
             <div className="min-h-0 flex-1 overflow-y-auto no-scrollbar">
-                <div className="relative h-28 bg-black/10">
+                <div className="relative h-32 bg-black/10">
                     {banner && <img src={banner} alt="" draggable={false} className="h-full w-full object-cover" />}
-                    <button type="button" onClick={() => setPicking('banner')} aria-label={t('birdy.changeCover', 'Change cover')} className="absolute left-1/2 top-1/2 flex h-10 w-10 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full text-white" style={{ background: 'rgba(0,0,0,0.4)' }}>
-                        <Camera className="h-5 w-5" />
+                    <button type="button" onClick={() => setPicking('banner')} aria-label={t('birdy.changeCover', 'Change cover')} className="absolute left-1/2 top-1/2 flex h-11 w-11 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full text-white" style={{ background: 'rgba(0,0,0,0.4)' }}>
+                        <Camera className="h-[22px] w-[22px]" />
                     </button>
-                    <button type="button" onClick={() => setPicking('avatar')} aria-label={t('birdy.changeAvatar', 'Change avatar')} className="absolute -bottom-7 left-4 flex h-16 w-16 items-center justify-center overflow-hidden rounded-full border-4 text-white" style={{ borderColor: '#f2f3f5', background: '#5b6671' }}>
+                    <button type="button" onClick={() => setPicking('avatar')} aria-label={t('birdy.changeAvatar', 'Change avatar')} className="absolute -bottom-10 left-4 flex h-20 w-20 items-center justify-center overflow-hidden rounded-full border-4 text-white" style={{ borderColor: BG, background: '#5b6671' }}>
                         {avatar
                             ? <img src={avatar} alt="" draggable={false} className="h-full w-full object-cover" />
-                            : <Camera className="h-6 w-6" />}
+                            : <Camera className="h-7 w-7" />}
                     </button>
                 </div>
-                <div className="h-9" aria-hidden />
+                <div className="h-14" aria-hidden />
 
-                <div className="bg-white">
+                <div className="mx-4 overflow-hidden rounded-[12px] bg-white">
                     <Row label={t('birdy.name', 'Name')}>
-                        <input value={name} onChange={e => setName(e.target.value)} className="w-full bg-transparent text-right text-[17px] outline-none" style={{ color: BLUE }} />
+                        <input value={name} onChange={e => setName(e.target.value)} className="w-full bg-transparent text-right text-[17px] text-black outline-none" style={{ caretColor: BLUE }} />
                     </Row>
 
-                    <div className="border-b border-black/[0.07] px-4 py-3.5">
+                    <div className="border-b border-black/10 px-4 py-3.5">
                         <div className="text-[17px] font-bold text-black">{t('birdy.bio', 'Bio')}</div>
                         <textarea
                             value={bio}
                             onChange={e => setBio(e.target.value)}
                             rows={3}
-                            className="mt-2 w-full resize-none rounded-xl border border-black/15 bg-white px-3 py-2.5 text-[17px] leading-snug outline-none focus:border-[#1d9bf0]"
-                            style={{ color: BLUE }}
+                            placeholder={t('birdy.bioPlaceholder', 'Tell people about yourself')}
+                            className="mt-1 w-full resize-none bg-transparent text-[17px] leading-snug text-black outline-none placeholder:text-black/35"
+                            style={{ caretColor: BLUE }}
                         />
                     </div>
 
@@ -109,14 +111,14 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onDeleted }
 
                     <div className="flex items-center justify-between px-4 py-3.5">
                         <span className="text-[17px] font-bold">{t('birdy.privateAccount', 'Private account')}</span>
-                        <Toggle on={protect} onChange={setProtect} activeColor={BLUE} scale={0.85} />
+                        <Toggle on={protect} onChange={setProtect} activeColor={BLUE} />
                     </div>
                 </div>
 
-                <div className="flex flex-col gap-3.5 px-4 py-8">
-                    <button type="button" onClick={() => setPwOpen(true)} className="w-full rounded-full bg-black/[0.06] py-4 text-[18px] font-bold text-black active:opacity-70">{t('birdy.changePassword', 'Change Password')}</button>
-                    <button type="button" onClick={() => setConfirmSignOut(true)} className="w-full rounded-full py-4 text-[18px] font-bold text-white" style={{ background: BLUE }}>{t('birdy.signOut', 'Sign Out')}</button>
-                    <button type="button" onClick={() => setConfirmDel(true)} className="w-full rounded-full py-4 text-[18px] font-bold text-white" style={{ background: RED }}>{t('birdy.deleteAccount', 'Delete Account')}</button>
+                <div className="flex flex-col gap-3 px-4 py-6">
+                    <button type="button" onClick={() => setPwOpen(true)} className="w-full rounded-[12px] bg-white py-4 text-[18px] font-semibold active:opacity-70" style={{ color: BLUE }}>{t('birdy.changePassword', 'Change Password')}</button>
+                    <button type="button" onClick={() => setConfirmSignOut(true)} className="w-full rounded-[12px] bg-white py-4 text-[18px] font-semibold active:opacity-70" style={{ color: RED }}>{t('birdy.signOut', 'Sign Out')}</button>
+                    <button type="button" onClick={() => setConfirmDel(true)} className="w-full rounded-[12px] bg-white py-4 text-[18px] font-semibold active:opacity-70" style={{ color: RED }}>{t('birdy.deleteAccount', 'Delete Account')}</button>
                 </div>
             </div>
 
@@ -163,7 +165,7 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onDeleted }
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
     return (
-        <div className="flex gap-4 border-b border-black/[0.07] px-4 py-3.5">
+        <div className="flex gap-4 border-b border-black/10 px-4 py-3.5">
             <div className="w-24 shrink-0 pt-0.5 text-[17px] font-bold text-black">{label}</div>
             <div className="flex-1">{children}</div>
         </div>

--- a/web/src/apps/birdy/profile/Profile.tsx
+++ b/web/src/apps/birdy/profile/Profile.tsx
@@ -5,7 +5,6 @@ import { BirdyBird } from '../BirdyBird';
 
 import { t } from '@/i18n';
 import { useAsyncData } from '@/hooks/useAsyncData';
-import { useStatusBarLight } from '@/shell/useStatusBarLight';
 import { EmptyState } from '@/ui/EmptyState';
 import { apiProfilePosts } from '../birdyApi';
 import { BG, BLUE, META, type BirdyAuthor, type BirdyProfile } from '../data';
@@ -59,9 +58,7 @@ export function Profile({ profile, me, handle, onBack, onEdit, onOpenPost, onTog
 
     useEffect(() => { setFollowing(!!profile?.isFollowing); }, [profile?.isFollowing]);
 
-    const [overBanner, setOverBanner] = useState(true);
     const [followView, setFollowView] = useState<'followers' | 'following' | null>(null);
-    useStatusBarLight(followView ? false : overBanner);
 
     function toggleFollow() {
         if (!handle) return;
@@ -77,10 +74,7 @@ export function Profile({ profile, me, handle, onBack, onEdit, onOpenPost, onTog
 
     return (
         <div className="relative flex h-full flex-col" style={{ background: BG }}>
-            <div
-                className="min-h-0 flex-1 overflow-y-auto no-scrollbar"
-                onScroll={e => setOverBanner(e.currentTarget.scrollTop < 72)}
-            >
+            <div className="min-h-0 flex-1 overflow-y-auto no-scrollbar">
                 <div className="relative h-[132px] w-full overflow-hidden" style={{ background: BLUE }}>
                     {banner && (
                         <img src={banner} alt="" draggable={false} className="h-full w-full object-cover" />


### PR DESCRIPTION
Frontend-only polish pass on Birdy. No server or bridge changes.

## Legibility

The feed and search rows read noticeably smaller than the rest of the phone.

- post avatars 56 -> 60, search avatars 48 -> 54
- body and name text 18 -> 19, 15/17 -> 16/18
- action icons 25/27 -> 27/29, with 40px tap targets
- nav unread badge 18 -> 22px, so a two-digit count is actually readable

## Edit Profile, matched to the iOS forms elsewhere in the phone

- fields sit in a grouped rounded card instead of a full-bleed white block
- Cancel is blue and 17px, matching Save
- destructive red is the system `#ff3b30` rather than Birdy's own `#f4212e`
- input text is black with a blue caret instead of all-blue
- surface uses the shared `BG` token rather than a hardcoded `#f2f3f5`
- cover and avatar wells grew to match the larger sheet

## New Message pushes

It was swapping the whole conversation list out, so it appeared instantly. Now an overlay driven by `useIosPush`, so it pushes in and back out like every other drill-in.

## Profile status bar

Drops the manual `useStatusBarLight` override and the `onScroll` listener feeding it. The shared auto-contrast already picks a legible status bar from the app's background, and the manual hint was fighting it over the blue banner. Also removes a `setState` on every scroll frame as a side effect.

## Seed content

Two seed posts with photos, so the mock feed exercises the single-image and multi-image layouts. Bundled webp assets, already covered by the `fxmanifest` whitelist - checked, and the build emits all four.

## Verification

`tsc` clean, `eslint` 0 errors (29 warnings, unchanged baseline), `vitest` 128/128, `knip` clean, `vite build` succeeds and emits `background7/12/15/20.webp`.

Not verified in-game. The one thing worth a visual check is the Profile status bar over the blue banner - that is exactly the case where auto-contrast and the removed manual override would have disagreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
