### PR TITLE
feat(camera): turn the phone on its side in landscape mode

### DIFF
--- a/client/pose.lua
+++ b/client/pose.lua
@@ -19,7 +19,8 @@ local FRAME_FLAGS <const> = 2 | 8 | 16 | 32 | 1048576
 ---@type table<string, table<string, { dict: string, anim: string, blendIn: number, blendOut: number, flags: integer }>>
 ---Held clip per action, split by whether the player is in a vehicle. The framing pose uses selfie
 ---rather than selfie_in because the latter animates raising the phone from the hip, which replays
----as a stow and redraw every time the clip is re-asserted on a phone already in hand.
+---as a stow and redraw every time the clip is re-asserted on a phone already in hand. The landscape
+---pose turns the wrist so the phone lies on its side, which is why it is wrong for portrait.
 local CLIPS = {
     default = {
         onFoot = { dict = 'cellphone@',          anim = 'cellphone_text_read_base', blendIn = 8.0,    blendOut = -8.0,    flags = READ_FLAGS },
@@ -28,6 +29,10 @@ local CLIPS = {
     camera = {
         onFoot = { dict = 'cellphone@self',      anim = 'selfie',                   blendIn = 8.0,    blendOut = -8.0,    flags = FRAME_FLAGS },
         inCar  = { dict = 'cellphone@self',      anim = 'selfie',                   blendIn = 8.0,    blendOut = -8.0,    flags = FRAME_FLAGS },
+    },
+    landscape = {
+        onFoot = { dict = 'cellphone@',          anim = 'cellphone_photo_idle',     blendIn = 8.0,    blendOut = -8.0,    flags = FRAME_FLAGS },
+        inCar  = { dict = 'cellphone@',          anim = 'cellphone_photo_idle',     blendIn = 8.0,    blendOut = -8.0,    flags = FRAME_FLAGS },
     },
 }
 
@@ -67,7 +72,11 @@ end
 local function currentClip()
     -- One camera pose covers both lenses, as lb-phone's animations.lua does. The native cell cam
     -- swapped pose on flip, but no outward-facing clip outside that native is verified to exist.
-    local action = (cameraOn and phonecam.active()) and 'camera' or 'default'
+    -- Landscape is the exception: it turns the phone on its side, so it gets its own clip.
+    local action = 'default'
+    if cameraOn and phonecam.active() then
+        action = landscape and 'landscape' or 'camera'
+    end
     return CLIPS[action][IsPedInAnyVehicle(PlayerPedId(), true) and 'inCar' or 'onFoot']
 end
 
@@ -167,13 +176,15 @@ function pose.reweld()
     attachProp(PlayerPedId())
 end
 
----Lays the prop on its side for the landscape viewfinder, or stands it back up.
+---Turns the phone on its side for the landscape viewfinder, or stands it back up. Swaps the held
+---clip as well as the grip, and puts the new pose up at once rather than waiting on the watchdog.
 ---@param wide any truthy for landscape
 function pose.setLandscape(wide)
     wide = wide and true or false
     if landscape == wide then return end
     landscape = wide
     pose.reweld()
+    if pose.shouldHold() then play() end
 end
 
 -- Keeps the holder out of their own rear shot. The framing pose raises the phone right in front of

--- a/configs/phone.lua
+++ b/configs/phone.lua
@@ -81,12 +81,13 @@ return {
     PropOffset = vec3(0.0, 0.0, 0.0),
     PropRot    = vec3(0.0, 0.0, 0.0),
 
-    -- Where the prop sits while the Camera app is in LANDSCAPE mode: the phone
-    -- lies on its side for the wide viewfinder, so the grip rolls 90 degrees
-    -- off the portrait transform above. Set either to nil to keep the portrait
-    -- grip in landscape too.
+    -- Where the prop sits while the Camera app is in LANDSCAPE mode. Landscape
+    -- plays its own clip, which turns the wrist so the phone already lies on its
+    -- side, so these match the portrait transform above: rolling the prop as well
+    -- would turn it twice. Nudge them only if a custom model sits off the grip in
+    -- that pose.
     PropLandscapeOffset = vec3(0.0, 0.0, 0.0),
-    PropLandscapeRot    = vec3(0.0, 90.0, 0.0),
+    PropLandscapeRot    = vec3(0.0, 0.0, 0.0),
 
     -- Let other players see the phone in your hand. When true, your ped broadcasts a replicated
     -- statebag while the phone is out and every nearby client spawns its own LOCAL welded copy of


### PR DESCRIPTION
## Summary

Landscape was a prop transform only: `PropLandscapeRot` rolled the phone 90 degrees inside a hand still in the portrait grip, so the model twisted rather than the player turning the phone.

Landscape now holds its own clip, `cellphone@` / `cellphone_photo_idle`, and returns to the selfie pose on the way back. That clip turns the wrist, which is precisely why it was wrong as a general camera pose earlier.

Because the clip supplies the rotation, `PropLandscapeRot` drops back to the portrait transform. Leaving it at 90 degrees would turn the phone twice.

## Notes

- `currentClip()` remains the single place that decides the held pose, so the new action cannot desync from the re-assert watchdog.
- `pose.setLandscape` now puts the new pose up immediately instead of leaving the old one until the watchdog next runs.
- The clip name is verified by observation: it was tried as the outward camera pose during #133 and visibly played.

## Testing

- Gates: build + tsc, eslint 0 errors, vitest 142/142, knip clean.
- Needs in-game confirmation of the pose itself, ideally from a second client since the holder is culled from their own outward lens.