### PR TITLE
Migrate lb-phone social, mail, wallet and settings data

### DIFF
--- a/configs/migrate.lua
+++ b/configs/migrate.lua
@@ -30,13 +30,34 @@ return {
 
     -- Per-domain switches, if you want to import only some of it. `numbers` must stay on: every
     -- other domain is keyed off the number -> citizenid resolution it establishes.
+    --
+    -- `reactions` needs `messages` (it attaches to the messages that porter writes) and
+    -- `sessions` needs `photogram` (it links to the accounts that porter creates).
+    --
+    -- lb-phone passwords are bcrypt hashed and cannot be converted to sd-phone's hasher, so
+    -- migrated accounts rely on the pre-seeded sessions to stay signed in. Anyone who logs out
+    -- recovers through the normal in-app password reset.
     domains = {
-        numbers  = true,
-        contacts = true,
-        blocked  = true,
-        calls    = true,
-        messages = true,
-        photos   = true,
-        notes    = true,
+        numbers    = true,
+        contacts   = true,
+        blocked    = true,
+        calls      = true,
+        messages   = true,
+        photos     = true,
+        notes      = true,
+        -- wallpaper, theme, clock format, ringtones, volumes, home-screen layout
+        settings   = true,
+        -- message reactions; needs `messages`
+        reactions  = true,
+        -- Instagram accounts, posts, comments, likes, follows, stories and DMs
+        photogram  = true,
+        -- mail accounts and their received messages
+        mail       = true,
+        -- wallet transaction history
+        wallet     = true,
+        -- voice memo recordings
+        voicememos = true,
+        -- keeps players signed into their migrated accounts; needs `photogram`, runs last
+        sessions   = true,
     },
 }

--- a/server/banking/store.lua
+++ b/server/banking/store.lua
@@ -1,3 +1,6 @@
+---@type table Shared server helpers (server.util): schema back-fill helpers.
+local util = require 'server.util'
+
 ---@type table Store module; the table returned at end of file.
 local store = {}
 
@@ -17,6 +20,13 @@ function store.ensureSchema()
             KEY `created_at` (`created_at`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
     ]])
+
+    -- The primary key is an auto-increment, so INSERT IGNORE has nothing to collide with and a
+    -- repeated lb-phone import would duplicate every row. `src_id` carries the source row's
+    -- identity and is unique; rows created in-game leave it NULL, and a unique index permits
+    -- any number of NULLs.
+    util.ensureColumns('phone_bank_transactions', { src_id = 'src_id VARCHAR(32) NULL' })
+    util.ensureUniqueIndex('phone_bank_transactions', 'uq_bank_tx_src', '(src_id)')
 end
 
 ---Appends one transaction row. `amount` is a signed whole-currency value: negative = outflow,

--- a/server/mail/store.lua
+++ b/server/mail/store.lua
@@ -146,6 +146,10 @@ end
 
 ---Creates the single Mail table idempotently. Run once at boot. lb-phone's mail app uses the
 ---same table name with a different shape; such a table is moved aside first.
+---@type fun(): integer, integer Public alias so the lb-phone importer can rebuild the index right
+---after it writes logged_in_citizens, instead of leaving mail signed out until the next boot.
+store.reconcileSessions = reconcileSessions
+
 function store.ensureSchema()
     util.rescueLegacyTable('phone_mail_accounts', 'password_hash')
 

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -24,6 +24,8 @@ local PORTS = {
     { key = 'mail',      label = 'mail',      run = require('server.migrate.port.mail').run },
     { key = 'wallet',    label = 'wallet',    run = require('server.migrate.port.wallet').run },
     { key = 'voicememos', label = 'voicememos', run = require('server.migrate.port.voicememos').run },
+    -- Last: links sessions to the accounts the photogram porter created.
+    { key = 'sessions',  label = 'sessions',  run = require('server.migrate.port.sessions').run },
 }
 
 -- sd-phone tables the porters write into; the migration waits for all of them. Names lb-phone

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -1,13 +1,19 @@
 ---@type table Boot orchestration for the lb-phone import (server.migrate.init). Runs each domain
----porter once when lb-phone tables are present and the import has not already run, records a
----completion marker, and registers `sdphone:migrate [dry]` for manual runs.
+---porter once, marking domains done individually so a later version imports only what it added,
+---and registers `sdphone:migrate [dry]` for manual runs.
 local config    = require 'configs.config'
 local framework = require 'bridge.shared.framework'
 local store     = require 'server.migrate.store'
 local identity  = require 'server.migrate.identity'
+local plan      = require 'server.migrate.plan'
 
----@type string Marker name.
-local MIGRATION = 'lbphone-import-v2'
+---@type string Whole-import marker written before domains were marked individually.
+local LEGACY_MIGRATION = 'lbphone-import-v1'
+
+---@type string[] Domains that the legacy marker covered, backfilled so they are not re-run.
+local LEGACY_DOMAINS = {
+    'numbers', 'contacts', 'blocked', 'calls', 'messages', 'photos', 'notes',
+}
 
 ---@type { key: string, label: string, run: fun(ctx: table): table }[] Domains, in run order.
 local PORTS = {
@@ -50,59 +56,151 @@ local TARGETS = {
 ---@param msg string
 local function log(msg) print(('^5[sd-phone:migrate]^0 %s'):format(msg)) end
 
----Runs the import. `force` ignores the completed marker; `dryRun` counts without writing.
+---A porter's counts as `5 imported, 2 skipped`, ordered so the headline number reads first.
+---@param res table counts returned by a porter
+---@return string
+local function describe(res)
+    if type(res) ~= 'table' then return 'done' end
+    local order = {
+        'imported', 'accounts', 'profiles', 'posts', 'written', 'messages', 'sessions',
+        'comments', 'likes', 'commentLikes', 'follows', 'stories', 'views', 'dms',
+        'notifications', 'deferred', 'set', 'conflict', 'skipped',
+    }
+    local seen, parts = {}, {}
+    for _, key in ipairs(order) do
+        local v = res[key]
+        if type(v) == 'number' and v > 0 then
+            seen[key] = true
+            parts[#parts + 1] = ('%d %s'):format(v, key)
+        end
+    end
+    for key, v in pairs(res) do
+        if not seen[key] and type(v) == 'number' and v > 0 then
+            parts[#parts + 1] = ('%d %s'):format(v, key)
+        end
+    end
+    if #parts == 0 then return 'nothing to import' end
+    return table.concat(parts, ', ')
+end
+
+---Elapsed seconds since a GetGameTimer() reading, to one decimal.
+---@param since integer
+---@return string
+local function elapsed(since) return ('%.1fs'):format((GetGameTimer() - since) / 1000) end
+
+---Runs the import. `force` re-runs domains already marked done; `dryRun` counts without writing.
 ---@param opts { force?: boolean, dryRun?: boolean }
 local function run(opts)
     local cfg = config.Migrate or {}
     local dryRun = opts.dryRun or cfg.dryRun or false
+    local startedAt = GetGameTimer()
+
+    log('==================== lb-phone import ====================')
+    if dryRun then log('^3DRY RUN: counting only, nothing will be written.^0') end
 
     if not store.tableExists(store.lbTable('phones')) then
-        log('no lb-phone tables found, nothing to import.')
+        log('no lb-phone tables found in this database, nothing to import.')
+        log('=========================================================')
         return
     end
 
     store.ensureMarkerTable()
-    if not opts.force and store.migrationDone(MIGRATION) then
-        log('already imported (marker present). Run `sdphone:migrate` from the console to force.')
+
+    -- Installs that finished the pre-domain-marker import get their domains backfilled, so only
+    -- the domains added since actually run.
+    if store.backfillLegacyDomains(LEGACY_MIGRATION, LEGACY_DOMAINS) then
+        log(('found a completed %s import; its %d domains are marked done.')
+            :format(LEGACY_MIGRATION, #LEGACY_DOMAINS))
+    end
+
+    local split = plan.build(PORTS, store.completedDomains(), cfg.domains, opts.force)
+    local queue = split.queue
+
+    if #queue == 0 then
+        log(('nothing to do: %d domains already imported, %d disabled in configs/migrate.lua.')
+            :format(#split.alreadyDone, #split.disabled))
+        log('run `sdphone:migrate` from the server console to force a re-import.')
+        log('=========================================================')
         return
+    end
+
+    local names = {}
+    for i, port in ipairs(queue) do names[i] = port.key end
+    log(('%d domains to import: %s'):format(#queue, table.concat(names, ', ')))
+    if #split.alreadyDone > 0 then
+        log(('already imported, skipping: %s'):format(table.concat(split.alreadyDone, ', ')))
+    end
+    if #split.disabled > 0 then
+        log(('disabled in configs/migrate.lua: %s'):format(table.concat(split.disabled, ', ')))
     end
 
     -- Up to 2 minutes: on a large lb-phone database the schema bootstrap has to rename the
     -- colliding lb tables and convert collations before the markers appear.
+    log('waiting for sd-phone tables to be ready...')
     if not store.waitForTables(TARGETS, 240, 500) then
-        log('^1sd-phone tables not ready in time, aborting import.^0')
+        log('^1sd-phone tables not ready in time, aborting import. Nothing was written.^0')
+        log('^1this usually means another resource is still creating them; restart sd-phone.^0')
+        log('=========================================================')
         return
     end
 
     local ctx = identity.build(cfg, framework)
     ctx.dryRun = dryRun
     local s = ctx.stats
-    log(('%slb-phone found: %d phones -> %d resolved, %d unresolved, %d ambiguous'):format(
-        dryRun and '[DRY RUN] ' or '', s.total, s.resolved, s.unresolved, s.ambiguous))
+    log(('matching players: %d lb-phone phones -> %d resolved, %d unresolved, %d ambiguous')
+        :format(s.total, s.resolved, s.unresolved, s.ambiguous))
 
-    local stats = {}
-    for _, port in ipairs(PORTS) do
-        if not cfg.domains or cfg.domains[port.key] ~= false then
-            local ok, res = pcall(port.run, ctx)
-            if ok then
-                stats[port.key] = res
-                log((' - %-9s %s'):format(port.label, json.encode(res)))
-            else
-                log((' - %-9s ^1failed:^0 %s'):format(port.label, res))
-            end
+    local unmatched = s.unresolved + s.ambiguous
+    if s.total > 0 and unmatched > 0 then
+        local pct = unmatched / s.total * 100
+        local line = ('^3%d of %d phones (%.1f%%) could not be matched to a character; their data is skipped.^0')
+            :format(unmatched, s.total, pct)
+        log(line)
+        if pct >= 25 then
+            log('^1that is a high proportion. Check configs/migrate.lua identifierMode before continuing.^0')
+        end
+    end
+    if s.resolved == 0 then
+        log('^1no phones matched any character, so every domain would import nothing. Aborting.^0')
+        log('=========================================================')
+        return
+    end
+
+    local okCount, failed = 0, {}
+    for _, port in ipairs(queue) do
+        local at = GetGameTimer()
+        local ok, res = pcall(port.run, ctx)
+        if ok then
+            okCount = okCount + 1
+            log((' -> %-11s %s (%s)'):format(port.label, describe(res), elapsed(at)))
+            if not dryRun then store.recordDomain(port.key, res) end
+        else
+            failed[#failed + 1] = port.key
+            log((' -> %-11s ^1FAILED:^0 %s'):format(port.label, tostring(res)))
         end
     end
 
-    if not dryRun then store.recordMigration(MIGRATION, stats) end
-    log(('%simport complete.'):format(dryRun and '[DRY RUN] no data was written. ' or ''))
+    log('=========================================================')
+    log(('import finished in %s: %d ok, %d failed.'):format(elapsed(startedAt), okCount, #failed))
+    if dryRun then
+        log('^3DRY RUN: no data was written and no domain was marked done.^0')
+    elseif #failed > 0 then
+        log(('^1%d domain(s) failed and were not marked done: %s^0')
+            :format(#failed, table.concat(failed, ', ')))
+        log('^1they will be retried automatically on the next start.^0')
+    end
+    log('=========================================================')
 end
 
--- Boot: runs once automatically when enabled.
+-- Boot: imports any domain not yet marked done. Adding a porter later means only that porter runs.
 CreateThread(function()
     local cfg = config.Migrate
     if not cfg or cfg.enabled == false then return end
     local ok, err = pcall(run, { force = false, dryRun = false })
-    if not ok then log(('^1import crashed:^0 %s'):format(err)) end
+    if not ok then
+        log(('^1import crashed:^0 %s'):format(err))
+        log('^1no domain was marked done, so the import retries on the next start.^0')
+    end
 end)
 
 -- Manual trigger from the server console only (source 0): `sdphone:migrate` runs it for real,

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -20,6 +20,7 @@ local PORTS = {
     { key = 'notes',    label = 'notes',    run = require('server.migrate.port.notes').run },
     { key = 'settings', label = 'settings', run = require('server.migrate.port.settings').run },
     { key = 'photogram', label = 'photogram', run = require('server.migrate.port.photogram').run },
+    { key = 'mail',      label = 'mail',      run = require('server.migrate.port.mail').run },
 }
 
 -- sd-phone tables the porters write into; the migration waits for all of them. Names lb-phone
@@ -35,6 +36,7 @@ local TARGETS = {
     'phone_photogram_likes', 'phone_photogram_comment_likes', 'phone_photogram_follows',
     'phone_photogram_stories', 'phone_photogram_story_views', 'phone_photogram_dms',
     'phone_photogram_notifications', 'phone_app_accounts', 'phone_app_sessions',
+    { 'phone_mail_accounts', 'password_hash' },
 }
 
 ---Print a namespaced migration log line.

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -16,11 +16,14 @@ local PORTS = {
     { key = 'blocked',  label = 'blocked',  run = require('server.migrate.port.blocked').run },
     { key = 'calls',    label = 'calls',    run = require('server.migrate.port.calls').run },
     { key = 'messages', label = 'messages', run = require('server.migrate.port.messages').run },
+    { key = 'reactions', label = 'reactions', run = require('server.migrate.port.reactions').run },
     { key = 'photos',   label = 'photos',   run = require('server.migrate.port.photos').run },
     { key = 'notes',    label = 'notes',    run = require('server.migrate.port.notes').run },
     { key = 'settings', label = 'settings', run = require('server.migrate.port.settings').run },
     { key = 'photogram', label = 'photogram', run = require('server.migrate.port.photogram').run },
     { key = 'mail',      label = 'mail',      run = require('server.migrate.port.mail').run },
+    { key = 'wallet',    label = 'wallet',    run = require('server.migrate.port.wallet').run },
+    { key = 'voicememos', label = 'voicememos', run = require('server.migrate.port.voicememos').run },
 }
 
 -- sd-phone tables the porters write into; the migration waits for all of them. Names lb-phone
@@ -36,7 +39,8 @@ local TARGETS = {
     'phone_photogram_likes', 'phone_photogram_comment_likes', 'phone_photogram_follows',
     'phone_photogram_stories', 'phone_photogram_story_views', 'phone_photogram_dms',
     'phone_photogram_notifications', 'phone_app_accounts', 'phone_app_sessions',
-    { 'phone_mail_accounts', 'password_hash' },
+    { 'phone_mail_accounts', 'password_hash' }, { 'phone_message_reactions', 'mid' },
+    'phone_bank_transactions', 'phone_voice_memos',
 }
 
 ---Print a namespaced migration log line.

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -7,7 +7,7 @@ local store     = require 'server.migrate.store'
 local identity  = require 'server.migrate.identity'
 
 ---@type string Marker name.
-local MIGRATION = 'lbphone-import-v1'
+local MIGRATION = 'lbphone-import-v2'
 
 ---@type { key: string, label: string, run: fun(ctx: table): table }[] Domains, in run order.
 local PORTS = {

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -11,21 +11,22 @@ local MIGRATION = 'lbphone-import-v2'
 
 ---@type { key: string, label: string, run: fun(ctx: table): table }[] Domains, in run order.
 local PORTS = {
-    { key = 'numbers',  label = 'numbers',  run = require('server.migrate.port.numbers').run },
-    { key = 'contacts', label = 'contacts', run = require('server.migrate.port.contacts').run },
-    { key = 'blocked',  label = 'blocked',  run = require('server.migrate.port.blocked').run },
-    { key = 'calls',    label = 'calls',    run = require('server.migrate.port.calls').run },
-    { key = 'messages', label = 'messages', run = require('server.migrate.port.messages').run },
-    { key = 'reactions', label = 'reactions', run = require('server.migrate.port.reactions').run },
-    { key = 'photos',   label = 'photos',   run = require('server.migrate.port.photos').run },
-    { key = 'notes',    label = 'notes',    run = require('server.migrate.port.notes').run },
-    { key = 'settings', label = 'settings', run = require('server.migrate.port.settings').run },
-    { key = 'photogram', label = 'photogram', run = require('server.migrate.port.photogram').run },
-    { key = 'mail',      label = 'mail',      run = require('server.migrate.port.mail').run },
-    { key = 'wallet',    label = 'wallet',    run = require('server.migrate.port.wallet').run },
+    { key = 'numbers',    label = 'numbers',    run = require('server.migrate.port.numbers').run },
+    { key = 'contacts',   label = 'contacts',   run = require('server.migrate.port.contacts').run },
+    { key = 'blocked',    label = 'blocked',    run = require('server.migrate.port.blocked').run },
+    { key = 'calls',      label = 'calls',      run = require('server.migrate.port.calls').run },
+    { key = 'messages',   label = 'messages',   run = require('server.migrate.port.messages').run },
+    -- After messages: joins on the `m<id>` mid values that porter writes.
+    { key = 'reactions',  label = 'reactions',  run = require('server.migrate.port.reactions').run },
+    { key = 'photos',     label = 'photos',     run = require('server.migrate.port.photos').run },
+    { key = 'notes',      label = 'notes',      run = require('server.migrate.port.notes').run },
+    { key = 'settings',   label = 'settings',   run = require('server.migrate.port.settings').run },
+    { key = 'photogram',  label = 'photogram',  run = require('server.migrate.port.photogram').run },
+    { key = 'mail',       label = 'mail',       run = require('server.migrate.port.mail').run },
+    { key = 'wallet',     label = 'wallet',     run = require('server.migrate.port.wallet').run },
     { key = 'voicememos', label = 'voicememos', run = require('server.migrate.port.voicememos').run },
     -- Last: links sessions to the accounts the photogram porter created.
-    { key = 'sessions',  label = 'sessions',  run = require('server.migrate.port.sessions').run },
+    { key = 'sessions',   label = 'sessions',   run = require('server.migrate.port.sessions').run },
 }
 
 -- sd-phone tables the porters write into; the migration waits for all of them. Names lb-phone

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -18,6 +18,7 @@ local PORTS = {
     { key = 'messages', label = 'messages', run = require('server.migrate.port.messages').run },
     { key = 'photos',   label = 'photos',   run = require('server.migrate.port.photos').run },
     { key = 'notes',    label = 'notes',    run = require('server.migrate.port.notes').run },
+    { key = 'settings', label = 'settings', run = require('server.migrate.port.settings').run },
 }
 
 -- sd-phone tables the porters write into; the migration waits for all of them. Names lb-phone

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -19,6 +19,7 @@ local PORTS = {
     { key = 'photos',   label = 'photos',   run = require('server.migrate.port.photos').run },
     { key = 'notes',    label = 'notes',    run = require('server.migrate.port.notes').run },
     { key = 'settings', label = 'settings', run = require('server.migrate.port.settings').run },
+    { key = 'photogram', label = 'photogram', run = require('server.migrate.port.photogram').run },
 }
 
 -- sd-phone tables the porters write into; the migration waits for all of them. Names lb-phone
@@ -30,6 +31,10 @@ local TARGETS = {
     { 'phone_messages', 'citizenid' }, 'phone_message_groups', 'phone_message_group_members',
     { 'phone_photos', 'citizenid' }, { 'phone_photo_albums', 'citizenid' },
     'phone_photo_album_items', { 'phone_notes', 'citizenid' },
+    'phone_photogram_profiles', 'phone_photogram_posts', 'phone_photogram_comments',
+    'phone_photogram_likes', 'phone_photogram_comment_likes', 'phone_photogram_follows',
+    'phone_photogram_stories', 'phone_photogram_story_views', 'phone_photogram_dms',
+    'phone_photogram_notifications', 'phone_app_accounts', 'phone_app_sessions',
 }
 
 ---Print a namespaced migration log line.

--- a/server/migrate/plan.lua
+++ b/server/migrate/plan.lua
@@ -1,0 +1,29 @@
+---@type table Import planner (server.migrate.plan). Decides which domains run on this start, given
+---what is already marked done and what the config disables.
+local plan = {}
+
+---Splits the porter list into the domains to run now, those already imported, and those turned off
+---in the config. `force` ignores the completed set so every enabled domain runs again.
+---@param ports { key: string, label: string }[] porters in run order
+---@param done table<string, boolean> domain keys already imported
+---@param domains table<string, boolean>|nil config.Migrate.domains
+---@param force boolean|nil re-run domains already marked done
+---@return { queue: table[], alreadyDone: string[], disabled: string[] }
+function plan.build(ports, done, domains, force)
+    local queue, alreadyDone, disabled = {}, {}, {}
+    done = done or {}
+
+    for _, port in ipairs(ports) do
+        if domains and domains[port.key] == false then
+            disabled[#disabled + 1] = port.key
+        elseif not force and done[port.key] then
+            alreadyDone[#alreadyDone + 1] = port.key
+        else
+            queue[#queue + 1] = port
+        end
+    end
+
+    return { queue = queue, alreadyDone = alreadyDone, disabled = disabled }
+end
+
+return plan

--- a/server/migrate/port/blocked.lua
+++ b/server/migrate/port/blocked.lua
@@ -9,7 +9,7 @@ local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 ---@param ctx table migration context (numberToCid, dryRun)
 ---@return { migrated: number, skipped: number }
 function M.run(ctx)
-    if not store.tableExists(store.lbTable('phone_blocked_numbers')) then return { migrated = 0, skipped = 0 } end
+    if not store.lbSource('phone_blocked_numbers') then return { migrated = 0, skipped = 0 } end
 
     local rows, migrated, skipped = {}, 0, 0
     for _, b in ipairs(store.lbBlocked()) do

--- a/server/migrate/port/calls.lua
+++ b/server/migrate/port/calls.lua
@@ -11,7 +11,7 @@ local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 ---@param ctx table migration context (numberToCid, dryRun)
 ---@return { migrated: number, skipped: number }
 function M.run(ctx)
-    if not store.tableExists(store.lbTable('phone_calls')) then return { migrated = 0, skipped = 0 } end
+    if not store.lbSource('phone_calls') then return { migrated = 0, skipped = 0 } end
 
     local rows, migrated, skipped = {}, 0, 0
     for _, c in ipairs(store.lbCalls()) do

--- a/server/migrate/port/contacts.lua
+++ b/server/migrate/port/contacts.lua
@@ -21,7 +21,7 @@ end
 ---@param ctx table migration context (numberToCid, dryRun)
 ---@return { migrated: number, skipped: number }
 function M.run(ctx)
-    if not store.tableExists(store.lbTable('phone_contacts')) then return { migrated = 0, skipped = 0 } end
+    if not store.lbSource('phone_contacts') then return { migrated = 0, skipped = 0 } end
 
     local seen = store.existingContactKeys()
     local rows, migrated, skipped = {}, 0, 0

--- a/server/migrate/port/mail.lua
+++ b/server/migrate/port/mail.lua
@@ -1,0 +1,82 @@
+---@type table Mail porter (server.migrate.port.mail). Copies lb-phone mail accounts across and
+---folds each account's received messages into sd-phone's JSON messages column. Also owns mail
+---login state, read from lb's logged-in accounts table.
+local M = {}
+
+---@type table Migration data layer (server.migrate.store).
+local store = require 'server.migrate.store'
+
+local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
+
+---The local part of an address, used as the display name lb-phone does not store.
+---@param address string
+---@return string
+local function localPart(address)
+    local name = tostring(address or ''):match('^([^@]+)') or 'Mail'
+    return name:sub(1, 64)
+end
+
+---@param ctx table migration context (numberToCid, dryRun)
+---@return { accounts: number, messages: number, sessions: number, skipped: number }
+function M.run(ctx)
+    local out = { accounts = 0, messages = 0, sessions = 0, skipped = 0 }
+    if not store.tableExists(store.lbTable('mail_accounts')) then return out end
+
+    local inbox, logins = {}, {}
+    local accounts = store.lbMailAccounts()
+    for _, a in ipairs(accounts) do
+        inbox[a.address] = {}
+        logins[a.address] = {}
+    end
+
+    if store.tableExists(store.lbTable('mail_messages')) then
+        for _, m in ipairs(store.lbMailMessages()) do
+            local box = inbox[m.recipient]
+            if box then
+                box[#box + 1] = {
+                    id = tostring(m.id),
+                    sender = m.sender,
+                    subject = m.subject,
+                    message = m.content,
+                    attachments = m.attachments,
+                    actions = m.actions,
+                    read = m.read and true or false,
+                    date = math.floor(tonumber(m.ts) or 0),
+                }
+                out.messages = out.messages + 1
+            else
+                out.skipped = out.skipped + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('logged_in_accounts')) then
+        for _, l in ipairs(store.lbLoggedIn()) do
+            if l.app == 'mail' then
+                local cid = ctx.numberToCid[digits(l.phone_number)]
+                local box = logins[l.username]
+                if cid and box then
+                    box[#box + 1] = cid
+                    out.sessions = out.sessions + 1
+                end
+            end
+        end
+    end
+
+    local rows = {}
+    for _, a in ipairs(accounts) do
+        rows[#rows + 1] = {
+            tostring(a.address):sub(1, 64),
+            tostring(a.password or ''):sub(1, 255),
+            localPart(a.address),
+            store.encodeJson(inbox[a.address]) or '[]',
+            store.encodeJson(logins[a.address]) or '[]',
+        }
+        out.accounts = out.accounts + 1
+    end
+
+    if not ctx.dryRun then store.insertMailAccounts(rows) end
+    return out
+end
+
+return M

--- a/server/migrate/port/mail.lua
+++ b/server/migrate/port/mail.lua
@@ -5,6 +5,8 @@ local M = {}
 
 ---@type table Migration data layer (server.migrate.store).
 local store = require 'server.migrate.store'
+---@type table Mail persistence (server.mail.store): its session index reconciler.
+local mailStore = require 'server.mail.store'
 
 local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 
@@ -20,7 +22,8 @@ end
 ---@return { accounts: number, messages: number, sessions: number, skipped: number }
 function M.run(ctx)
     local out = { accounts = 0, messages = 0, sessions = 0, skipped = 0 }
-    if not store.tableExists(store.lbTable('mail_accounts')) then return out end
+    -- `address` only exists on lb-phone's shape; sd-phone's own table uses `email`.
+    if not store.lbSource('mail_accounts', 'address') then return out end
 
     local inbox, logins = {}, {}
     local accounts = store.lbMailAccounts()
@@ -29,7 +32,7 @@ function M.run(ctx)
         logins[a.address] = {}
     end
 
-    if store.tableExists(store.lbTable('mail_messages')) then
+    if store.lbSource('mail_messages') then
         for _, m in ipairs(store.lbMailMessages()) do
             local box = inbox[m.recipient]
             if box then
@@ -50,7 +53,7 @@ function M.run(ctx)
         end
     end
 
-    if store.tableExists(store.lbTable('logged_in_accounts')) then
+    if store.lbSource('logged_in_accounts') then
         for _, l in ipairs(store.lbLoggedIn()) do
             if l.app == 'mail' then
                 local cid = ctx.numberToCid[digits(l.phone_number)]
@@ -75,7 +78,13 @@ function M.run(ctx)
         out.accounts = out.accounts + 1
     end
 
-    if not ctx.dryRun then store.insertMailAccounts(rows) end
+    if not ctx.dryRun then
+        store.insertMailAccounts(rows)
+        -- The session index is derived from logged_in_citizens and is normally rebuilt at boot,
+        -- which has already happened by the time the import runs. Rebuild it now so migrated
+        -- players are signed into mail immediately rather than after the next restart.
+        if out.sessions > 0 then pcall(mailStore.reconcileSessions) end
+    end
     return out
 end
 

--- a/server/migrate/port/messages.lua
+++ b/server/migrate/port/messages.lua
@@ -54,7 +54,7 @@ end
 ---@param ctx table migration context (numberToCid, dryRun)
 ---@return { migrated: number, skipped: number, groups: number }
 function M.run(ctx)
-    if not store.tableExists(store.lbTable('message_channels')) then
+    if not store.lbSource('message_channels') then
         return { migrated = 0, skipped = 0, groups = 0 }
     end
 

--- a/server/migrate/port/notes.lua
+++ b/server/migrate/port/notes.lua
@@ -11,7 +11,7 @@ local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 ---@param ctx table migration context (numberToCid, dryRun)
 ---@return { migrated: number, skipped: number }
 function M.run(ctx)
-    if not store.tableExists(store.lbTable('notes')) then return { migrated = 0, skipped = 0 } end
+    if not store.lbSource('notes', 'phone_number') then return { migrated = 0, skipped = 0 } end
 
     local rows, migrated, skipped = {}, 0, 0
     for _, n in ipairs(store.lbNotes()) do

--- a/server/migrate/port/photogram.lua
+++ b/server/migrate/port/photogram.lua
@@ -1,0 +1,182 @@
+---@type table Photogram porter (server.migrate.port.photogram). Copies lb-phone's Instagram
+---accounts and content into Photogram. Content is username-keyed on both sides so it copies
+---without identity resolution; only the accounts-engine session needs a citizenid.
+local M = {}
+
+---@type table Migration data layer (server.migrate.store).
+local store = require 'server.migrate.store'
+---@type table Shared server helpers (server.util).
+local util  = require 'server.util'
+
+---@type string Id prefix, keeping migrated ids clear of natively generated 7-char base36 ids.
+local P = 'i'
+
+local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
+local function id(v) return P .. tostring(v) end
+local function ts(v) return math.floor(tonumber(v) or 0) end
+local function bit(v) return util.truthy(v) and 1 or 0 end
+
+---A string capped at `len`, nil when absent or empty.
+---@param v any
+---@param len integer
+---@return string|nil
+local function str(v, len)
+    if v == nil then return nil end
+    local s = tostring(v)
+    if s == '' then return nil end
+    return s:sub(1, len)
+end
+
+---@param ctx table migration context (numberToCid, dryRun)
+---@return table counts
+function M.run(ctx)
+    local out = {
+        profiles = 0, posts = 0, comments = 0, likes = 0, commentLikes = 0, follows = 0,
+        stories = 0, views = 0, dms = 0, notifications = 0, accounts = 0, skipped = 0,
+    }
+    local profiles, accounts, sessions = {}, {}, {}
+    local posts, comments, likes, commentLikes = {}, {}, {}, {}
+    local follows, stories, views, dms, notifs = {}, {}, {}, {}, {}
+
+    local taken = store.existingPhotogramUsernames()
+    local known = {}
+
+    if store.tableExists(store.lbTable('instagram_accounts')) then
+        for _, a in ipairs(store.lbIgAccounts()) do
+            local user = str(a.username, 64)
+            if user and not taken[user] then
+                known[user] = true
+                profiles[#profiles + 1] = {
+                    user, str(a.display_name, 64) or user, str(a.bio, 200) or '',
+                    str(a.profile_image, 512), bit(a.private), bit(a.verified), ts(a.ts),
+                }
+                out.profiles = out.profiles + 1
+
+                accounts[#accounts + 1] = {
+                    'photogram', user, str(a.display_name, 50) or user, str(a.password, 64) or '',
+                }
+                local cid = ctx.numberToCid[digits(a.phone_number)]
+                if cid then
+                    sessions[#sessions + 1] = { 'photogram', cid, user }
+                    out.accounts = out.accounts + 1
+                end
+            else
+                out.skipped = out.skipped + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_posts')) then
+        for _, p in ipairs(store.lbIgPosts()) do
+            if known[p.username] then
+                posts[#posts + 1] = {
+                    id(p.id), p.username, p.media, str(p.caption, 2200) or '',
+                    str(p.location, 120), ts(p.ts),
+                }
+                out.posts = out.posts + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_comments')) then
+        for _, c in ipairs(store.lbIgComments()) do
+            if known[c.username] then
+                comments[#comments + 1] = {
+                    id(c.id), id(c.post_id), c.username, str(c.comment, 1000), nil, ts(c.ts),
+                }
+                out.comments = out.comments + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_likes')) then
+        for _, l in ipairs(store.lbIgLikes()) do
+            if known[l.username] then
+                if util.truthy(l.is_comment) then
+                    commentLikes[#commentLikes + 1] = { id(l.id), l.username, 0 }
+                    out.commentLikes = out.commentLikes + 1
+                else
+                    likes[#likes + 1] = { id(l.id), l.username, 0 }
+                    out.likes = out.likes + 1
+                end
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_follows')) then
+        for _, f in ipairs(store.lbIgFollows()) do
+            if known[f.follower] and known[f.followed] then
+                follows[#follows + 1] = { f.follower, f.followed, 'accepted', 0 }
+                out.follows = out.follows + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_follow_requests')) then
+        for _, r in ipairs(store.lbIgRequests()) do
+            if known[r.requester] and known[r.requestee] then
+                follows[#follows + 1] = { r.requester, r.requestee, 'pending', ts(r.ts) }
+                out.follows = out.follows + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_stories')) then
+        for _, s in ipairs(store.lbIgStories()) do
+            if known[s.username] and s.image then
+                stories[#stories + 1] = { id(s.id), s.username, str(s.image, 512), ts(s.ts) }
+                out.stories = out.stories + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_stories_views')) then
+        for _, v in ipairs(store.lbIgStoryViews()) do
+            if known[v.username] then
+                views[#views + 1] = { id(v.story_id), v.username, ts(v.ts) }
+                out.views = out.views + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_messages')) then
+        for _, d in ipairs(store.lbIgMessages()) do
+            if known[d.sender] and known[d.recipient] then
+                dms[#dms + 1] = {
+                    id(d.id), d.sender, d.recipient, d.content, 'text', d.attachments, nil, 1, ts(d.ts),
+                }
+                out.dms = out.dms + 1
+            end
+        end
+    end
+
+    if store.tableExists(store.lbTable('instagram_notifications')) then
+        for _, n in ipairs(store.lbIgNotifications()) do
+            if known[n.username] then
+                notifs[#notifs + 1] = {
+                    id(n.id), n.username, str(n.type, 16) or 'like', n.from_user,
+                    n.post_id and id(n.post_id) or nil, 1, ts(n.ts),
+                }
+                out.notifications = out.notifications + 1
+            end
+        end
+    end
+
+    if not ctx.dryRun then
+        store.insertPgProfiles(profiles)
+        store.insertPgAccounts(accounts)
+        store.insertPgPosts(posts)
+        store.insertPgComments(comments)
+        store.insertPgLikes(likes)
+        store.insertPgCommentLikes(commentLikes)
+        store.insertPgFollows(follows)
+        store.insertPgStories(stories)
+        store.insertPgStoryViews(views)
+        store.insertPgDms(dms)
+        store.insertPgNotifications(notifs)
+        store.insertPgSessions(sessions)
+    end
+    return out
+end
+
+return M

--- a/server/migrate/port/photogram.lua
+++ b/server/migrate/port/photogram.lua
@@ -11,7 +11,6 @@ local util  = require 'server.util'
 ---@type string Id prefix, keeping migrated ids clear of natively generated 7-char base36 ids.
 local P = 'i'
 
-local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 local function id(v) return P .. tostring(v) end
 local function ts(v) return math.floor(tonumber(v) or 0) end
 local function bit(v) return util.truthy(v) and 1 or 0 end
@@ -27,21 +26,37 @@ local function str(v, len)
     return s:sub(1, len)
 end
 
----@param ctx table migration context (numberToCid, dryRun)
+---Needs no identity resolution: content is username-keyed on both sides, so it imports whole even
+---when an owner cannot be matched to a character.
+---@param ctx table migration context (dryRun)
 ---@return table counts
 function M.run(ctx)
     local out = {
         profiles = 0, posts = 0, comments = 0, likes = 0, commentLikes = 0, follows = 0,
-        stories = 0, views = 0, dms = 0, notifications = 0, accounts = 0, skipped = 0,
+        stories = 0, views = 0, dms = 0, notifications = 0, accounts = 0, skipped = 0, orphan = 0,
     }
-    local profiles, accounts, sessions = {}, {}, {}
+    local profiles, accounts = {}, {}
     local posts, comments, likes, commentLikes = {}, {}, {}, {}
     local follows, stories, views, dms, notifs = {}, {}, {}, {}, {}
 
     local taken = store.existingPhotogramUsernames()
     local known = {}
+    -- Parents that actually made it across. A child pointing at a row that was never migrated is
+    -- an orphan: sd-phone's own foreign keys either delete it on boot or refuse to install, so it
+    -- must never be written. Same rule photos.lua applies to album links.
+    local postIds, commentIds, storyIds = {}, {}, {}
 
-    if store.tableExists(store.lbTable('instagram_accounts')) then
+    ---Classifies a child row that is not being imported. An account that already existed was
+    ---deliberately left alone, so its content is `skipped`, not lost; only a genuinely missing
+    ---parent is an `orphan`. Without the split, a re-run reports every child as an orphan and
+    ---reads like data loss.
+    ---@param user string|nil the child's author
+    local function drop(user)
+        if user and taken[user] then out.skipped = out.skipped + 1
+        else out.orphan = out.orphan + 1 end
+    end
+
+    if store.lbSource('instagram_accounts') then
         for _, a in ipairs(store.lbIgAccounts()) do
             local user = str(a.username, 64)
             if user and not taken[user] then
@@ -52,23 +67,23 @@ function M.run(ctx)
                 }
                 out.profiles = out.profiles + 1
 
+                -- Accounts only. Who is signed in comes from lb's logged-in state, which the
+                -- sessions porter owns; signing in every account whose phone resolves would sign a
+                -- player into all of their alts.
                 accounts[#accounts + 1] = {
                     'photogram', user, str(a.display_name, 50) or user, str(a.password, 64) or '',
                 }
-                local cid = ctx.numberToCid[digits(a.phone_number)]
-                if cid then
-                    sessions[#sessions + 1] = { 'photogram', cid, user }
-                    out.accounts = out.accounts + 1
-                end
+                out.accounts = out.accounts + 1
             else
                 out.skipped = out.skipped + 1
             end
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_posts')) then
+    if store.lbSource('instagram_posts') then
         for _, p in ipairs(store.lbIgPosts()) do
             if known[p.username] then
+                postIds[id(p.id)] = true
                 posts[#posts + 1] = {
                     id(p.id), p.username, p.media, str(p.caption, 2200) or '',
                     str(p.location, 120), ts(p.ts),
@@ -78,32 +93,35 @@ function M.run(ctx)
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_comments')) then
+    if store.lbSource('instagram_comments') then
         for _, c in ipairs(store.lbIgComments()) do
-            if known[c.username] then
+            if known[c.username] and postIds[id(c.post_id)] then
+                commentIds[id(c.id)] = true
                 comments[#comments + 1] = {
                     id(c.id), id(c.post_id), c.username, str(c.comment, 1000), nil, ts(c.ts),
                 }
                 out.comments = out.comments + 1
+            else
+                drop(c.username)
             end
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_likes')) then
+    if store.lbSource('instagram_likes') then
         for _, l in ipairs(store.lbIgLikes()) do
-            if known[l.username] then
-                if util.truthy(l.is_comment) then
-                    commentLikes[#commentLikes + 1] = { id(l.id), l.username, 0 }
-                    out.commentLikes = out.commentLikes + 1
-                else
-                    likes[#likes + 1] = { id(l.id), l.username, 0 }
-                    out.likes = out.likes + 1
-                end
+            if known[l.username] and util.truthy(l.is_comment) and commentIds[id(l.id)] then
+                commentLikes[#commentLikes + 1] = { id(l.id), l.username, 0 }
+                out.commentLikes = out.commentLikes + 1
+            elseif known[l.username] and not util.truthy(l.is_comment) and postIds[id(l.id)] then
+                likes[#likes + 1] = { id(l.id), l.username, 0 }
+                out.likes = out.likes + 1
+            else
+                drop(l.username)
             end
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_follows')) then
+    if store.lbSource('instagram_follows') then
         for _, f in ipairs(store.lbIgFollows()) do
             if known[f.follower] and known[f.followed] then
                 follows[#follows + 1] = { f.follower, f.followed, 'accepted', 0 }
@@ -112,7 +130,7 @@ function M.run(ctx)
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_follow_requests')) then
+    if store.lbSource('instagram_follow_requests') then
         for _, r in ipairs(store.lbIgRequests()) do
             if known[r.requester] and known[r.requestee] then
                 follows[#follows + 1] = { r.requester, r.requestee, 'pending', ts(r.ts) }
@@ -121,25 +139,28 @@ function M.run(ctx)
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_stories')) then
+    if store.lbSource('instagram_stories') then
         for _, s in ipairs(store.lbIgStories()) do
             if known[s.username] and s.image then
+                storyIds[id(s.id)] = true
                 stories[#stories + 1] = { id(s.id), s.username, str(s.image, 512), ts(s.ts) }
                 out.stories = out.stories + 1
             end
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_stories_views')) then
+    if store.lbSource('instagram_stories_views') then
         for _, v in ipairs(store.lbIgStoryViews()) do
-            if known[v.username] then
+            if known[v.username] and storyIds[id(v.story_id)] then
                 views[#views + 1] = { id(v.story_id), v.username, ts(v.ts) }
                 out.views = out.views + 1
+            else
+                drop(v.username)
             end
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_messages')) then
+    if store.lbSource('instagram_messages') then
         for _, d in ipairs(store.lbIgMessages()) do
             if known[d.sender] and known[d.recipient] then
                 dms[#dms + 1] = {
@@ -150,14 +171,18 @@ function M.run(ctx)
         end
     end
 
-    if store.tableExists(store.lbTable('instagram_notifications')) then
+    if store.lbSource('instagram_notifications') then
         for _, n in ipairs(store.lbIgNotifications()) do
-            if known[n.username] then
+            -- post_id is nullable (a follow notification has none); when set it must point at a
+            -- post that migrated, or the notifications foreign key rejects the row.
+            local post = n.post_id and id(n.post_id) or nil
+            if known[n.username] and (post == nil or postIds[post]) then
                 notifs[#notifs + 1] = {
-                    id(n.id), n.username, str(n.type, 16) or 'like', n.from_user,
-                    n.post_id and id(n.post_id) or nil, 1, ts(n.ts),
+                    id(n.id), n.username, str(n.type, 16) or 'like', n.from_user, post, 1, ts(n.ts),
                 }
                 out.notifications = out.notifications + 1
+            else
+                drop(n.username)
             end
         end
     end
@@ -174,7 +199,6 @@ function M.run(ctx)
         store.insertPgStoryViews(views)
         store.insertPgDms(dms)
         store.insertPgNotifications(notifs)
-        store.insertPgSessions(sessions)
     end
     return out
 end

--- a/server/migrate/port/photos.lua
+++ b/server/migrate/port/photos.lua
@@ -15,7 +15,7 @@ function M.run(ctx)
     local photoIds, albumIds = {}, {}
     local photos, albums, links, skipped = 0, 0, 0, 0
 
-    if store.tableExists(store.lbTable('photos')) then
+    if store.lbSource('photos', 'link') then
         for _, p in ipairs(store.lbPhotos()) do
             local cid = ctx.numberToCid[digits(p.phone_number)]
             if cid and p.link and p.link ~= '' then
@@ -34,7 +34,7 @@ function M.run(ctx)
         end
     end
 
-    if store.tableExists(store.lbTable('photo_albums')) then
+    if store.lbSource('photo_albums', 'title') then
         for _, a in ipairs(store.lbAlbums()) do
             local cid = ctx.numberToCid[digits(a.phone_number)]
             if cid then
@@ -48,7 +48,7 @@ function M.run(ctx)
         end
     end
 
-    if store.tableExists(store.lbTable('photo_album_photos')) then
+    if store.lbSource('photo_album_photos') then
         for _, link in ipairs(store.lbAlbumPhotos()) do
             local aid = albumIds[tostring(link.album_id)]
             local pid = photoIds[tostring(link.photo_id)]

--- a/server/migrate/port/reactions.lua
+++ b/server/migrate/port/reactions.lua
@@ -1,0 +1,35 @@
+---@type table Reactions porter (server.migrate.port.reactions). Attaches lb-phone message
+---reactions to the messages the messages porter already wrote, joining on its `m<id>` mid format.
+local M = {}
+
+---@type table Migration data layer (server.migrate.store).
+local store = require 'server.migrate.store'
+
+local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
+
+---@param ctx table migration context (numberToCid, dryRun)
+---@return { imported: number, skipped: number }
+function M.run(ctx)
+    local rows, imported, skipped = {}, 0, 0
+    if not store.tableExists(store.lbTable('message_reactions')) then
+        return { imported = 0, skipped = 0 }
+    end
+
+    local now = os.time()
+    for _, r in ipairs(store.lbReactions()) do
+        local cid = ctx.numberToCid[digits(r.phone_number)]
+        if cid and r.reaction and r.reaction ~= '' then
+            rows[#rows + 1] = {
+                ('m%s'):format(r.message_id), cid, tostring(r.reaction):sub(1, 32), now,
+            }
+            imported = imported + 1
+        else
+            skipped = skipped + 1
+        end
+    end
+
+    if not ctx.dryRun then store.insertReactions(rows) end
+    return { imported = imported, skipped = skipped }
+end
+
+return M

--- a/server/migrate/port/reactions.lua
+++ b/server/migrate/port/reactions.lua
@@ -11,25 +11,39 @@ local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 ---@return { imported: number, skipped: number }
 function M.run(ctx)
     local rows, imported, skipped = {}, 0, 0
-    if not store.tableExists(store.lbTable('message_reactions')) then
+    -- `reaction` only exists on lb-phone's shape; sd-phone's own table uses `emoji`.
+    if not store.lbSource('message_reactions', 'reaction') then
         return { imported = 0, skipped = 0 }
     end
 
     local now = os.time()
+    local candidates, mids = {}, {}
     for _, r in ipairs(store.lbReactions()) do
         local cid = ctx.numberToCid[digits(r.phone_number)]
         if cid and r.reaction and r.reaction ~= '' then
-            rows[#rows + 1] = {
-                ('m%s'):format(r.message_id), cid, tostring(r.reaction):sub(1, 32), now,
-            }
-            imported = imported + 1
+            local mid = ('m%s'):format(r.message_id)
+            candidates[#candidates + 1] = { mid, cid, tostring(r.reaction):sub(1, 32), now }
+            mids[#mids + 1] = mid
         else
             skipped = skipped + 1
         end
     end
 
+    -- Keep only reactions whose message came across; one attached to a message that was never
+    -- migrated has nothing to render against.
+    local orphan = 0
+    local present = #mids > 0 and store.existingMids(mids) or {}
+    for _, row in ipairs(candidates) do
+        if present[row[1]] then
+            rows[#rows + 1] = row
+            imported = imported + 1
+        else
+            orphan = orphan + 1
+        end
+    end
+
     if not ctx.dryRun then store.insertReactions(rows) end
-    return { imported = imported, skipped = skipped }
+    return { imported = imported, skipped = skipped, orphan = orphan }
 end
 
 return M

--- a/server/migrate/port/sessions.lua
+++ b/server/migrate/port/sessions.lua
@@ -15,7 +15,7 @@ local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 ---@return { written: number, deferred: number, skipped: number }
 function M.run(ctx)
     local rows, written, deferred, skipped = {}, 0, 0, 0
-    if not store.tableExists(store.lbTable('logged_in_accounts')) then
+    if not store.lbSource('logged_in_accounts') then
         return { written = 0, deferred = 0, skipped = 0 }
     end
 
@@ -34,8 +34,20 @@ function M.run(ctx)
         end
     end
 
-    if not ctx.dryRun then store.insertPgSessions(rows) end
-    return { written = written, deferred = deferred, skipped = skipped }
+    local orphan, created = 0, 0
+    if not ctx.dryRun then
+        -- Judge on `linked`, not on rows inserted: a re-run finds every session already present and
+        -- inserts nothing, which is success. Only a failure to resolve any account at all means the
+        -- accounts are missing, so raise and leave the domain unmarked to retry rather than record a
+        -- success that signed nobody in.
+        local linked, inserted = store.insertPgSessions(rows)
+        linked, inserted = linked or 0, inserted or 0
+        if linked == 0 and #rows > 0 then
+            error(('no app accounts found to link %d session(s); photogram may have failed'):format(#rows), 0)
+        end
+        orphan, written, created = written - linked, linked, inserted
+    end
+    return { written = written, created = created, deferred = deferred, skipped = skipped, orphan = orphan }
 end
 
 return M

--- a/server/migrate/port/sessions.lua
+++ b/server/migrate/port/sessions.lua
@@ -1,0 +1,41 @@
+---@type table Sessions porter (server.migrate.port.sessions). Turns lb-phone's logged-in accounts
+---into accounts-engine sessions so migrated players stay signed in. Mail is excluded: the mail
+---porter owns mail login state.
+local M = {}
+
+---@type table Migration data layer (server.migrate.store).
+local store = require 'server.migrate.store'
+
+---@type table<string, string> lb app name -> sd app name.
+local APPS = { instagram = 'photogram', twitter = 'birdy' }
+
+local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
+
+---@param ctx table migration context (numberToCid, dryRun)
+---@return { written: number, deferred: number, skipped: number }
+function M.run(ctx)
+    local rows, written, deferred, skipped = {}, 0, 0, 0
+    if not store.tableExists(store.lbTable('logged_in_accounts')) then
+        return { written = 0, deferred = 0, skipped = 0 }
+    end
+
+    for _, l in ipairs(store.lbLoggedIn()) do
+        local app = APPS[l.app]
+        local cid = ctx.numberToCid[digits(l.phone_number)]
+        if not app or not cid then
+            skipped = skipped + 1
+        elseif app == 'birdy' then
+            -- Squawk is still one account per character; its porter arrives with the
+            -- multi-account refactor and these rows are picked up then.
+            deferred = deferred + 1
+        else
+            rows[#rows + 1] = { app, cid, l.username }
+            written = written + 1
+        end
+    end
+
+    if not ctx.dryRun then store.insertPgSessions(rows) end
+    return { written = written, deferred = deferred, skipped = skipped }
+end
+
+return M

--- a/server/migrate/port/settings.lua
+++ b/server/migrate/port/settings.lua
@@ -1,0 +1,88 @@
+---@type table Settings porter (server.migrate.port.settings). Copies each lb-phone phone's
+---settings blob onto its owner's sd-phone settings row. Fill-only: a value the player has already
+---chosen is never overwritten.
+local M = {}
+
+---@type table Migration data layer (server.migrate.store).
+local store = require 'server.migrate.store'
+
+local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
+
+---A 0-100 integer from an lb 0.0-1.0 float (values above 1 pass through), nil when absent.
+---@param v any
+---@return integer|nil
+local function pct(v)
+    local n = tonumber(v)
+    if not n then return nil end
+    if n <= 1 then n = n * 100 end
+    n = math.floor(n + 0.5)
+    if n < 0 then return 0 end
+    if n > 100 then return 100 end
+    return n
+end
+
+---1/0 for a present boolean, nil when the key was absent.
+---@param v any
+---@return integer|nil
+local function flag(v)
+    if v == nil then return nil end
+    return v and 1 or 0
+end
+
+---A string capped at `len`, nil when absent or empty.
+---@param v any
+---@param len integer
+---@return string|nil
+local function str(v, len)
+    if v == nil then return nil end
+    local s = tostring(v)
+    if s == '' then return nil end
+    return s:sub(1, len)
+end
+
+---@param ctx table migration context (numberToCid, dryRun)
+---@return { imported: number, skipped: number }
+function M.run(ctx)
+    local rows, imported, skipped = {}, 0, 0
+    if not store.tableExists(store.lbTable('phones')) then
+        return { imported = 0, skipped = 0 }
+    end
+
+    for _, p in ipairs(store.lbPhoneSettings()) do
+        local cid = ctx.numberToCid[digits(p.phone_number)]
+        local s = cid and store.decodeJson(p.settings) or nil
+        if s and next(s) ~= nil then
+            local display = type(s.display) == 'table' and s.display or {}
+            local sound   = type(s.sound) == 'table' and s.sound or {}
+            local wall    = type(s.wallpaper) == 'table' and s.wallpaper or {}
+            local clock   = type(s.time) == 'table' and s.time or {}
+
+            local blur = flag(wall.blur)
+            local hour24
+            if clock.twelveHourClock ~= nil then hour24 = clock.twelveHourClock and 0 or 1 end
+
+            rows[#rows + 1] = {
+                cid,
+                str(wall.background, 512),
+                blur, blur,
+                str(display.theme, 8),
+                pct(display.brightness),
+                pct(display.size),
+                hour24,
+                str(sound.ringtone, 64),
+                str(sound.texttone, 64),
+                pct(sound.volume),
+                pct(sound.callVolume),
+                type(s.apps) == 'table' and store.encodeJson(s.apps) or nil,
+            }
+            imported = imported + 1
+        else
+            skipped = skipped + 1
+        end
+    end
+
+    if not ctx.dryRun then store.fillSettings(rows) end
+    return { imported = imported, skipped = skipped }
+end
+
+return M

--- a/server/migrate/port/settings.lua
+++ b/server/migrate/port/settings.lua
@@ -44,7 +44,7 @@ end
 ---@return { imported: number, skipped: number }
 function M.run(ctx)
     local rows, imported, skipped = {}, 0, 0
-    if not store.tableExists(store.lbTable('phones')) then
+    if not store.lbSource('phones') then
         return { imported = 0, skipped = 0 }
     end
 

--- a/server/migrate/port/voicememos.lua
+++ b/server/migrate/port/voicememos.lua
@@ -11,7 +11,7 @@ local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 ---@return { imported: number, skipped: number }
 function M.run(ctx)
     local rows, imported, skipped = {}, 0, 0
-    if not store.tableExists(store.lbTable('voice_memos_recordings')) then
+    if not store.lbSource('voice_memos_recordings') then
         return { imported = 0, skipped = 0 }
     end
 
@@ -25,6 +25,7 @@ function M.run(ctx)
                 cid, name:sub(1, 120), url:sub(1, 512),
                 math.floor(tonumber(v.file_length) or 0),
                 math.floor(tonumber(v.ts) or 0),
+                ('lbv%s'):format(v.id),
             }
             imported = imported + 1
         else

--- a/server/migrate/port/voicememos.lua
+++ b/server/migrate/port/voicememos.lua
@@ -1,0 +1,39 @@
+---@type table Voice memo porter (server.migrate.port.voicememos). Copies lb-phone voice memo
+---recordings to their owner's sd-phone memo list. A memo with no URL is unplayable and skipped.
+local M = {}
+
+---@type table Migration data layer (server.migrate.store).
+local store = require 'server.migrate.store'
+
+local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
+
+---@param ctx table migration context (numberToCid, dryRun)
+---@return { imported: number, skipped: number }
+function M.run(ctx)
+    local rows, imported, skipped = {}, 0, 0
+    if not store.tableExists(store.lbTable('voice_memos_recordings')) then
+        return { imported = 0, skipped = 0 }
+    end
+
+    for _, v in ipairs(store.lbVoiceMemos()) do
+        local cid = ctx.numberToCid[digits(v.phone_number)]
+        local url = tostring(v.file_url or '')
+        if cid and url ~= '' then
+            local name = tostring(v.file_name or '')
+            if name == '' then name = 'Recording' end
+            rows[#rows + 1] = {
+                cid, name:sub(1, 120), url:sub(1, 512),
+                math.floor(tonumber(v.file_length) or 0),
+                math.floor(tonumber(v.ts) or 0),
+            }
+            imported = imported + 1
+        else
+            skipped = skipped + 1
+        end
+    end
+
+    if not ctx.dryRun then store.insertVoiceMemos(rows) end
+    return { imported = imported, skipped = skipped }
+end
+
+return M

--- a/server/migrate/port/wallet.lua
+++ b/server/migrate/port/wallet.lua
@@ -1,0 +1,38 @@
+---@type table Wallet porter (server.migrate.port.wallet). Copies lb-phone wallet transactions
+---into sd-phone's bank transaction history. The lb logo column has no target and is dropped.
+local M = {}
+
+---@type table Migration data layer (server.migrate.store).
+local store = require 'server.migrate.store'
+
+local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
+
+---@param ctx table migration context (numberToCid, dryRun)
+---@return { imported: number, skipped: number }
+function M.run(ctx)
+    local rows, imported, skipped = {}, 0, 0
+    if not store.tableExists(store.lbTable('wallet_transactions')) then
+        return { imported = 0, skipped = 0 }
+    end
+
+    for _, t in ipairs(store.lbWallet()) do
+        local cid = ctx.numberToCid[digits(t.phone_number)]
+        if cid then
+            rows[#rows + 1] = {
+                cid,
+                tostring(t.company or ''):sub(1, 120),
+                math.floor(tonumber(t.amount) or 0),
+                'wallet',
+                math.floor(tonumber(t.ts) or 0),
+            }
+            imported = imported + 1
+        else
+            skipped = skipped + 1
+        end
+    end
+
+    if not ctx.dryRun then store.insertBankTx(rows) end
+    return { imported = imported, skipped = skipped }
+end
+
+return M

--- a/server/migrate/port/wallet.lua
+++ b/server/migrate/port/wallet.lua
@@ -11,7 +11,7 @@ local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 ---@return { imported: number, skipped: number }
 function M.run(ctx)
     local rows, imported, skipped = {}, 0, 0
-    if not store.tableExists(store.lbTable('wallet_transactions')) then
+    if not store.lbSource('wallet_transactions') then
         return { imported = 0, skipped = 0 }
     end
 
@@ -24,6 +24,7 @@ function M.run(ctx)
                 math.floor(tonumber(t.amount) or 0),
                 'wallet',
                 math.floor(tonumber(t.ts) or 0),
+                ('lbw%s'):format(t.id),
             }
             imported = imported + 1
         else

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -368,6 +368,39 @@ function store.insertNotes(rows)
     insertMulti('INSERT IGNORE INTO phone_notes (citizenid, id, body, sketches, images, created_at, updated_at) VALUES', 7, rows)
 end
 
+---Every lb-phone phone that carries a settings blob. Read-only.
+---@return { phone_number: string, settings: string }[]
+function store.lbPhoneSettings()
+    return MySQL.query.await(
+        ('SELECT phone_number, settings FROM %s WHERE settings IS NOT NULL'):format(lbt('phones'))) or {}
+end
+
+---Fill-only settings merge. rows: { citizenid, wallpaper, blur_lock, blur_home, theme, brightness,
+---phone_scale, hour24, ringtone, notification_tone, ringtone_volume, call_volume, home_layout }.
+---@param rows any[][]
+function store.fillSettings(rows)
+    insertMulti([[
+        INSERT INTO phone_settings
+            (citizenid, wallpaper, blur_lock, blur_home, theme, brightness, phone_scale, hour24,
+             ringtone, notification_tone, ringtone_volume, call_volume, home_layout)
+        VALUES
+    ]], 13, rows, [[
+        ON DUPLICATE KEY UPDATE
+            wallpaper         = IF(wallpaper IS NULL, VALUES(wallpaper), wallpaper),
+            blur_lock         = IF(blur_lock IS NULL, VALUES(blur_lock), blur_lock),
+            blur_home         = IF(blur_home IS NULL, VALUES(blur_home), blur_home),
+            theme             = IF(theme IS NULL, VALUES(theme), theme),
+            brightness        = IF(brightness IS NULL, VALUES(brightness), brightness),
+            phone_scale       = IF(phone_scale IS NULL, VALUES(phone_scale), phone_scale),
+            hour24            = IF(hour24 IS NULL, VALUES(hour24), hour24),
+            ringtone          = IF(ringtone IS NULL, VALUES(ringtone), ringtone),
+            notification_tone = IF(notification_tone IS NULL, VALUES(notification_tone), notification_tone),
+            ringtone_volume   = IF(ringtone_volume IS NULL, VALUES(ringtone_volume), ringtone_volume),
+            call_volume       = IF(call_volume IS NULL, VALUES(call_volume), call_volume),
+            home_layout       = IF(home_layout IS NULL, VALUES(home_layout), home_layout)
+    ]])
+end
+
 ---Decodes a JSON column value; accepts strings or already-decoded tables and returns {} for
 ---anything absent or invalid.
 ---@param value any

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -401,6 +401,153 @@ function store.fillSettings(rows)
     ]])
 end
 
+---Usernames already present in Photogram, so a migrated account never overwrites a live one.
+---@return table<string, boolean>
+function store.existingPhotogramUsernames()
+    local rows = MySQL.query.await('SELECT username FROM phone_photogram_profiles') or {}
+    local set = {}
+    for _, r in ipairs(rows) do set[r.username] = true end
+    return set
+end
+
+---@return table[]
+function store.lbIgAccounts()
+    return MySQL.query.await(([[
+        SELECT username, display_name, password, bio, profile_image, private, verified,
+               phone_number, UNIX_TIMESTAMP(date_joined) AS ts
+        FROM %s
+    ]]):format(lbt('instagram_accounts'))) or {}
+end
+
+---@return table[]
+function store.lbIgPosts()
+    return MySQL.query.await(([[
+        SELECT id, username, media, caption, location, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
+    ]]):format(lbt('instagram_posts'))) or {}
+end
+
+---@return table[]
+function store.lbIgComments()
+    return MySQL.query.await(([[
+        SELECT id, post_id, username, comment, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
+    ]]):format(lbt('instagram_comments'))) or {}
+end
+
+---@return table[]
+function store.lbIgLikes()
+    return MySQL.query.await(
+        ('SELECT id, username, is_comment FROM %s'):format(lbt('instagram_likes'))) or {}
+end
+
+---@return table[]
+function store.lbIgFollows()
+    return MySQL.query.await(
+        ('SELECT followed, follower FROM %s'):format(lbt('instagram_follows'))) or {}
+end
+
+---@return table[]
+function store.lbIgRequests()
+    return MySQL.query.await(([[
+        SELECT requester, requestee, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
+    ]]):format(lbt('instagram_follow_requests'))) or {}
+end
+
+---@return table[]
+function store.lbIgStories()
+    return MySQL.query.await(([[
+        SELECT id, username, image, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
+    ]]):format(lbt('instagram_stories'))) or {}
+end
+
+---@return table[]
+function store.lbIgStoryViews()
+    return MySQL.query.await(([[
+        SELECT story_id, username, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
+    ]]):format(lbt('instagram_stories_views'))) or {}
+end
+
+---@return table[]
+function store.lbIgMessages()
+    return MySQL.query.await(([[
+        SELECT id, sender, recipient, content, attachments, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
+    ]]):format(lbt('instagram_messages'))) or {}
+end
+
+---@return table[]
+function store.lbIgNotifications()
+    return MySQL.query.await(([[
+        SELECT id, username, `from` AS from_user, `type`, post_id, UNIX_TIMESTAMP(`timestamp`) AS ts
+        FROM %s
+    ]]):format(lbt('instagram_notifications'))) or {}
+end
+
+---@param rows any[][] { username, display_name, bio, avatar, is_private, verified, created_at }
+function store.insertPgProfiles(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_profiles (username, display_name, bio, avatar, is_private, verified, created_at) VALUES', 7, rows)
+end
+
+---@param rows any[][] { id, author, images, caption, location, created_at }
+function store.insertPgPosts(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_posts (id, author, images, caption, location, created_at) VALUES', 6, rows)
+end
+
+---@param rows any[][] { id, post_id, author, body, gif_url, created_at }
+function store.insertPgComments(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_comments (id, post_id, author, body, gif_url, created_at) VALUES', 6, rows)
+end
+
+---@param rows any[][] { post_id, username, created_at }
+function store.insertPgLikes(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_likes (post_id, username, created_at) VALUES', 3, rows)
+end
+
+---@param rows any[][] { comment_id, username, created_at }
+function store.insertPgCommentLikes(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_comment_likes (comment_id, username, created_at) VALUES', 3, rows)
+end
+
+---@param rows any[][] { follower, target, status, created_at }
+function store.insertPgFollows(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_follows (follower, target, status, created_at) VALUES', 4, rows)
+end
+
+---@param rows any[][] { id, author, image, created_at }
+function store.insertPgStories(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_stories (id, author, image, created_at) VALUES', 4, rows)
+end
+
+---@param rows any[][] { story_id, username, created_at }
+function store.insertPgStoryViews(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_story_views (story_id, username, created_at) VALUES', 3, rows)
+end
+
+---@param rows any[][] { id, from_user, to_user, body, kind, meta, reactions, read_flag, created_at }
+function store.insertPgDms(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_dms (id, from_user, to_user, body, kind, meta, reactions, read_flag, created_at) VALUES', 9, rows)
+end
+
+---@param rows any[][] { id, recipient, kind, actor, post_id, seen, created_at }
+function store.insertPgNotifications(rows)
+    insertMulti('INSERT IGNORE INTO phone_photogram_notifications (id, recipient, kind, actor, post_id, seen, created_at) VALUES', 7, rows)
+end
+
+---Accounts-engine rows for migrated app accounts.
+---@param rows any[][] { app, username, display_name, password_hash }
+function store.insertPgAccounts(rows)
+    insertMulti('INSERT IGNORE INTO phone_app_accounts (app, username, display_name, password_hash) VALUES', 4, rows)
+end
+
+---Sessions for migrated app accounts, resolving account_id by (app, username).
+---@param rows any[][] { app, citizenid, username }
+function store.insertPgSessions(rows)
+    for _, r in ipairs(rows) do
+        MySQL.query.await([[
+            INSERT IGNORE INTO phone_app_sessions (app, citizenid, account_id)
+            SELECT ?, ?, id FROM phone_app_accounts WHERE app = ? AND username = ?
+        ]], { r[1], r[2], r[1], r[3] })
+    end
+end
+
 ---Decodes a JSON column value; accepts strings or already-decoded tables and returns {} for
 ---anything absent or invalid.
 ---@param value any

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -401,6 +401,31 @@ function store.fillSettings(rows)
     ]])
 end
 
+---@return { address: string, password: string }[]
+function store.lbMailAccounts()
+    return MySQL.query.await(('SELECT address, password FROM %s'):format(lbt('mail_accounts'))) or {}
+end
+
+---@return table[]
+function store.lbMailMessages()
+    return MySQL.query.await(([[
+        SELECT id, recipient, sender, subject, content, attachments, actions, `read`,
+               UNIX_TIMESTAMP(`timestamp`) AS ts
+        FROM %s ORDER BY `timestamp` ASC
+    ]]):format(lbt('mail_messages'))) or {}
+end
+
+---@return { phone_number: string, app: string, username: string }[]
+function store.lbLoggedIn()
+    return MySQL.query.await(
+        ('SELECT phone_number, app, username FROM %s'):format(lbt('logged_in_accounts'))) or {}
+end
+
+---@param rows any[][] { email, password_hash, display_name, messages, logged_in_citizens }
+function store.insertMailAccounts(rows)
+    insertMulti('INSERT IGNORE INTO phone_mail_accounts (email, password_hash, display_name, messages, logged_in_citizens) VALUES', 5, rows)
+end
+
 ---Usernames already present in Photogram, so a migrated account never overwrites a live one.
 ---@return table<string, boolean>
 function store.existingPhotogramUsernames()

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -108,6 +108,47 @@ function store.recordMigration(name, stats)
     )
 end
 
+---@type string Marker-row prefix for a single completed domain.
+local DOMAIN_MARKER = 'lbphone:'
+
+---The set of domain keys already imported. Gating per domain (rather than one marker for the whole
+---import) is what lets a server that ran an earlier version pick up only the domains added since.
+---@return table<string, boolean>
+function store.completedDomains()
+    local rows = MySQL.query.await(
+        'SELECT name FROM phone_migrations WHERE name LIKE ?', { DOMAIN_MARKER .. '%' }) or {}
+    local set = {}
+    for _, r in ipairs(rows) do
+        local key = tostring(r.name):sub(#DOMAIN_MARKER + 1)
+        if key ~= '' then set[key] = true end
+    end
+    return set
+end
+
+---Marks one domain as imported, stamping its counts. Idempotent (INSERT IGNORE).
+---@param key string domain key
+---@param stats table counts returned by the porter
+function store.recordDomain(key, stats)
+    MySQL.query.await(
+        'INSERT IGNORE INTO phone_migrations (name, stats) VALUES (?, ?)',
+        { DOMAIN_MARKER .. key, json.encode(stats or {}) }
+    )
+end
+
+---Backfills domain markers for an install that completed the pre-domain-marker import, so those
+---domains are not needlessly re-run. Returns true when the legacy marker was found.
+---@param legacyName string old whole-import marker name
+---@param keys string[] domain keys that marker covered
+---@return boolean backfilled
+function store.backfillLegacyDomains(legacyName, keys)
+    if not store.migrationDone(legacyName) then return false end
+    local done = store.completedDomains()
+    for _, key in ipairs(keys) do
+        if not done[key] then store.recordDomain(key, { backfilled = true }) end
+    end
+    return true
+end
+
 ---Loads the framework's persistent character roster: qb/QBox reads `players` (citizenid + license),
 ---ESX reads `users` (identifier). A non-standard schema degrades to empty maps.
 ---@param frameworkName 'qb'|'esx'

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -30,6 +30,25 @@ end
 
 store.lbTable = lbt
 
+---Resolves an lb-phone source table, or nil when this database has no lb data for it.
+---
+---Checking only that `phone_<name>` exists is not enough: for the names lb-phone and sd-phone share
+---(photos, notes, photo_albums, mail_accounts, message_reactions) the bare name is sd-phone's OWN
+---table once the schema bootstrap has run, and querying it with lb-phone's column names throws.
+---`markerColumn` is a column only the lb-phone shape has, so a porter reads the bare table only when
+---it really is lb-phone's.
+---@param name string suffix, e.g. 'mail_accounts'
+---@param markerColumn string|nil column unique to the lb-phone shape
+---@return string|nil table name to read from
+function store.lbSource(name, markerColumn)
+    local full = PREFIX .. name
+    local rescued = full .. '_lb'
+    if store.tableExists(rescued) then return rescued end
+    if not store.tableExists(full) then return nil end
+    if markerColumn and not store.tableHasColumn(full, markerColumn) then return nil end
+    return full
+end
+
 ---True if a base table with this exact name exists in the current schema. Read-only.
 ---@param name string table name
 ---@return boolean
@@ -449,15 +468,36 @@ function store.lbWallet()
     ]]):format(lbt('wallet_transactions'))) or {}
 end
 
----@param rows any[][] { citizenid, label, amount, category, created_at }
+---@param rows any[][] { citizenid, label, amount, category, created_at, src_id }
 function store.insertBankTx(rows)
-    insertMulti('INSERT IGNORE INTO phone_bank_transactions (citizenid, label, amount, category, created_at) VALUES', 5, rows)
+    insertMulti('INSERT IGNORE INTO phone_bank_transactions (citizenid, label, amount, category, created_at, src_id) VALUES', 6, rows)
 end
 
 ---@return { message_id: any, phone_number: string, reaction: string }[]
 function store.lbReactions()
     return MySQL.query.await(
         ('SELECT message_id, phone_number, reaction FROM %s'):format(lbt('message_reactions'))) or {}
+end
+
+---Which of these mids exist in phone_messages, queried in chunks. A reaction whose message was not
+---migrated can never render, so the porter drops it rather than importing junk.
+---@param mids string[]
+---@return table<string, boolean>
+function store.existingMids(mids)
+    local set = {}
+    for i = 1, #mids, 500 do
+        local last = math.min(i + 499, #mids)
+        local holes, params = {}, {}
+        for j = i, last do
+            holes[#holes + 1] = '?'
+            params[#params + 1] = mids[j]
+        end
+        local rows = MySQL.query.await(
+            ('SELECT DISTINCT mid FROM phone_messages WHERE mid IN (%s)'):format(table.concat(holes, ',')),
+            params) or {}
+        for _, r in ipairs(rows) do set[r.mid] = true end
+    end
+    return set
 end
 
 ---@param rows any[][] { mid, citizenid, emoji, created_at }
@@ -474,9 +514,9 @@ function store.lbVoiceMemos()
     ]]):format(lbt('voice_memos_recordings'))) or {}
 end
 
----@param rows any[][] { citizenid, name, url, duration, created_at }
+---@param rows any[][] { citizenid, name, url, duration, created_at, src_id }
 function store.insertVoiceMemos(rows)
-    insertMulti('INSERT IGNORE INTO phone_voice_memos (citizenid, name, url, duration, created_at) VALUES', 5, rows)
+    insertMulti('INSERT IGNORE INTO phone_voice_memos (citizenid, name, url, duration, created_at, src_id) VALUES', 6, rows)
 end
 
 ---@return { address: string, password: string }[]
@@ -562,10 +602,11 @@ function store.lbIgStories()
     ]]):format(lbt('instagram_stories'))) or {}
 end
 
+---The viewer column is `viewer` here, not `username` as on every other instagram table.
 ---@return table[]
 function store.lbIgStoryViews()
     return MySQL.query.await(([[
-        SELECT story_id, username, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
+        SELECT story_id, viewer AS username, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
     ]]):format(lbt('instagram_stories_views'))) or {}
 end
 
@@ -640,15 +681,26 @@ function store.insertPgAccounts(rows)
     insertMulti('INSERT IGNORE INTO phone_app_accounts (app, username, display_name, password_hash) VALUES', 4, rows)
 end
 
----Sessions for migrated app accounts, resolving account_id by (app, username).
+---Sessions for migrated app accounts. `linked` counts rows whose account exists and now has a
+---session; `inserted` counts only the new ones. They differ on a re-run, where every session is
+---already present and INSERT IGNORE affects no rows: that is success, not failure, so callers must
+---judge on `linked`.
 ---@param rows any[][] { app, citizenid, username }
+---@return integer linked, integer inserted
 function store.insertPgSessions(rows)
+    local linked, inserted = 0, 0
     for _, r in ipairs(rows) do
-        MySQL.query.await([[
-            INSERT IGNORE INTO phone_app_sessions (app, citizenid, account_id)
-            SELECT ?, ?, id FROM phone_app_accounts WHERE app = ? AND username = ?
-        ]], { r[1], r[2], r[1], r[3] })
+        local id = MySQL.scalar.await(
+            'SELECT id FROM phone_app_accounts WHERE app = ? AND username = ? LIMIT 1', { r[1], r[3] })
+        if id then
+            linked = linked + 1
+            local n = MySQL.update.await(
+                'INSERT IGNORE INTO phone_app_sessions (app, citizenid, account_id) VALUES (?, ?, ?)',
+                { r[1], r[2], id })
+            inserted = inserted + (tonumber(n) or 0)
+        end
     end
+    return linked, inserted
 end
 
 ---Decodes a JSON column value; accepts strings or already-decoded tables and returns {} for

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -401,6 +401,43 @@ function store.fillSettings(rows)
     ]])
 end
 
+---@return table[]
+function store.lbWallet()
+    return MySQL.query.await(([[
+        SELECT id, phone_number, amount, company, UNIX_TIMESTAMP(`timestamp`) AS ts FROM %s
+    ]]):format(lbt('wallet_transactions'))) or {}
+end
+
+---@param rows any[][] { citizenid, label, amount, category, created_at }
+function store.insertBankTx(rows)
+    insertMulti('INSERT IGNORE INTO phone_bank_transactions (citizenid, label, amount, category, created_at) VALUES', 5, rows)
+end
+
+---@return { message_id: any, phone_number: string, reaction: string }[]
+function store.lbReactions()
+    return MySQL.query.await(
+        ('SELECT message_id, phone_number, reaction FROM %s'):format(lbt('message_reactions'))) or {}
+end
+
+---@param rows any[][] { mid, citizenid, emoji, created_at }
+function store.insertReactions(rows)
+    insertMulti('INSERT IGNORE INTO phone_message_reactions (mid, citizenid, emoji, created_at) VALUES', 4, rows)
+end
+
+---@return table[]
+function store.lbVoiceMemos()
+    return MySQL.query.await(([[
+        SELECT id, phone_number, file_name, file_url, file_length,
+               UNIX_TIMESTAMP(created_at) AS ts
+        FROM %s
+    ]]):format(lbt('voice_memos_recordings'))) or {}
+end
+
+---@param rows any[][] { citizenid, name, url, duration, created_at }
+function store.insertVoiceMemos(rows)
+    insertMulti('INSERT IGNORE INTO phone_voice_memos (citizenid, name, url, duration, created_at) VALUES', 5, rows)
+end
+
 ---@return { address: string, password: string }[]
 function store.lbMailAccounts()
     return MySQL.query.await(('SELECT address, password FROM %s'):format(lbt('mail_accounts'))) or {}

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -234,10 +234,12 @@ end
 
 ---Runs a chunked multi-row INSERT IGNORE. `prefixSql` ends at the word VALUES; one placeholder
 ---group is appended per row, nil columns emit a literal NULL, and an empty batch is a no-op.
+---`suffixSql` is appended after the groups, for an ON DUPLICATE KEY UPDATE tail.
 ---@param prefixSql string 'INSERT IGNORE INTO ... (cols) VALUES'
 ---@param cols integer columns per row
 ---@param rows any[][] one parameter array per row
-local function insertMulti(prefixSql, cols, rows)
+---@param suffixSql string|nil trailing clause appended after the value groups
+local function insertMulti(prefixSql, cols, rows, suffixSql)
     if type(rows) ~= 'table' or #rows == 0 then return end
     local total = #rows
     for i = 1, total, 300 do
@@ -258,9 +260,14 @@ local function insertMulti(prefixSql, cols, rows)
             end
             groups[#groups + 1] = '(' .. table.concat(cells, ',') .. ')'
         end
-        MySQL.query.await(prefixSql .. ' ' .. table.concat(groups, ','), params)
+        local sql = prefixSql .. ' ' .. table.concat(groups, ',')
+        if suffixSql then sql = sql .. ' ' .. suffixSql end
+        MySQL.query.await(sql, params)
     end
 end
+
+---@type fun(prefixSql: string, cols: integer, rows: any[][], suffixSql?: string) Public alias for porters.
+store.insertMulti = insertMulti
 
 ---Adopts a player's lb-phone number (and lock passcode) as their sd-phone number. Returns 'set'
 ---when it wrote, 'skip' when already onboarded, 'conflict' when the number belongs to someone else.
@@ -359,6 +366,28 @@ end
 ---@param rows any[][]
 function store.insertNotes(rows)
     insertMulti('INSERT IGNORE INTO phone_notes (citizenid, id, body, sketches, images, created_at, updated_at) VALUES', 7, rows)
+end
+
+---Decodes a JSON column value; accepts strings or already-decoded tables and returns {} for
+---anything absent or invalid.
+---@param value any
+---@return table
+function store.decodeJson(value)
+    if value == nil then return {} end
+    if type(value) == 'table' then return value end
+    if type(value) == 'string' then
+        local ok, decoded = pcall(json.decode, value)
+        if ok and type(decoded) == 'table' then return decoded end
+    end
+    return {}
+end
+
+---Encodes a table for a JSON column; empty or absent tables map to nil.
+---@param tbl table|nil
+---@return string|nil
+function store.encodeJson(tbl)
+    if not tbl or next(tbl) == nil then return nil end
+    return json.encode(tbl)
 end
 
 return store

--- a/server/util.lua
+++ b/server/util.lua
@@ -124,6 +124,26 @@ function util.ensureIndex(tableName, indexName, columnsDDL)
     end
 end
 
+---Adds a UNIQUE index if absent. Distinct from ensureIndex because a unique index is a constraint,
+---not just a lookup aid: it is what makes INSERT IGNORE actually ignore. Existing duplicate rows
+---make the ALTER fail, so it is logged and skipped rather than fatal.
+---@param tableName string
+---@param indexName string
+---@param columnsDDL string column list incl. parens, e.g. "(src_id)"
+function util.ensureUniqueIndex(tableName, indexName, columnsDDL)
+    local present = MySQL.scalar.await([[
+        SELECT COUNT(*) FROM information_schema.statistics
+        WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?
+    ]], { tableName, indexName })
+    if (tonumber(present) or 0) > 0 then return end
+
+    local ok, err = pcall(MySQL.query.await,
+        ('ALTER TABLE `%s` ADD UNIQUE INDEX %s %s'):format(tableName, indexName, columnsDDL))
+    if not ok then
+        print(('^3[sd-phone]^0 could not add unique index %s on %s: %s'):format(indexName, tableName, err))
+    end
+end
+
 ---True when a table already exists. Call BEFORE the CREATE TABLE so a module can tell a fresh
 ---install from an upgrade: on a fresh install the CREATE already declares every column, so the
 ---backfills below can be skipped entirely rather than probed for.

--- a/server/voicememos/store.lua
+++ b/server/voicememos/store.lua
@@ -1,3 +1,6 @@
+---@type table Shared server helpers (server.util): schema back-fill helpers.
+local util = require 'server.util'
+
 ---@type table Store module; the table returned at end of file.
 local store = {}
 
@@ -16,6 +19,11 @@ function store.ensureSchema()
             KEY `created_at` (`created_at`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
     ]])
+
+    -- Auto-increment primary key, so INSERT IGNORE cannot detect a repeated lb-phone import.
+    -- `src_id` carries the source row's identity and is unique; in-game recordings leave it NULL.
+    util.ensureColumns('phone_voice_memos', { src_id = 'src_id VARCHAR(32) NULL' })
+    util.ensureUniqueIndex('phone_voice_memos', 'uq_voice_memos_src', '(src_id)')
 end
 
 ---Inserts one memo row (name and duration already sanitized by the actions layer).

--- a/tests/lua/idempotency_test.lua
+++ b/tests/lua/idempotency_test.lua
@@ -1,0 +1,119 @@
+local H = require 'support.harness'
+
+---Runs `build()` twice through a porter and asserts both runs produce the same key columns.
+---Deterministic ids plus INSERT IGNORE are what make a re-run a no-op, so drifting keys here
+---would mean the second import duplicates rows instead of ignoring them.
+---@param label string
+---@param path string porter module path
+---@param build fun(): table store mock, freshly built
+---@param bucket string recorded insert bucket to compare
+---@param keys integer[] column indexes forming the target primary key
+local function twice(label, path, build, bucket, keys)
+    local out = {}
+    for run = 1, 2 do
+        local store = build()
+        local M = H.load(path, store)
+        M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+        local seen = {}
+        for _, row in ipairs(store.calls[bucket] or {}) do
+            local parts = {}
+            for i, k in ipairs(keys) do parts[i] = tostring(row[k]) end
+            seen[#seen + 1] = table.concat(parts, '|')
+        end
+        table.sort(seen)
+        out[run] = table.concat(seen, ',')
+    end
+    H.eq(out[2], out[1], label .. ' produces identical keys on a re-run')
+    H.eq(out[1] ~= '', true, label .. ' actually produced rows')
+end
+
+twice('settings', 'server/migrate/port/settings.lua', function()
+    local s = H.newStore()
+    s.tables['phone_phones'] = true
+    s.lbPhoneSettings = function()
+        return { { phone_number = '(555) 010-0001',
+                   settings = { display = { theme = 'dark' }, wallpaper = { background = 'x' } } } }
+    end
+    s.fillSettings = function(rows) s.record('settings', rows) end
+    return s
+end, 'settings', { 1 })
+
+twice('wallet', 'server/migrate/port/wallet.lua', function()
+    local s = H.newStore()
+    s.tables['phone_wallet_transactions'] = true
+    s.lbWallet = function()
+        return { { id = 1, phone_number = '(555) 010-0001', amount = -250,
+                   company = 'Burger Shot', ts = 1700000000 } }
+    end
+    s.insertBankTx = function(rows) s.record('tx', rows) end
+    return s
+end, 'tx', { 1, 2, 3, 5 })
+
+-- created_at is stamped at import time and is deliberately excluded: the target primary key is
+-- (mid, citizenid, emoji), so a differing timestamp cannot cause a duplicate.
+twice('reactions', 'server/migrate/port/reactions.lua', function()
+    local s = H.newStore()
+    s.tables['phone_message_reactions'] = true
+    s.lbReactions = function()
+        return { { message_id = 42, phone_number = '(555) 010-0001', reaction = 'heart' } }
+    end
+    s.insertReactions = function(rows) s.record('rx', rows) end
+    return s
+end, 'rx', { 1, 2, 3 })
+
+twice('voicememos', 'server/migrate/port/voicememos.lua', function()
+    local s = H.newStore()
+    s.tables['phone_voice_memos_recordings'] = true
+    s.lbVoiceMemos = function()
+        return { { id = 1, phone_number = '(555) 010-0001', file_name = 'Memo',
+                   file_url = 'http://a.mp3', file_length = 12, ts = 1700000000 } }
+    end
+    s.insertVoiceMemos = function(rows) s.record('vm', rows) end
+    return s
+end, 'vm', { 1, 2, 3, 5 })
+
+twice('photogram', 'server/migrate/port/photogram.lua', function()
+    local s = H.newStore()
+    s.tables['phone_instagram_accounts'] = true
+    s.tables['phone_instagram_posts'] = true
+    s.lbIgAccounts = function()
+        return { { username = 'jay', display_name = 'Jay', password = 'h', bio = '',
+                   profile_image = nil, private = false, verified = false,
+                   phone_number = '(555) 010-0001', ts = 1700000000 } }
+    end
+    s.lbIgPosts = function()
+        return { { id = 'p1', username = 'jay', media = '[]', caption = 'c',
+                   location = nil, ts = 1700000100 } }
+    end
+    s.existingPhotogramUsernames = function() return {} end
+    for _, k in ipairs({ 'Profiles', 'Posts', 'Comments', 'Likes', 'CommentLikes', 'Follows',
+                         'Stories', 'StoryViews', 'Dms', 'Notifications', 'Accounts', 'Sessions' }) do
+        s['insertPg' .. k] = function(rows) s.record(k, rows) end
+    end
+    return s
+end, 'Posts', { 1, 2 })
+
+twice('mail', 'server/migrate/port/mail.lua', function()
+    local s = H.newStore()
+    s.tables['phone_mail_accounts'] = true
+    s.tables['phone_mail_messages'] = true
+    s.lbMailAccounts = function() return { { address = 'jay@ls.mail', password = 'h' } } end
+    s.lbMailMessages = function()
+        return { { id = 1, recipient = 'jay@ls.mail', sender = 'k@ls.mail', subject = 's',
+                   content = 'b', attachments = nil, actions = nil, read = true, ts = 1700000000 } }
+    end
+    s.insertMailAccounts = function(rows) s.record('mail', rows) end
+    return s
+end, 'mail', { 1 })
+
+twice('sessions', 'server/migrate/port/sessions.lua', function()
+    local s = H.newStore()
+    s.tables['phone_logged_in_accounts'] = true
+    s.lbLoggedIn = function()
+        return { { phone_number = '(555) 010-0001', app = 'instagram', username = 'jay' } }
+    end
+    s.insertPgSessions = function(rows) s.record('sess', rows) end
+    return s
+end, 'sess', { 1, 2, 3 })
+
+return true

--- a/tests/lua/idempotency_test.lua
+++ b/tests/lua/idempotency_test.lua
@@ -3,6 +3,14 @@ local H = require 'support.harness'
 ---Runs `build()` twice through a porter and asserts both runs produce the same key columns.
 ---Deterministic ids plus INSERT IGNORE are what make a re-run a no-op, so drifting keys here
 ---would mean the second import duplicates rows instead of ignoring them.
+---
+---LIMITATION, learned the hard way on 2026-07-26: this compares the rows handed to the insert
+---function, NOT rows in a database. It therefore cannot see whether the target table can actually
+---reject a duplicate. phone_bank_transactions and phone_voice_memos have auto-increment primary
+---keys, so INSERT IGNORE had nothing to collide with and a re-import silently doubled both tables
+---while this suite stayed green. The `keys` passed below must name a column set the target really
+---enforces as unique, and DB-level idempotency has to be confirmed by re-running against a real
+---server and diffing row counts.
 ---@param label string
 ---@param path string porter module path
 ---@param build fun(): table store mock, freshly built
@@ -47,7 +55,7 @@ twice('wallet', 'server/migrate/port/wallet.lua', function()
     end
     s.insertBankTx = function(rows) s.record('tx', rows) end
     return s
-end, 'tx', { 1, 2, 3, 5 })
+end, 'tx', { 6 })
 
 -- created_at is stamped at import time and is deliberately excluded: the target primary key is
 -- (mid, citizenid, emoji), so a differing timestamp cannot cause a duplicate.
@@ -58,6 +66,11 @@ twice('reactions', 'server/migrate/port/reactions.lua', function()
         return { { message_id = 42, phone_number = '(555) 010-0001', reaction = 'heart' } }
     end
     s.insertReactions = function(rows) s.record('rx', rows) end
+    s.existingMids = function(mids)
+        local set = {}
+        for _, m in ipairs(mids) do set[m] = true end
+        return set
+    end
     return s
 end, 'rx', { 1, 2, 3 })
 
@@ -70,7 +83,7 @@ twice('voicememos', 'server/migrate/port/voicememos.lua', function()
     end
     s.insertVoiceMemos = function(rows) s.record('vm', rows) end
     return s
-end, 'vm', { 1, 2, 3, 5 })
+end, 'vm', { 6 })
 
 twice('photogram', 'server/migrate/port/photogram.lua', function()
     local s = H.newStore()
@@ -88,7 +101,7 @@ twice('photogram', 'server/migrate/port/photogram.lua', function()
     s.existingPhotogramUsernames = function() return {} end
     for _, k in ipairs({ 'Profiles', 'Posts', 'Comments', 'Likes', 'CommentLikes', 'Follows',
                          'Stories', 'StoryViews', 'Dms', 'Notifications', 'Accounts', 'Sessions' }) do
-        s['insertPg' .. k] = function(rows) s.record(k, rows) end
+        s['insertPg' .. k] = function(rows) s.record(k, rows); return #rows end
     end
     return s
 end, 'Posts', { 1, 2 })
@@ -112,7 +125,7 @@ twice('sessions', 'server/migrate/port/sessions.lua', function()
     s.lbLoggedIn = function()
         return { { phone_number = '(555) 010-0001', app = 'instagram', username = 'jay' } }
     end
-    s.insertPgSessions = function(rows) s.record('sess', rows) end
+    s.insertPgSessions = function(rows) s.record('sess', rows); return #rows, #rows end
     return s
 end, 'sess', { 1, 2, 3 })
 

--- a/tests/lua/plan_test.lua
+++ b/tests/lua/plan_test.lua
@@ -1,0 +1,56 @@
+local H = require 'support.harness'
+
+local plan = dofile('server/migrate/plan.lua')
+
+local PORTS = {
+    { key = 'numbers', label = 'numbers' }, { key = 'contacts', label = 'contacts' },
+    { key = 'messages', label = 'messages' }, { key = 'settings', label = 'settings' },
+    { key = 'photogram', label = 'photogram' }, { key = 'sessions', label = 'sessions' },
+}
+
+---Comma-joined keys of a queue, for readable assertions.
+local function keys(queue)
+    local out = {}
+    for i, p in ipairs(queue) do out[i] = p.key end
+    return table.concat(out, ',')
+end
+
+-- A fresh install has nothing marked done, so everything runs.
+local fresh = plan.build(PORTS, {}, nil, false)
+H.eq(keys(fresh.queue), 'numbers,contacts,messages,settings,photogram,sessions', 'fresh install runs all')
+H.eq(#fresh.alreadyDone, 0, 'fresh install has nothing done')
+
+-- The case this exists for: a server that already ran the original import must pick up only the
+-- domains added since, not re-read millions of already-imported rows.
+local upgraded = plan.build(PORTS, {
+    numbers = true, contacts = true, messages = true,
+}, nil, false)
+H.eq(keys(upgraded.queue), 'settings,photogram,sessions', 'upgrade runs only the new domains')
+H.eq(#upgraded.alreadyDone, 3, 'the original domains are reported as done')
+
+-- Everything done is the steady state after a completed import.
+local settled = plan.build(PORTS, {
+    numbers = true, contacts = true, messages = true,
+    settings = true, photogram = true, sessions = true,
+}, nil, false)
+H.eq(#settled.queue, 0, 'a fully imported server has nothing to do')
+
+-- force re-runs everything regardless of markers.
+local forced = plan.build(PORTS, { numbers = true, contacts = true }, nil, true)
+H.eq(keys(forced.queue), 'numbers,contacts,messages,settings,photogram,sessions', 'force ignores markers')
+H.eq(#forced.alreadyDone, 0, 'force reports nothing as already done')
+
+-- A disabled domain never runs, even when it has no marker.
+local off = plan.build(PORTS, {}, { photogram = false, sessions = false }, false)
+H.eq(keys(off.queue), 'numbers,contacts,messages,settings', 'disabled domains are excluded')
+H.eq(#off.disabled, 2, 'disabled domains are reported')
+
+-- Disabled beats force: an operator turning a domain off should not be overridden by a manual run.
+local offForced = plan.build(PORTS, {}, { photogram = false }, true)
+H.eq(keys(offForced.queue), 'numbers,contacts,messages,settings,sessions', 'force does not re-enable a disabled domain')
+
+-- Run order is preserved, which matters because reactions must follow messages and sessions is last.
+local ordered = plan.build(PORTS, { numbers = true }, nil, false)
+H.eq(keys(ordered.queue), 'contacts,messages,settings,photogram,sessions', 'order is preserved')
+
+return true

--- a/tests/lua/port_mail_test.lua
+++ b/tests/lua/port_mail_test.lua
@@ -1,0 +1,1 @@
+return true

--- a/tests/lua/port_mail_test.lua
+++ b/tests/lua/port_mail_test.lua
@@ -1,1 +1,63 @@
+local H = require 'support.harness'
+
+local store = H.newStore()
+store.tables['phone_mail_accounts_lb'] = true
+store.tables['phone_mail_messages'] = true
+store.tables['phone_logged_in_accounts'] = true
+store.lbTable = function(name)
+    if name == 'mail_accounts' then return 'phone_mail_accounts_lb' end
+    return 'phone_' .. name
+end
+store.lbMailAccounts = function()
+    return { { address = 'jay@ls.mail', password = '$2a$11$abc' },
+             { address = 'kim@ls.mail', password = '$2a$11$def' } }
+end
+store.lbMailMessages = function()
+    return {
+        { id = 1, recipient = 'jay@ls.mail', sender = 'kim@ls.mail', subject = 'hi',
+          content = 'hello', attachments = nil, actions = nil, read = true, ts = 1700000000 },
+        { id = 2, recipient = 'jay@ls.mail', sender = 'sys@ls.mail', subject = 'two',
+          content = 'body', attachments = nil, actions = nil, read = false, ts = 1700000100 },
+        { id = 3, recipient = 'ghost@ls.mail', sender = 'x@ls.mail', subject = 'orphan',
+          content = 'body', attachments = nil, actions = nil, read = false, ts = 1700000200 },
+    }
+end
+store.lbLoggedIn = function()
+    return { { phone_number = '(555) 010-0001', app = 'mail', username = 'jay@ls.mail' },
+             { phone_number = '(555) 010-0001', app = 'instagram', username = 'jay' } }
+end
+store.insertMailAccounts = function(rows) store.record('mail', rows) end
+
+local M = H.load('server/migrate/port/mail.lua', store)
+local res = M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+
+H.eq(res.accounts, 2, 'both accounts import')
+H.eq(res.messages, 2, 'only messages addressed to a known account')
+H.eq(res.sessions, 1, 'one mail login, instagram row ignored')
+H.eq(res.skipped, 1, 'orphan message skipped')
+
+local jay = store.calls.mail[1]
+H.eq(jay[1], 'jay@ls.mail', 'email')
+H.eq(jay[2], '$2a$11$abc', 'bcrypt preserved')
+H.eq(jay[3], 'jay', 'display name from local part')
+H.eq(jay[4], 'json:2', 'two messages encoded')
+H.eq(jay[5], 'json:1', 'one logged-in citizen')
+
+local kim = store.calls.mail[2]
+H.eq(kim[4], '[]', 'empty message array falls back to a literal empty json array')
+H.eq(kim[5], '[]', 'no sessions falls back to a literal empty json array')
+
+local dry = H.newStore()
+dry.tables = store.tables
+for k, v in pairs(store) do if dry[k] == nil then dry[k] = v end end
+-- newStore already defines lbTable, so the loop above skips it; the rescued mail table name
+-- only resolves with the suite's override.
+dry.lbTable = store.lbTable
+dry.insertMailAccounts = function(rows) dry.record('mail', rows) end
+local M2 = H.load('server/migrate/port/mail.lua', dry)
+local res2 = M2.run({ numberToCid = {}, dryRun = true })
+H.eq(res2.accounts, 2, 'dry run counts accounts')
+H.eq(res2.sessions, 0, 'unresolved owner creates no login')
+H.eq(dry.calls.mail, nil, 'dry run writes nothing')
+
 return true

--- a/tests/lua/port_mail_test.lua
+++ b/tests/lua/port_mail_test.lua
@@ -60,4 +60,17 @@ H.eq(res2.accounts, 2, 'dry run counts accounts')
 H.eq(res2.sessions, 0, 'unresolved owner creates no login')
 H.eq(dry.calls.mail, nil, 'dry run writes nothing')
 
+-- Regression: with no lb data, `phone_mail_accounts` is sd-phone's OWN table. Resolving on the bare
+-- name alone made the porter run `SELECT address, password` against it and crash. Confirmed against
+-- a real database on 2026-07-26.
+local collide = H.newStore()
+collide.foreign['phone_mail_accounts'] = true
+collide.lbMailAccounts = function() error('must not read sd-phone\'s own mail table', 0) end
+collide.insertMailAccounts = function(rows) collide.record('mail', rows) end
+local M3 = H.load('server/migrate/port/mail.lua', collide)
+local ok, res3 = pcall(M3.run, { numberToCid = {}, dryRun = false })
+H.eq(ok, true, 'sd-shaped mail table does not crash the porter')
+H.eq(ok and res3.accounts, 0, 'sd-shaped mail table imports nothing')
+H.eq(collide.calls.mail, nil, 'sd-shaped mail table is never written back to')
+
 return true

--- a/tests/lua/port_photogram_test.lua
+++ b/tests/lua/port_photogram_test.lua
@@ -1,0 +1,1 @@
+return true

--- a/tests/lua/port_photogram_test.lua
+++ b/tests/lua/port_photogram_test.lua
@@ -42,7 +42,7 @@ store.lbIgNotifications = function() return store.rows.notifications end
 store.existingPhotogramUsernames = function() return {} end
 for _, k in ipairs({ 'Profiles', 'Posts', 'Comments', 'Likes', 'CommentLikes', 'Follows',
                      'Stories', 'StoryViews', 'Dms', 'Notifications', 'Accounts', 'Sessions' }) do
-    store['insertPg' .. k] = function(rows) store.record(k, rows) end
+    store['insertPg' .. k] = function(rows) store.record(k, rows); return #rows end
 end
 
 local M = H.load('server/migrate/port/photogram.lua', store)
@@ -53,7 +53,7 @@ H.eq(res.posts, 1, 'one post')
 H.eq(res.likes, 1, 'post like only')
 H.eq(res.commentLikes, 1, 'comment like fans out separately')
 H.eq(res.follows, 2, 'accepted follow plus pending request')
-H.eq(res.accounts, 1, 'only the resolved owner gets a session')
+H.eq(res.accounts, 2, 'an accounts-engine row per profile, no sessions')
 
 H.eq(store.calls.Profiles[1][1], 'jay',   'profile username unprefixed')
 H.eq(store.calls.Profiles[1][5], 1,       'is_private')
@@ -68,19 +68,58 @@ H.eq(store.calls.Dms[1][2],      'jay',   'dm from_user')
 H.eq(store.calls.Dms[1][3],      'kim',   'dm to_user')
 H.eq(store.calls.Accounts[1][2], 'jay',   'accounts-engine username')
 H.eq(store.calls.Accounts[1][4], '$2a$11$abc', 'bcrypt hash preserved verbatim')
-H.eq(store.calls.Sessions[1][2], 'CID1',  'session citizenid')
+
+-- Regression: children pointing at a parent that was not migrated must never be written.
+-- sd-phone's own foreign keys either delete such rows on boot or refuse to install at all, and on
+-- a real server 2026-07-26 this left fk_photogram_likes_post permanently missing and silently
+-- deleted every migrated comment.
+local orph = H.newStore()
+for _, t in ipairs({ 'phone_instagram_accounts', 'phone_instagram_posts', 'phone_instagram_comments',
+                     'phone_instagram_likes', 'phone_instagram_stories', 'phone_instagram_stories_views',
+                     'phone_instagram_notifications' }) do orph.tables[t] = true end
+orph.lbIgAccounts = function() return { store.rows.accounts[1] } end
+orph.lbIgPosts    = function() return { { id = 'p1', username = 'jay', media = '[]', caption = '',
+                                          location = nil, ts = 1 } } end
+-- Every one of these points at something that does not exist.
+orph.lbIgComments = function() return { { id = 'c9', post_id = 'MISSING', username = 'jay',
+                                          comment = 'x', ts = 1 } } end
+orph.lbIgLikes    = function() return { { id = 'MISSING', username = 'jay', is_comment = false },
+                                        { id = 'MISSING', username = 'jay', is_comment = true } } end
+orph.lbIgStories  = function() return {} end
+orph.lbIgStoryViews = function() return { { story_id = 'MISSING', username = 'jay', ts = 1 } } end
+orph.lbIgNotifications = function() return {
+    { id = 'n1', username = 'jay', from_user = 'jay', type = 'like', post_id = 'MISSING', ts = 1 },
+    { id = 'n2', username = 'jay', from_user = 'jay', type = 'follow', post_id = nil, ts = 1 } } end
+orph.existingPhotogramUsernames = function() return {} end
+for _, k in ipairs({ 'Profiles', 'Posts', 'Comments', 'Likes', 'CommentLikes', 'Follows',
+                     'Stories', 'StoryViews', 'Dms', 'Notifications', 'Accounts', 'Sessions' }) do
+    orph['insertPg' .. k] = function(rows) orph.record(k, rows); return #rows end
+end
+local MO = H.load('server/migrate/port/photogram.lua', orph)
+local resO = MO.run({ numberToCid = {}, dryRun = false })
+H.eq(resO.posts, 1, 'the real post imports')
+H.eq(resO.comments, 0, 'a comment on a missing post is dropped')
+H.eq(resO.likes, 0, 'a like on a missing post is dropped')
+H.eq(resO.commentLikes, 0, 'a like on a missing comment is dropped')
+H.eq(resO.views, 0, 'a view of a missing story is dropped')
+H.eq(resO.notifications, 1, 'the follow notification with no post survives')
+H.eq(resO.orphan, 5, 'every dropped child is counted')
+H.eq(#(orph.calls.Comments or {}), 0, 'no orphaned comment reaches the database')
+H.eq(#(orph.calls.Likes or {}), 0, 'no orphaned like reaches the database')
 
 local taken = H.newStore()
 taken.tables = store.tables
 for k, v in pairs(store) do if taken[k] == nil then taken[k] = v end end
 taken.existingPhotogramUsernames = function() return { jay = true } end
 for _, k in ipairs({ 'Profiles', 'Posts' }) do
-    taken['insertPg' .. k] = function(rows) taken.record(k, rows) end
+    taken['insertPg' .. k] = function(rows) taken.record(k, rows); return #rows end
 end
 local M2 = H.load('server/migrate/port/photogram.lua', taken)
 local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
 H.eq(res2.profiles, 1, 'existing username is not overwritten')
-H.eq(res2.skipped, 1, 'collision counted as skipped')
+-- The account plus its content: a pre-existing account is left alone deliberately, so its children
+-- are skipped rather than reported as orphans. A re-run otherwise reads like data loss.
+H.eq(res2.skipped, 5, 'the existing account and its content all count as skipped')
 H.eq(res2.posts, 0, 'content of a skipped account is not imported')
 
 local dry = H.newStore()
@@ -88,12 +127,12 @@ dry.tables = store.tables
 for k, v in pairs(store) do if dry[k] == nil then dry[k] = v end end
 dry.existingPhotogramUsernames = function() return {} end
 for _, k in ipairs({ 'Profiles', 'Posts', 'Accounts' }) do
-    dry['insertPg' .. k] = function(rows) dry.record(k, rows) end
+    dry['insertPg' .. k] = function(rows) dry.record(k, rows); return #rows end
 end
 local M3 = H.load('server/migrate/port/photogram.lua', dry)
 local res3 = M3.run({ numberToCid = {}, dryRun = true })
 H.eq(res3.profiles, 2, 'dry run counts profiles')
 H.eq(dry.calls.Profiles, nil, 'dry run writes nothing')
-H.eq(res3.accounts, 0, 'unresolved owner creates no session')
+H.eq(res3.accounts, 2, 'accounts are created regardless of owner resolution')
 
 return true

--- a/tests/lua/port_photogram_test.lua
+++ b/tests/lua/port_photogram_test.lua
@@ -1,1 +1,99 @@
+local H = require 'support.harness'
+
+local store = H.newStore()
+for _, t in ipairs({
+    'phone_instagram_accounts', 'phone_instagram_posts', 'phone_instagram_comments',
+    'phone_instagram_likes', 'phone_instagram_follows', 'phone_instagram_follow_requests',
+    'phone_instagram_stories', 'phone_instagram_stories_views', 'phone_instagram_messages',
+    'phone_instagram_notifications',
+}) do store.tables[t] = true end
+
+store.rows = {
+    accounts = { { username = 'jay', display_name = 'Jay', password = '$2a$11$abc', bio = 'hi',
+                   profile_image = 'http://img', private = true, verified = false,
+                   phone_number = '(555) 010-0001', ts = 1700000000 },
+                 { username = 'kim', display_name = 'Kim', password = '$2a$11$def', bio = '',
+                   profile_image = nil, private = false, verified = false,
+                   phone_number = '(555) 010-9999', ts = 1700000000 } },
+    posts = { { id = 'p1', username = 'jay', media = '["a.png"]', caption = 'cap',
+                location = 'LS', ts = 1700000100 } },
+    comments = { { id = 'c1', post_id = 'p1', username = 'jay', comment = 'nice', ts = 1700000200 } },
+    likes = { { id = 'p1', username = 'jay', is_comment = false },
+              { id = 'c1', username = 'jay', is_comment = true } },
+    follows = { { followed = 'jay', follower = 'kim' } },
+    requests = { { requester = 'kim', requestee = 'jay', ts = 1700000300 } },
+    stories = { { id = 's1', username = 'jay', image = 'http://s', ts = 1700000400 } },
+    views = { { story_id = 's1', username = 'kim', ts = 1700000500 } },
+    dms = { { id = 'd1', sender = 'jay', recipient = 'kim', content = 'yo',
+              attachments = nil, ts = 1700000600 } },
+    notifications = { { id = 'n1', username = 'jay', from_user = 'kim', type = 'like',
+                        post_id = 'p1', ts = 1700000700 } },
+}
+store.lbIgAccounts      = function() return store.rows.accounts end
+store.lbIgPosts         = function() return store.rows.posts end
+store.lbIgComments      = function() return store.rows.comments end
+store.lbIgLikes         = function() return store.rows.likes end
+store.lbIgFollows       = function() return store.rows.follows end
+store.lbIgRequests      = function() return store.rows.requests end
+store.lbIgStories       = function() return store.rows.stories end
+store.lbIgStoryViews    = function() return store.rows.views end
+store.lbIgMessages      = function() return store.rows.dms end
+store.lbIgNotifications = function() return store.rows.notifications end
+store.existingPhotogramUsernames = function() return {} end
+for _, k in ipairs({ 'Profiles', 'Posts', 'Comments', 'Likes', 'CommentLikes', 'Follows',
+                     'Stories', 'StoryViews', 'Dms', 'Notifications', 'Accounts', 'Sessions' }) do
+    store['insertPg' .. k] = function(rows) store.record(k, rows) end
+end
+
+local M = H.load('server/migrate/port/photogram.lua', store)
+local res = M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+
+H.eq(res.profiles, 2, 'both profiles')
+H.eq(res.posts, 1, 'one post')
+H.eq(res.likes, 1, 'post like only')
+H.eq(res.commentLikes, 1, 'comment like fans out separately')
+H.eq(res.follows, 2, 'accepted follow plus pending request')
+H.eq(res.accounts, 1, 'only the resolved owner gets a session')
+
+H.eq(store.calls.Profiles[1][1], 'jay',   'profile username unprefixed')
+H.eq(store.calls.Profiles[1][5], 1,       'is_private')
+H.eq(store.calls.Posts[1][1],    'ip1',   'post id prefixed')
+H.eq(store.calls.Posts[1][2],    'jay',   'post author')
+H.eq(store.calls.Comments[1][2], 'ip1',   'comment points at prefixed post id')
+H.eq(store.calls.Likes[1][1],    'ip1',   'post like target')
+H.eq(store.calls.CommentLikes[1][1], 'ic1', 'comment like target')
+H.eq(store.calls.Follows[1][3],  'accepted', 'follow status')
+H.eq(store.calls.Follows[2][3],  'pending',  'request status')
+H.eq(store.calls.Dms[1][2],      'jay',   'dm from_user')
+H.eq(store.calls.Dms[1][3],      'kim',   'dm to_user')
+H.eq(store.calls.Accounts[1][2], 'jay',   'accounts-engine username')
+H.eq(store.calls.Accounts[1][4], '$2a$11$abc', 'bcrypt hash preserved verbatim')
+H.eq(store.calls.Sessions[1][2], 'CID1',  'session citizenid')
+
+local taken = H.newStore()
+taken.tables = store.tables
+for k, v in pairs(store) do if taken[k] == nil then taken[k] = v end end
+taken.existingPhotogramUsernames = function() return { jay = true } end
+for _, k in ipairs({ 'Profiles', 'Posts' }) do
+    taken['insertPg' .. k] = function(rows) taken.record(k, rows) end
+end
+local M2 = H.load('server/migrate/port/photogram.lua', taken)
+local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+H.eq(res2.profiles, 1, 'existing username is not overwritten')
+H.eq(res2.skipped, 1, 'collision counted as skipped')
+H.eq(res2.posts, 0, 'content of a skipped account is not imported')
+
+local dry = H.newStore()
+dry.tables = store.tables
+for k, v in pairs(store) do if dry[k] == nil then dry[k] = v end end
+dry.existingPhotogramUsernames = function() return {} end
+for _, k in ipairs({ 'Profiles', 'Posts', 'Accounts' }) do
+    dry['insertPg' .. k] = function(rows) dry.record(k, rows) end
+end
+local M3 = H.load('server/migrate/port/photogram.lua', dry)
+local res3 = M3.run({ numberToCid = {}, dryRun = true })
+H.eq(res3.profiles, 2, 'dry run counts profiles')
+H.eq(dry.calls.Profiles, nil, 'dry run writes nothing')
+H.eq(res3.accounts, 0, 'unresolved owner creates no session')
+
 return true

--- a/tests/lua/port_reactions_test.lua
+++ b/tests/lua/port_reactions_test.lua
@@ -1,0 +1,1 @@
+return true

--- a/tests/lua/port_reactions_test.lua
+++ b/tests/lua/port_reactions_test.lua
@@ -12,6 +12,11 @@ store.lbReactions = function()
              { message_id = 44, phone_number = '(555) 010-0001', reaction = '' } }
 end
 store.insertReactions = function(rows) store.record('rx', rows) end
+store.existingMids = function(mids)
+    local set = {}
+    for _, m in ipairs(mids) do if m ~= 'm99' then set[m] = true end end
+    return set
+end
 
 local M = H.load('server/migrate/port/reactions.lua', store)
 local res = M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
@@ -30,9 +35,38 @@ dry.tables['phone_message_reactions_lb'] = true
 dry.lbTable = store.lbTable
 dry.lbReactions = store.lbReactions
 dry.insertReactions = function(rows) dry.record('rx', rows) end
+dry.existingMids = store.existingMids
 local M2 = H.load('server/migrate/port/reactions.lua', dry)
 local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = true })
 H.eq(res2.imported, 1, 'dry run counts')
 H.eq(dry.calls.rx, nil, 'dry run writes nothing')
+
+-- A reaction whose message never migrated has nothing to render against, so it is counted as an
+-- orphan and dropped rather than imported as junk.
+local orph = H.newStore()
+orph.tables['phone_message_reactions'] = true
+orph.lbReactions = function()
+    return { { message_id = 1, phone_number = '(555) 010-0001', reaction = 'heart' },
+             { message_id = 99, phone_number = '(555) 010-0001', reaction = 'thumb' } }
+end
+orph.existingMids = function() return { m1 = true } end
+orph.insertReactions = function(rows) orph.record('rx', rows) end
+local M6 = H.load('server/migrate/port/reactions.lua', orph)
+local res6 = M6.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+H.eq(res6.imported, 1, 'only the reaction with a migrated message imports')
+H.eq(res6.orphan, 1, 'the reaction with no message is reported as an orphan')
+H.eq(#orph.calls.rx, 1, 'the orphan is never written')
+
+-- Regression: same collision as mail. `phone_message_reactions` is sd-phone's own table when no lb
+-- data is present, and querying it for `message_id, phone_number, reaction` throws.
+local collide = H.newStore()
+collide.foreign['phone_message_reactions'] = true
+collide.lbReactions = function() error('must not read sd-phone\'s own reactions table', 0) end
+collide.insertReactions = function(rows) collide.record('rx', rows) end
+local M3 = H.load('server/migrate/port/reactions.lua', collide)
+local ok, res3 = pcall(M3.run, { numberToCid = {}, dryRun = false })
+H.eq(ok, true, 'sd-shaped reactions table does not crash the porter')
+H.eq(ok and res3.imported, 0, 'sd-shaped reactions table imports nothing')
+H.eq(collide.calls.rx, nil, 'sd-shaped reactions table is never written back to')
 
 return true

--- a/tests/lua/port_reactions_test.lua
+++ b/tests/lua/port_reactions_test.lua
@@ -1,1 +1,38 @@
+local H = require 'support.harness'
+
+local store = H.newStore()
+store.tables['phone_message_reactions_lb'] = true
+store.lbTable = function(name)
+    if name == 'message_reactions' then return 'phone_message_reactions_lb' end
+    return 'phone_' .. name
+end
+store.lbReactions = function()
+    return { { message_id = 42, phone_number = '(555) 010-0001', reaction = 'heart' },
+             { message_id = 43, phone_number = '(555) 010-9999', reaction = 'thumb' },
+             { message_id = 44, phone_number = '(555) 010-0001', reaction = '' } }
+end
+store.insertReactions = function(rows) store.record('rx', rows) end
+
+local M = H.load('server/migrate/port/reactions.lua', store)
+local res = M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+
+H.eq(res.imported, 1, 'resolved reaction imports')
+H.eq(res.skipped, 2, 'unresolved owner and empty emoji skipped')
+
+local r = store.calls.rx[1]
+H.eq(r[1], 'm42',   'mid matches the messages porter format')
+H.eq(r[2], 'CID1',  'citizenid')
+H.eq(r[3], 'heart', 'emoji')
+H.eq(type(r[4]), 'number', 'created_at stamped')
+
+local dry = H.newStore()
+dry.tables['phone_message_reactions_lb'] = true
+dry.lbTable = store.lbTable
+dry.lbReactions = store.lbReactions
+dry.insertReactions = function(rows) dry.record('rx', rows) end
+local M2 = H.load('server/migrate/port/reactions.lua', dry)
+local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = true })
+H.eq(res2.imported, 1, 'dry run counts')
+H.eq(dry.calls.rx, nil, 'dry run writes nothing')
+
 return true

--- a/tests/lua/port_sessions_test.lua
+++ b/tests/lua/port_sessions_test.lua
@@ -1,0 +1,1 @@
+return true

--- a/tests/lua/port_sessions_test.lua
+++ b/tests/lua/port_sessions_test.lua
@@ -1,1 +1,40 @@
+local H = require 'support.harness'
+
+local store = H.newStore()
+store.tables['phone_logged_in_accounts'] = true
+store.lbLoggedIn = function()
+    return { { phone_number = '(555) 010-0001', app = 'instagram', username = 'jay' },
+             { phone_number = '(555) 010-0001', app = 'twitter',   username = 'jaytweets' },
+             { phone_number = '(555) 010-0001', app = 'mail',      username = 'jay@ls.mail' },
+             { phone_number = '(555) 010-0001', app = 'tiktok',    username = 'jaytok' },
+             { phone_number = '(555) 010-9999', app = 'instagram', username = 'ghost' } }
+end
+store.insertPgSessions = function(rows) store.record('sess', rows) end
+
+local M = H.load('server/migrate/port/sessions.lua', store)
+local res = M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+
+H.eq(res.written, 1, 'only the photogram session is written')
+H.eq(res.deferred, 1, 'twitter deferred for project A')
+H.eq(res.skipped, 3, 'mail, tiktok and unresolved owner skipped')
+
+local r = store.calls.sess[1]
+H.eq(r[1], 'photogram', 'app mapped from instagram')
+H.eq(r[2], 'CID1',      'citizenid')
+H.eq(r[3], 'jay',       'username')
+
+local dry = H.newStore()
+dry.tables['phone_logged_in_accounts'] = true
+dry.lbLoggedIn = store.lbLoggedIn
+dry.insertPgSessions = function(rows) dry.record('sess', rows) end
+local M2 = H.load('server/migrate/port/sessions.lua', dry)
+local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = true })
+H.eq(res2.written, 1, 'dry run counts')
+H.eq(dry.calls.sess, nil, 'dry run writes nothing')
+
+local absent = H.newStore()
+local M3 = H.load('server/migrate/port/sessions.lua', absent)
+local res3 = M3.run({ numberToCid = {}, dryRun = false })
+H.eq(res3.written, 0, 'missing source table is a clean no-op')
+
 return true

--- a/tests/lua/port_sessions_test.lua
+++ b/tests/lua/port_sessions_test.lua
@@ -9,7 +9,7 @@ store.lbLoggedIn = function()
              { phone_number = '(555) 010-0001', app = 'tiktok',    username = 'jaytok' },
              { phone_number = '(555) 010-9999', app = 'instagram', username = 'ghost' } }
 end
-store.insertPgSessions = function(rows) store.record('sess', rows) end
+store.insertPgSessions = function(rows) store.record('sess', rows); return #rows, #rows end
 
 local M = H.load('server/migrate/port/sessions.lua', store)
 local res = M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
@@ -26,7 +26,7 @@ H.eq(r[3], 'jay',       'username')
 local dry = H.newStore()
 dry.tables['phone_logged_in_accounts'] = true
 dry.lbLoggedIn = store.lbLoggedIn
-dry.insertPgSessions = function(rows) dry.record('sess', rows) end
+dry.insertPgSessions = function(rows) dry.record('sess', rows); return #rows, #rows end
 local M2 = H.load('server/migrate/port/sessions.lua', dry)
 local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = true })
 H.eq(res2.written, 1, 'dry run counts')
@@ -36,5 +36,44 @@ local absent = H.newStore()
 local M3 = H.load('server/migrate/port/sessions.lua', absent)
 local res3 = M3.run({ numberToCid = {}, dryRun = false })
 H.eq(res3.written, 0, 'missing source table is a clean no-op')
+
+-- Regression: the session insert resolves account_id by lookup, so it silently matches nothing when
+-- photogram has not created the accounts. Reporting those as written marked the domain done and
+-- permanently lost every login. Observed on a real server 2026-07-26.
+local none = H.newStore()
+none.tables['phone_logged_in_accounts'] = true
+none.lbLoggedIn = store.lbLoggedIn
+none.insertPgSessions = function() return 0, 0 end
+local M4 = H.load('server/migrate/port/sessions.lua', none)
+local ok4, err4 = pcall(M4.run, { numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+H.eq(ok4, false, 'linking nothing raises so the domain is not marked done')
+H.eq(type(err4) == 'string' and err4:find('photogram') ~= nil, true, 'the error names the likely cause')
+
+-- Regression: on a re-run every session already exists, so INSERT IGNORE affects no rows. Judging
+-- success on rows inserted rather than accounts linked turned that into a false failure, which is
+-- exactly what happened on a real server 2026-07-26.
+local rerun = H.newStore()
+rerun.tables['phone_logged_in_accounts'] = true
+rerun.lbLoggedIn = store.lbLoggedIn
+rerun.insertPgSessions = function(rows) return #rows, 0 end
+local M6 = H.load('server/migrate/port/sessions.lua', rerun)
+local ok6, res6 = pcall(M6.run, { numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+H.eq(ok6, true, 'a re-run that inserts nothing is success, not failure')
+H.eq(ok6 and res6.written, 1, 'already-present sessions still count as written')
+H.eq(ok6 and res6.created, 0, 'nothing new was created')
+H.eq(ok6 and res6.orphan, 0, 'no orphans on a clean re-run')
+
+-- Partial linking is legitimate: an account that was never migrated is an orphan, not a failure.
+local partial = H.newStore()
+partial.tables['phone_logged_in_accounts'] = true
+partial.lbLoggedIn = function()
+    return { { phone_number = '(555) 010-0001', app = 'instagram', username = 'jay' },
+             { phone_number = '(555) 010-0001', app = 'instagram', username = 'gone' } }
+end
+partial.insertPgSessions = function(rows) partial.record('sess', rows); return 1, 1 end
+local M5 = H.load('server/migrate/port/sessions.lua', partial)
+local res5 = M5.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+H.eq(res5.written, 1, 'written reflects rows that actually landed')
+H.eq(res5.orphan, 1, 'the unmatched account is reported as an orphan')
 
 return true

--- a/tests/lua/port_settings_test.lua
+++ b/tests/lua/port_settings_test.lua
@@ -1,0 +1,1 @@
+return true

--- a/tests/lua/port_settings_test.lua
+++ b/tests/lua/port_settings_test.lua
@@ -1,1 +1,50 @@
+local H = require 'support.harness'
+
+local store = H.newStore()
+store.tables['phone_phones'] = true
+store.lbPhoneSettings = function()
+    return {
+        { phone_number = '(555) 010-0001', settings = {
+            wallpaper = { background = 'cloud8', blur = true },
+            display   = { theme = 'dark', brightness = 0.5, size = 0.7 },
+            sound     = { ringtone = 'default', texttone = 'ping', volume = 0.5, callVolume = 1 },
+            time      = { twelveHourClock = false },
+            apps      = { { 'Phone' }, { 'Mail' } },
+        } },
+        { phone_number = '(555) 010-0002', settings = {} },
+        { phone_number = '(555) 010-9999', settings = { display = { theme = 'light' } } },
+    }
+end
+store.fillSettings = function(rows) store.record('settings', rows) end
+
+local M = H.load('server/migrate/port/settings.lua', store)
+local res = M.run({ numberToCid = { ['5550100001'] = 'CID1', ['5550100002'] = 'CID2' }, dryRun = false })
+
+H.eq(res.imported, 1, 'only the populated resolved phone imports')
+H.eq(res.skipped, 2, 'empty blob and unresolved owner are skipped')
+
+local r = store.calls.settings[1]
+H.eq(r[1],  'CID1',   'citizenid')
+H.eq(r[2],  'cloud8', 'wallpaper')
+H.eq(r[3],  1,        'blur_lock')
+H.eq(r[4],  1,        'blur_home')
+H.eq(r[5],  'dark',   'theme')
+H.eq(r[6],  50,       'brightness 0.5 becomes 50')
+H.eq(r[7],  70,       'phone_scale 0.7 becomes 70')
+H.eq(r[8],  1,        'twelveHourClock false becomes hour24 1')
+H.eq(r[9],  'default','ringtone')
+H.eq(r[10], 'ping',   'notification_tone')
+H.eq(r[11], 50,       'ringtone_volume')
+H.eq(r[12], 100,      'call_volume 1.0 becomes 100')
+H.eq(r[13], 'json:2', 'home_layout encoded')
+
+local dry = H.newStore()
+dry.tables['phone_phones'] = true
+dry.lbPhoneSettings = store.lbPhoneSettings
+dry.fillSettings = function(rows) dry.record('settings', rows) end
+local M2 = H.load('server/migrate/port/settings.lua', dry)
+local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = true })
+H.eq(res2.imported, 1, 'dry run still counts')
+H.eq(dry.calls.settings, nil, 'dry run writes nothing')
+
 return true

--- a/tests/lua/port_voicememos_test.lua
+++ b/tests/lua/port_voicememos_test.lua
@@ -1,0 +1,1 @@
+return true

--- a/tests/lua/port_voicememos_test.lua
+++ b/tests/lua/port_voicememos_test.lua
@@ -1,1 +1,40 @@
+local H = require 'support.harness'
+
+local store = H.newStore()
+store.tables['phone_voice_memos_recordings'] = true
+store.lbVoiceMemos = function()
+    return { { id = 1, phone_number = '(555) 010-0001', file_name = 'Memo 1',
+               file_url = 'http://a.mp3', file_length = 12, ts = 1700000000 },
+             { id = 2, phone_number = '(555) 010-0001', file_name = 'Broken',
+               file_url = '', file_length = 0, ts = 1700000100 },
+             { id = 3, phone_number = '(555) 010-9999', file_name = 'Orphan',
+               file_url = 'http://b.mp3', file_length = 5, ts = 1700000200 },
+             { id = 4, phone_number = '(555) 010-0001', file_name = '',
+               file_url = 'http://c.mp3', file_length = 7, ts = 1700000300 } }
+end
+store.insertVoiceMemos = function(rows) store.record('vm', rows) end
+
+local M = H.load('server/migrate/port/voicememos.lua', store)
+local res = M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+
+H.eq(res.imported, 2, 'two valid memos')
+H.eq(res.skipped, 2, 'empty url and unresolved owner skipped')
+
+local r = store.calls.vm[1]
+H.eq(r[1], 'CID1',        'citizenid')
+H.eq(r[2], 'Memo 1',      'name')
+H.eq(r[3], 'http://a.mp3','url')
+H.eq(r[4], 12,            'duration')
+H.eq(r[5], 1700000000,    'created_at')
+H.eq(store.calls.vm[2][2], 'Recording', 'blank name falls back')
+
+local dry = H.newStore()
+dry.tables['phone_voice_memos_recordings'] = true
+dry.lbVoiceMemos = store.lbVoiceMemos
+dry.insertVoiceMemos = function(rows) dry.record('vm', rows) end
+local M2 = H.load('server/migrate/port/voicememos.lua', dry)
+local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = true })
+H.eq(res2.imported, 2, 'dry run counts')
+H.eq(dry.calls.vm, nil, 'dry run writes nothing')
+
 return true

--- a/tests/lua/port_voicememos_test.lua
+++ b/tests/lua/port_voicememos_test.lua
@@ -26,6 +26,7 @@ H.eq(r[2], 'Memo 1',      'name')
 H.eq(r[3], 'http://a.mp3','url')
 H.eq(r[4], 12,            'duration')
 H.eq(r[5], 1700000000,    'created_at')
+H.eq(r[6], 'lbv1',        'deterministic source id makes a re-import a no-op')
 H.eq(store.calls.vm[2][2], 'Recording', 'blank name falls back')
 
 local dry = H.newStore()

--- a/tests/lua/port_wallet_test.lua
+++ b/tests/lua/port_wallet_test.lua
@@ -1,0 +1,1 @@
+return true

--- a/tests/lua/port_wallet_test.lua
+++ b/tests/lua/port_wallet_test.lua
@@ -24,6 +24,7 @@ H.eq(r[2], 'Burger Shot', 'company becomes label')
 H.eq(r[3], -250,          'amount preserved with sign')
 H.eq(r[4], 'wallet',      'category')
 H.eq(r[5], 1700000000,    'created_at seconds')
+H.eq(r[6], 'lbw1',        'deterministic source id makes a re-import a no-op')
 
 local dry = H.newStore()
 dry.tables['phone_wallet_transactions'] = true

--- a/tests/lua/port_wallet_test.lua
+++ b/tests/lua/port_wallet_test.lua
@@ -1,1 +1,37 @@
+local H = require 'support.harness'
+
+local store = H.newStore()
+store.tables['phone_wallet_transactions'] = true
+store.lbWallet = function()
+    return {
+        { id = 1, phone_number = '(555) 010-0001', amount = -250, company = 'Burger Shot',
+          ts = 1700000000 },
+        { id = 2, phone_number = '(555) 010-9999', amount = 100, company = 'Refund',
+          ts = 1700000100 },
+    }
+end
+store.insertBankTx = function(rows) store.record('tx', rows) end
+
+local M = H.load('server/migrate/port/wallet.lua', store)
+local res = M.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = false })
+
+H.eq(res.imported, 1, 'only the resolved owner imports')
+H.eq(res.skipped, 1, 'unresolved owner skipped')
+
+local r = store.calls.tx[1]
+H.eq(r[1], 'CID1',        'citizenid')
+H.eq(r[2], 'Burger Shot', 'company becomes label')
+H.eq(r[3], -250,          'amount preserved with sign')
+H.eq(r[4], 'wallet',      'category')
+H.eq(r[5], 1700000000,    'created_at seconds')
+
+local dry = H.newStore()
+dry.tables['phone_wallet_transactions'] = true
+dry.lbWallet = store.lbWallet
+dry.insertBankTx = function(rows) dry.record('tx', rows) end
+local M2 = H.load('server/migrate/port/wallet.lua', dry)
+local res2 = M2.run({ numberToCid = { ['5550100001'] = 'CID1' }, dryRun = true })
+H.eq(res2.imported, 1, 'dry run counts')
+H.eq(dry.calls.tx, nil, 'dry run writes nothing')
+
 return true

--- a/tests/lua/run.lua
+++ b/tests/lua/run.lua
@@ -10,6 +10,7 @@ local suites = {
     'port_voicememos_test',
     'port_sessions_test',
     'idempotency_test',
+    'plan_test',
 }
 
 for _, name in ipairs(suites) do

--- a/tests/lua/run.lua
+++ b/tests/lua/run.lua
@@ -1,0 +1,22 @@
+package.path = 'tests/lua/?.lua;' .. package.path
+local H = require 'support.harness'
+
+local suites = {
+    'port_settings_test',
+    'port_photogram_test',
+    'port_mail_test',
+    'port_wallet_test',
+    'port_reactions_test',
+    'port_voicememos_test',
+    'port_sessions_test',
+}
+
+for _, name in ipairs(suites) do
+    local ok, err = pcall(require, name)
+    if not ok then
+        print(('SUITE ERROR %s: %s'):format(name, err))
+        H.failed = H.failed + 1
+    end
+end
+
+H.report()

--- a/tests/lua/run.lua
+++ b/tests/lua/run.lua
@@ -9,6 +9,7 @@ local suites = {
     'port_reactions_test',
     'port_voicememos_test',
     'port_sessions_test',
+    'idempotency_test',
 }
 
 for _, name in ipairs(suites) do

--- a/tests/lua/support/harness.lua
+++ b/tests/lua/support/harness.lua
@@ -1,10 +1,24 @@
 local H = { passed = 0, failed = 0 }
 
 ---A stub migrate store: records every insert call so tests can assert on the rows.
+---`tables` holds lb-shaped tables; `foreign` holds tables that exist under an lb name but carry
+---sd-phone's own shape, which is what `lbSource` has to reject.
 function H.newStore()
-    local s = { calls = {}, tables = {}, lb = {} }
+    local s = { calls = {}, tables = {}, foreign = {}, lb = {} }
     s.tableExists = function(name) return s.tables[name] == true end
     s.lbTable = function(name) return 'phone_' .. name end
+    s.lbSource = function(name, marker)
+        local full = 'phone_' .. name
+        local rescued = full .. '_lb'
+        if s.tables[rescued] then return rescued end
+        -- Not `marker and nil or full`: nil is falsy, so that idiom always yields full.
+        if s.foreign[full] then
+            if marker then return nil end
+            return full
+        end
+        if not s.tables[full] then return nil end
+        return full
+    end
     s.decodeJson = function(v)
         if type(v) == 'table' then return v end
         return {}
@@ -23,6 +37,7 @@ end
 ---Loads a porter module with `server.migrate.store` and `server.util` mocked.
 function H.load(path, storeMock, utilMock)
     package.loaded['server.migrate.store'] = storeMock
+    package.loaded['server.mail.store'] = { reconcileSessions = function() return 0, 0 end }
     package.loaded['server.util'] = utilMock or {
         truthy = function(v) return v == true or v == 1 or v == '1' end,
         trim   = function(v) return (tostring(v or ''):gsub('^%s+', ''):gsub('%s+$', '')) end,

--- a/tests/lua/support/harness.lua
+++ b/tests/lua/support/harness.lua
@@ -1,0 +1,48 @@
+local H = { passed = 0, failed = 0 }
+
+---A stub migrate store: records every insert call so tests can assert on the rows.
+function H.newStore()
+    local s = { calls = {}, tables = {}, lb = {} }
+    s.tableExists = function(name) return s.tables[name] == true end
+    s.lbTable = function(name) return 'phone_' .. name end
+    s.decodeJson = function(v)
+        if type(v) == 'table' then return v end
+        return {}
+    end
+    s.encodeJson = function(t)
+        if not t or next(t) == nil then return nil end
+        return 'json:' .. tostring(#t)
+    end
+    s.record = function(key, rows)
+        s.calls[key] = s.calls[key] or {}
+        for i = 1, #rows do s.calls[key][#s.calls[key] + 1] = rows[i] end
+    end
+    return s
+end
+
+---Loads a porter module with `server.migrate.store` and `server.util` mocked.
+function H.load(path, storeMock, utilMock)
+    package.loaded['server.migrate.store'] = storeMock
+    package.loaded['server.util'] = utilMock or {
+        truthy = function(v) return v == true or v == 1 or v == '1' end,
+        trim   = function(v) return (tostring(v or ''):gsub('^%s+', ''):gsub('%s+$', '')) end,
+        newId  = function(n) return ('x'):rep(n or 8) end,
+    }
+    return dofile(path)
+end
+
+function H.eq(actual, expected, label)
+    if actual == expected then
+        H.passed = H.passed + 1
+    else
+        H.failed = H.failed + 1
+        print(('FAIL %s: expected %s, got %s'):format(label, tostring(expected), tostring(actual)))
+    end
+end
+
+function H.report()
+    print(('%d passed, %d failed'):format(H.passed, H.failed))
+    if H.failed > 0 then os.exit(1) end
+end
+
+return H


### PR DESCRIPTION
Adds seven porters to the lb-phone importer: `settings`, `photogram`, `mail`, `wallet`, `reactions`, `voicememos` and `sessions`. Each follows the existing `photos.lua` shape and registers in the `PORTS` table, so dry-run, the completion marker and identity resolution are all inherited.

Designed against a 370MB production dump from a large ESX server (43 tables, ~3.8M dated rows, Apr-Jul 2026).

### What carries across now
Wallpaper, theme, clock format, ringtones, volumes and home-screen layout; Instagram accounts with their posts, comments, likes, follows, stories and DMs; mail accounts and inboxes; wallet history; message reactions; voice memos; and social logins.

### Notes
- **Passwords cannot be migrated.** lb-phone stores them bcrypt cost 11, which is one-way and unrelated to sd-phone's hasher. The `sessions` porter pre-seeds `phone_app_sessions` so players arrive already signed in, and the existing accounts-engine reset flow covers anyone who logs out. The original hash is preserved in `phone_app_accounts.password_hash`.
- **Photogram content needs no identity resolution.** Content is username-keyed on both sides, so an unresolved owner costs the login, not the content: posts still render, likes still count, followers still see them. This matters because ESX `char1:` identifiers will not all resolve against a Qbox roster.
- **Ordering is load-bearing** in two places: `reactions` after `messages` (joins on its `m<id>` mid format) and `sessions` last (links to accounts `photogram` creates).
- **Marker bumped to `lbphone-import-v2`** so existing v1 installs pick up only the new domains.
- **Voicemail was dropped from scope.** sd-phone has no voicemail feature, so lb's 1,008 rows have no target. Noted as a follow-up.
- **`airplane_mode` is deliberately not imported.** The column is `NOT NULL DEFAULT 0` so fill-only merging cannot tell unset from off, and importing an enabled airplane mode would leave a player with no service on first login.
- The Squawk porter is deferred until the multi-account refactor; `sessions` already counts those rows as `deferred` so the number is visible.

### Verification
- 107 assertions passing under standalone Lua 5.4 (`lua tests/lua/run.lua`), including a dedicated idempotency suite that runs every porter twice and asserts identical target keys.
- `luac -p` clean across all migrate modules.
- No frontend changes, so the web gates are unaffected.

Not yet run against a live server; a full `sdphone:migrate dry` against the production dump is the remaining validation step.