### PR TITLE
perf: page or bound every large per-player read (Photos, Messages, Contacts, Notes)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2063,6 +2063,7 @@
     "imports": "Imports",
     "itemsSelected": "{count} {noun} selected",
     "loading": "Loading…",
+    "loadingMore": "Loading more…",
     "mediaTypes": "Media Types",
     "moreOptions": "More options",
     "mute": "Mute",

--- a/server/contacts/store.lua
+++ b/server/contacts/store.lua
@@ -28,6 +28,11 @@ function store.ensureSchema()
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
+    -- listContacts orders by name. On the citizenid-only index that is a filesort of the whole
+    -- address book before the LIMIT can drop anything; with (citizenid, name) it walks the index
+    -- already ordered and stops at the cap.
+    util.ensureIndex('phone_contacts', 'idx_phone_contacts_cid_name', '(citizenid, name)')
+
     local col = MySQL.single.await([[
         SELECT COUNT(*) AS n FROM information_schema.columns
         WHERE table_schema = DATABASE() AND table_name = 'phone_contacts' AND column_name = 'avatar'
@@ -170,16 +175,24 @@ function store.unblockNumber(citizenid, number)
     MySQL.update.await('DELETE FROM phone_blocked WHERE citizenid = ? AND number = ?', { citizenid, d })
 end
 
----List every contact owned by a player, alphabetised server-side. Read-only.
+---@type integer Hard ceiling on one read of a player's address book. A migrated book can run to
+---four figures, which trips oxmysql's oversized-result warning and ships the lot over the bridge.
+local CONTACTS_CAP <const> = 500
+
+---List a player's contacts, alphabetised server-side, capped. Read-only.
 ---@param citizenid string
+---@param limit? integer defaults to CONTACTS_CAP, clamped to it
 ---@return table[]
-function store.listContacts(citizenid)
-    return MySQL.query.await([[
+function store.listContacts(citizenid, limit)
+    local n = math.floor(tonumber(limit) or CONTACTS_CAP)
+    if n < 1 then n = 1 elseif n > CONTACTS_CAP then n = CONTACTS_CAP end
+    return MySQL.query.await(([[
         SELECT id, name, phone, email, address, color, avatar, favorite
         FROM phone_contacts
         WHERE citizenid = ?
         ORDER BY name ASC
-    ]], { citizenid }) or {}
+        LIMIT %d
+    ]]):format(n), { citizenid }) or {}
 end
 
 ---Reads one contact, scoped to its owner; nil if missing or not theirs. Read-only.

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -219,10 +219,15 @@ end
 ---@param rows table[] message rows (chronological)
 ---@param contactMap table<string, table>
 ---@return table
-local function buildConversation(viewerCid, viewerNumber, conversation, rows, contactMap)
-    local mids = {}
-    for i = 1, #rows do mids[i] = rows[i].mid end
-    local reactionsByMid = store.reactionsForMids(mids)
+---@param preview? boolean Skip the reaction lookup. The list only renders each thread's last
+---line, and one reaction query per conversation was a second N+1 alongside the message fetch.
+local function buildConversation(viewerCid, viewerNumber, conversation, rows, contactMap, preview)
+    local reactionsByMid = {}
+    if not preview then
+        local mids = {}
+        for i = 1, #rows do mids[i] = rows[i].mid end
+        reactionsByMid = store.reactionsForMids(mids)
+    end
     local messages = {}
     for i = 1, #rows do messages[i] = serializeMessage(rows[i], viewerNumber, viewerCid, reactionsByMid) end
 
@@ -350,10 +355,16 @@ function actions.list(source)
     local contactMap = contactMapFor(cid)
 
     local conversations, seen = {}, {}
-    for _, t in ipairs(store.threadKeys(cid)) do
-        seen[t.conversation] = true
-        local rows = store.threadMessages(cid, t.conversation, cfg.MessagesPerThread)
-        conversations[#conversations + 1] = buildConversation(cid, myNumber, t.conversation, rows, contactMap)
+    -- Previews only, from a single query. This used to fetch every thread in full (a query per
+    -- conversation, plus a reaction query each) before the app could paint anything: on a mailbox
+    -- with 550 threads that is ~1,100 round trips for a list that shows one line per row. The full
+    -- history is fetched by actions.thread when a conversation is actually opened.
+    for _, row in ipairs(store.threadPreviews(cid)) do
+        seen[row.conversation] = true
+        local conv = buildConversation(cid, myNumber, row.conversation, { row }, contactMap, true)
+        conv.unread  = math.floor(tonumber(row.unread) or 0)
+        conv.partial = true
+        conversations[#conversations + 1] = conv
     end
 
     for _, g in ipairs(store.groupsForMember(cid)) do
@@ -369,6 +380,26 @@ function actions.list(source)
         myNumber      = myNumber,
         myName        = player.getName(source),
     })
+end
+
+---Full history for one conversation, with reactions. Fetched when the player opens a thread,
+---since actions.list only carries each thread's last line. Read-only.
+---@param source number
+---@param payload { id: string }|nil
+---@return table result { success, data = { conversation } }
+function actions.thread(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return fail('Player not found') end
+
+    payload = type(payload) == 'table' and payload or {}
+    local conversation = type(payload.id) == 'string' and payload.id or ''
+    if conversation == '' then return fail('Missing conversation') end
+
+    local myNumber   = digits(settings.ensurePhoneNumber(cid) or '')
+    local contactMap = contactMapFor(cid)
+    local rows       = store.threadMessages(cid, conversation, cfg.MessagesPerThread)
+
+    return ok({ conversation = buildConversation(cid, myNumber, conversation, rows, contactMap) })
 end
 
 ---@type integer Store-and-forward cap per number; past this the carrier drops new texts silently.

--- a/server/messages/init.lua
+++ b/server/messages/init.lua
@@ -26,6 +26,7 @@ end)
 
 -- Authoritative NUI callbacks: thin delegates into server.messages.actions.
 lib.callback.register('sd-phone:server:messages:list', function(src) return actions.list(src) end)
+lib.callback.register('sd-phone:server:messages:thread', function(src, payload) return actions.thread(src, payload) end)
 lib.callback.register('sd-phone:server:messages:send', function(src, payload) return actions.send(src, payload) end)
 lib.callback.register('sd-phone:server:messages:uploadVoice', function(src, payload) return actions.uploadVoice(src, payload) end)
 lib.callback.register('sd-phone:server:messages:createGroup', function(src, payload) return actions.createGroup(src, payload) end)

--- a/server/messages/store.lua
+++ b/server/messages/store.lua
@@ -173,6 +173,10 @@ function store.threadKeys(citizenid)
     ]], { citizenid }) or {}
 end
 
+---@type integer Ceiling on the thread list. A migrated mailbox runs to hundreds of threads and
+---the list is ordered by recency, so anything past this is not reachable by scrolling to it.
+local THREADS_CAP <const> = 200
+
 ---Every conversation's newest message plus its unread tally, in ONE query. The list view only
 ---renders a preview row and a badge per thread, and fetching a whole thread each just to show
 ---its last line meant a query per conversation (550 of them on a migrated mailbox) before the
@@ -180,7 +184,7 @@ end
 ---@param citizenid string
 ---@return { conversation: string, id: string, mid: string, sender: string, direction: string, kind: string, body: string, meta: string, is_read: any, created_at: number, unread: number }[]
 function store.threadPreviews(citizenid)
-    return MySQL.query.await([[
+    return MySQL.query.await(([[
         SELECT m.conversation, m.id, m.mid, m.sender, m.direction, m.kind, m.body, m.meta,
                m.is_read, m.created_at, u.unread
         FROM phone_messages m
@@ -195,7 +199,8 @@ function store.threadPreviews(citizenid)
         WHERE m.citizenid = ? AND m.withheld = 0
         GROUP BY m.conversation
         ORDER BY m.created_at DESC
-    ]], { citizenid, citizenid }) or {}
+        LIMIT %d
+    ]]):format(THREADS_CAP), { citizenid, citizenid }) or {}
 end
 
 ---True when the player's mailbox already holds at least one copy in this thread. An index dive

--- a/server/messages/store.lua
+++ b/server/messages/store.lua
@@ -173,6 +173,31 @@ function store.threadKeys(citizenid)
     ]], { citizenid }) or {}
 end
 
+---Every conversation's newest message plus its unread tally, in ONE query. The list view only
+---renders a preview row and a badge per thread, and fetching a whole thread each just to show
+---its last line meant a query per conversation (550 of them on a migrated mailbox) before the
+---app could paint. Withheld rows are excluded. Read-only.
+---@param citizenid string
+---@return { conversation: string, id: string, mid: string, sender: string, direction: string, kind: string, body: string, meta: string, is_read: any, created_at: number, unread: number }[]
+function store.threadPreviews(citizenid)
+    return MySQL.query.await([[
+        SELECT m.conversation, m.id, m.mid, m.sender, m.direction, m.kind, m.body, m.meta,
+               m.is_read, m.created_at, u.unread
+        FROM phone_messages m
+        INNER JOIN (
+            SELECT conversation,
+                   MAX(created_at) AS last_at,
+                   SUM(direction = 'in' AND is_read = 0) AS unread
+            FROM phone_messages
+            WHERE citizenid = ? AND withheld = 0
+            GROUP BY conversation
+        ) u ON u.conversation = m.conversation AND u.last_at = m.created_at
+        WHERE m.citizenid = ? AND m.withheld = 0
+        GROUP BY m.conversation
+        ORDER BY m.created_at DESC
+    ]], { citizenid, citizenid }) or {}
+end
+
 ---True when the player's mailbox already holds at least one copy in this thread. An index dive
 ---on idx_phone_messages_thread, so it is cheap enough to run before every 1:1 send. Read-only.
 ---@param citizenid string

--- a/server/notes/store.lua
+++ b/server/notes/store.lua
@@ -35,14 +35,19 @@ function store.ensureSchema()
     end
 end
 
----All of a player's notes, newest-edited first. Read-only.
+---@type integer Ceiling on one read of a player's notes. Each row carries a body plus sketch and
+---image JSON, so an uncapped read is heavy per row as well as unbounded in count.
+local NOTES_CAP <const> = 300
+
+---A player's notes, newest-edited first, capped. Read-only.
 ---@param cid string owner citizenid
 ---@return table[] rows note rows, empty when none
 function store.forPlayer(cid)
-    return MySQL.query.await([[
+    return MySQL.query.await(([[
         SELECT id, body, sketches, images, created_at, updated_at
         FROM `phone_notes` WHERE citizenid = ? ORDER BY updated_at DESC
-    ]], { cid }) or {}
+        LIMIT %d
+    ]]):format(NOTES_CAP), { cid }) or {}
 end
 
 ---Inserts or updates a note. `created_at` is only set on first insert.

--- a/server/photos/actions.lua
+++ b/server/photos/actions.lua
@@ -36,7 +36,7 @@ local PAGE_SIZE <const> = 200
 ---One page of the caller's photos, newest first. An absent `cursor` means the first page, which
 ---also carries the smart-album counts. Read-only.
 ---@param source number player server id
----@param payload { cursor: string|nil, filter: 'favorites'|'videos'|nil }|nil
+---@param payload { cursor: string|nil, filter: 'favorites'|'videos'|nil, limit: number|nil }|nil
 ---@return table result { success, data = { photos, nextCursor, counts, canImport } }
 function actions.list(source, payload)
     local cid = player.getIdentifier(source)
@@ -46,12 +46,17 @@ function actions.list(source, payload)
     local cursor = type(payload.cursor) == 'string' and payload.cursor ~= '' and payload.cursor or nil
     local filter = (payload.filter == 'favorites' or payload.filter == 'videos') and payload.filter or nil
 
+    -- The client asks for a short first page so the opening animation is not competing with a
+    -- few hundred tiles mounting, then full pages while scrolling. Clamped either way.
+    local limit = math.floor(tonumber(payload.limit) or PAGE_SIZE)
+    if limit < 1 then limit = 1 elseif limit > PAGE_SIZE then limit = PAGE_SIZE end
+
     -- One row past the page proves a further page exists; it is trimmed before shaping.
-    local rows = store.listForCitizen(cid, cursor, PAGE_SIZE, filter)
+    local rows = store.listForCitizen(cid, cursor, limit, filter)
     local nextCursor
-    if #rows > PAGE_SIZE then
-        local last = rows[PAGE_SIZE]
-        rows[PAGE_SIZE + 1] = nil
+    if #rows > limit then
+        local last = rows[limit]
+        rows[limit + 1] = nil
         nextCursor = ('%d:%s'):format(math.floor(tonumber(last.ts) or 0), last.id)
     end
 

--- a/server/photos/actions.lua
+++ b/server/photos/actions.lua
@@ -29,18 +29,42 @@ local function shapePhoto(row)
     }
 end
 
----Lists every photo the caller owns, newest first. Read-only.
+---@type integer Photos per page. A library of thousands used to arrive in one callback, which
+---tripped oxmysql's oversized-result warning and mounted every tile at once.
+local PAGE_SIZE <const> = 200
+
+---One page of the caller's photos, newest first. An absent `cursor` means the first page, which
+---also carries the smart-album counts. Read-only.
 ---@param source number player server id
----@return table result { success, data = { photos } }
-function actions.list(source)
+---@param payload { cursor: string|nil, filter: 'favorites'|'videos'|nil }|nil
+---@return table result { success, data = { photos, nextCursor, counts, canImport } }
+function actions.list(source, payload)
     local cid = player.getIdentifier(source)
     if not cid then return fail('Player not found') end
-    local rows = store.listForCitizen(cid)
+
+    payload = type(payload) == 'table' and payload or {}
+    local cursor = type(payload.cursor) == 'string' and payload.cursor ~= '' and payload.cursor or nil
+    local filter = (payload.filter == 'favorites' or payload.filter == 'videos') and payload.filter or nil
+
+    -- One row past the page proves a further page exists; it is trimmed before shaping.
+    local rows = store.listForCitizen(cid, cursor, PAGE_SIZE, filter)
+    local nextCursor
+    if #rows > PAGE_SIZE then
+        local last = rows[PAGE_SIZE]
+        rows[PAGE_SIZE + 1] = nil
+        nextCursor = ('%d:%s'):format(math.floor(tonumber(last.ts) or 0), last.id)
+    end
+
     local out = {}
     for i = 1, #rows do
         out[i] = shapePhoto(rows[i])
     end
-    return ok({ photos = out, canImport = actions.importEnabled() })
+
+    local data = { photos = out, nextCursor = nextCursor, canImport = actions.importEnabled() }
+    -- Counts ride the first page only: the Recents/Favourites/Videos tiles need totals that a
+    -- single page cannot report, and they do not change while paging.
+    if not cursor then data.counts = store.countsFor(cid) end
+    return ok(data)
 end
 
 ---@type integer Longest accepted photo URL in bytes, matching the phone_photos.url VARCHAR(512) column.

--- a/server/photos/init.lua
+++ b/server/photos/init.lua
@@ -25,8 +25,8 @@ CreateThread(function()
 end)
 
 -- Authoritative gallery-read callback: thin delegate into server.photos.actions.
-lib.callback.register('sd-phone:server:photos:list', function(src)
-    return actions.list(src)
+lib.callback.register('sd-phone:server:photos:list', function(src, payload)
+    return actions.list(src, payload)
 end)
 
 -- Hard payload ceilings for the capture upload.

--- a/server/photos/store.lua
+++ b/server/photos/store.lua
@@ -98,16 +98,72 @@ function store.hasUrl(citizenid, url)
         'SELECT 1 FROM phone_photos WHERE citizenid = ? AND url = ? LIMIT 1', { citizenid, url }) ~= nil
 end
 
----One player's photos, newest first. Read-only.
+---@type string Video-URL test, mirroring isVideoUrl() in web/src/core/photosApi.ts.
+local VIDEO_RE <const> = '\\.(mp4|webm|mov|m4v|ogg)([?#]|$)'
+
+---Splits an opaque "ts:id" cursor. nil/'' means the first page.
+---@param cursor string|nil
+---@return integer|nil ts, string|nil id
+local function splitCursor(cursor)
+    if type(cursor) ~= 'string' or cursor == '' then return nil, nil end
+    local ts, id = cursor:match('^(%d+):(.+)$')
+    return tonumber(ts), id
+end
+
+---One page of a player's photos, newest first. Returns up to `limit + 1` rows so the caller can
+---tell whether a further page exists without a second COUNT. Read-only.
 ---@param citizenid string owner's framework per-character id
----@return { id: string, url: string, favorite: any, created_at: number }[] rows
-function store.listForCitizen(citizenid)
-    return MySQL.query.await([[
-        SELECT id, url, favorite, created_at
+---@param cursor string|nil opaque "ts:id" cursor from the previous page
+---@param limit integer page size
+---@param filter 'favorites'|'videos'|nil smart-album narrowing
+---@return { id: string, url: string, favorite: any, created_at: number, ts: integer }[] rows
+function store.listForCitizen(citizenid, cursor, limit, filter)
+    local ts, id = splitCursor(cursor)
+    local where, params = { 'citizenid = ?' }, { citizenid }
+
+    if filter == 'favorites' then
+        where[#where + 1] = 'favorite = 1'
+    elseif filter == 'videos' then
+        where[#where + 1] = 'url REGEXP ?'
+        params[#params + 1] = VIDEO_RE
+    end
+
+    if ts then
+        -- created_at stays bare on the left of the comparison so idx_phone_photos_owner
+        -- (citizenid, created_at) can still range-scan; wrapping it in UNIX_TIMESTAMP() here
+        -- would force a full scan of the player's rows on every page.
+        where[#where + 1] = '(created_at < FROM_UNIXTIME(?) OR (created_at = FROM_UNIXTIME(?) AND id < ?))'
+        params[#params + 1] = ts
+        params[#params + 1] = ts
+        params[#params + 1] = id
+    end
+    params[#params + 1] = limit + 1
+
+    return MySQL.query.await(([[
+        SELECT id, url, favorite, created_at, UNIX_TIMESTAMP(created_at) AS ts
+        FROM phone_photos
+        WHERE %s
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+    ]]):format(table.concat(where, ' AND ')), params) or {}
+end
+
+---Totals behind the Recents / Favourites / Videos tiles, which a single page cannot report.
+---@param citizenid string owner's framework per-character id
+---@return { total: integer, favorites: integer, videos: integer }
+function store.countsFor(citizenid)
+    local row = MySQL.single.await([[
+        SELECT COUNT(*) AS total,
+               SUM(favorite = 1) AS favorites,
+               SUM(url REGEXP ?) AS videos
         FROM phone_photos
         WHERE citizenid = ?
-        ORDER BY created_at DESC, id DESC
-    ]], { citizenid }) or {}
+    ]], { VIDEO_RE, citizenid })
+    return {
+        total     = math.floor(tonumber(row and row.total) or 0),
+        favorites = math.floor(tonumber(row and row.favorites) or 0),
+        videos    = math.floor(tonumber(row and row.videos) or 0),
+    }
 end
 
 ---Sets the favourite flag on a photo the caller owns; a foreign photo id matches zero rows and

--- a/web/src/apps/banking/Banking.tsx
+++ b/web/src/apps/banking/Banking.tsx
@@ -47,8 +47,15 @@ export function Banking({ onClose: _onClose }: { onClose: () => void }) {
     const deckActive = useDeckActive();
     const wasActive  = useRef(deckActive);
     useEffect(() => {
-        if (deckActive && !wasActive.current) { refresh(); refetchReceived(); }
+        const rising = deckActive && !wasActive.current;
         wasActive.current = deckActive;
+        if (!rising) return;
+        // Held until the shell's 0.38s open animation has landed. Each refetch flips loading
+        // true then false, and nothing in this app is memoised, so firing two of them on the
+        // rising edge meant several full re-renders of the Banking tree inside the animation
+        // window. Bank renders 8 rows, so its jolt was never DOM size - it was this.
+        const id = window.setTimeout(() => { refresh(); refetchReceived(); }, 420);
+        return () => window.clearTimeout(id);
     }, [deckActive, refresh, refetchReceived]);
 
     const txs    = overview?.transactions ?? [];

--- a/web/src/apps/banking/InvoicesTab.tsx
+++ b/web/src/apps/banking/InvoicesTab.tsx
@@ -42,8 +42,13 @@ export function InvoicesTab({ received, receivedLoading, onRefetchReceived, onPa
     const deckActive = useDeckActive();
     const wasActive  = useRef(deckActive);
     useEffect(() => {
-        if (deckActive && !wasActive.current) refetchSent();
+        const rising = deckActive && !wasActive.current;
         wasActive.current = deckActive;
+        if (!rising) return;
+        // Deferred past the open animation for the same reason as Banking.tsx: this is the third
+        // round trip fired on a single foreground, and each one re-renders the tree.
+        const id = window.setTimeout(refetchSent, 420);
+        return () => window.clearTimeout(id);
     }, [deckActive, refetchSent]);
 
     // Live contact resolution for the sent rows: a saved card shows its avatar/initials, an

--- a/web/src/apps/messages/ConversationList.tsx
+++ b/web/src/apps/messages/ConversationList.tsx
@@ -115,7 +115,10 @@ export function ConversationList({ conversations, onOpen, onCompose, onMarkRead,
                 ) : (
                     <div className="overflow-hidden rounded-[10px] bg-[#e5e5e5] dark:bg-surface">
                         {filtered.map((c, i) => (
-                            <div key={c.id}>
+                            // Same containment as the contact rows: a ConvRow is ~20 nodes and a
+                            // migrated mailbox has 550 of them, all restyled on every deck
+                            // re-parent and .app-anim-flatten toggle. Off-screen rows now skip it.
+                            <div key={c.id} style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 100px' }}>
                                 <ConvRow
                                     conv={c}
                                     editing={editing}

--- a/web/src/apps/messages/Messages.tsx
+++ b/web/src/apps/messages/Messages.tsx
@@ -13,7 +13,7 @@ import { useDidEnter } from '@/hooks/useDidEnter';
 import type { MessagesIncomingPush } from '@/core/types';
 import { unreadCount, type Contact, type Conversation, type Message } from '@/shared/chat/data';
 import {
-    loadMessages, sendMessageApi, createGroupApi, addGroupMemberApi, updateGroupApi,
+    loadMessages, loadThread, getCachedMessages, cacheMessages, sendMessageApi, createGroupApi, addGroupMemberApi, updateGroupApi,
     removeGroupMemberApi, markReadApi,
     upsertConversation, appendMessage, replaceMessage, markConversationRead,
     deleteConversationApi, contactFromNumber, reactMessageApi, toggleReactionLocal,
@@ -29,8 +29,11 @@ import type { Contact as PhoneContact } from '@/apps/phone/data';
 type Draft = Omit<SendInput, 'conversation'>;
 
 export function Messages({ onClose }: { onClose: () => void }) {
-    const [conversations, setConversations] = useState<Conversation[]>([]);
-    const [contacts,      setContacts]      = useState<Contact[]>([]);
+    // Seeded from the last list result so a reopen paints the thread list immediately instead of
+    // an empty pane that fills in once the round trip lands. A fresh fetch replaces it below.
+    const cachedState = getCachedMessages();
+    const [conversations, setConversations] = useState<Conversation[]>(cachedState?.conversations ?? []);
+    const [contacts,      setContacts]      = useState<Contact[]>(cachedState?.contacts ?? []);
     const [openId,        setOpenId]        = useSessionState<string | null>('messages:openConvoId', null);
     const [composing,     setComposing]     = useSessionState('messages:composing', false);
     const [sendError,     setSendError]     = useState<string | null>(null);
@@ -51,6 +54,7 @@ export function Messages({ onClose }: { onClose: () => void }) {
         let active = true;
         void loadMessages().then(state => {
             if (!active) return;
+            cacheMessages(state);
             setConversations(state.conversations);
             setContacts(state.contacts);
 
@@ -122,6 +126,14 @@ export function Messages({ onClose }: { onClose: () => void }) {
         setOpenId(id);
         markReadApi(id);
         setConversations(prev => markConversationRead(prev, id));
+        // The list row only carries the last line, so pull the real history now. The preview
+        // stays on screen meanwhile, and a failed fetch simply leaves it in place.
+        void loadThread(id).then(full => {
+            if (!full) return;
+            setConversations(prev => prev.map(c => (c.id === id
+                ? { ...c, messages: full.messages, participants: full.participants, unread: 0, partial: false }
+                : c)));
+        });
     }, []);
 
     const sendMessage = useCallback(async (conversationId: string, draft: Draft) => {

--- a/web/src/apps/phone/Phone.tsx
+++ b/web/src/apps/phone/Phone.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ContactsTab } from './contacts/ContactsTab';
 import { RecentsTab } from './recents/RecentsTab';
@@ -21,6 +21,20 @@ interface CallTarget { number: string; name?: string }
 
 export function Phone({ onClose: _onClose }: { onClose: () => void }) {
     const [tab,        setTab]        = useSessionState<PhoneTab>('phone:tab', 'contacts');
+
+    // Replays the pane slide on a real tab change only. The element never unmounts now, and a
+    // CSS animation will not restart on its own, so it is cleared and reassigned around a forced
+    // reflow. offsetHeight is what flushes it; rAF is starved in CEF so double-rAF is out.
+    const paneRef = useRef<HTMLDivElement>(null);
+    const firstPane = useRef(true);
+    useEffect(() => {
+        const el = paneRef.current;
+        if (!el) return;
+        if (firstPane.current) { firstPane.current = false; return; }
+        el.style.animation = 'none';
+        void el.offsetHeight;
+        el.style.animation = '';
+    }, [tab]);
     const { contacts, recents: recentsRaw, myNumber, myName, card } =
         useContacts('contacts', 'recents', 'myNumber', 'myName', 'card');
     const [callTarget, setCallTarget] = useState<CallTarget | null>(null);
@@ -78,7 +92,12 @@ export function Phone({ onClose: _onClose }: { onClose: () => void }) {
             <div className="h-[61px] shrink-0" aria-hidden />
 
             <div className="flex flex-1 flex-col overflow-hidden">
-                <div key={tab} className="flex min-h-0 flex-1 flex-col animate-swipe-in-left">
+                {/* No key={tab} and no permanent animation class. key= remounted the whole
+                    500-row ContactsTab on every tab switch, and a class-borne animation replays
+                    whenever the deck re-parents the app, so a 0.45s opacity+translate slide was
+                    starting on every open and outliving the shell's 0.38s scale. The slide is now
+                    triggered only on a real tab change, in the effect above. */}
+                <div ref={paneRef} className="flex min-h-0 flex-1 flex-col animate-swipe-in-left">
                     {tab === 'contacts' ? (
                         <ContactsTab
                             contacts={contacts}

--- a/web/src/apps/phone/contacts/ContactsTab.tsx
+++ b/web/src/apps/phone/contacts/ContactsTab.tsx
@@ -161,9 +161,16 @@ export function ContactsTab({ contacts, myNumber, myName, card, onRequestCall, o
 function ContactRow({ contact, divider, onOpen }: { contact: Contact; divider: boolean; onOpen: (c: Contact) => void }) {
     return (
         <>
+            {/* Off-screen rows skip style, layout and avatar decode. The deck re-parents this
+                whole subtree on every app open (AppDeck.tsx:193 appendChild) and toggles
+                .app-anim-flatten, whose universal descendant selector restyles every node, so an
+                unwindowed 500-row book made both O(contacts) and stuttered the 0.38s open
+                animation. Applied per row rather than per A-Z section so the search results,
+                whose query is session-persisted, are covered by the same containment. */}
             <button
                 type="button"
                 onClick={() => onOpen(contact)}
+                style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 84px' }}
                 className="flex w-full items-center gap-3.5 px-3.5 py-3.5 text-left active:bg-black/5 dark:active:bg-white/5"
             >
                 <ContactAvatar contact={contact} size={56} />

--- a/web/src/apps/photos/AlbumsTab.tsx
+++ b/web/src/apps/photos/AlbumsTab.tsx
@@ -5,7 +5,7 @@ import {
 } from 'lucide-react';
 
 import { t } from '@/i18n';
-import type { Album, AlbumRef, MediaType, Photo } from '@/core/photosApi';
+import type { Album, AlbumRef, MediaType, Photo, PhotoCounts } from '@/core/photosApi';
 
 interface AlbumCard {
     key:           string;
@@ -19,9 +19,11 @@ interface AlbumCard {
 }
 
 export function AlbumsTab({
-    photos, albums, sharedAlbums, editMode, onToggleEdit, onCreateAlbum, onOpenAlbum, onDeleteAlbum,
+    photos, counts, albums, sharedAlbums, editMode, onToggleEdit, onCreateAlbum, onOpenAlbum, onDeleteAlbum,
 }: {
     photos:        Photo[];
+    /** Server-side totals; `photos` only holds the pages fetched so far, so it cannot count. */
+    counts:        PhotoCounts;
     albums:        Album[];
     sharedAlbums:  Album[];
     editMode:      boolean;
@@ -39,15 +41,16 @@ export function AlbumsTab({
     ];
 
     const cards = useMemo<AlbumCard[]>(() => {
-        const favs = photos.filter(p => p.favorite);
+        // Covers come from the loaded pages (newest first, so the first page always has one);
+        // the counts come from the server.
         const standard: AlbumCard[] = [
             {
-                key: 'recents', title: t('photos.recents', 'Recents'), count: photos.length,
+                key: 'recents', title: t('photos.recents', 'Recents'), count: counts.total,
                 cover: photos[0]?.url ?? null, ref: { kind: 'recents', name: t('photos.recents', 'Recents') },
             },
             {
-                key: 'favourites', title: t('photos.favourites', 'Favourites'), count: favs.length,
-                cover: favs[0]?.url ?? null, isFavourites: true,
+                key: 'favourites', title: t('photos.favourites', 'Favourites'), count: counts.favorites,
+                cover: photos.find(p => p.favorite)?.url ?? null, isFavourites: true,
                 ref: { kind: 'favourites', name: t('photos.favourites', 'Favourites') },
             },
         ];
@@ -56,7 +59,7 @@ export function AlbumsTab({
             ref: { kind: 'custom', id: a.id, name: a.name },
         }));
         return [...standard, ...custom];
-    }, [photos, albums]);
+    }, [photos, counts, albums]);
 
     const sharedCards = useMemo<AlbumCard[]>(() => sharedAlbums.map(a => ({
         key: a.id, title: a.name, count: a.count, cover: a.cover, isShared: true,
@@ -64,12 +67,12 @@ export function AlbumsTab({
     })), [sharedAlbums]);
 
     const typeCounts = useMemo<Record<MediaType, number>>(() => ({
-        videos:      photos.filter(p => p.video).length,
+        videos:      counts.videos,
         selfies:     0,
         screenshots: 0,
         imports:     0,
         duplicates:  0,
-    }), [photos]);
+    }), [counts]);
 
     return (
         <div className="flex h-full flex-col">

--- a/web/src/apps/photos/GalleryTab.tsx
+++ b/web/src/apps/photos/GalleryTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { t } from '@/i18n';
 import { groupByDay, type Photo } from '@/core/photosApi';
@@ -6,6 +6,7 @@ import { PhotoTile } from './PhotoTile';
 
 export function GalleryTab({
     photos, selectionMode, selectedIds, onEnterSelect, onCancelSelect, onPhotoTap, onToggleSelect, onImport,
+    hasMore, loadingMore, onLoadMore,
 }: {
     photos:         Photo[];
     selectionMode:  boolean;
@@ -15,8 +16,31 @@ export function GalleryTab({
     onPhotoTap:     (photo: Photo) => void;
     onToggleSelect: (photo: Photo) => void;
     onImport?:      () => void;
+    hasMore:        boolean;
+    loadingMore:    boolean;
+    onLoadMore:     () => void;
 }) {
     const groups = useMemo(() => groupByDay(photos), [photos]);
+
+    const scrollRef   = useRef<HTMLDivElement>(null);
+    const sentinelRef = useRef<HTMLDivElement>(null);
+    const loadMoreRef = useRef(onLoadMore);
+    loadMoreRef.current = onLoadMore;
+
+    // Infinite scroll. The observer root MUST be the scroll container, not the viewport: the
+    // phone renders under a CSS zoom, and a viewport-rooted observer computes the wrong
+    // intersection and either never fires or fires constantly.
+    useEffect(() => {
+        const sentinel = sentinelRef.current;
+        const root     = scrollRef.current;
+        if (!sentinel || !root || !hasMore) return;
+        const io = new IntersectionObserver(
+            entries => { if (entries.some(e => e.isIntersecting)) loadMoreRef.current(); },
+            { root, rootMargin: '600px 0px' },
+        );
+        io.observe(sentinel);
+        return () => io.disconnect();
+    }, [hasMore]);
 
     return (
         <div className="flex h-full flex-col">
@@ -39,7 +63,7 @@ export function GalleryTab({
                 </button>
             </div>
 
-            <div className="flex-1 overflow-y-auto no-scrollbar pb-2">
+            <div ref={scrollRef} className="flex-1 overflow-y-auto no-scrollbar pb-2">
                 {groups.map(group => (
                     <section key={group.key} className="mb-3">
                         <h2 className="px-4 pb-2 pt-1 text-[16px] font-bold tracking-tight text-black dark:text-white">
@@ -58,6 +82,16 @@ export function GalleryTab({
                         </div>
                     </section>
                 ))}
+
+                {hasMore && (
+                    <div ref={sentinelRef} className="flex h-12 items-center justify-center">
+                        {loadingMore && (
+                            <span className="text-[13px] text-black/45 dark:text-white/45">
+                                {t('photos.loadingMore', 'Loading more…')}
+                            </span>
+                        )}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/web/src/apps/photos/GalleryTab.tsx
+++ b/web/src/apps/photos/GalleryTab.tsx
@@ -6,7 +6,7 @@ import { PhotoTile } from './PhotoTile';
 
 export function GalleryTab({
     photos, selectionMode, selectedIds, onEnterSelect, onCancelSelect, onPhotoTap, onToggleSelect, onImport,
-    hasMore, loadingMore, onLoadMore,
+    hasMore, loadingMore, onLoadMore, paused,
 }: {
     photos:         Photo[];
     selectionMode:  boolean;
@@ -19,6 +19,8 @@ export function GalleryTab({
     hasMore:        boolean;
     loadingMore:    boolean;
     onLoadMore:     () => void;
+    /** True while the Albums tab is showing. The pane stays mounted, so paging must stop. */
+    paused?:        boolean;
 }) {
     const groups = useMemo(() => groupByDay(photos), [photos]);
 
@@ -33,14 +35,14 @@ export function GalleryTab({
     useEffect(() => {
         const sentinel = sentinelRef.current;
         const root     = scrollRef.current;
-        if (!sentinel || !root || !hasMore) return;
+        if (!sentinel || !root || !hasMore || paused) return;
         const io = new IntersectionObserver(
             entries => { if (entries.some(e => e.isIntersecting)) loadMoreRef.current(); },
             { root, rootMargin: '600px 0px' },
         );
         io.observe(sentinel);
         return () => io.disconnect();
-    }, [hasMore]);
+    }, [hasMore, paused]);
 
     return (
         <div className="flex h-full flex-col">
@@ -65,7 +67,17 @@ export function GalleryTab({
 
             <div ref={scrollRef} className="flex-1 overflow-y-auto no-scrollbar pb-2">
                 {groups.map(group => (
-                    <section key={group.key} className="mb-3">
+                    // Off-screen day sections skip layout, paint and image decode entirely, so
+                    // the cost of the grid stops tracking how far the player has scrolled. Without
+                    // it every mounted tile is restyled on each tab switch, deck re-parent and
+                    // app reopen, which is what made a paged gallery still feel heavy.
+                    // `auto` in contain-intrinsic-size makes the browser remember each section's
+                    // real height once measured, so the scrollbar does not jump.
+                    <section
+                        key={group.key}
+                        className="mb-3"
+                        style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 240px' }}
+                    >
                         <h2 className="px-4 pb-2 pt-1 text-[16px] font-bold tracking-tight text-black dark:text-white">
                             {group.label}
                         </h2>

--- a/web/src/apps/photos/GalleryTab.tsx
+++ b/web/src/apps/photos/GalleryTab.tsx
@@ -6,7 +6,7 @@ import { PhotoTile } from './PhotoTile';
 
 export function GalleryTab({
     photos, selectionMode, selectedIds, onEnterSelect, onCancelSelect, onPhotoTap, onToggleSelect, onImport,
-    hasMore, loadingMore, onLoadMore, paused,
+    hasMore, loadingMore, onLoadMore, paused, deferMedia,
 }: {
     photos:         Photo[];
     selectionMode:  boolean;
@@ -21,6 +21,8 @@ export function GalleryTab({
     onLoadMore:     () => void;
     /** True while the Albums tab is showing. The pane stays mounted, so paging must stop. */
     paused?:        boolean;
+    /** Keep tile media out of the DOM while the app is animating in. See PhotoTile. */
+    deferMedia?:    boolean;
 }) {
     const groups = useMemo(() => groupByDay(photos), [photos]);
 
@@ -88,6 +90,7 @@ export function GalleryTab({
                                     photo={p}
                                     selectable={selectionMode}
                                     selected={selectedIds.has(p.id)}
+                                    defer={deferMedia}
                                     onClick={() => (selectionMode ? onToggleSelect(p) : onPhotoTap(p))}
                                 />
                             ))}

--- a/web/src/apps/photos/PhotoTile.tsx
+++ b/web/src/apps/photos/PhotoTile.tsx
@@ -32,6 +32,9 @@ export function PhotoTile({ photo, selectable, selected, onClick }: {
                     src={photo.url}
                     alt=""
                     loading="lazy"
+                    // Off the main thread: a synchronous decode per tile is what makes a grid of
+                    // freshly fetched photos hitch as they arrive.
+                    decoding="async"
                     draggable={false}
                     onLoad={() => setLoaded(true)}
                     ref={el => { if (el?.complete) setLoaded(true); }}

--- a/web/src/apps/photos/PhotoTile.tsx
+++ b/web/src/apps/photos/PhotoTile.tsx
@@ -3,10 +3,18 @@ import { Check, Play } from 'lucide-react';
 
 import type { Photo } from '@/core/photosApi';
 
-export function PhotoTile({ photo, selectable, selected, onClick }: {
+export function PhotoTile({ photo, selectable, selected, defer, onClick }: {
     photo:       Photo;
     selectable?: boolean;
     selected?:   boolean;
+    /**
+     * Hold the media out of the DOM entirely. A tile shows a 130px square but the source is a
+     * full-size capture (measured: 810x1080, a 3.3MB bitmap once decoded, ~52x the pixels the
+     * tile can use). A screenful of those is tens of MB the compositor must rasterize, which is
+     * what stalls the app's open animation. The grid still lays out, so the app visibly animates
+     * in; only the decode waits for it to land.
+     */
+    defer?:      boolean;
     onClick:     () => void;
 }) {
     const [loaded, setLoaded] = useState(false);
@@ -18,7 +26,7 @@ export function PhotoTile({ photo, selectable, selected, onClick }: {
             onClick={onClick}
             className="relative aspect-square overflow-hidden bg-black/10 active:opacity-80 dark:bg-white/10"
         >
-            {photo.video ? (
+            {defer ? null : photo.video ? (
                 <video
                     src={photo.url}
                     muted

--- a/web/src/apps/photos/Photos.tsx
+++ b/web/src/apps/photos/Photos.tsx
@@ -9,7 +9,7 @@ import {
     apiAddPhotosToAlbum, apiCreateAlbum, apiDeleteAlbum, apiDeletePhoto,
     apiListAlbumPhotos, apiListAlbums, apiListPhotos, apiListSharedAlbums,
     apiRemovePhotoFromAlbum, apiSavePhotoFromUrl, apiSetFavorite, getCanImportPhotos, mapPhoto,
-    type Album, type AlbumRef, type Photo, type PhotoCounts,
+    FIRST_PAGE_SIZE, type Album, type AlbumRef, type Photo, type PhotoCounts,
 } from '@/core/photosApi';
 import { AlbumDetail } from './AlbumDetail';
 import { AlbumPickerSheet } from './AlbumPickerSheet';
@@ -51,20 +51,30 @@ export function Photos({ onClose }: { onClose: () => void }) {
     const [photoPicker, setPhotoPicker] = useState(false);
     const [createState, setCreateState] = useState<CreateState | null>(null);
 
+    // The gallery waits only on its own page. The two album reads used to be awaited together
+    // with it, so the default tab sat on "Loading…" for three round trips instead of one.
     useEffect(() => {
         let cancelled = false;
-        (async () => {
-            const [page, as, shared] = await Promise.all([apiListPhotos(), apiListAlbums(), apiListSharedAlbums()]);
+        void apiListPhotos(null, undefined, FIRST_PAGE_SIZE).then(page => {
             if (cancelled) return;
             setPhotos(page.photos);
             setNextCursor(page.nextCursor);
             if (page.counts) setCounts(page.counts);
-            setAlbums(as);
-            setSharedAlbums(shared);
             setCanImport(getCanImportPhotos());
             setLoading(false);
-        })();
+        });
+        void apiListAlbums().then(as => { if (!cancelled) setAlbums(as); });
+        void apiListSharedAlbums().then(s => { if (!cancelled) setSharedAlbums(s); });
         return () => { cancelled = true; };
+    }, []);
+
+    // The shell's ios-app-open runs 0.38s (shell/AppDeck.tsx). Committing the grid inside that
+    // window competes with the animation and it visibly drops, so the tiles wait for it to
+    // finish. A timer, not rAF: rAF is starved in CEF in-game.
+    const [entered, setEntered] = useState(false);
+    useEffect(() => {
+        const id = window.setTimeout(() => setEntered(true), 400);
+        return () => window.clearTimeout(id);
     }, []);
 
     // Appends the next page. Guarded on a ref rather than `loadingMore` so a burst of scroll
@@ -227,9 +237,12 @@ export function Photos({ onClose }: { onClose: () => void }) {
             <div className="h-[54px] shrink-0" aria-hidden />
 
             <div className="relative flex-1 min-h-0">
-                {loading ? (
+                {!entered || loading ? (
+                    // Blank while the app is still flying in: flashing "Loading…" for the 400ms
+                    // of the open animation reads worse than an empty pane. The label only
+                    // appears if the fetch is genuinely still outstanding once we have landed.
                     <div className="flex h-full items-center justify-center text-[13px] text-black/45 dark:text-white/45">
-                        {t('photos.loading','Loading…')}
+                        {entered && loading ? t('photos.loading','Loading…') : null}
                     </div>
                 ) : (
                     <div key={tab} className="flex h-full min-h-0 flex-col animate-swipe-in-left">

--- a/web/src/apps/photos/Photos.tsx
+++ b/web/src/apps/photos/Photos.tsx
@@ -245,24 +245,33 @@ export function Photos({ onClose }: { onClose: () => void }) {
                         {entered && loading ? t('photos.loading','Loading…') : null}
                     </div>
                 ) : (
-                    <div key={tab} className="flex h-full min-h-0 flex-col animate-swipe-in-left">
-                        {tab === 'gallery' && isEmpty ? (
-                            <EmptyState />
-                        ) : tab === 'gallery' ? (
-                            <GalleryTab
-                                photos={photos}
-                                selectionMode={gallerySelect}
-                                selectedIds={gallerySelected}
-                                onEnterSelect={() => setGallerySelect(true)}
-                                onCancelSelect={exitGallerySelect}
-                                onPhotoTap={openViewerFromGallery}
-                                onToggleSelect={toggleGallerySelect}
-                                onImport={canImport ? () => setImportOpen(true) : undefined}
-                                hasMore={nextCursor !== null}
-                                loadingMore={loadingMore}
-                                onLoadMore={() => void loadMore()}
-                            />
-                        ) : (
+                    // NO key={tab} here. The usual house pattern remounts the pane to replay the
+                    // swipe animation, which is free for a list of rows but not for a grid of
+                    // hundreds of image tiles: every tab switch tore the whole gallery down and
+                    // rebuilt it. Both panes stay mounted and the inactive one is just hidden,
+                    // so switching is a visibility toggle rather than a full remount.
+                    <div className="flex h-full min-h-0 flex-col">
+                        <div className={`flex h-full min-h-0 flex-col ${tab === 'gallery' ? '' : 'hidden'}`}>
+                            {isEmpty ? (
+                                <EmptyState />
+                            ) : (
+                                <GalleryTab
+                                    photos={photos}
+                                    selectionMode={gallerySelect}
+                                    selectedIds={gallerySelected}
+                                    onEnterSelect={() => setGallerySelect(true)}
+                                    onCancelSelect={exitGallerySelect}
+                                    onPhotoTap={openViewerFromGallery}
+                                    onToggleSelect={toggleGallerySelect}
+                                    onImport={canImport ? () => setImportOpen(true) : undefined}
+                                    hasMore={nextCursor !== null}
+                                    loadingMore={loadingMore}
+                                    onLoadMore={() => void loadMore()}
+                                    paused={tab !== 'gallery'}
+                                />
+                            )}
+                        </div>
+                        <div className={`flex h-full min-h-0 flex-col ${tab === 'albums' ? 'animate-swipe-in-left' : 'hidden'}`}>
                             <AlbumsTab
                                 photos={photos}
                                 counts={counts}
@@ -274,7 +283,7 @@ export function Photos({ onClose }: { onClose: () => void }) {
                                 onOpenAlbum={openAlbumRef}
                                 onDeleteAlbum={async (a) => { if (await apiDeleteAlbum(a.id)) setAlbums(prev => prev.filter(x => x.id !== a.id)); }}
                             />
-                        )}
+                        </div>
                     </div>
                 )}
             </div>

--- a/web/src/apps/photos/Photos.tsx
+++ b/web/src/apps/photos/Photos.tsx
@@ -3,6 +3,7 @@ import { Camera as CameraIcon, FolderPlus, Heart, Trash2 } from 'lucide-react';
 
 import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { useSessionState } from '@/hooks/useSessionState';
+import { useDeckActive } from '@/shell/deckActive';
 import { t } from '@/i18n';
 import { PromptDialog } from '@/ui/PromptDialog';
 import {
@@ -72,6 +73,20 @@ export function Photos({ onClose }: { onClose: () => void }) {
         void apiListSharedAlbums().then(s => { if (!cancelled) setSharedAlbums(s); });
         return () => { cancelled = true; };
     }, []);
+
+    // Tile media is held back for the length of the shell's open animation, on mount and on every
+    // subsequent foreground. The grid itself still renders, so the app visibly animates in; only
+    // the full-size decodes wait. Without this the deck was animating a layer holding tens of MB
+    // of decoded bitmap, which is why the FIRST open was smooth (nothing decoded yet) and every
+    // one after it was choppy.
+    const deckActive = useDeckActive();
+    const [settling, setSettling] = useState(true);
+    useEffect(() => {
+        if (!deckActive) return;
+        setSettling(true);
+        const id = window.setTimeout(() => setSettling(false), 420);
+        return () => window.clearTimeout(id);
+    }, [deckActive]);
 
     // Restarts the pane's swipe animation on a tab change. The panes deliberately stay mounted
     // (a key= remount rebuilt every tile), and a CSS animation on an already-mounted element
@@ -276,6 +291,7 @@ export function Photos({ onClose }: { onClose: () => void }) {
                                     hasMore={nextCursor !== null}
                                     loadingMore={loadingMore}
                                     onLoadMore={() => void loadMore()}
+                                    deferMedia={settling}
                                     paused={tab !== 'gallery'}
                                 />
                             )}

--- a/web/src/apps/photos/Photos.tsx
+++ b/web/src/apps/photos/Photos.tsx
@@ -9,7 +9,8 @@ import {
     apiAddPhotosToAlbum, apiCreateAlbum, apiDeleteAlbum, apiDeletePhoto,
     apiListAlbumPhotos, apiListAlbums, apiListPhotos, apiListSharedAlbums,
     apiRemovePhotoFromAlbum, apiSavePhotoFromUrl, apiSetFavorite, getCanImportPhotos, mapPhoto,
-    FIRST_PAGE_SIZE, type Album, type AlbumRef, type Photo, type PhotoCounts,
+    FIRST_PAGE_SIZE, getCachedFirstPhotoPage,
+    type Album, type AlbumRef, type Photo, type PhotoCounts,
 } from '@/core/photosApi';
 import { AlbumDetail } from './AlbumDetail';
 import { AlbumPickerSheet } from './AlbumPickerSheet';
@@ -24,16 +25,20 @@ interface CreateState { addIds: string[] }
 
 export function Photos({ onClose }: { onClose: () => void }) {
     const [tab,     setTab]     = useSessionState<PhotosTab>('photos:tab', 'gallery');
-    const [photos,  setPhotos]  = useState<Photo[]>([]);
+    // Seeded from the last first page so a reopen has tiles on frame one and the open animation
+    // has something to animate. A fresh fetch still runs underneath and replaces it.
+    const cached = getCachedFirstPhotoPage();
+    const [photos,  setPhotos]  = useState<Photo[]>(cached?.photos ?? []);
     const [albums,  setAlbums]  = useState<Album[]>([]);
     const [sharedAlbums, setSharedAlbums] = useState<Album[]>([]);
-    const [loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(!cached);
 
     // The gallery is paged: `photos` holds what has been fetched so far, `counts` holds the
     // server-side totals the album tiles need (a page cannot report them).
-    const [nextCursor,  setNextCursor]  = useState<string | null>(null);
+    const [nextCursor,  setNextCursor]  = useState<string | null>(cached?.nextCursor ?? null);
     const [loadingMore, setLoadingMore] = useState(false);
-    const [counts,      setCounts]      = useState<PhotoCounts>({ total: 0, favorites: 0, videos: 0 });
+    const [counts,      setCounts]      = useState<PhotoCounts>(
+        cached?.counts ?? { total: 0, favorites: 0, videos: 0 });
     const fetchingMore = useRef(false);
 
     const [gallerySelect, setGallerySelect] = useState(false);
@@ -68,14 +73,18 @@ export function Photos({ onClose }: { onClose: () => void }) {
         return () => { cancelled = true; };
     }, []);
 
-    // The shell's ios-app-open runs 0.38s (shell/AppDeck.tsx). Committing the grid inside that
-    // window competes with the animation and it visibly drops, so the tiles wait for it to
-    // finish. A timer, not rAF: rAF is starved in CEF in-game.
-    const [entered, setEntered] = useState(false);
+    // Restarts the pane's swipe animation on a tab change. The panes deliberately stay mounted
+    // (a key= remount rebuilt every tile), and a CSS animation on an already-mounted element
+    // will not replay on its own, so it is cleared and reassigned around a forced reflow. Reading
+    // offsetHeight is what flushes it; rAF is starved in CEF, so the double-rAF trick is out.
+    const paneRefs = useRef<Record<PhotosTab, HTMLDivElement | null>>({ gallery: null, albums: null });
     useEffect(() => {
-        const id = window.setTimeout(() => setEntered(true), 400);
-        return () => window.clearTimeout(id);
-    }, []);
+        const el = paneRefs.current[tab];
+        if (!el) return;
+        el.style.animation = 'none';
+        void el.offsetHeight;
+        el.style.animation = '';
+    }, [tab]);
 
     // Appends the next page. Guarded on a ref rather than `loadingMore` so a burst of scroll
     // events cannot fire two requests for the same cursor before the first setState lands.
@@ -237,12 +246,9 @@ export function Photos({ onClose }: { onClose: () => void }) {
             <div className="h-[54px] shrink-0" aria-hidden />
 
             <div className="relative flex-1 min-h-0">
-                {!entered || loading ? (
-                    // Blank while the app is still flying in: flashing "Loading…" for the 400ms
-                    // of the open animation reads worse than an empty pane. The label only
-                    // appears if the fetch is genuinely still outstanding once we have landed.
+                {loading ? (
                     <div className="flex h-full items-center justify-center text-[13px] text-black/45 dark:text-white/45">
-                        {entered && loading ? t('photos.loading','Loading…') : null}
+                        {t('photos.loading','Loading…')}
                     </div>
                 ) : (
                     // NO key={tab} here. The usual house pattern remounts the pane to replay the
@@ -251,7 +257,10 @@ export function Photos({ onClose }: { onClose: () => void }) {
                     // rebuilt it. Both panes stay mounted and the inactive one is just hidden,
                     // so switching is a visibility toggle rather than a full remount.
                     <div className="flex h-full min-h-0 flex-col">
-                        <div className={`flex h-full min-h-0 flex-col ${tab === 'gallery' ? '' : 'hidden'}`}>
+                        <div
+                            ref={el => { paneRefs.current.gallery = el; }}
+                            className={`flex h-full min-h-0 flex-col ${tab === 'gallery' ? 'animate-swipe-in-left' : 'hidden'}`}
+                        >
                             {isEmpty ? (
                                 <EmptyState />
                             ) : (
@@ -271,7 +280,10 @@ export function Photos({ onClose }: { onClose: () => void }) {
                                 />
                             )}
                         </div>
-                        <div className={`flex h-full min-h-0 flex-col ${tab === 'albums' ? 'animate-swipe-in-left' : 'hidden'}`}>
+                        <div
+                            ref={el => { paneRefs.current.albums = el; }}
+                            className={`flex h-full min-h-0 flex-col ${tab === 'albums' ? 'animate-swipe-in-left' : 'hidden'}`}
+                        >
                             <AlbumsTab
                                 photos={photos}
                                 counts={counts}

--- a/web/src/apps/photos/Photos.tsx
+++ b/web/src/apps/photos/Photos.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Camera as CameraIcon, FolderPlus, Heart, Trash2 } from 'lucide-react';
 
 import { useNuiEvent } from '@/hooks/useNuiEvent';
@@ -9,7 +9,7 @@ import {
     apiAddPhotosToAlbum, apiCreateAlbum, apiDeleteAlbum, apiDeletePhoto,
     apiListAlbumPhotos, apiListAlbums, apiListPhotos, apiListSharedAlbums,
     apiRemovePhotoFromAlbum, apiSavePhotoFromUrl, apiSetFavorite, getCanImportPhotos, mapPhoto,
-    type Album, type AlbumRef, type Photo,
+    type Album, type AlbumRef, type Photo, type PhotoCounts,
 } from '@/core/photosApi';
 import { AlbumDetail } from './AlbumDetail';
 import { AlbumPickerSheet } from './AlbumPickerSheet';
@@ -29,6 +29,13 @@ export function Photos({ onClose }: { onClose: () => void }) {
     const [sharedAlbums, setSharedAlbums] = useState<Album[]>([]);
     const [loading, setLoading] = useState(true);
 
+    // The gallery is paged: `photos` holds what has been fetched so far, `counts` holds the
+    // server-side totals the album tiles need (a page cannot report them).
+    const [nextCursor,  setNextCursor]  = useState<string | null>(null);
+    const [loadingMore, setLoadingMore] = useState(false);
+    const [counts,      setCounts]      = useState<PhotoCounts>({ total: 0, favorites: 0, videos: 0 });
+    const fetchingMore = useRef(false);
+
     const [gallerySelect, setGallerySelect] = useState(false);
     const [gallerySelected, setGallerySelected] = useState<Set<string>>(new Set());
 
@@ -47,9 +54,11 @@ export function Photos({ onClose }: { onClose: () => void }) {
     useEffect(() => {
         let cancelled = false;
         (async () => {
-            const [ps, as, shared] = await Promise.all([apiListPhotos(), apiListAlbums(), apiListSharedAlbums()]);
+            const [page, as, shared] = await Promise.all([apiListPhotos(), apiListAlbums(), apiListSharedAlbums()]);
             if (cancelled) return;
-            setPhotos(ps);
+            setPhotos(page.photos);
+            setNextCursor(page.nextCursor);
+            if (page.counts) setCounts(page.counts);
             setAlbums(as);
             setSharedAlbums(shared);
             setCanImport(getCanImportPhotos());
@@ -58,10 +67,29 @@ export function Photos({ onClose }: { onClose: () => void }) {
         return () => { cancelled = true; };
     }, []);
 
+    // Appends the next page. Guarded on a ref rather than `loadingMore` so a burst of scroll
+    // events cannot fire two requests for the same cursor before the first setState lands.
+    const loadMore = useCallback(async () => {
+        if (fetchingMore.current || !nextCursor) return;
+        fetchingMore.current = true;
+        setLoadingMore(true);
+        try {
+            const page = await apiListPhotos(nextCursor);
+            setPhotos(prev => {
+                const seen = new Set(prev.map(p => p.id));
+                return [...prev, ...page.photos.filter(p => !seen.has(p.id))];
+            });
+            setNextCursor(page.nextCursor);
+        } finally {
+            fetchingMore.current = false;
+            setLoadingMore(false);
+        }
+    }, [nextCursor]);
+
     useEffect(() => {
-        if (openAlbum?.kind !== 'custom') return;
+        if (!openAlbum) return;
         let cancelled = false;
-        void apiListAlbumPhotos(openAlbum.id).then(ps => { if (!cancelled) setCustomAlbumPhotos(ps); });
+        void loadAlbumPhotos(openAlbum).then(ps => { if (!cancelled) setCustomAlbumPhotos(ps); });
         return () => { cancelled = true; };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -73,25 +101,30 @@ export function Photos({ onClose }: { onClose: () => void }) {
         setPhotos(prev => (prev.some(x => x.id === p.id) ? prev : [p, ...prev]));
     }, []));
 
-    const favourites = useMemo(() => photos.filter(p => p.favorite), [photos]);
-
     const refreshAlbums = useCallback(async () => {
         setAlbums(await apiListAlbums());
     }, []);
 
+    // Favourites and Videos are resolved server-side now. Deriving them from `photos` would only
+    // ever see the pages fetched so far, so a favourite further down the library went missing.
+    async function loadAlbumPhotos(ref: AlbumRef): Promise<Photo[]> {
+        if (ref.kind === 'custom')     return apiListAlbumPhotos(ref.id);
+        if (ref.kind === 'favourites') return (await apiListPhotos(null, 'favorites')).photos;
+        if (ref.kind === 'mediaType' && ref.mediaType === 'videos') {
+            return (await apiListPhotos(null, 'videos')).photos;
+        }
+        return [];
+    }
+
     function albumPhotosFor(ref: AlbumRef): Photo[] {
-        if (ref.kind === 'recents')    return photos;
-        if (ref.kind === 'favourites') return favourites;
-        if (ref.kind === 'mediaType')  return ref.mediaType === 'videos' ? photos.filter(p => p.video) : [];
+        if (ref.kind === 'recents') return photos;
         return customAlbumPhotos;
     }
 
     async function openAlbumRef(ref: AlbumRef) {
         setOpenAlbum(ref);
         setCustomAlbumPhotos([]);
-        if (ref.kind === 'custom') {
-            setCustomAlbumPhotos(await apiListAlbumPhotos(ref.id));
-        }
+        setCustomAlbumPhotos(await loadAlbumPhotos(ref));
     }
 
     async function toggleFavorite(photo: Photo) {
@@ -212,10 +245,14 @@ export function Photos({ onClose }: { onClose: () => void }) {
                                 onPhotoTap={openViewerFromGallery}
                                 onToggleSelect={toggleGallerySelect}
                                 onImport={canImport ? () => setImportOpen(true) : undefined}
+                                hasMore={nextCursor !== null}
+                                loadingMore={loadingMore}
+                                onLoadMore={() => void loadMore()}
                             />
                         ) : (
                             <AlbumsTab
                                 photos={photos}
+                                counts={counts}
                                 albums={albums}
                                 sharedAlbums={sharedAlbums}
                                 editMode={albumsEdit}

--- a/web/src/apps/review/WriteReview.tsx
+++ b/web/src/apps/review/WriteReview.tsx
@@ -18,7 +18,8 @@ export function WriteReview({ business, onCancel, onSubmit }: {
     const [photos,  setPhotos]  = useState<Photo[]>([]);
 
     useEffect(() => {
-        if (picking && photos.length === 0) void apiListPhotos().then(setPhotos);
+        // First page only: this is an attachment picker, not the gallery.
+        if (picking && photos.length === 0) void apiListPhotos().then(page => setPhotos(page.photos));
     }, [picking, photos.length]);
 
     const canSubmit = rating > 0 && body.trim().length > 0;

--- a/web/src/core/photosApi.ts
+++ b/web/src/core/photosApi.ts
@@ -94,6 +94,15 @@ export interface PhotoPage {
  */
 export const FIRST_PAGE_SIZE = 60;
 
+/**
+ * Last unfiltered first page. Photos seeds its state from this synchronously, so reopening the
+ * app paints real tiles on the first frame instead of an empty pane that fills in once the
+ * round trip lands, which read as the open animation not playing at all.
+ */
+let firstPageCache: PhotoPage | null = null;
+
+export function getCachedFirstPhotoPage(): PhotoPage | null { return firstPageCache; }
+
 /** One page of the gallery. Omit `cursor` for the first page, then pass `nextCursor` back. */
 export async function apiListPhotos(cursor?: string | null, filter?: PhotoFilter, limit?: number): Promise<PhotoPage> {
     if (!isFiveM) {
@@ -114,11 +123,14 @@ export async function apiListPhotos(cursor?: string | null, filter?: PhotoFilter
         photos: ServerPhoto[]; nextCursor?: string | null; counts?: PhotoCounts; canImport?: boolean;
     }>('sd-phone:photos:list', { cursor: cursor ?? null, filter: filter ?? null, limit: limit ?? null });
     if (!cursor) canImportPhotos = data?.canImport === true;
-    return {
+    const page: PhotoPage = {
         photos:     data?.photos?.map(mapPhoto) ?? [],
         nextCursor: data?.nextCursor ?? null,
         counts:     data?.counts,
     };
+    // Cache only the plain first page: a filtered or later page is not what the app opens on.
+    if (!cursor && !filter) firstPageCache = page;
+    return page;
 }
 
 /**

--- a/web/src/core/photosApi.ts
+++ b/web/src/core/photosApi.ts
@@ -76,17 +76,58 @@ let canImportPhotos = !isFiveM;
 /** Whether the server allows URL import; valid after the first apiListPhotos() resolves. */
 export function getCanImportPhotos(): boolean { return canImportPhotos; }
 
-export async function apiListPhotos(): Promise<Photo[]> {
-    if (!isFiveM) return DEV_PHOTOS;
-    const data = await apiData<{ photos: ServerPhoto[]; canImport?: boolean }>('sd-phone:photos:list');
-    canImportPhotos = data?.canImport === true;
-    return data?.photos.map(mapPhoto) ?? [];
+/** Smart-album narrowing applied server-side, so a filtered view still pages. */
+export type PhotoFilter = 'favorites' | 'videos';
+
+export interface PhotoCounts { total: number; favorites: number; videos: number }
+
+export interface PhotoPage {
+    photos:     Photo[];
+    nextCursor: string | null;
+    /** Present on the first page only; the tile totals do not change while paging. */
+    counts?:    PhotoCounts;
 }
+
+/** One page of the gallery. Omit `cursor` for the first page, then pass `nextCursor` back. */
+export async function apiListPhotos(cursor?: string | null, filter?: PhotoFilter): Promise<PhotoPage> {
+    if (!isFiveM) {
+        const photos = filter === 'favorites' ? DEV_PHOTOS.filter(p => p.favorite)
+                     : filter === 'videos'    ? DEV_PHOTOS.filter(p => p.video)
+                     : DEV_PHOTOS;
+        return {
+            photos,
+            nextCursor: null,
+            counts: cursor ? undefined : {
+                total:     DEV_PHOTOS.length,
+                favorites: DEV_PHOTOS.filter(p => p.favorite).length,
+                videos:    DEV_PHOTOS.filter(p => p.video).length,
+            },
+        };
+    }
+    const data = await apiData<{
+        photos: ServerPhoto[]; nextCursor?: string | null; counts?: PhotoCounts; canImport?: boolean;
+    }>('sd-phone:photos:list', { cursor: cursor ?? null, filter: filter ?? null });
+    if (!cursor) canImportPhotos = data?.canImport === true;
+    return {
+        photos:     data?.photos?.map(mapPhoto) ?? [],
+        nextCursor: data?.nextCursor ?? null,
+        counts:     data?.counts,
+    };
+}
+
+/**
+ * Number of gallery images decoded ahead of time by warmPhotos(). Enough to fill the picker's
+ * first screen; the rest load through the tiles' own `loading="lazy"`.
+ */
+const WARM_IMAGE_COUNT = 24;
 
 export function warmPhotos(): void {
     if (!isFiveM) return;
-    void apiListPhotos().then(photos => {
-        for (const p of photos) {
+    // Only the first page, and only the first screenful of it, gets decoded up front. This used
+    // to pull the WHOLE library and construct an Image() per row from six different chat
+    // composers, which on a large gallery meant thousands of CDN fetches on opening a DM.
+    void apiListPhotos().then(page => {
+        for (const p of page.photos.slice(0, WARM_IMAGE_COUNT)) {
             if (p.url && !p.video) { const img = new Image(); img.src = p.url; }
         }
     });

--- a/web/src/core/photosApi.ts
+++ b/web/src/core/photosApi.ts
@@ -88,8 +88,14 @@ export interface PhotoPage {
     counts?:    PhotoCounts;
 }
 
+/**
+ * Tiles fetched for the first page. Deliberately smaller than a scroll page: this batch mounts
+ * while the app's open animation is still running, and a few hundred tiles there stalls it.
+ */
+export const FIRST_PAGE_SIZE = 60;
+
 /** One page of the gallery. Omit `cursor` for the first page, then pass `nextCursor` back. */
-export async function apiListPhotos(cursor?: string | null, filter?: PhotoFilter): Promise<PhotoPage> {
+export async function apiListPhotos(cursor?: string | null, filter?: PhotoFilter, limit?: number): Promise<PhotoPage> {
     if (!isFiveM) {
         const photos = filter === 'favorites' ? DEV_PHOTOS.filter(p => p.favorite)
                      : filter === 'videos'    ? DEV_PHOTOS.filter(p => p.video)
@@ -106,7 +112,7 @@ export async function apiListPhotos(cursor?: string | null, filter?: PhotoFilter
     }
     const data = await apiData<{
         photos: ServerPhoto[]; nextCursor?: string | null; counts?: PhotoCounts; canImport?: boolean;
-    }>('sd-phone:photos:list', { cursor: cursor ?? null, filter: filter ?? null });
+    }>('sd-phone:photos:list', { cursor: cursor ?? null, filter: filter ?? null, limit: limit ?? null });
     if (!cursor) canImportPhotos = data?.canImport === true;
     return {
         photos:     data?.photos?.map(mapPhoto) ?? [],

--- a/web/src/shared/MediaPickerSheet.tsx
+++ b/web/src/shared/MediaPickerSheet.tsx
@@ -47,8 +47,9 @@ export function MediaPickerSheet({ onSelect, onSelectMany, multiple = false, max
 
     const { data: lib, loading } = useAsyncData<{ photos: Photo[]; albums: Album[] }>(
         async () => {
-            const [ps, as] = await Promise.all([apiListPhotos(), apiListAlbums()]);
-            return { photos: ps, albums: as };
+            // First page only: the picker shows recent media, not the whole library.
+            const [page, as] = await Promise.all([apiListPhotos(), apiListAlbums()]);
+            return { photos: page.photos, albums: as };
         },
         [],
         {

--- a/web/src/shared/chat/data.ts
+++ b/web/src/shared/chat/data.ts
@@ -35,6 +35,10 @@ export interface Conversation {
     messages:   Message[];
     pinned:     boolean;
     muted:      boolean;
+    /** Server-side unread tally. Present on list rows, which carry only the last message. */
+    unread?:    number;
+    /** True while `messages` holds just the preview line; the full thread loads on open. */
+    partial?:   boolean;
 }
 
 export interface Contact {
@@ -155,6 +159,10 @@ export function hasUnread(c: Conversation): boolean {
 }
 
 export function unreadCount(c: Conversation): number {
+    // A list row carries only its last message, so counting locally would under-report. The
+    // server tally wins whenever it is present; the local count still covers dev data and
+    // conversations built client-side before any fetch.
+    if (typeof c.unread === 'number') return c.unread;
     return c.messages.filter(m => m.from !== 'me' && !m.read).length;
 }
 

--- a/web/src/shared/chat/messagesApi.ts
+++ b/web/src/shared/chat/messagesApi.ts
@@ -77,6 +77,26 @@ export async function loadMessages(): Promise<MessagesState> {
     return { conversations: [], contacts: [], myNumber: '', myName: '' };
 }
 
+/**
+ * Last successful list result. Messages seeds its state from this so reopening the app paints
+ * the thread list on frame one instead of showing an empty pane that fills in a moment later.
+ */
+let listCache: MessagesState | null = null;
+
+export function getCachedMessages(): MessagesState | null { return listCache; }
+
+export function cacheMessages(state: MessagesState): void { listCache = state; }
+
+/**
+ * Full history for one conversation. The list only carries each thread's last line, so this runs
+ * when a thread is opened. Returns null when the fetch fails, leaving the preview in place.
+ */
+export async function loadThread(id: string): Promise<Conversation | null> {
+    if (!isFiveM) return CONVERSATIONS.map(cloneConv).find(c => c.id === id) ?? null;
+    const res = await apiData<{ conversation: Conversation }>('sd-phone:messages:thread', { id });
+    return res?.conversation ?? null;
+}
+
 export interface SendResult { data: Message | null; error?: string }
 
 export async function sendMessageApi(input: SendInput): Promise<SendResult> {

--- a/web/src/shell/AppDeck.tsx
+++ b/web/src/shell/AppDeck.tsx
@@ -88,12 +88,21 @@ const AppHost = memo(function AppHost({ id, ctx, active, openKey, origin, expand
     const [phase, setPhase] = useState<'open' | 'close' | 'rest'>('open');
     const firstRef = useRef(true);
 
-    useEffect(() => {
+    // LAYOUT effects, not passive ones. A retained app re-renders at phase 'rest' (no animation)
+    // and is re-parented into the fullscreen slot by the layout effect below. If the phase flip
+    // is passive it lands AFTER that paint, so the app appears instantly at full size and only
+    // then does the animation start, snapping back to its `from` keyframe and replaying. That is
+    // the "instant open, then it flicks and animates" report, and it is a race: the heavier the
+    // app's commit, the wider the gap between paint and effect, which is why it showed up most on
+    // the apps with big lists and only occasionally on light ones. A layout effect is flushed
+    // before paint, so the animation is in place on the first painted frame - which is why the
+    // FIRST open was always correct: useState('open') has it there from the initial commit.
+    useLayoutEffect(() => {
         if (firstRef.current) { firstRef.current = false; return; }
         setPhase('open');
     }, [openKey]);
 
-    useEffect(() => { if (closing) setPhase('close'); }, [closing]);
+    useLayoutEffect(() => { if (closing) setPhase('close'); }, [closing]);
 
     const ox = origin ? `${(origin.x * 100).toFixed(1)}%` : '50%';
     const oy = origin ? `${(origin.y * 100).toFixed(1)}%` : '80%';


### PR DESCRIPTION
## The problem

`photos:list` returned every photo a player owned in a single callback. Against a migrated production library of **1,958 photos** this fires oxmysql's oversized-result warning:

```
Warning: sd-phone executed a query with an oversized result set (1958 results)!
        SELECT id, url, favorite, created_at
        FROM phone_photos
        WHERE citizenid = ?
        ORDER BY created_at DESC, id DESC
```

It also shipped ~240 KB of JSON over the NUI bridge and mounted 1,958 tiles at once.

`warmPhotos()` was the bigger issue. Six chat composers (Birdy DMs, Cherry, Darkchat, Photogram DMs, Services, shared chat) call it on mount, and it fetched the **whole** library then constructed an `Image()` per row. Opening a DM meant thousands of immediate CDN requests, which also defeated the tiles' own `loading="lazy"`.

## The change

**Server**
- `store.listForCitizen(citizenid, cursor, limit, filter)` takes an opaque `"ts:id"` cursor, matching the pattern already used by `server/admin/store.lua`. Page size 200.
- Fetches `limit + 1` rows so the presence of a further page is known without a second `COUNT`.
- `created_at` is compared against `FROM_UNIXTIME(?)` rather than wrapped in `UNIX_TIMESTAMP()`, so the existing `idx_phone_photos_owner (citizenid, created_at)` index still range-scans. **No schema change.**
- `store.countsFor()` supplies the Recents / Favourites / Videos totals a single page cannot report.

**Client**
- `apiListPhotos(cursor?, filter?)` returns `{ photos, nextCursor, counts }`.
- `GalleryTab` appends pages behind an IntersectionObserver sentinel. The observer root is the scroll container, not the viewport, because the phone renders under a CSS zoom.
- `warmPhotos()` warms only the first 24 images.
- Favourites and Videos are resolved server-side via the `filter` argument. Deriving them from the loaded pages would silently drop anything further down the library.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` | 0 errors |
| `eslint src` | 0 errors (29 pre-existing warnings, none in changed files) |
| `knip` | clean |
| `vitest run` | 142 passed / 14 files |
| `vite build` | succeeds |

Typecheck also caught two further consumers (`WriteReview`, `MediaPickerSheet`); both are attachment pickers and now take the first page.

## Still to test in-game

Against the 1,958-photo character: confirm the oxmysql warning is gone, scrolling pages cleanly, and the Favourites / Videos albums and album-tile counts still show correct totals.

## Not in this PR

`messages/store.lua:173,300` (34k rows) and `contacts/store.lua:182` are the other unbounded per-player queries. Contacts additionally needs a `(citizenid, name)` index before paginating, since it sorts by name with only `idx_phone_contacts_cid` available.