### PR TITLE
feat(web): demo build mode for the public website preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 web/build/
+web/build-demo/
 
 # High-res map tiles — hosted on CDN, not committed (see web HIGH_RES_TILES.md)
 maptiles/

--- a/web/.env.demo
+++ b/web/.env.demo
@@ -1,0 +1,1 @@
+VITE_DEMO=1

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "dev": "vite",
         "build": "tsc --noEmit && vite build",
+        "build:demo": "tsc --noEmit && vite build --mode demo",
         "preview": "vite preview",
         "lint": "eslint src",
         "test": "vitest run",

--- a/web/src/apps/birdy/birdyApi.ts
+++ b/web/src/apps/birdy/birdyApi.ts
@@ -1,4 +1,5 @@
 import { fetchNui, isFiveM } from '@/core/nui';
+import { useMocks } from '@/core/demo';
 import { apiCall, apiData as call } from '@/core/api';
 import { formatClockTime } from '@/lib/time';
 import type { MessageDraft } from '@/shared/chat/ChatView';
@@ -22,7 +23,7 @@ function clock(): string {
     return formatClockTime(new Date(), true);
 }
 
-let devLoggedIn = import.meta.env.DEV;
+let devLoggedIn = useMocks;
 
 export interface AuthState { loggedIn: boolean; me: BirdyAuthor | null }
 export interface AuthResult { ok: boolean; me?: BirdyAuthor; message?: string }

--- a/web/src/apps/ryde/data.ts
+++ b/web/src/apps/ryde/data.ts
@@ -1,5 +1,6 @@
 
 import { t } from '@/i18n';
+import { useMocks } from '@/core/demo';
 import { readJson, writeJson } from '@/lib/storage';
 import { newId } from '@/lib/format';
 
@@ -272,7 +273,7 @@ function numifyRide(r: Ride): Ride {
 export function loadRides(): Ride[] {
     const raw = readJson<Ride[]>(RIDES_KEY, p => Array.isArray(p) && p.length > 0);
     if (raw) return raw.map(numifyRide);
-    if (import.meta.env.DEV && !ryDevDataHidden()) { const seed = seedRides(); saveRides(seed); return seed; }
+    if (useMocks && !ryDevDataHidden()) { const seed = seedRides(); saveRides(seed); return seed; }
     return [];
 }
 export function saveRides(r: Ride[]): void { writeJson(RIDES_KEY, r); }
@@ -282,7 +283,7 @@ export const DEFAULT_DRIVER: DriverProfile = { enabled: false, online: false, ca
 export function loadDriver(): DriverProfile {
     const r = readJson<DriverProfile>(DRV_KEY);
     if (r) return r;
-    if (import.meta.env.DEV) {
+    if (useMocks) {
         return { enabled: true, online: false, car: 'Karin Sultan', plate: '12 ABC 34', color: '#111', rating: 4.92, ratingCount: 138, trips: 8, earningsTotal: 0 };
     }
     return { ...DEFAULT_DRIVER };

--- a/web/src/core/accountsApi.ts
+++ b/web/src/core/accountsApi.ts
@@ -1,4 +1,5 @@
 import { fetchNui, isFiveM } from './nui';
+import { useMocks } from './demo';
 import { apiCall, apiData } from '@/core/api';
 
 export let MAIL_DOMAIN = 'lifeinvader.com';
@@ -14,7 +15,7 @@ const devSessions: Record<string, AccountMe | null> = {};
 
 export async function accountsMe(app: string): Promise<{ loggedIn: boolean; me: AccountMe | null }> {
     if (!isFiveM) {
-        const me = devSessions[app] ?? (import.meta.env.DEV ? { username: 'dev', name: 'Dev User' } : null);
+        const me = devSessions[app] ?? (useMocks ? { username: 'dev', name: 'Dev User' } : null);
         return { loggedIn: !!me, me };
     }
     const data = await apiData<{ loggedIn: boolean; me?: AccountMe }>('sd-phone:accounts:me', { app });

--- a/web/src/core/demo.ts
+++ b/web/src/core/demo.ts
@@ -1,5 +1,9 @@
 
-// True in `npm run dev` and in the public website demo build (`npm run
-// build:demo`). Gates the seeded sessions that stand in for a logged-in
-// player, so account-gated apps open instead of showing a login wall.
-export const useMocks: boolean = import.meta.env.DEV || import.meta.env.VITE_DEMO === '1';
+// True only in the public website demo build (`npm run build:demo`), where
+// the phone is embedded in a page that draws its own backdrop.
+export const isDemo: boolean = import.meta.env.VITE_DEMO === '1';
+
+// True in `npm run dev` and in the demo build. Gates the seeded sessions
+// that stand in for a logged-in player, so account-gated apps open instead
+// of showing a login wall.
+export const useMocks: boolean = import.meta.env.DEV || isDemo;

--- a/web/src/core/demo.ts
+++ b/web/src/core/demo.ts
@@ -1,0 +1,5 @@
+
+// True in `npm run dev` and in the public website demo build (`npm run
+// build:demo`). Gates the seeded sessions that stand in for a logged-in
+// player, so account-gated apps open instead of showing a login wall.
+export const useMocks: boolean = import.meta.env.DEV || import.meta.env.VITE_DEMO === '1';

--- a/web/src/core/dev.ts
+++ b/web/src/core/dev.ts
@@ -79,10 +79,12 @@ export function devInjectMockData(): () => void {
         data:   { startMs: Date.now() - (2 * 3600 + 17 * 60) * 1000 },
     }, '*');
 
+    // Base apps only: these land on a phone that has just been set up, before
+    // anything has been installed from the App Store.
     const seedNotifs = [
-        { id: 'seed-vibez',    app: 'vibez',    appId: 'vibez',    title: 'Marcus',         body: 'hey',                                        time: '11 Jun' },
-        { id: 'seed-messages', app: 'messages', appId: 'messages', title: 'Tommy V',        body: 'Sure Thing!',                                time: '13:15'  },
-        { id: 'seed-garages',  app: 'garages',  appId: 'garages',  title: 'Vehicle Update', body: 'Your vehicle (ABC 123) is ready for pickup', time: '15:14'  },
+        { id: 'seed-mail',     app: 'mail',     appId: 'mail',     title: 'Marcus Baker', body: 'Sent over the paperwork you asked for.', time: '11 Jun' },
+        { id: 'seed-messages', app: 'messages', appId: 'messages', title: 'Tommy V',      body: 'Sure Thing!',                            time: '13:15'  },
+        { id: 'seed-bank',     app: 'bank',     appId: 'bank',     title: 'Maze Bank',    body: 'Payment received: $2,500',               time: '15:14'  },
     ];
     const seedTimers: number[] = [];
     function seedNotifications(): void {

--- a/web/src/core/dev.ts
+++ b/web/src/core/dev.ts
@@ -1,9 +1,15 @@
 import type { OpenPayload } from './types';
+import { isDemo } from './demo';
 
 
 export function devInjectMockData(): () => void {
-    document.documentElement.style.setProperty('background', '#0a0a0a', 'important');
-    document.body.style.setProperty('background', '#0a0a0a', 'important');
+    // The dev server needs a dark canvas to see the phone against. The demo
+    // build is embedded in a page that draws its own, so painting one here
+    // would show as a black slab around the device.
+    if (!isDemo) {
+        document.documentElement.style.setProperty('background', '#0a0a0a', 'important');
+        document.body.style.setProperty('background', '#0a0a0a', 'important');
+    }
     document.body.style.minHeight = '100vh';
 
     const payload: OpenPayload = {

--- a/web/src/core/dev.ts
+++ b/web/src/core/dev.ts
@@ -84,14 +84,40 @@ export function devInjectMockData(): () => void {
         { id: 'seed-messages', app: 'messages', appId: 'messages', title: 'Tommy V',        body: 'Sure Thing!',                                time: '13:15'  },
         { id: 'seed-garages',  app: 'garages',  appId: 'garages',  title: 'Vehicle Update', body: 'Your vehicle (ABC 123) is ready for pickup', time: '15:14'  },
     ];
-    const seedTimers = seedNotifs.map((n, i) =>
-        window.setTimeout(() => window.postMessage({ action: 'sd-phone:notification', data: n }, '*'), 400 + i * 350),
-    );
+    const seedTimers: number[] = [];
+    function seedNotifications(): void {
+        seedNotifs.forEach((n, i) => seedTimers.push(
+            window.setTimeout(() => window.postMessage({ action: 'sd-phone:notification', data: n }, '*'), 400 + i * 350),
+        ));
+        seedTimers.push(window.setTimeout(
+            () => window.postMessage({ action: 'sd-phone:badges', data: { messages: 2, phone: 3, mail: 5, groups: 1 } }, '*'),
+            400,
+        ));
+    }
 
-    seedTimers.push(window.setTimeout(
-        () => window.postMessage({ action: 'sd-phone:badges', data: { messages: 2, phone: 3, mail: 5, groups: 1 } }, '*'),
-        400,
-    ));
+    // Setup is a full-screen takeover, so a seeded notification lands with no
+    // visible banner but an audible tone. Hold them until the flow is done.
+    // Only reachable outside FiveM, where a player in setup gets no traffic.
+    function setupPending(): boolean {
+        try {
+            const raw = window.localStorage.getItem('sd-phone:setup:v1');
+            return !!raw && (JSON.parse(raw) as { completed?: boolean }).completed === false;
+        } catch {
+            return false;
+        }
+    }
+
+    let setupWatch = 0;
+    if (setupPending()) {
+        setupWatch = window.setInterval(() => {
+            if (setupPending()) return;
+            window.clearInterval(setupWatch);
+            setupWatch = 0;
+            seedNotifications();
+        }, 400);
+    } else {
+        seedNotifications();
+    }
 
     let battery = payload.battery;
     const tick = window.setInterval(() => {
@@ -146,6 +172,7 @@ export function devInjectMockData(): () => void {
         window.clearInterval(tick);
         window.clearInterval(weatherTick);
         window.clearInterval(healthTick);
+        if (setupWatch) window.clearInterval(setupWatch);
         seedTimers.forEach(window.clearTimeout);
     };
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -14,6 +14,7 @@ import '@fontsource/great-vibes/greek-ext-400.css';
 import '@fontsource/great-vibes/vietnamese-400.css';
 
 import { App } from './App';
+import { useMocks } from '@/core/demo';
 import { initTileCheck } from '@/apps/maps/tileCheck';
 import './index.css';
 
@@ -25,7 +26,13 @@ document.addEventListener('mousedown', e => {
     if (sel && !sel.isCollapsed) sel.removeAllRanges();
 });
 
-if(import.meta.env.DEV){localStorage.setItem('sd-phone:setup:v1',JSON.stringify({completed:true,theme:'light',wallpaper:'lockscreen.jpg'}));localStorage.setItem('sd-phone:cookie:v1',JSON.stringify({cookies:25040,earned:25040,owned:{cursor:8,grandma:4},achievements:['a100','a1k','a10k','cps5'],rainOn:true}));}
+// Seeded only when absent, so clearing a key replays that flow on reload
+// (the website demo's "Replay setup" button relies on this) instead of
+// having the seed stomp it straight back.
+if (useMocks) {
+    if (!localStorage.getItem('sd-phone:setup:v1')) localStorage.setItem('sd-phone:setup:v1', JSON.stringify({ completed: true, theme: 'light', wallpaper: 'lockscreen.jpg' }));
+    if (!localStorage.getItem('sd-phone:cookie:v1')) localStorage.setItem('sd-phone:cookie:v1', JSON.stringify({ cookies: 25040, earned: 25040, owned: { cursor: 8, grandma: 4 }, achievements: ['a100', 'a1k', 'a10k', 'cps5'], rainOn: true }));
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 
+import { useMocks } from '@/core/demo';
+
 
 interface AuthRecord {
     profile: Record<string, string>;
@@ -48,7 +50,7 @@ function readAuth(appKey: string): AuthRecord | null {
 }
 
 export function isAuthed(appKey: string): boolean {
-    if (import.meta.env.DEV) return true;
+    if (useMocks) return true;
     return readAuth(appKey) !== null;
 }
 

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -6,6 +6,7 @@ import { useShallow } from 'zustand/react/shallow';
 import lockscreenAsset from '@/assets/wallpapers/lockscreen.webp';
 import devDefaultAsset from '@/assets/photos/background5.webp';
 import { fetchNui, isFiveM } from '@/core/nui';
+import { isDemo } from '@/core/demo';
 import { wallpaperKey } from '@/shell/wallpapers';
 import { DEFAULT_LOCK_CLOCK, loadLockClockLocal, saveLockClockLocal, type LockClock } from '@/shell/lockClock';
 import { DEFAULT_NOTIFICATION, DEFAULT_RINGTONE } from '@/apps/settings/tones';
@@ -270,7 +271,9 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     hour24: false,
     reopenLastApp: false,
     ringtone: DEFAULT_RINGTONE,
-    notificationTone: DEFAULT_NOTIFICATION,
+    // The website demo opens on Chime, which carries better than the stock
+    // tone through laptop speakers. In game the default is unchanged.
+    notificationTone: isDemo ? 'chime' : DEFAULT_NOTIFICATION,
     customRingtones: [],
     customNotificationTones: [],
     statusLightOverride: null,

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    // '1' in the public website demo build. See core/demo.ts.
+    readonly VITE_DEMO?: string;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
     plugins: [react()],
     base: './',
     resolve: {
@@ -18,8 +18,10 @@ export default defineConfig({
         target: 'chrome110',
         // Output to `web/build/` so fxmanifest.lua's `ui_page` reference
         // (`web/build/index.html`) resolves both pre-build (vanilla
-        // fallback) and post-build (Vite-rendered React).
-        outDir: 'build',
+        // fallback) and post-build (Vite-rendered React). The website demo
+        // build gets its own folder — it bypasses the account gates, so it
+        // must never end up as the bundle the game serves.
+        outDir: mode === 'demo' ? 'build-demo' : 'build',
         emptyOutDir: true,
         assetsDir: 'assets',
         cssCodeSplit: false,
@@ -37,4 +39,4 @@ export default defineConfig({
             },
         },
     },
-});
+}));


### PR DESCRIPTION
Adds `npm run build:demo`, a browser-only bundle of the phone that stands in for a live server, so it can be embedded and actually used on the website.

## Why this is needed

Mock data already worked outside FiveM — the injection in `App.tsx` gates on `!isFiveM`, not on `DEV` — so a plain production build already boots with the full mock payload, live battery drain, rotating weather and ticking health data.

What was missing is the seeded **sessions**. Those were gated on `import.meta.env.DEV`, so a normal production build hit a login wall on every account-gated app (Birdy, Photogram, Cherry, DarkChat).

## What changed

`web/src/core/demo.ts` exports `useMocks`, true in `npm run dev` and when `VITE_DEMO=1`. Five session gates now read it instead of `import.meta.env.DEV`:

| File | Gate |
|---|---|
| `stores/authStore.ts` | `isAuthed()` bypass |
| `core/accountsApi.ts` | seeded account session |
| `apps/birdy/birdyApi.ts` | `devLoggedIn` |
| `apps/ryde/data.ts` | seeded rides + driver profile |
| `main.tsx` | setup/cookie seeds |

The four floating debug buttons in `App.tsx` and the Clock dev toggle **deliberately stay** on `import.meta.env.DEV`, so they never reach the public build.

## Two things worth a look

**Separate output directory.** `build:demo` writes to `web/build-demo/`, not `web/build/`. The demo bypasses the account gates, so it must never end up as the bundle the game serves — sharing an `outDir` with `emptyOutDir: true` would have silently swapped it on the next build.

**Seeds are now write-if-absent.** `main.tsx` previously stomped `sd-phone:setup:v1` on every load, which fought the existing "Show Setup" debug button (toggle it, reload, and it was forced back to completed). It now only writes when the key is missing, so clearing a key replays that flow.

## Verification

- `tsc --noEmit` clean
- `eslint src` — 0 errors (29 pre-existing warnings, unchanged)
- `vitest run` — 137/137 pass
- `knip` clean
- `vite build --mode demo` succeeds into `web/build-demo/`
- Playwright against the demo build: boots to the lockscreen with mock notifications, **no debug buttons**, and `postMessage({action:'sd-phone:launchApp',data:{id:'birdy'}})` opens Birdy straight into a logged-in feed rather than the auth wall.

Nothing in the game path changes: without `VITE_DEMO`, `useMocks` collapses to `import.meta.env.DEV`, which is exactly the previous behaviour.