### PR TITLE
fix(blackjack): stop the bet climbing after a double, say why Double is unavailable

### DIFF
--- a/web/src/apps/blackjack/Blackjack.tsx
+++ b/web/src/apps/blackjack/Blackjack.tsx
@@ -8,7 +8,7 @@ import { BlackjackIcon } from '@/shell/AppIconSVG';
 import {
     type Card, type Outcome,
     SUIT_GLYPH,
-    fmtChips, handValue, isBlackjack, isBust, isRed, statResultFor,
+    fmtChips, handValue, isBlackjack, isBust, isRed, openingBet, statResultFor,
 } from './logic';
 import { type BjResult, bjDeal, bjDouble, bjHit, bjStand } from './blackjackApi';
 import { isFiveM } from '@/core/nui';
@@ -87,7 +87,7 @@ export function Blackjack({ onClose: _onClose }: Props) {
     function enterSolo() {
         timers.current.forEach(clearTimeout); timers.current = [];
         setPhase('betting'); setPlayer([]); setDealer([]); setHoleUp(false); setDoubled(false); setOutcome(null); setPayout(0);
-        setBet(Math.min(Math.max(lastBet || 25, 5), chipsRef.current) || Math.min(5, chipsRef.current));
+        setBet(openingBet(lastBet, chipsRef.current));
         setScreen('solo');
     }
 
@@ -166,7 +166,9 @@ export function Blackjack({ onClose: _onClose }: Props) {
     }
     function soloNewHand() {
         setPhase('betting'); setPlayer([]); setDealer([]); setHoleUp(false); setDoubled(false); setOutcome(null);
-        setBet(b => Math.min(Math.max(b, 5), chipsRef.current) || Math.min(5, chipsRef.current));
+        // From the chosen stake, not the hand just played: doubling raises that hand's wager, and
+        // carrying it over made the bet climb on its own after every double.
+        setBet(openingBet(lastBet, chipsRef.current));
     }
 
     function openLeaderboard() { setScreen('leaderboard'); setLbLoading(true); void loadLeaderboard(GAME).then(d => { setLeaderboard(d); setLbLoading(false); }); }
@@ -232,6 +234,7 @@ export function Blackjack({ onClose: _onClose }: Props) {
                     <SoloTable
                         phase={phase} bet={bet} chips={chips} player={player} dealer={dealer} holeUp={holeUp} outcome={outcome} payout={payout}
                         canDouble={phase === 'playing' && player.length === 2 && !doubled && chips >= bet}
+                        doubleBlocked={phase === 'playing' && player.length === 2 && !doubled && chips < bet ? 'chips' : null}
                         onAdjust={adjustBet} onMax={setBetMax} onSet={setBetTo} onDeal={deal}
                         onHit={hit} onStand={stand} onDouble={doubleDown} onNewHand={soloNewHand} onCashier={() => setScreen('cashier')}
                     />
@@ -349,8 +352,8 @@ function PayoutRow({ label, sub, result, example, highlight }: { label: string; 
     );
 }
 
-function SoloTable({ phase, bet, chips, player, dealer, holeUp, outcome, payout, canDouble, onAdjust, onMax, onSet, onDeal, onHit, onStand, onDouble, onNewHand, onCashier }: {
-    phase: Phase; bet: number; chips: number; player: Card[]; dealer: Card[]; holeUp: boolean; outcome: Outcome | null; payout: number; canDouble: boolean;
+function SoloTable({ phase, bet, chips, player, dealer, holeUp, outcome, payout, canDouble, doubleBlocked, onAdjust, onMax, onSet, onDeal, onHit, onStand, onDouble, onNewHand, onCashier }: {
+    phase: Phase; bet: number; chips: number; player: Card[]; dealer: Card[]; holeUp: boolean; outcome: Outcome | null; payout: number; canDouble: boolean; doubleBlocked: 'chips' | null;
     onAdjust: (d: number) => void; onMax: () => void; onSet: (n: number) => void; onDeal: () => void;
     onHit: () => void; onStand: () => void; onDouble: () => void; onNewHand: () => void; onCashier: () => void;
 }) {
@@ -379,7 +382,7 @@ function SoloTable({ phase, bet, chips, player, dealer, holeUp, outcome, payout,
                 {phase === 'betting'
                     ? <BetControls bet={bet} chips={chips} onAdjust={onAdjust} onMax={onMax} onSet={onSet} onDeal={onDeal} onCashier={onCashier} />
                     : phase === 'playing'
-                        ? <PlayControls onHit={onHit} onStand={onStand} onDouble={onDouble} canDouble={canDouble} />
+                        ? <PlayControls onHit={onHit} onStand={onStand} onDouble={onDouble} canDouble={canDouble} doubleBlocked={doubleBlocked} />
                         : phase === 'dealer'
                             ? <WaitNote text={t('blackjack.dealerPlaying', 'Dealer is playing…')} />
                             : <ResultControls onNewHand={onNewHand} canPlay={chips > 0} onCashier={onCashier} />}
@@ -515,12 +518,24 @@ function BetControls({ bet, chips, onAdjust, onMax, onSet, onDeal, onCashier }: 
     );
 }
 
-function PlayControls({ onHit, onStand, onDouble, canDouble }: { onHit: () => void; onStand: () => void; onDouble: () => void; canDouble: boolean }) {
+function PlayControls({ onHit, onStand, onDouble, canDouble, doubleBlocked }: {
+    onHit: () => void; onStand: () => void; onDouble: () => void; canDouble: boolean;
+    doubleBlocked: 'chips' | null;
+}) {
     return (
-        <div className="flex items-stretch gap-2.5">
-            <ActionButton label={t('blackjack.hit', 'Hit')} onClick={onHit} tone="light" />
-            <ActionButton label={t('blackjack.stand', 'Stand')} onClick={onStand} tone="gold" />
-            <ActionButton label={t('blackjack.double', 'Double')} onClick={onDouble} tone="dark" disabled={!canDouble} />
+        <div className="flex flex-col gap-1.5">
+            <div className="flex items-stretch gap-2.5">
+                <ActionButton label={t('blackjack.hit', 'Hit')} onClick={onHit} tone="light" />
+                <ActionButton label={t('blackjack.stand', 'Stand')} onClick={onStand} tone="gold" />
+                <ActionButton label={t('blackjack.double', 'Double')} onClick={onDouble} tone="dark" disabled={!canDouble} />
+            </div>
+            {/* Doubling needs a second wager equal to the first, and the first is already on the
+                table - so a large bet silently greys the button out. Say which it is. */}
+            {doubleBlocked === 'chips' && (
+                <div className="text-center text-[12px] text-ios-gray">
+                    {t('blackjack.doubleNeedsChips', 'Not enough chips left to double')}
+                </div>
+            )}
         </div>
     );
 }

--- a/web/src/apps/blackjack/logic.test.ts
+++ b/web/src/apps/blackjack/logic.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Card } from './logic';
-import { dealerShouldHit, handValue, isBlackjack, isBust, outcomeVsDealer, payoutFor } from './logic';
+import { dealerShouldHit, handValue, isBlackjack, isBust, openingBet, outcomeVsDealer, payoutFor } from './logic';
 
 // These rules are the oracle the server-authoritative Lua (server/games/blackjack.lua) mirrors.
 // Keep the two in lockstep: any change here must be reflected there.
@@ -74,5 +74,35 @@ describe('payoutFor', () => {
         expect(payoutFor(100, 'win')).toEqual({ credit: 200, net: 100 });
         expect(payoutFor(100, 'push')).toEqual({ credit: 100, net: 0 });
         expect(payoutFor(100, 'lose')).toEqual({ credit: 0, net: -100 });
+    });
+});
+
+describe('openingBet', () => {
+    // The bug this guards: doubling raises the hand's wager, and the next hand used to open on
+    // THAT figure instead of the stake the player chose, so the bet climbed every double.
+    it('opens on the chosen stake, not a doubled wager', () => {
+        expect(openingBet(25, 1000)).toBe(25);
+    });
+
+    it('does not compound across repeated doubles', () => {
+        let chosen = 25;
+        for (let i = 0; i < 5; i++) chosen = openingBet(chosen, 1000);
+        expect(chosen).toBe(25);
+    });
+
+    it('floors a real stake at the table minimum', () => {
+        expect(openingBet(1, 1000)).toBe(5);
+        expect(openingBet(4, 1000)).toBe(5);
+    });
+
+    it('never opens above what the player can cover', () => {
+        expect(openingBet(500, 80)).toBe(80);
+        expect(openingBet(25, 0)).toBe(0);
+    });
+
+    it('falls back to the default stake when the stored value is unusable', () => {
+        expect(openingBet(NaN, 1000)).toBe(25);
+        expect(openingBet(-40, 1000)).toBe(25);
+        expect(openingBet(0, 1000)).toBe(25);
     });
 });

--- a/web/src/apps/blackjack/logic.ts
+++ b/web/src/apps/blackjack/logic.ts
@@ -82,3 +82,17 @@ export function statResultFor(outcome: Outcome): 'win' | 'loss' | 'draw' {
     if (outcome === 'push') return 'draw';
     return 'loss';
 }
+
+/** Smallest wager the table accepts. */
+const MIN_BET = 5;
+
+/**
+ * The bet a fresh hand opens on: the player's own last chosen stake, floored at the table minimum
+ * and capped by what they can actually cover. Derived from the CHOSEN stake, never from the
+ * previous hand's wager - doubling raises that wager, and carrying it into the next hand made the
+ * stake climb on its own every time the player doubled.
+ */
+export function openingBet(lastBet: number, chips: number): number {
+    const wanted = Number.isFinite(lastBet) && lastBet > 0 ? Math.floor(lastBet) : 25;
+    return Math.min(Math.max(wanted, MIN_BET), Math.max(0, Math.floor(chips)));
+}


### PR DESCRIPTION
Two of the four reported items were real. The other two are covered below with why they are not.

## 1. The bet climbed after doubling — fixed

Doubling raises the hand's wager, and the UI adopts that figure so the table shows what is actually at stake. But `soloNewHand` opened the next hand on the **current** bet — the doubled one:

```ts
setBet(b => Math.min(Math.max(b, 5), chipsRef.current) || …)   // b = the doubled wager
```

So the stake ratcheted. Double a 25 and the next hand starts at 50; double that and the next starts at 100.

`enterSolo` already had this right, opening from `lastBet` — the stake the player *chose*, recorded on deal and never from a double. The two paths had simply drifted.

Both now call one `openingBet(lastBet, chips)` in `logic.ts`, so they cannot disagree again, and the rule is unit-tested instead of duplicated inline: the chosen stake, repeated doubles not compounding, the table minimum, the chip ceiling, and unusable stored values.

## 2. "Sometimes won't let you double" — not a bug, but now explained

Double is blocked in two correct cases: after a hit (first two cards only), and when the player cannot cover the second wager.

The second is invisible. The first wager is already off the balance, so betting much of a stack greys the button out with no explanation — which reads as random. A line under the controls now names that case. **No rules changed.**

## 3. Split — not implemented, and not patched here

The server holds one hand per player (`hands[cid]` is a single object), so split needs per-hand state, sequential play, and rules decisions up front — resplit allowed? split aces get one card? double-after-split? That is its own change with its own tests.

## 4. Dealer standing on 17 — already correct

`dealerShouldHit` stands on all 17s including soft 17. That is **S17**, the standard and more player-favourable rule. **H17** (dealer hits soft 17) is the alternative and costs the player roughly 0.2%. Nothing to fix unless you want the house edge raised.

## Verification

`tsc` clean, `eslint` 0 errors (29 warnings, unchanged baseline), `knip` clean, `vitest` **137/137** (was 132), build succeeds.

Not runtime-tested in-game. Worth confirming: bet 25, double, finish the hand, start another — it should open at 25, not 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
