### PR TITLE
feat(services) add online indicator to each company, lit if any playe…

### DIFF
--- a/server/services/actions.lua
+++ b/server/services/actions.lua
@@ -193,6 +193,19 @@ local function buildMyCompany(src)
     return mc
 end
 
+-- Check if any (including self) staff are online for a given job.
+-- @param jobName: string
+-- @return boolean
+function actions.checkAnyOnDutyStaff(jobName)
+    for _, tsrc in pairs(player.onlineCidMap()) do
+        local onDuty  = job.getDuty(tsrc)
+        if onDuty == true and job.getName(tsrc) == jobName then
+            return true
+        end
+    end
+    return false
+end
+
 ---Tells every online boss of a job to refresh their roster; the push carries no data.
 ---@param jobName string|nil
 function actions.notifyRoster(jobName)
@@ -219,6 +232,7 @@ function actions.companyList()
             canCall    = c.canCall == true,
             callNumber = c.callNumber,
             coords     = c.coords and { x = c.coords.x, y = c.coords.y, z = c.coords.z } or nil,
+            onDuty     = actions.checkAnyOnDutyStaff(c.job)
         }
     end
     return companies

--- a/web/src/apps/services/CompaniesTab.tsx
+++ b/web/src/apps/services/CompaniesTab.tsx
@@ -111,9 +111,14 @@ function CompanyCard({ company, onLocate, onCall, onMessage }: {
 }) {
     return (
         <div className="flex items-center gap-4 rounded-[16px] bg-[#e5e5e5] px-4 py-4 dark:bg-surface">
-            <ServiceAvatar color={company.color} emoji={company.emoji} size={58} />
+            <div className="flex items-center gap-2">
+                <div className={`h-3 w-3 shrink-0 rounded-full border border-red-500 ${company.onDuty ? 'bg-red-500' : 'bg-transparent'}`} />
+                <ServiceAvatar color={company.color} emoji={company.emoji} size={58} />
+            </div>
+            
 
             <div className="min-w-0 flex-1">
+
                 <div className="truncate text-[20px] font-semibold text-black dark:text-white">{company.name}</div>
                 <div className="mt-1 flex items-center gap-1.5 text-[15px] font-medium text-ios-gray">
                     <Building2 className="h-[15px] w-[15px] shrink-0 text-ios-gray" strokeWidth={2.2} />

--- a/web/src/apps/services/data.ts
+++ b/web/src/apps/services/data.ts
@@ -9,6 +9,7 @@ export interface Company {
     canCall:     boolean;
     callNumber?: string;
     coords?:     { x: number; y: number; z: number };
+    onDuty?:     boolean;
 }
 
 export interface Employee {


### PR DESCRIPTION
…r in that job is on duty

## Summary

I wanted a way to quickly tell if any players are on duty for the listed jobs without having to call or text them. I added a small red indicator to the left of the logos showing this status at a glance.

This does a refresh whenever the player opens the services app to check. So if you are in the app and switching between on and off duty or between jobs, it does seem to not call a refresh every time you switch back to the companies tab.

Maybe this as an optional configuration would be appropriate if people really don't like this idea?

<img width="333" height="694" alt="image" src="https://github.com/user-attachments/assets/8d73138a-146c-42d4-a849-fc6f474042fd" />


## Type of Change
- [ ] New Feature

## Testing

Describe how this was tested.

- [yes] Tested locally
- [yes] Tested with latest sd-phone
- [yes] Tested with latest ox_lib
- [yes] Tested with latest ox_inventory
- [no] Multiplayer tested

## Breaking Changes

No breaking changes

---

## Checklist

- [yes] My code follows the existing style of the project.
- [yes] I have tested my changes.
- [I think none apply] I have updated any necessary documentation.
- [yes] I have removed any debug code.
- [yes] This PR does not include unrelated changes.
- [yes] I have verified this works on the latest version of sd-phone.