### PR TITLE
fix(birdy): make the recovery contact optional at sign-up

### DIFF
--- a/server/birdy/actions.lua
+++ b/server/birdy/actions.lua
@@ -242,8 +242,15 @@ function actions.register(source, payload)
     local bio = trimmed(payload.bio) or ''
     if #bio > birdyCfg.MaxBioLength then return fail('Bio is too long') end
 
-    if not trimmed(payload.email) or trimmed(payload.email) == '' then
-        return fail('Email is required so you can recover the account')
+    -- Recovery contact. The accounts engine needs an email OR a phone; when the player supplies
+    -- neither, fall back to their own number so signup only asks for username/name/password.
+    local email = trimmed(payload.email)
+    local phone = trimmed(payload.phone)
+    if (not email or email == '') and (not phone or phone == '') then
+        phone = settings.getPhoneNumber(cid)
+        if not phone or phone == '' then
+            return fail('No phone number yet - add an email so you can recover the account')
+        end
     end
 
     if store.getProfileByHandle(handle) or acctStore.getAccount('birdy', handle) then
@@ -255,7 +262,7 @@ function actions.register(source, payload)
 
     local acctRes = acctActions.createAccount('birdy', {
         username = handle, password = password, name = name,
-        email = payload.email, phone = payload.phone,
+        email = email, phone = phone,
     })
     if not acctRes.success then return acctRes end
 

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -318,8 +318,8 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     { key: 'username', label: t('birdy.username', 'Username') },
                     { key: 'name',     label: t('birdy.name', 'Name') },
                     { key: 'password', label: t('birdy.password', 'Password'), type: 'password' },
-                    { key: 'email',    label: t('birdy.email', 'Email'), suffix: `@${MAIL_DOMAIN}`, createOnly: true },
-                    { key: 'phone',    label: t('birdy.phone', 'Phone'), type: 'tel',   createOnly: true },
+                    { key: 'email',    label: t('birdy.email', 'Email'), suffix: `@${MAIL_DOMAIN}`, createOnly: true, optional: true },
+                    { key: 'phone',    label: t('birdy.phone', 'Phone'), type: 'tel',   createOnly: true, optional: true },
                     { key: 'bio',      label: t('birdy.bio', 'Bio'), createOnly: true, optional: true },
                 ]}
                 onSubmit={async (mode, vals) => {


### PR DESCRIPTION
## Summary

Creating a Birdy account currently demands five fields: username, name, password, email **and** phone. The email is gated twice — `actions.register` rejects a blank one outright, and the register form marks both contact fields required (`AppAuth` treats a field as required unless it carries `optional`).

The accounts engine underneath is already more permissive than that. `createAccount` only needs an email *or* a phone (`server/accounts/actions.lua:122`):

```lua
if not email and not phone then
    return fail('Add an email or phone number so you can recover the account')
end
```

...and the server already knows the character's number, so it can satisfy that requirement itself instead of asking. This drops the extra email gate, marks both contact fields optional in the form, and falls back to `settings.getPhoneNumber(cid)` when the player fills in neither.

Changed in:

- `server/birdy/actions.lua` — `actions.register`: the standalone email check becomes an email-or-phone check with the character's own number as the fallback; the trimmed values are what get passed to `acctActions.createAccount`
- `web/src/apps/birdy/Birdy.tsx` — the `email` and `phone` create-only fields gain `optional: true`

Sign-up becomes username / name / password. A player who wants an email can still add one, and the `tel` field keeps its "From your phone number" autofill.

Recovery is not weakened. `resolveRecovery` picks its channel from what the player types — an address routes to `sendCodeEmail`, a bare number routes to `sendCodeSms` — so a phone-only account resets by SMS. Login is unaffected either way: it matches the handle directly via `acctStore.getAccount('birdy', handle)` before it ever tries the `handle@<domain>` contact lookup.

The only case that still errors is a character with no assigned number yet, which now asks for an email specifically rather than failing generically.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [x] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

None filed.

## Testing

- [ ] Tested locally
- [ ] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

Verified statically so far:

- `settings` is already required at `server/birdy/actions.lua:12`, and `cid` is in scope from the top of `register`
- `store.generateNumber()` issues ten raw digits, which clears `validPhone`'s 7–15 digit range
- `AppAuth` honours `optional` in both places that matter — the submit validator (`web/src/shared/AppAuth.tsx:396`) and the input's `required` attribute (line 509)
- the account phone is unique per app, but Birdy already caps one account per character (`store.getProfile(cid)`), so the fallback cannot collide with the same player's own number

## Breaking Changes

None. Existing accounts keep whatever contacts they were created with, and no stored data changes shape.

Worth noting rather than breaking: accounts created after this change may have no email. Nothing in the Birdy or accounts code paths assumes one — `sendCodeEmail` is only reached when the player *enters* an address — but a server that scripted its own mail-based flow against Birdy accounts would want to check.

---

## Checklist

- [x] My code follows the existing style of the project.
- [ ] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [ ] I have verified this works on the latest version of sd-phone.
