### PR TITLE
Fix the import summary crash and batch per-row login work

### DIFF
--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -114,24 +114,6 @@ local function plural(n, noun)
     end
     return ('%s %s'):format(comma(n), suffixed)
 end
-
----A one-line human summary of what a domain actually brought across, or nil when it brought
----nothing. Reads the counters the porter returned rather than what it was asked to process, so the
----figures are what landed.
----@param key string domain key
----@param res table|nil counts returned by the porter
----@return string|nil
-local function summarise(key, res)
-    if type(res) ~= 'table' then return nil end
-    local parts = {}
-    for _, field in ipairs(SUMMARY_FIELDS[key] or {}) do
-        local n = tonumber(res[field[1]]) or 0
-        if n > 0 then parts[#parts + 1] = plural(n, field[2]) end
-    end
-    if #parts == 0 then return nil end
-    return table.concat(parts, ', ')
-end
-
 ---@type table<string, { [1]: string, [2]: string }[]> What to show per domain in the closing
 ---summary: the counter each porter returns, paired with a human noun. Counters that are zero are
 ---left out, so a server without a given app produces no line for it.
@@ -154,6 +136,24 @@ local SUMMARY_FIELDS = {
     voicememos = { { 'imported', 'voice memo' } },
     sessions   = { { 'written', 'signed-in account' }, { 'deferred', 'login held for Squawk' } },
 }
+
+
+---A one-line human summary of what a domain actually brought across, or nil when it brought
+---nothing. Reads the counters the porter returned rather than what it was asked to process, so the
+---figures are what landed.
+---@param key string domain key
+---@param res table|nil counts returned by the porter
+---@return string|nil
+local function summarise(key, res)
+    if type(res) ~= 'table' then return nil end
+    local parts = {}
+    for _, field in ipairs(SUMMARY_FIELDS[key] or {}) do
+        local n = tonumber(res[field[1]]) or 0
+        if n > 0 then parts[#parts + 1] = plural(n, field[2]) end
+    end
+    if #parts == 0 then return nil end
+    return table.concat(parts, ', ')
+end
 
 ---Print a namespaced migration log line.
 ---@param msg string
@@ -381,8 +381,11 @@ CreateThread(function()
     if not cfg or cfg.enabled == false then return end
     local ok, err = pcall(run, { force = false, dryRun = false })
     if not ok then
+        -- Domains are marked as each one finishes, so a crash here only loses the domains that had
+        -- not run yet; those retry on the next start. Saying otherwise sent me hunting for data
+        -- loss that had not happened.
         log(('^1import crashed:^0 %s'):format(err))
-        log('^1no domain was marked done, so the import retries on the next start.^0')
+        log('^1domains that completed are marked done; the rest retry on the next start.^0')
     end
 end)
 

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -725,17 +725,52 @@ end
 function store.grantMigratedLogins(entries)
     if #entries == 0 then return 0 end
     local accounts = require 'server.accounts.store'
-    local granted = 0
-    for _, e in ipairs(entries) do
-        local plain = newPassword()
-        local n = MySQL.update.await(
-            'UPDATE phone_app_accounts SET password_hash = ? WHERE app = ? AND username = ?',
-            { accounts.hashPassword(plain), e.app, e.username })
-        if (tonumber(n) or 0) > 0 then
-            accounts.saveVaultEntry(e.cid, e.app, e.username, plain, e.email, nil)
-            granted = granted + 1
+
+    -- Staged and joined rather than two queries per account: row-by-row took 47s on a full dump.
+    local tmp = '_sdphone_migrate_logins'
+    MySQL.query.await(('DROP TABLE IF EXISTS `%s`'):format(tmp))
+    MySQL.query.await(([[
+        CREATE TABLE `%s` (
+            app VARCHAR(24) NOT NULL, username VARCHAR(64) NOT NULL, citizenid VARCHAR(64) NOT NULL,
+            plain VARCHAR(64) NOT NULL, hash VARCHAR(64) NOT NULL, email VARCHAR(120) NULL,
+            PRIMARY KEY (app, username, citizenid)
+        ) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    ]]):format(tmp))
+
+    for i = 1, #entries, 300 do
+        local last = math.min(i + 299, #entries)
+        local groups, params = {}, {}
+        for j = i, last do
+            local e = entries[j]
+            local plain = newPassword()
+            groups[#groups + 1] = '(?,?,?,?,?,?)'
+            params[#params + 1] = e.app
+            params[#params + 1] = e.username
+            params[#params + 1] = e.cid
+            params[#params + 1] = plain
+            params[#params + 1] = accounts.hashPassword(plain)
+            params[#params + 1] = e.email
         end
+        MySQL.query.await(([[
+            INSERT IGNORE INTO `%s` (app, username, citizenid, plain, hash, email) VALUES %s
+        ]]):format(tmp, table.concat(groups, ',')), params)
     end
+
+    -- Only accounts that exist get a password, and only those get a vault entry, so the vault never
+    -- lists a login that cannot be used.
+    local granted = tonumber(MySQL.update.await(([[
+        UPDATE phone_app_accounts a JOIN `%s` t ON t.app = a.app AND t.username = a.username
+        SET a.password_hash = t.hash
+    ]]):format(tmp))) or 0
+
+    MySQL.query.await(([[
+        INSERT INTO phone_passwords (citizenid, app, username, password, email)
+        SELECT t.citizenid, t.app, t.username, t.plain, t.email FROM `%s` t
+        JOIN phone_app_accounts a ON a.app = t.app AND a.username = t.username
+        ON DUPLICATE KEY UPDATE password = VALUES(password), email = VALUES(email)
+    ]]):format(tmp))
+
+    MySQL.query.await(('DROP TABLE IF EXISTS `%s`'):format(tmp))
     return granted
 end
 
@@ -746,18 +781,45 @@ end
 ---@param rows any[][] { app, citizenid, username }
 ---@return integer linked, integer inserted
 function store.insertPgSessions(rows)
-    local linked, inserted = 0, 0
-    for _, r in ipairs(rows) do
-        local id = MySQL.scalar.await(
-            'SELECT id FROM phone_app_accounts WHERE app = ? AND username = ? LIMIT 1', { r[1], r[3] })
-        if id then
-            linked = linked + 1
-            local n = MySQL.update.await(
-                'INSERT IGNORE INTO phone_app_sessions (app, citizenid, account_id) VALUES (?, ?, ?)',
-                { r[1], r[2], id })
-            inserted = inserted + (tonumber(n) or 0)
+    if #rows == 0 then return 0, 0 end
+
+    -- Set-based, not row-by-row: the previous loop ran two queries per session and took 23s on a
+    -- full dump. Staging the pairs and joining once turns that into a handful of statements.
+    local tmp = '_sdphone_migrate_sessions'
+    MySQL.query.await(('DROP TABLE IF EXISTS `%s`'):format(tmp))
+    MySQL.query.await(([[
+        CREATE TABLE `%s` (
+            app VARCHAR(24) NOT NULL, citizenid VARCHAR(64) NOT NULL, username VARCHAR(64) NOT NULL,
+            PRIMARY KEY (app, citizenid, username)
+        ) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    ]]):format(tmp))
+
+    for i = 1, #rows, 300 do
+        local last = math.min(i + 299, #rows)
+        local groups, params = {}, {}
+        for j = i, last do
+            groups[#groups + 1] = '(?,?,?)'
+            params[#params + 1] = rows[j][1]
+            params[#params + 1] = rows[j][2]
+            params[#params + 1] = rows[j][3]
         end
+        MySQL.query.await(
+            ('INSERT IGNORE INTO `%s` (app, citizenid, username) VALUES %s'):format(tmp, table.concat(groups, ',')),
+            params)
     end
+
+    local linked = tonumber(MySQL.scalar.await(([[
+        SELECT COUNT(*) FROM `%s` t
+        JOIN phone_app_accounts a ON a.app = t.app AND a.username = t.username
+    ]]):format(tmp))) or 0
+
+    local inserted = tonumber(MySQL.update.await(([[
+        INSERT IGNORE INTO phone_app_sessions (app, citizenid, account_id)
+        SELECT t.app, t.citizenid, a.id FROM `%s` t
+        JOIN phone_app_accounts a ON a.app = t.app AND a.username = t.username
+    ]]):format(tmp))) or 0
+
+    MySQL.query.await(('DROP TABLE IF EXISTS `%s`'):format(tmp))
     return linked, inserted
 end
 

--- a/web/src/admin/usePaged.ts
+++ b/web/src/admin/usePaged.ts
@@ -22,17 +22,30 @@ export function usePaged<T, C>(
         const gen = ++generation.current;
         setLoading(true);
         if (reset) setError(null);
-        const res = await fetchPage(reset ? null : cursor);
+
+        // `loading` gates loadMore, so it has to be cleared on every exit. A throw from fetchPage,
+        // or an early return, used to leave it stuck true: the Load more button kept rendering but
+        // every click was a no-op, which reads as pagination silently running out.
+        let res: PagedResult<T, C> | null = null;
+        let failed = false;
+        try {
+            res = await fetchPage(reset ? null : cursor);
+        } catch {
+            failed = true;
+        } finally {
+            if (gen === generation.current) setLoading(false);
+        }
         if (gen !== generation.current) return;
-        setLoading(false);
-        if (!res) {
+
+        if (failed || !res) {
             setError('Request failed');
             if (reset) { setItems([]); setHasMore(false); }
             return;
         }
-        setItems(prev => reset ? res.items : [...prev, ...res.items]);
-        setCursor(res.nextCursor ?? null);
-        setHasMore(res.nextCursor != null);
+        const page = res;
+        setItems(prev => reset ? page.items : [...prev, ...page.items]);
+        setCursor(page.nextCursor ?? null);
+        setHasMore(page.nextCursor != null);
     }, [fetchPage, cursor]);
 
     useEffect(() => {


### PR DESCRIPTION
Follow-ups from a full-scale run with every phone resolving to a character.

### The summary crashed every import

`SUMMARY_FIELDS` was declared below `summarise`, which uses it, so it resolved as a nil global and threw after the last domain finished. Same scoping mistake as `OWNED` earlier, so this time I checked every upper-case local across the migrate modules at bytecode level rather than fixing only the one that bit:

```
SUMMARY_FIELDS   0 global reads
DOMAIN_SOURCES   0
LEGACY_DOMAINS   0
ROWS_PER_SECOND  0
```

The crash message also claimed `no domain was marked done`. Domains are marked as each completes, so all 14 were recorded and the data was intact — the message sent me hunting for data loss that had not happened.

### Two porters ran a query per row

On a dump where every phone resolves:

| | Was | Cause |
|---|---|---|
| photogram | 47.3s | `UPDATE` + vault `INSERT` per account, 5,346 times |
| sessions | 22.8s | `SELECT` + `INSERT` per session |

Over 20,000 round trips between them. Both now stage their rows into a `MEMORY` table and join once.

### Closing overview

The per-domain lines scroll past on a long import, so what actually landed is restated at the end in plain terms — counters the porters returned, zero-count fields omitted, and an explicit line when nothing matched a character.

### Admin pagination could stick

`usePaged` awaited `fetchPage` with no error handling, and `fetchNui` calls `fetch()` and `JSON.parse()` bare. One rejected request left `loading` true forever, and since `loadMore` is gated on `!loading`, the button kept rendering but every click was a no-op with no error shown.

### Verification

161 Lua assertions, 142 frontend tests, 0 eslint errors, TypeScript clean.