### PR TITLE
fix(settings): persist screen brightness across restarts

### DIFF
--- a/client/apps/settings.lua
+++ b/client/apps/settings.lua
@@ -21,6 +21,7 @@ proxyCallback('sd-phone:settings:wallpapers:add',    'sd-phone:server:settings:w
 proxyCallback('sd-phone:settings:wallpapers:remove', 'sd-phone:server:settings:wallpapers:remove')
 proxyCallback('sd-phone:settings:setChatTextScale', 'sd-phone:server:settings:setChatTextScale')
 proxyCallback('sd-phone:settings:setPhoneScale',    'sd-phone:server:settings:setPhoneScale')
+proxyCallback('sd-phone:settings:setBrightness',    'sd-phone:server:settings:setBrightness')
 proxyCallback('sd-phone:settings:setPhoneAlign',    'sd-phone:server:settings:setPhoneAlign')
 proxyCallback('sd-phone:settings:setVolumes',       'sd-phone:server:settings:setVolumes')
 proxyCallback('sd-phone:settings:setLocale',        'sd-phone:server:settings:setLocale')

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -150,6 +150,15 @@ lib.callback.register('sd-phone:server:settings:setPhoneScale', function(source,
     return { success = true }
 end)
 
+---Persists the caller's screen brightness (0-100 slider).
+lib.callback.register('sd-phone:server:settings:setBrightness', function(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    payload = type(payload) == 'table' and payload or {}
+    store.setBrightness(cid, payload.brightness)
+    return { success = true }
+end)
+
 ---Persists the caller's phone anchor position (whitelisted).
 lib.callback.register('sd-phone:server:settings:setPhoneAlign', function(source, payload)
     local cid = player.getIdentifier(source)

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -88,6 +88,7 @@ function store.ensureSchema()
             face_id            TINYINT(1)   NOT NULL DEFAULT 0,
             chat_text_scale    DECIMAL(3,2) NULL,
             phone_scale        TINYINT UNSIGNED NULL,
+            brightness         TINYINT UNSIGNED NULL,
             phone_align        VARCHAR(16) NULL,
             hour24             TINYINT(1)   NULL,
             reopen_app         TINYINT(1)   NULL,
@@ -169,6 +170,9 @@ function store.ensureSchema()
     end
     if not columnExists('phone_settings', 'phone_scale') then
         MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN phone_scale TINYINT UNSIGNED NULL')
+    end
+    if not columnExists('phone_settings', 'brightness') then
+        MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN brightness TINYINT UNSIGNED NULL')
     end
     if not columnExists('phone_settings', 'phone_align') then
         MySQL.query.await('ALTER TABLE phone_settings ADD COLUMN phone_align VARCHAR(16) NULL')
@@ -721,11 +725,11 @@ function store.setChatTextScale(citizenid, scale)
     ]], { citizenid, clean })
 end
 
----Clamps the phone frame scale to an integer 0-100; nil for non-numbers and NaN, out-of-range
----values fall to the nearest bound.
----@param v any client-supplied scale
----@return number|nil scale integer 0-100, nil if unusable
-local function clampPhoneScale(v)
+---Clamps a 0-100 slider value to an integer; nil for non-numbers and NaN, out-of-range values
+---fall to the nearest bound. Shared by the phone frame scale and screen brightness.
+---@param v any client-supplied slider value
+---@return number|nil value integer 0-100, nil if unusable
+local function clampSlider(v)
     local n = tonumber(v)
     if not n or n ~= n then return nil end
     n = math.floor(n + 0.5)
@@ -750,11 +754,36 @@ end
 ---@param scale number slider value (clamped to 0-100)
 function store.setPhoneScale(citizenid, scale)
     if not citizenid or citizenid == '' then return end
-    local clean = clampPhoneScale(scale)
+    local clean = clampSlider(scale)
     if not clean then return end
     MySQL.update.await([[
         INSERT INTO phone_settings (citizenid, phone_scale) VALUES (?, ?)
         ON DUPLICATE KEY UPDATE phone_scale = VALUES(phone_scale)
+    ]], { citizenid, clean })
+end
+
+---Reads a player's screen brightness (slider value 0-100), or nil when never set.
+---@param citizenid string framework per-character id
+---@return number|nil brightness
+function store.getBrightness(citizenid)
+    if not citizenid or citizenid == '' then return nil end
+    local row = MySQL.single.await('SELECT brightness FROM phone_settings WHERE citizenid = ?', { citizenid })
+    if not row or row.brightness == nil then return nil end
+    return tonumber(row.brightness)
+end
+
+---Persists a player's screen brightness, leaving other settings intact. An out-of-range /
+---non-numeric value is ignored. 0 is a valid setting (fully dimmed), so the clamp result is
+---compared against nil rather than tested for truthiness.
+---@param citizenid string framework per-character id
+---@param brightness number slider value (clamped to 0-100)
+function store.setBrightness(citizenid, brightness)
+    if not citizenid or citizenid == '' then return end
+    local clean = clampSlider(brightness)
+    if clean == nil then return end
+    MySQL.update.await([[
+        INSERT INTO phone_settings (citizenid, brightness) VALUES (?, ?)
+        ON DUPLICATE KEY UPDATE brightness = VALUES(brightness)
     ]], { citizenid, clean })
 end
 
@@ -1198,6 +1227,7 @@ function store.snapshot(citizenid)
         customWallpapers = row and decodeColumn(row.custom_wallpapers, {}) or {},
         chatTextScale    = (row and row.chat_text_scale ~= nil) and tonumber(row.chat_text_scale) or nil,
         phoneScale       = (row and row.phone_scale ~= nil) and tonumber(row.phone_scale) or nil,
+        brightness       = (row and row.brightness ~= nil) and tonumber(row.brightness) or nil,
         phoneAlign       = (row and row.phone_align ~= '') and row.phone_align or nil,
         ringtoneVol      = (row and row.ringtone_volume ~= nil) and tonumber(row.ringtone_volume) or nil,
         callVol          = (row and row.call_volume ~= nil) and tonumber(row.call_volume) or nil,

--- a/web/src/stores/themeStore.test.ts
+++ b/web/src/stores/themeStore.test.ts
@@ -228,3 +228,56 @@ describe('themeStore phone align persistence (in-game)', () => {
         expect(store.getState().phoneAlign).toBe('top-right');
     });
 });
+
+describe('themeStore brightness persistence', () => {
+    it('debounces a drag gesture into one NUI persist with the final value', async () => {
+        vi.useFakeTimers();
+        const fetchNui = vi.fn().mockResolvedValue({ success: true });
+        vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
+        const store = await importStore();
+        store.getState().setBrightness(70);
+        store.getState().setBrightness(55);
+        store.getState().setBrightness(42);
+        expect(store.getState().brightness).toBe(42);
+        expect(fetchNui).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(300);
+        expect(fetchNui).toHaveBeenCalledTimes(1);
+        expect(fetchNui).toHaveBeenCalledWith('sd-phone:settings:setBrightness', { brightness: 42 });
+    });
+
+    it('clamps out-of-range values before storing them', async () => {
+        const store = await importStore();
+        store.getState().setBrightness(500);
+        expect(store.getState().brightness).toBe(100);
+        store.getState().setBrightness(-20);
+        expect(store.getState().brightness).toBe(0);
+    });
+
+    it('applies the server-saved brightness on hydrate', async () => {
+        const fetchNui = vi.fn().mockImplementation((event: string) => {
+            if (event === 'sd-phone:settings:get') {
+                return Promise.resolve({ data: { brightness: 35 } });
+            }
+            return Promise.resolve({ success: true });
+        });
+        vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
+        const store = await importStore();
+        store.getState().hydrate();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(store.getState().brightness).toBe(35);
+    });
+
+    it('ignores a garbage brightness from the server', async () => {
+        const fetchNui = vi.fn().mockImplementation((event: string) => {
+            if (event === 'sd-phone:settings:get') {
+                return Promise.resolve({ data: { brightness: 'very bright' } });
+            }
+            return Promise.resolve({ success: true });
+        });
+        vi.doMock('@/core/nui', () => ({ isFiveM: true, fetchNui }));
+        const store = await importStore();
+        store.getState().hydrate();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(store.getState().brightness).toBe(100);
+    });
+});

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -117,6 +117,7 @@ function saveChatScaleLocal(v: number) {
 }
 
 const PHONE_SCALE_KEY = 'sd-phone:phoneScale';
+// Shared by the phone frame scale and screen brightness; both are 0-100 sliders.
 const clampPhoneScale = (n: number) => Math.min(100, Math.max(0, Math.round(n)));
 function loadPhoneScaleLocal(): number {
     try {
@@ -341,7 +342,10 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
         else saveDarkThemeLocal(next);
     },
 
-    setBrightness:     (v) => set({ brightness: v }),
+    setBrightness: (v) => {
+        set({ brightness: clampPhoneScale(v) });
+        if (isFiveM) persistDebounced('brightness', () => { void fetchNui('sd-phone:settings:setBrightness', { brightness: get().brightness }).catch(() => {}); });
+    },
 
     setBlurLock: (v) => {
         set({ blurLock: v });
@@ -497,7 +501,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
             }
         };
         const keyAtRequest = wallpaperProfileKey;
-        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; wallpaperHome?: string; blurLock?: boolean; blurHome?: boolean; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
+        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; wallpaperHome?: string; blurLock?: boolean; blurHome?: boolean; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; brightness?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
             .then(res => {
                 if (!res?.data) { retry(); return; }
                 const d = res.data;
@@ -527,6 +531,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 if (typeof d.darkTheme === 'string' && (DARK_THEMES as string[]).includes(d.darkTheme)) patch.darkTheme = d.darkTheme as DarkTheme;
                 if (typeof d.chatTextScale === 'number') patch.chatTextScale = clampChatScale(d.chatTextScale);
                 if (typeof d.phoneScale === 'number') patch.phoneScale = clampPhoneScale(d.phoneScale);
+                if (typeof d.brightness === 'number') patch.brightness = clampPhoneScale(d.brightness);
                 if (typeof d.phoneAlign === 'string' && (PHONE_ALIGNS as string[]).includes(d.phoneAlign)) patch.phoneAlign = d.phoneAlign as PhoneAlign;
                 if (typeof d.ringtoneVol === 'number') patch.ringtoneVol = clampVol(d.ringtoneVol);
                 if (typeof d.callVol === 'number') patch.callVol = clampVol(d.callVol);


### PR DESCRIPTION
Reported in-game: the brightness setting did not survive a restart. Long-standing, not a regression.

## Root cause

`themeStore.tsx` had:

```ts
setBrightness: (v) => set({ brightness: v }),
```

Every other setter in that file fires a `fetchNui('sd-phone:settings:set…')`. Brightness had **no persistence chain at all** - no `phone_settings` column, no server callback, no client proxy, no persist call, and nothing read it back on open. It initialised to a hardcoded `100`, so any NUI reload or resource restart threw it away.

## Fix

Wired through the same path `phoneScale` already uses:

| Layer | Change |
|---|---|
| `server/settings/store.lua` | `brightness` column (+ `columnExists` backfill), `getBrightness` / `setBrightness`, included in `snapshot()` |
| `server/settings/init.lua` | `sd-phone:server:settings:setBrightness` |
| `client/apps/settings.lua` | proxy |
| `web/src/stores/themeStore.tsx` | clamp 0-100, debounced persist, hydrate on open |

The persist is debounced, so dragging the slider writes **once with the final value** rather than once per tick.

`setBrightness` also clamps 0-100 now. It previously stored whatever it was handed; both sliders bound to it are 0-100, but nothing enforced it.

Two details worth noting:

- `store.setBrightness` tests the clamp result against `nil` rather than truthiness. **0 is a valid brightness** (fully dimmed), and this codebase has already shipped one 0-truthiness bug (documents `locked = 0` inserting as locked). Lua treats 0 as truthy so either form works here, but the explicit check states the intent.
- The shared 0-100 clamp is renamed `clampPhoneScale` -> `clampSlider`, since brightness now uses it and the old name would be lying at the call site.

## Verification

**Four new `themeStore` tests, written before the fix and failing in exactly the predicted shape** - `expected "vi.fn()" to be called 1 times, but got 0` (no persist), `expected 500 to be 100` (no clamp), `expected 100 to be 35` (no hydrate). Green after. They cover: the drag debounces into one call with the final value, out-of-range clamps, a server value hydrates, and a non-numeric one is ignored. Suite **132 passing** (was 128).

`luac -p` clean, `tsc` clean, `eslint` 0 errors (29 warnings, unchanged baseline), `knip` clean, `vite build` succeeds.

Playwright against the real Display & Brightness slider: `100 -> dim 0`, `50 -> 0.425`, `0 -> 0.85`, and the clamp holds (`999 -> 100`, `-50 -> 0`), matching `dimOpacity = (1 - brightness/100) * 0.85`.

**Confirmed working in-game before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
