### PR TITLE
Fix migrated mail rendering, email domains, and account recovery

### DIFF
--- a/server/migrate/port/mail.lua
+++ b/server/migrate/port/mail.lua
@@ -7,44 +7,110 @@ local M = {}
 local store = require 'server.migrate.store'
 ---@type table Mail persistence (server.mail.store): its session index reconciler.
 local mailStore = require 'server.mail.store'
+---@type table Mail app config (configs.mail): the one domain this server issues addresses on.
+local mailCfg = require 'configs.mail'
 
 local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 
----The local part of an address, used as the display name lb-phone does not store.
----@param address string
+---The local part of an address, also used as the display name lb-phone does not store.
+---@param address any
 ---@return string
 local function localPart(address)
-    local name = tostring(address or ''):match('^([^@]+)') or 'Mail'
-    return name:sub(1, 64)
+    return (tostring(address or ''):match('^([^@]+)') or 'mail'):lower()
+end
+
+---Rewrites an address onto this server's configured mail domain.
+---
+---lb-phone servers run their own domain (eyefind.info on the dump this was built against), but
+---every sd-phone path that validates an address assumes `configs/mail.lua` Domain: registration
+---rejects anything else outright, and recovery appends it. A migrated account left on a foreign
+---domain is second-class, so the local part is kept and the domain replaced.
+---@param address any
+---@return string
+local function onOurDomain(address)
+    return localPart(address) .. '@' .. mailCfg.Domain
+end
+
+---@type table<string, string> HTML entities worth decoding; anything rarer is left alone.
+local ENTITIES = {
+    ['&nbsp;'] = ' ', ['&amp;'] = '&', ['&lt;'] = '<', ['&gt;'] = '>',
+    ['&quot;'] = '"', ['&#39;'] = "'", ['&apos;'] = "'", ['&hellip;'] = '...',
+}
+
+---Flattens an HTML mail body into readable plain text.
+---
+---Other lb-phone resources send formatted mail (`<h2>`, `<br>`, `<strong>`), but sd-phone renders a
+---body as plain text, so the markup showed up raw. Converting here rather than rendering the HTML
+---keeps foreign, player-authored content away from `dangerouslySetInnerHTML`.
+---@param body any
+---@return string
+local function htmlToText(body)
+    local s = tostring(body or '')
+    if not s:find('<') then return s end
+
+    s = s:gsub('<%s*[bB][rR]%s*/?%s*>', '\n')
+    s = s:gsub('<%s*/%s*[pP]%s*>', '\n\n')
+    s = s:gsub('<%s*/%s*[hH]%d%s*>', '\n\n')
+    s = s:gsub('<%s*/%s*[dD][iI][vV]%s*>', '\n')
+    s = s:gsub('<%s*[lL][iI]%s*>', '\n- ')
+    s = s:gsub('<[^>]->', '')
+    for entity, char in pairs(ENTITIES) do s = s:gsub(entity, char) end
+
+    -- Markup-heavy templates are written across indented source lines; without this the text keeps
+    -- their leading whitespace and reads as though it is badly aligned.
+    s = s:gsub('[ \t]+\n', '\n'):gsub('\n[ \t]+', '\n')
+    s = s:gsub('\n\n\n+', '\n\n')
+    return (s:gsub('^%s+', ''):gsub('%s+$', ''))
 end
 
 ---@param ctx table migration context (numberToCid, dryRun)
----@return { accounts: number, messages: number, sessions: number, skipped: number }
+---@return { accounts: number, messages: number, sessions: number, logins: number, collided: number, skipped: number }
 function M.run(ctx)
-    local out = { accounts = 0, messages = 0, sessions = 0, skipped = 0 }
-    -- `address` only exists on lb-phone's shape; sd-phone's own table uses `email`.
+    local out = { accounts = 0, messages = 0, sessions = 0, logins = 0, collided = 0, skipped = 0 }
     if not store.lbSource('mail_accounts', 'address') then return out end
 
-    local inbox, logins = {}, {}
-    local accounts = store.lbMailAccounts()
+    -- Two lb addresses can share a local part across different domains and collide once both are
+    -- rewritten onto ours. First one wins; the rest are counted and dropped rather than silently
+    -- merged into someone else's inbox.
+    local accounts, addressOf, taken = store.lbMailAccounts(), {}, {}
+    local kept = {}
     for _, a in ipairs(accounts) do
-        inbox[a.address] = {}
-        logins[a.address] = {}
+        local addr = onOurDomain(a.address)
+        if taken[addr] then
+            out.collided = out.collided + 1
+        else
+            taken[addr] = true
+            addressOf[a.address] = addr
+            kept[#kept + 1] = { raw = a.address, email = addr, password = a.password }
+        end
+    end
+
+    local inbox, logins = {}, {}
+    for _, a in ipairs(kept) do
+        inbox[a.email] = {}
+        logins[a.email] = {}
     end
 
     if store.lbSource('mail_messages') then
         for _, m in ipairs(store.lbMailMessages()) do
-            local box = inbox[m.recipient]
+            local to = addressOf[m.recipient]
+            local box = to and inbox[to]
             if box then
+                local from = addressOf[m.sender] or onOurDomain(m.sender)
+                -- Built to the shape server/mail/actions.lua writes for a real send. Getting this
+                -- wrong renders a message with an empty sender, no recipients and no body.
+                -- Attachments are deliberately dropped: sd-phone's are a tagged union
+                -- ({ kind = 'photo' | 'audio' | ... }) and lb's format is unrelated.
                 box[#box + 1] = {
-                    id = tostring(m.id),
-                    sender = m.sender,
-                    subject = m.subject,
-                    message = m.content,
-                    attachments = m.attachments,
-                    actions = m.actions,
-                    read = m.read and true or false,
-                    date = math.floor(tonumber(m.ts) or 0),
+                    id      = ('lbm%s'):format(m.id),
+                    folder  = 'inbox',
+                    from    = { name = localPart(m.sender), email = from },
+                    to      = { to },
+                    subject = tostring(m.subject or ''),
+                    body    = htmlToText(m.content),
+                    sentAt  = os.date('!%Y-%m-%dT%H:%M:%S', math.floor(tonumber(m.ts) or os.time())),
+                    read    = m.read and true or false,
+                    flagged = false,
                 }
                 out.messages = out.messages + 1
             else
@@ -53,37 +119,50 @@ function M.run(ctx)
         end
     end
 
+    local grants = {}
     if store.lbSource('logged_in_accounts') then
         for _, l in ipairs(store.lbLoggedIn()) do
             if l.app == 'mail' then
                 local cid = ctx.numberToCid[digits(l.phone_number)]
-                local box = logins[l.username]
+                local addr = addressOf[l.username]
+                local box = addr and logins[addr]
                 if cid and box then
                     box[#box + 1] = cid
                     out.sessions = out.sessions + 1
+                    grants[#grants + 1] = { app = 'mail', username = addr, cid = cid, email = addr }
                 end
             end
         end
     end
 
     local rows = {}
-    for _, a in ipairs(accounts) do
+    for _, a in ipairs(kept) do
         rows[#rows + 1] = {
-            tostring(a.address):sub(1, 64),
+            a.email:sub(1, 64),
             tostring(a.password or ''):sub(1, 255),
-            localPart(a.address),
-            store.encodeJson(inbox[a.address]) or '[]',
-            store.encodeJson(logins[a.address]) or '[]',
+            localPart(a.raw):sub(1, 64),
+            store.encodeJson(inbox[a.email]) or '[]',
+            store.encodeJson(logins[a.email]) or '[]',
         }
         out.accounts = out.accounts + 1
     end
 
+    -- The accounts engine copies mail accounts across at boot, which has already happened by the
+    -- time the import runs. Insert them here too, or these accounts have no engine row for the
+    -- login grant below to attach a password to, and no recovery path at all until a restart.
+    local engineRows = {}
+    for _, a in ipairs(kept) do
+        engineRows[#engineRows + 1] = { 'mail', a.email:sub(1, 64), localPart(a.raw):sub(1, 50), '' }
+    end
+
     if not ctx.dryRun then
         store.insertMailAccounts(rows)
+        store.insertPgAccounts(engineRows)
         -- The session index is derived from logged_in_citizens and is normally rebuilt at boot,
         -- which has already happened by the time the import runs. Rebuild it now so migrated
         -- players are signed into mail immediately rather than after the next restart.
         if out.sessions > 0 then pcall(mailStore.reconcileSessions) end
+        out.logins = store.grantMigratedLogins(grants)
     end
     return out
 end

--- a/server/migrate/port/photogram.lua
+++ b/server/migrate/port/photogram.lua
@@ -11,6 +11,7 @@ local util  = require 'server.util'
 ---@type string Id prefix, keeping migrated ids clear of natively generated 7-char base36 ids.
 local P = 'i'
 
+local function digits(s) return (tostring(s or ''):gsub('%D', '')) end
 local function id(v) return P .. tostring(v) end
 local function ts(v) return math.floor(tonumber(v) or 0) end
 local function bit(v) return util.truthy(v) and 1 or 0 end
@@ -26,16 +27,19 @@ local function str(v, len)
     return s:sub(1, len)
 end
 
----Needs no identity resolution: content is username-keyed on both sides, so it imports whole even
----when an owner cannot be matched to a character.
----@param ctx table migration context (dryRun)
+---Content needs no identity resolution: it is username-keyed on both sides, so it imports whole even
+---when an owner cannot be matched to a character. Ownership is only consulted to hand the owner a
+---usable password for the account.
+---@param ctx table migration context (numberToCid, dryRun)
 ---@return table counts
 function M.run(ctx)
     local out = {
         profiles = 0, posts = 0, comments = 0, likes = 0, commentLikes = 0, follows = 0,
         stories = 0, views = 0, dms = 0, notifications = 0, accounts = 0, skipped = 0, orphan = 0,
+        logins = 0,
     }
     local profiles, accounts = {}, {}
+    local grants = {}
     local posts, comments, likes, commentLikes = {}, {}, {}, {}
     local follows, stories, views, dms, notifs = {}, {}, {}, {}, {}
 
@@ -74,6 +78,11 @@ function M.run(ctx)
                     'photogram', user, str(a.display_name, 50) or user, str(a.password, 64) or '',
                 }
                 out.accounts = out.accounts + 1
+
+                -- lb's hash is bcrypt and unusable here, so the owner needs a password they can
+                -- actually read and type. Granted after the insert below.
+                local cid = ctx.numberToCid[digits(a.phone_number)]
+                if cid then grants[#grants + 1] = { app = 'photogram', username = user, cid = cid } end
             else
                 out.skipped = out.skipped + 1
             end
@@ -199,6 +208,7 @@ function M.run(ctx)
         store.insertPgStoryViews(views)
         store.insertPgDms(dms)
         store.insertPgNotifications(notifs)
+        out.logins = store.grantMigratedLogins(grants)
     end
     return out
 end

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -680,6 +680,49 @@ function store.insertPgAccounts(rows)
     insertMulti('INSERT IGNORE INTO phone_app_accounts (app, username, display_name, password_hash) VALUES', 4, rows)
 end
 
+---@type string Alphabet for generated passwords; no look-alike characters, so a player can read one
+---off the Passwords app and type it without ambiguity.
+local PW_CHARS = 'abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+
+---A fresh readable password.
+---@return string
+local function newPassword()
+    local out = {}
+    for i = 1, 12 do
+        local n = math.random(1, #PW_CHARS)
+        out[i] = PW_CHARS:sub(n, n)
+    end
+    return table.concat(out)
+end
+
+---Gives migrated accounts a login their owner can actually use.
+---
+---lb-phone hashes passwords with bcrypt, which sd-phone cannot verify and cannot reverse, so a
+---migrated account is unreachable the moment its owner signs out. Each account with a resolved
+---owner therefore gets a freshly generated password: stored as the engine hash on the account, and
+---written to that owner's vault so it shows up in the Passwords app.
+---
+---Accounts with no resolved owner keep whatever hash they came with. Nobody can sign into them, but
+---there is also no one to hand a password to.
+---@param entries { app: string, username: string, cid: string, email: string|nil }[]
+---@return integer granted
+function store.grantMigratedLogins(entries)
+    if #entries == 0 then return 0 end
+    local accounts = require 'server.accounts.store'
+    local granted = 0
+    for _, e in ipairs(entries) do
+        local plain = newPassword()
+        local n = MySQL.update.await(
+            'UPDATE phone_app_accounts SET password_hash = ? WHERE app = ? AND username = ?',
+            { accounts.hashPassword(plain), e.app, e.username })
+        if (tonumber(n) or 0) > 0 then
+            accounts.saveVaultEntry(e.cid, e.app, e.username, plain, e.email, nil)
+            granted = granted + 1
+        end
+    end
+    return granted
+end
+
 ---Sessions for migrated app accounts. `linked` counts rows whose account exists and now has a
 ---session; `inserted` counts only the new ones. They differ on a re-run, where every session is
 ---already present and INSERT IGNORE affects no rows: that is success, not failure, so callers must


### PR DESCRIPTION
Four defects found by running the importer against real data in-game.

### Mail rendered with no sender, recipients or body

The porter wrote `sender` / `message` / `date`; the UI reads `from: {name, email}` / `to: string[]` / `body` / `sentAt`, plus `folder` and `flagged`. Only `subject` happened to line up, which is exactly what showed. Messages are now built to the shape `server/mail/actions.lua` writes for a real send.

lb attachments are dropped rather than passed through: sd-phone's are a tagged union (`{kind: 'photo' | 'audio' | ...}`) and lb's format is unrelated, so forwarding them risked a render crash.

### Foreign email domains

lb servers run their own domain (`eyefind.info` on the dump this was built against) while every sd-phone path assumes `configs/mail.lua` `Domain` — registration rejects anything else, recovery appends yours. Migrated accounts were second-class.

Addresses now move onto the configured domain with the local part kept, and `from`/`to` inside migrated messages are rewritten through the same map so threads stay coherent. Two lb addresses colliding on one local part keep the first and count the rest as `collided` rather than merging into someone else's inbox.

### No way back into a migrated account

lb hashes with bcrypt, which sd-phone can neither verify nor reverse, so an account was unreachable the moment its owner signed out — the pre-seeded session was the only way in.

Each account with a resolved owner now gets a freshly generated readable password, stored as the engine hash and written to that owner's vault, so it appears in the **Passwords app**. Covers Photogram and Mail, and Squawk automatically once its porter lands. Accounts with no resolved owner keep their unusable hash, since there is no one to hand a password to.

### HTML mail showed raw markup

Other lb resources send formatted mail (`<h2>`, `<br>`, `<strong>`). sd-phone renders a body as plain text, so the tags showed. Bodies are flattened to readable text in the porter, which keeps foreign player-authored content away from `dangerouslySetInnerHTML`.

### Verification

161 assertions in the local Lua harness, `luac -p` clean. Covers the message shape, domain normalisation, address collisions, and HTML flattening.