### PR TITLE
fix(sim): activate a blank SIM dropped into a phone's tray

### DIFF
--- a/server/sim/inv.lua
+++ b/server/sim/inv.lua
@@ -4,6 +4,8 @@ local config = require 'configs.config'
 local bridge = require 'bridge.server.inventory'
 ---@type table Shared server helpers (server.util): digits/formatNumber.
 local util   = require 'server.util'
+---@type table SIM registry (server.sim.store): mints a number for a blank card dropped in a tray.
+local simStore = require 'server.sim.store'
 
 ---@type table Inv module; the table returned at end of file. SIM-feature glue over the bridge's
 ---slot-level API: find phone items, read/write the SIM number on them, and (container mode)
@@ -56,22 +58,37 @@ end
 
 ---The SIM number installed in one phone row from findPhones, honouring the configured attach
 ---mode: container mode reads the sim_card item inside the phone's SIM tray, metadata mode reads
----the number written onto the phone item itself. Read-only.
+---the number written onto the phone item itself.
+---
+---Container mode activates a blank card found in the tray, because dragging one in is the whole
+---interaction there and nothing else would ever stamp it.
 ---@param source number player server id
 ---@param phone { slot: number, metadata: table }
 ---@return string|nil number bare-digit SIM number, nil when no SIM is installed
 function inv.getSimNumber(source, phone)
     if config.Sim.UseContainers and inv.isOx() then
-        if not phone.metadata or not phone.metadata.container then return nil end
+        local containerId = phone.metadata and phone.metadata.container
+        if not containerId then return nil end
         local items = bridge.containerItems(source, phone.slot)
         if type(items) ~= 'table' then return nil end
+
+        local blank
         for _, item in pairs(items) do
-            if item and item.name == config.Sim.SimItem and item.metadata then
-                local digits = util.digits(item.metadata.number)
+            if item and item.name == config.Sim.SimItem then
+                local digits = util.digits(item.metadata and item.metadata.number)
                 if digits ~= '' then return digits end
+                blank = blank or item
             end
         end
-        return nil
+        if not blank or config.Sim.ActivateBlankSims == false then return nil end
+
+        local number = simStore.create({})
+        if not number then return nil end
+        local metadata = type(blank.metadata) == 'table' and blank.metadata or {}
+        metadata.number      = number
+        metadata.description = ('SIM: %s'):format(util.formatNumber(number))
+        local ok = pcall(function() exports[OX]:SetMetadata(containerId, blank.slot, metadata) end)
+        return ok and number or nil
     end
 
     local digits = util.digits(phone.metadata and phone.metadata.simNumber)


### PR DESCRIPTION
Relates to #127. Left open deliberately, see the merge note.

## What was happening

With unique phones + SIMs in **container mode**, the reporter did exactly what the feature invites: dragged a `sim_card` into the phone's SIM tray and opened the phone. They got the **No SIM Card** screen.

## Why

Blank cards only ever got a number in the usable-item handler:

```lua
inv.registerUsable(config.Sim.SimItem, function(source, itemArg, _invArg, slotArg)
    local slot, number = usedSim(source, itemArg, slotArg)
    local blank = number == nil
    ...
```

That fires when a player **uses** a `sim_card`. In container mode there is no reason to ever use one, since the entire interaction is dragging it into the tray, so a card from a shop, a loot table or an admin spawn stayed blank forever.

`inv.getSimNumber` then found the item in the tray, read an empty `metadata.number` off it, and reported no SIM:

```lua
if item and item.name == config.Sim.SimItem and item.metadata then
    local digits = util.digits(item.metadata.number)
    if digits ~= '' then return digits end   -- blank card falls through
end
return nil
```

On a fresh install **every** card is blank, so this was the default first experience of the feature rather than an edge case. It also explains the empty logs on the issue: nothing errored, the phone correctly reported the state it was given.

## The fix

Container mode now activates a blank card it finds in the tray, minting a number and stamping it onto the item exactly as the used-item path does. Behaviour elsewhere is unchanged:

- a numbered card still returns its number and mints nothing
- `ActivateBlankSims = false` still refuses, and mints nothing
- metadata mode is untouched
- an empty tray, a non-SIM item, or a phone with no container metadata all still return nil

## Verification

No FiveM runtime here, so I exercised the real module under stubs for the inventory bridge, the SIM store and `ox_inventory:SetMetadata`. 13 assertions, all passing:

- numbered SIM returns its number, and mints nothing
- blank SIM activates, and the number is stamped onto the item with the right container id and slot
- a card with `metadata = nil` activates too
- blanks refused when `ActivateBlankSims = false`, nothing minted
- empty tray, non-SIM item and missing container metadata all return nil with no phantom mint

`luac -p` clean. `server/sim/store.lua` has no load-time side effects and is already required by `server/sim/init.lua`, so requiring it from `inv.lua` adds no cycle and no boot ordering change.

## Worth a second opinion

The activation happens inside what was documented as a read-only function. That is deliberate, since all three session resolvers plus the export funnel through it and it is the only place that sees the tray contents, but if you would rather it sat in an explicit step on phone open, say so and I will move it.