### PR TITLE
fix(housing): detect RxHousing by its real resource name

### DIFF
--- a/bridge/server/housing.lua
+++ b/bridge/server/housing.lua
@@ -150,7 +150,7 @@ end
 --   rtx_housing  export GetPlayerOwnedProperties / GetPropertyData(.enter.coords) / Get|SetPropertyLockStatus
 --   bcs_housing  export GetOwnedHomes / GetHome(.properties.entry) / LockHome / isLocked / Add|RemoveKeyHolder / GetKeyHolders
 --   tk_housing   export getPropertiesByIdentifier (list only - no coords/lock/keys public)
---   rx_housing   export GetOwnedProperties / GetProperty / AddKeyholder / RemoveKeyholder / GetPropertyKeyholders
+--   RxHousing   export GetOwnedProperties / GetProperty / AddKeyholder / RemoveKeyholder / GetPropertyKeyholders
 --   loaf_housing export GetPlayerHouses | DB `loaf_houses`.entrance (coords only; keys need an undocumented keyId)
 --   origen_housing exports getPlayerHouses(.entryCoords) / toggleDoor / getHouseDoor / addKeyHolder / removeKeyHolder
 ---@type table<string, fun(source: number, id: string): table[]> Per-system property-list adapters.
@@ -324,11 +324,11 @@ ADAPTERS['tk_housing'] = function(_source, id)
     return out
 end
 
----rx_housing: export namespace is `RxHousing`; coords probed across common field names.
+---RxHousing: export namespace is `RxHousing`; coords probed across common field names.
 ---@param _source number caller server id (unused - the export keys by identifier)
 ---@param id string caller identifier
 ---@return table[] homes
-ADAPTERS['rx_housing'] = function(_source, id)
+ADAPTERS['RxHousing'] = function(_source, id)
     local props
     local ok, res = pcall(function() return exports['RxHousing']:GetOwnedProperties(id) end)
     if ok and type(res) == 'table' then props = res end
@@ -455,7 +455,7 @@ local CAPS = {
     ['rtx_housing']    = { lock = true,  keyList = false, keyManage = false },
     ['tk_housing']     = { lock = false, keyList = false, keyManage = false },
     ['origen_housing'] = { lock = true,  keyList = false, keyManage = true  },
-    ['rx_housing']     = { lock = false, keyList = true,  keyManage = true  },
+    ['RxHousing']      = { lock = false, keyList = true,  keyManage = true  },
     ['qs-housing']     = { lock = false, keyList = true,  keyManage = false },
     ['vms_housing']    = { lock = false, keyList = false, keyManage = true  },
     ['loaf_housing']   = { lock = false, keyList = false, keyManage = false },
@@ -602,7 +602,7 @@ function housing.keyHolders(src, id)
             out[#out + 1] = { id = tostring(k.identifier or k.id or ''), name = s(k.name) or 'Resident' }
         end
         return out
-    elseif ACTIVE == 'rx_housing' then
+    elseif ACTIVE == 'RxHousing' then
         local ok, list = pcall(function() return exports['RxHousing']:GetPropertyKeyholders(p) end)
         return ok and resolveCids(list) or {}
     elseif ACTIVE == 'qs-housing' then
@@ -640,7 +640,7 @@ function housing.giveKey(src, id, targetSrc)
         local ok = pcall(function() exports.bcs_housing:AddKeyHolder(p, targetSrc, bcsDefaultKey(p)) end)
         if ok then refreshHomes(src, targetSrc) end
         return ok
-    elseif ACTIVE == 'rx_housing' then
+    elseif ACTIVE == 'RxHousing' then
         local cid = player.getIdentifier(targetSrc)
         if not cid then return false end
         local ok, res = pcall(function() return exports['RxHousing']:AddKeyholder(p, cid) end)
@@ -680,7 +680,7 @@ function housing.removeKey(src, id, holderId)
         local ok = pcall(function() exports.bcs_housing:RemoveKeyHolder(p, holderId) end)
         if ok then refreshHomes(src, holderId) end
         return ok
-    elseif ACTIVE == 'rx_housing' then
+    elseif ACTIVE == 'RxHousing' then
         local ok = pcall(function() exports['RxHousing']:RemoveKeyholder(p, holderId) end)
         if ok then refreshHomes(src, holderId) end
         return ok

--- a/configs/housing.lua
+++ b/configs/housing.lua
@@ -12,6 +12,6 @@ return {
     -- Checked in priority order when System = 'auto'; first `started` wins.
     Resources = {
         'qs-housing', 'ps-housing', 'vms_housing', 'rtx_housing',
-        'origen_housing', 'bcs_housing', 'loaf_housing', 'tk_housing', 'rx_housing', 'LNS_Housing',
+        'origen_housing', 'bcs_housing', 'loaf_housing', 'tk_housing', 'RxHousing', 'LNS_Housing',
     },
 }


### PR DESCRIPTION
## Summary

The Homes auto-detect list probes for a resource named `rx_housing`, but RxHousing ships as `RxHousing`. `GetResourceState('rx_housing')` never reports `started`, so with `System = 'auto'` the bridge resolves `ACTIVE = nil` and the Homes app silently lists nothing on every RxHousing server.

This renames the profile key to match the real resource name in:

- `configs/housing.lua` auto-detect resource list
- `bridge/server/housing.lua` `ADAPTERS`, `CAPS`, and the three `ACTIVE ==` branches (`keyHolders`, `giveKey`, `removeKey`)

The key is internal only and appears nowhere else in the repo, so this is a self-contained rename. The adapter already called `exports['RxHousing']`, which is unchanged. That is what makes the bug easy to miss when grepping: the export calls look correct, only the detection key is wrong.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [x] Compatibility
- [ ] Other

## Related Issues

None filed.

## Testing

Tested on a server running RxHousing.

Also verified statically: the rename is consistent across all six call sites, and `rx_housing` no longer appears anywhere in the repo.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [x] Tested with latest ox_lib
- [x] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

Yes, for one narrow case.

`detectSystem()` returns `H.System` verbatim when it is not `'auto'`, bypassing the `GetResourceState` check. So anyone who worked around this bug by hard setting `System = 'rx_housing'` currently has a working setup, and this rename breaks it: `ACTIVE` resolves to `'rx_housing'` but `ADAPTERS['rx_housing']` no longer exists.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.
