### PR TITLE
docs: say what the phone actually ships in the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # sd-phone (THIS IS A BETA RELEASE, WILL HAVE ISSUES)
 
-**An iOS-themed smartphone for FiveM. 45+ server-backed apps, real app accounts, a live game-view camera, online multiplayer games, and drop-in lb-phone compatibility.**
+**An iOS-themed smartphone for FiveM.** 45+ server-backed apps, real app accounts, a live game-view camera and online multiplayer games. Ships eight phone items in eight colours, each tinting the on-screen frame and the in-hand prop it is held with, plus optional unique phones where every handset keeps its own data and numbers ride on SIM card items.
+
+**A drop-in lb-phone replacement.** Scripts and custom apps written against lb-phone's exports and events keep running unmodified, and a first-boot migration carries your players across rather than resetting them: phone numbers and lock passcodes, contacts, call history, blocked numbers, SMS threads including groups, photos and albums, and notes.
 
 [![Live demo](https://img.shields.io/badge/Live%20demo-try%20it%20in%20your%20browser-F0E155?style=for-the-badge)](https://fivem.samueldev.shop/phone)
 
@@ -24,14 +26,6 @@
 Thanks for trying this so early. I'd put the phone at about 90% done as of writing, so expect rough edges and a few gaps. Some apps are still mock-only or not fully wired up yet (Vibez, for example, has no backend at this point and only a mock frontend), and there's a good amount of polish and fixes left across the board
 
 Any issues or PRs are highly appreciated. Ohhh and please ⭐the repo! :)
-
-## Try it first
-
-**[Open the live demo →](https://fivem.samueldev.shop/phone)**
-
-The real phone UI, running in your browser on sample data. No download, no server, no account: unlock it, open apps, install more from the in-phone App Store, send yourself a notification, change the frame colour, run the first-boot setup. It starts with only its base apps installed, exactly like a fresh install in game.
-
-It is the production UI built with `VITE_DEMO=1`, so it runs entirely in your browser and never talks to a server. Your setup choices and installed apps persist in that browser between visits; the demo's Reset button puts it back to a fresh install. Anything genuinely server-backed (real calls, the live game-view camera, player-to-player features) only works in game, so the demo stands in for those with sample data.
 
 ## Preview
 


### PR DESCRIPTION
The intro sold "an iOS-themed smartphone for FiveM" and left the differentiators to be found further down, and "drop-in lb-phone compatibility" was the vaguest claim on the page.

## Intro now names what ships

**Props and colours.** Eight phone items, one per colour, each tinting the on-screen frame *and* the in-hand prop model it is held with (`configs/phone.lua`, props from `sd-phone-props`).

**Unique phones and SIMs.** Described as **optional**, because it is: `configs/uniqueandsim.lua` ships `Enabled = false`. The wording is "optional unique phones where every handset keeps its own data and numbers ride on SIM card items", which matches the default `DataOwner = 'device'` setup without implying the other three modes do not exist.

## lb-phone compatibility now says what it means

Split into the two things it actually covers, taken from `configs/migrate.lua`:

- **Code**: scripts and custom apps written against lb-phone's exports and events keep running unmodified.
- **Data**: a first-boot migration carries players across rather than resetting them, specifically phone numbers and lock passcodes, contacts, call history, blocked numbers, SMS threads including groups, photos and albums, and notes.

## Removed

The `Try it first` section from #128. Three links to the same demo above the fold was excessive; the badge and the `Live demo · Documentation · Store · Discord` line already cover it.

That section also carried caveats (the demo starts with base apps only, server-backed features stand in with sample data). Those are gone with it. Happy to put a one-line version back if the "is the demo broken?" question ever comes up.

## Verification

Rendered through GitHub's markdown API to confirm both paragraphs render as intended inside the centred block. Docs only, no code touched.