### PR TITLE
fix(nui): prevent spacebar keydown leak

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -137,6 +137,12 @@ const RETAIN_CAP = RECENTS_CAP;
 
 const ALARM_TEST_ID = '__alarm_test__';
 
+// Anything that swallows a keystroke as text rather than as a shortcut.
+function isTextEntry(el: EventTarget | null): boolean {
+    const t = el as HTMLElement | null;
+    return !!t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
+}
+
 export function App() {
     return (
         <ThemeProvider>
@@ -1064,10 +1070,6 @@ function AppContent() {
 
     useEffect(() => {
         if (!isFiveM) return;
-        const isText = (el: EventTarget | null) => {
-            const t = el as HTMLElement | null;
-            return !!t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
-        };
         // Digit-only inputs take the numeric typing tier: the player keeps moving while the
         // field is focused (client/main.lua suppresses the digit weapon binds instead).
         const isNumeric = (el: EventTarget | null) => {
@@ -1075,8 +1077,8 @@ function AppContent() {
             return !!t && t.tagName === 'INPUT'
                 && (['numeric', 'tel', 'decimal'].includes(t.inputMode) || ['number', 'tel'].includes(t.type));
         };
-        const onFocus = (e: FocusEvent) => { if (isText(e.target)) void fetchNui('sd-phone:typing', { typing: true, numeric: isNumeric(e.target) }); };
-        const onBlur  = (e: FocusEvent) => { if (isText(e.target)) void fetchNui('sd-phone:typing', { typing: false }); };
+        const onFocus = (e: FocusEvent) => { if (isTextEntry(e.target)) void fetchNui('sd-phone:typing', { typing: true, numeric: isNumeric(e.target) }); };
+        const onBlur  = (e: FocusEvent) => { if (isTextEntry(e.target)) void fetchNui('sd-phone:typing', { typing: false }); };
         document.addEventListener('focusin', onFocus);
         document.addEventListener('focusout', onBlur);
         return () => {
@@ -1085,12 +1087,16 @@ function AppContent() {
         };
     }, []);
 
+    // Jump stays enabled while the phone is open (client/main.lua deliberately leaves control 22
+    // alone), so under keep-input every jump also lands on the page. Cancelling the keydown stops
+    // the button activation Chromium would otherwise dispatch on the matching keyup.
+    // Only the native activation: this does not stop propagation, so a component with its own
+    // Space handler still has to opt out for itself the way Lockscreen does.
     useEffect(() => {
         if (!isFiveM) return;
         function blockSpace(e: KeyboardEvent) {
-            if (e.key !== ' ') return;
-            const el = e.target as HTMLElement | null;
-            if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+            if (e.key !== ' ' && e.code !== 'Space') return;
+            if (isTextEntry(e.target)) return;
             e.preventDefault();
         }
         window.addEventListener('keydown', blockSpace, true);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1085,6 +1085,18 @@ function AppContent() {
         };
     }, []);
 
+    useEffect(() => {
+        if (!isFiveM) return;
+        function blockSpace(e: KeyboardEvent) {
+            if (e.key !== ' ') return;
+            const el = e.target as HTMLElement | null;
+            if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+            e.preventDefault();
+        }
+        window.addEventListener('keydown', blockSpace, true);
+        return () => window.removeEventListener('keydown', blockSpace, true);
+    }, []);
+
     const resetNonce = usePhoneReset(s => s.nonce);
     useEffect(() => {
         if (!resetNonce) return;

--- a/web/src/apps/_classifieds/ListingCard.tsx
+++ b/web/src/apps/_classifieds/ListingCard.tsx
@@ -1,3 +1,4 @@
+import { isFiveM } from '@/core/nui';
 import { ContactActions } from './ContactActions';
 import { fmtPrice, type ClassifiedItem } from './types';
 
@@ -19,7 +20,9 @@ export function ListingCard({ item, subject, onOpen, onMessage, onCall, onEmail,
             role={onOpen ? 'button' : undefined}
             tabIndex={onOpen ? 0 : undefined}
             onClick={onOpen}
-            onKeyDown={onOpen ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpen(); } } : undefined}
+            // Space is the jump key in game, and this card activates itself rather than relying on
+            // the native button behaviour App.tsx cancels, so it has to ignore Space for itself.
+            onKeyDown={onOpen ? (e) => { if (e.key === 'Enter' || (e.key === ' ' && !isFiveM)) { e.preventDefault(); onOpen(); } } : undefined}
             className={`rounded-[16px] bg-[#e5e5e5] px-5 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.06)] ring-1 ring-black/[0.04] dark:bg-surface dark:shadow-none dark:ring-white/[0.06] ${onOpen ? 'cursor-pointer transition-colors duration-150 hover:bg-[#dadada] active:bg-[#d2d2d2] dark:hover:bg-[#262628] dark:active:bg-[#2e2e30]' : ''}`}
         >
             <div className="block w-full text-left">

--- a/web/src/shell/Lockscreen.tsx
+++ b/web/src/shell/Lockscreen.tsx
@@ -110,7 +110,7 @@ export function Lockscreen({ use24h, showDate, wallpaper, unlockTrigger, onUnloc
     useEffect(() => {
         function onKey(e: KeyboardEvent) {
             if ((e.key === 'h' || e.key === 'H') && !isFiveM) latest.current.forceUnlock();
-            else if (e.key === 'Enter' || e.key === ' ') latest.current.commitUnlock();
+            else if (e.key === 'Enter' || (e.key === ' ' && !isFiveM)) latest.current.commitUnlock();
         }
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);


### PR DESCRIPTION
## Summary
Prevents spacebar presses from triggering focused NUI buttons while walking or navigating in-game.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor

## Testing
- [x] Tested locally on FiveM client
- [x] Verified spacebar inputs no longer trigger focused NUI elements