### PR TITLE
feat(sim): back the SIM tray with a stash so using the phone opens the phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ Ready-made ox_inventory definitions live in the [installation docs](https://docs
 
 Players can also open the phone with a keybind (<kbd>F1</kbd> by default), which still requires owning one of these items.
 
+Running unique phones with physical SIM trays (`SimTray` in `configs/uniqueandsim.lua`, ox_inventory only)? Give every phone item a `buttons` entry so players can open its tray:
+
+```lua
+buttons = {
+    { label = 'SIM Tray', action = function(slot) exports['sd-phone']:openSimTray(slot) end },
+},
+```
+
+Using the phone item opens the phone itself, so the tray needs its own button. Skip this in metadata mode, where SIMs are installed by using the `sim_card` item.
+
 ### 3. Add your API keys
 
 In `configs/server/apikeys.lua`:

--- a/client/apps/sim.lua
+++ b/client/apps/sim.lua
@@ -9,3 +9,10 @@ proxy('sd-phone:sim:backup:sync',    'sd-phone:server:sim:backup:sync')
 proxy('sd-phone:sim:backup:setAuto', 'sd-phone:server:sim:backup:setAuto')
 proxy('sd-phone:sim:backup:delete',  'sd-phone:server:sim:backup:delete')
 proxy('sd-phone:sim:backup:restore', 'sd-phone:server:sim:backup:restore')
+
+---Opens the SIM tray of the phone in `slot`. Exported for the phone item's ox_inventory `buttons`
+---entry (see the README); the server re-derives the tray from the slot and force-opens it.
+---@param slot number inventory slot holding the phone
+exports('openSimTray', function(slot)
+    TriggerServerEvent('sd-phone:server:sim:openTray', slot)
+end)

--- a/configs/uniqueandsim.lua
+++ b/configs/uniqueandsim.lua
@@ -30,27 +30,27 @@
 -- lets a player carry their data to a new phone (the number stays behind on the old SIM).
 --
 -- Backend support: reading/writing per-slot item metadata is required. Supported out of the box:
---   * ox_inventory              (metadata mode, or the physical SIM-tray container mode below)
+--   * ox_inventory              (metadata mode, or the physical SIM-tray mode below)
 --   * qb-inventory / ps / lj    (metadata mode via the QBCore item `info` table)
 -- Other inventories (qs / tgiann / codem / origen / jaksam) need a small adapter in
 -- server/sim/inv.lua; plain ESX inventory has no item metadata and cannot support this feature.
 return {
     -- Master switch. Off = sd-phone behaves exactly as before (numbers auto-assigned per
     -- character, phone always has service).
-    Enabled = false,
+    Enabled = true,
 
     -- Where the phone DATA lives: 'device' | 'sim' | 'character' (see the header above).
     -- Flipping an existing 'sim' server to 'device' is safe: on first use each phone ADOPTS the
     -- identity of the SIM currently in it (grandfathering, no data copied or lost), and only
     -- from then on does the number float free of the data. (The pre-DataOwner boolean
     -- `DeviceIdentity` is still honoured when this key is absent.)
-    DataOwner = 'device',
+    DataOwner = 'sim',
 
     -- Unique phones WITHOUT SIM cards ("eSIM"): every phone mints its own permanent number the
     -- first time it is used - no sim_card item, no install/eject, the number lives and dies
     -- with the phone. Pairs with DataOwner 'device' or 'character' ('sim' has no SIM identity
-    -- to own data and coerces to 'device'); forces the metadata attach mode. SimItem,
-    -- UseContainers, AllowEject, ActivateBlankSims and /givesim become inert.
+    -- to own data and coerces to 'device'); forces the metadata attach mode. SimItem, SimTray,
+    -- AllowEject, ActivateBlankSims and /givesim become inert.
     BuiltInNumbers = false,
 
     -- Inventory item that carries a phone number in its metadata ({ number = '2075550123' }).
@@ -64,17 +64,26 @@ return {
     -- export (character-bound or hardcoded numbers) produce usable SIMs.
     ActivateBlankSims = true,
 
-    -- ox_inventory only: register every phone item as a 1-slot container ("SIM tray") instead
-    -- of writing the number onto the phone item. Players right-click/use the phone to open the
-    -- tray and drag the SIM in or out. Trade-off: with containers, USING the phone item opens
-    -- the tray (ox intercepts container items client-side), so the phone UI itself only opens
-    -- via the keybind. Leave false for the universal metadata mode, where using the phone opens
-    -- the phone UI and the SIM is installed by using the sim_card item.
-    UseContainers = false,
+    -- ox_inventory only: give every phone item a 1-slot "SIM tray" instead of writing the number
+    -- onto the phone item. Using the phone opens the phone UI as normal; the tray is a separate
+    -- right-click button players drag the SIM in and out of. That button has to be declared on
+    -- the phone item in ox_inventory/data/items.lua (see README - "Unique Phones & SIM Cards"):
+    --
+    --   buttons = {
+    --       { label = 'SIM Tray', action = function(slot) exports['sd-phone']:openSimTray(slot) end },
+    --   },
+    --
+    -- Leave false for the universal metadata mode, where the SIM is installed by using the
+    -- sim_card item and no inventory edit is needed.
+    --
+    -- Renamed from `UseContainers`, which is still read when this key is absent. The old name
+    -- described the ox item-container this used to be built on; trays are ox stashes now, because
+    -- ox opens a container item on USE and that made the phone itself keybind-only.
+    SimTray = true,
 
     -- Metadata mode only: allow ejecting the installed SIM from Settings -> SIM & Backup. The
-    -- player gets the sim_card item back (number intact) and the phone loses service. In
-    -- container mode ejecting is physical (drag it out of the tray) and this flag is ignored.
+    -- player gets the sim_card item back (number intact) and the phone loses service. In tray
+    -- mode ejecting is physical (drag it out of the tray) and this flag is ignored.
     AllowEject = true,
 
     -- Cloud Backup (Settings -> SIM & Backup). The backup account is the CHARACTER, so a SIM

--- a/locales/en.json
+++ b/locales/en.json
@@ -2725,7 +2725,7 @@
     "simEjectConfirm": "Eject",
     "simEjectMessage": "The SIM card returns to your inventory and this phone loses service until a SIM is installed again.",
     "simEjectTitle": "Eject SIM Card?",
-    "simFooterContainer": "Your number lives on the SIM card in this phone. Open the phone in your inventory to swap the SIM.",
+    "simFooterTray": "Your number lives on the SIM card in this phone. Right-click the phone in your inventory and pick SIM Tray to swap it.",
     "simFooterMetadata": "Your number lives on the SIM card installed in this phone. Use a SIM card item to install it.",
     "simInstalled": "Installed",
     "simNone": "No SIM",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -2539,7 +2539,6 @@
     "simEjectConfirm": "Çıkar",
     "simEjectMessage": "SIM kart envanterinize döner ve tekrar bir SIM kart takılana kadar bu telefon kapsama alanı dışında kalır.",
     "simEjectTitle": "SIM Kart Çıkarılsın mı?",
-    "simFooterContainer": "Numaranız bu telefondaki SIM kartta tanımlıdır. SIM kartı değiştirmek için envanterinizdeki telefonu açın.",
     "simFooterMetadata": "Numaranız bu telefona takılı olan SIM kartta tanımlıdır. Takmak için bir SIM kart eşyası kullanın.",
     "simInstalled": "Takılı",
     "simNone": "SIM Yok",

--- a/server/sim/init.lua
+++ b/server/sim/init.lua
@@ -13,6 +13,9 @@ if not config.Sim or not config.Sim.Enabled then return {} end
 local simStore = require 'server.sim.store'
 ---@type table Slot-level inventory access for SIMs (server.sim.inv).
 local siminv   = require 'server.sim.inv'
+---@type table SIM tray (server.sim.tray): per-phone stash, its access hooks and the legacy
+---container migration.
+local tray     = require 'server.sim.tray'
 ---@type table SIM session resolution (server.sim.session): source -> acting identity.
 local session  = require 'server.sim.session'
 ---@type table Cloud-backup restore engine (server.sim.backup).
@@ -94,7 +97,8 @@ end
 
 ---ox_inventory only: watch SIM/phone item moves so a pulled SIM cuts service within a swap, not
 ---a cache TTL. Any matching move flushes the whole session cache (rare event, cheap rescan) and
----pushes fresh state to the player who moved it.
+---pushes fresh state to the player who moved it. Tray mode adds two guards ox gave containers for
+---free: only the phone's holder may open its tray, and only a SIM may go in it.
 local function registerHooks()
     local watched = { [config.Sim.SimItem] = true }
     for item in pairs(siminv.phoneColors) do watched[item] = true end
@@ -107,6 +111,26 @@ local function registerHooks()
                 if src then session.push(src) end
             end)
         end, {})
+    end)
+
+    if state.mode ~= 'tray' then return end
+
+    -- A tray id ships to the client inside the phone's own metadata, and a stash id alone is
+    -- enough to open a stash from anywhere. Containers were gated on holding the item; a stash
+    -- is not, so without this anyone who ever held the phone could lift its SIM remotely.
+    pcall(function()
+        exports.ox_inventory:registerHook('openInventory', function(payload)
+            local src = tonumber(payload.source)
+            if not src or not tray.holderSlot(src, payload.inventoryId) then return false end
+        end, { inventoryFilter = { '^simtray:' } })
+    end)
+
+    -- Stashes have no whitelist property, which the container did.
+    pcall(function()
+        exports.ox_inventory:registerHook('swapItems', function(payload)
+            local moved = payload.fromSlot and payload.fromSlot.name
+            if moved and moved ~= config.Sim.SimItem then return false end
+        end, { inventoryFilter = { '^simtray:' } })
     end)
 end
 
@@ -142,9 +166,8 @@ CreateThread(function()
     state.device    = owner == 'device'
     state.character = owner == 'character'
     -- Attach mode is always metadata without SIM items (nothing to drag into a tray).
-    state.mode   = (not state.builtin and config.Sim.UseContainers and siminv.isOx()) and 'container' or 'metadata'
+    state.mode   = (not state.builtin and tray.configured and siminv.isOx()) and 'tray' or 'metadata'
     state.active = true
-    if state.mode == 'container' then siminv.registerContainers() end
     if siminv.isOx() then registerHooks() end
     print(('^2[sd-phone:sim]^0 unique phones active (%s mode, %s identity%s, %s backend)')
         :format(state.mode, owner, state.builtin and ', built-in numbers' or '', siminv.backendName()))
@@ -194,7 +217,7 @@ inv.registerUsable(config.Sim.SimItem, function(source, itemArg, _invArg, slotAr
         return
     end
 
-    if state.mode == 'container' then
+    if state.mode == 'tray' then
         if blank then
             -- Swap the blank item for one stamped with the freshly registered number.
             number = simStore.create({})
@@ -253,6 +276,18 @@ inv.registerUsable(config.Sim.SimItem, function(source, itemArg, _invArg, slotAr
         or 'SIM installed - your number is %s.'):format(util.formatNumber(number)), 'success')
 end)
 end
+
+---The phone item's inventory button: opens that exact phone's SIM tray. Fire-and-forget, because
+---the slot is the only input and the server re-derives everything else from it - a hand-crafted
+---event can still only open a tray belonging to a phone the sender actually carries.
+---@param slot number inventory slot holding the phone
+RegisterNetEvent('sd-phone:server:sim:openTray', function(slot)
+    local source = source
+    if state.mode ~= 'tray' then return end
+    if not tray.open(source, slot) then
+        toast(source, 'That phone has no SIM tray.', 'error')
+    end
+end)
 
 ---@type table<number, number> Last requestPush per source (GetGameTimer ms); floods are dropped.
 local lastRequestPush = {}

--- a/server/sim/inv.lua
+++ b/server/sim/inv.lua
@@ -6,6 +6,8 @@ local bridge = require 'bridge.server.inventory'
 local util   = require 'server.util'
 ---@type table SIM registry (server.sim.store): mints a number for a blank card dropped in a tray.
 local simStore = require 'server.sim.store'
+---@type table SIM tray (server.sim.tray): the per-phone 1-slot stash a SIM is dragged into.
+local tray     = require 'server.sim.tray'
 
 ---@type table Inv module; the table returned at end of file. SIM-feature glue over the bridge's
 ---slot-level API: find phone items, read/write the SIM number on them, and (container mode)
@@ -53,23 +55,28 @@ function inv.findPhones(source)
             }
         end
     end
+    -- Every phone lookup funnels through here, so it is also where a phone still carrying a
+    -- legacy ox container gets spotted and converted (deferred, debounced).
+    if inv.isOx() then tray.sweepLegacy(source, out) end
     return out
 end
 
 ---The SIM number installed in one phone row from findPhones, honouring the configured attach
----mode: container mode reads the sim_card item inside the phone's SIM tray, metadata mode reads
----the number written onto the phone item itself.
+---mode: tray mode reads the sim_card item inside the phone's SIM tray, metadata mode reads the
+---number written onto the phone item itself.
 ---
----Container mode activates a blank card found in the tray, because dragging one in is the whole
+---Tray mode activates a blank card found in the tray, because dragging one in is the whole
 ---interaction there and nothing else would ever stamp it.
 ---@param source number player server id
 ---@param phone { slot: number, metadata: table }
 ---@return string|nil number bare-digit SIM number, nil when no SIM is installed
 function inv.getSimNumber(source, phone)
-    if config.Sim.UseContainers and inv.isOx() then
-        local containerId = phone.metadata and phone.metadata.container
-        if not containerId then return nil end
-        local items = bridge.containerItems(source, phone.slot)
+    if tray.configured and inv.isOx() then
+        -- No tray id means this phone's tray has never been opened, so it holds no SIM. Minting
+        -- one here would write metadata on every read for no gain.
+        local trayId = phone.metadata and phone.metadata.simTray
+        if not tray.isTrayId(trayId) then return nil end
+        local items = tray.items(trayId)
         if type(items) ~= 'table' then return nil end
 
         local blank
@@ -87,7 +94,7 @@ function inv.getSimNumber(source, phone)
         local metadata = type(blank.metadata) == 'table' and blank.metadata or {}
         metadata.number      = number
         metadata.description = ('SIM: %s'):format(util.formatNumber(number))
-        local ok = pcall(function() exports[OX]:SetMetadata(containerId, blank.slot, metadata) end)
+        local ok = pcall(function() exports[OX]:SetMetadata(trayId, blank.slot, metadata) end)
         return ok and number or nil
     end
 
@@ -167,45 +174,29 @@ function inv.giveSimItem(source, number)
 end
 
 ---Rewrites the number on the SIM inside a phone: metadata mode updates the phone item itself,
----container mode updates the sim_card item inside the phone's tray (ox SetMetadata on the
----container inventory). Used by the setSimNumber export.
+---tray mode updates the sim_card item inside the phone's tray (ox SetMetadata on the tray
+---inventory). Used by the setSimNumber export.
 ---@param source number player server id
 ---@param phone { slot: number, metadata: table }
 ---@param number string new bare-digit number
 ---@return boolean ok
 function inv.rewriteSimNumber(source, phone, number)
-    if config.Sim.UseContainers and inv.isOx() then
-        local containerId = phone.metadata and phone.metadata.container
-        if not containerId then return false end
-        local items = bridge.containerItems(source, phone.slot)
+    if tray.configured and inv.isOx() then
+        local trayId = phone.metadata and phone.metadata.simTray
+        local items = tray.isTrayId(trayId) and tray.items(trayId)
         if type(items) ~= 'table' then return false end
         for _, item in pairs(items) do
             if item and item.name == config.Sim.SimItem then
                 local metadata = type(item.metadata) == 'table' and item.metadata or {}
                 metadata.number      = number
                 metadata.description = ('SIM: %s'):format(util.formatNumber(number))
-                local ok = pcall(function() exports[OX]:SetMetadata(containerId, item.slot, metadata) end)
+                local ok = pcall(function() exports[OX]:SetMetadata(trayId, item.slot, metadata) end)
                 return ok
             end
         end
         return false
     end
     return inv.setPhoneSim(source, phone.slot, number)
-end
-
----Registers every configured phone item as a 1-slot ox container whitelisted to the SIM item.
----Container mode boot step; a no-op off ox.
-function inv.registerContainers()
-    if not inv.isOx() then return end
-    for _, entry in ipairs(config.Phone.Items or {}) do
-        pcall(function()
-            exports[OX]:setContainerProperties(entry.item, {
-                slots     = 1,
-                maxWeight = 1000,
-                whitelist = { config.Sim.SimItem },
-            })
-        end)
-    end
 end
 
 ---@type table<string, string> Public copy of the phone item -> colour map.

--- a/server/sim/state.lua
+++ b/server/sim/state.lua
@@ -5,7 +5,7 @@
 return {
     ---@type boolean True while unique-phones/SIM indirection is fully enabled this session.
     active = false,
-    ---@type 'container'|'metadata'|nil How SIMs attach to phones; nil while inactive.
+    ---@type 'tray'|'metadata'|nil How SIMs attach to phones; nil while inactive.
     mode = nil,
     ---@type boolean True in DEVICE-identity mode (config.Sim.DeviceIdentity): the phone item
     ---owns the data and a SIM only lends a number. False = LEGACY, where the SIM is the identity.

--- a/server/sim/tray.lua
+++ b/server/sim/tray.lua
@@ -1,0 +1,204 @@
+---@type table sd-phone config root (configs/config.lua).
+local config = require 'configs.config'
+---@type table Inventory bridge (bridge.server.inventory): slot-level item ops.
+local bridge = require 'bridge.server.inventory'
+---@type table Shared server helpers (server.util): random id generation.
+local util   = require 'server.util'
+
+---@type table Tray module; the table returned at end of file. A phone's SIM tray is a 1-slot ox
+---stash whose id lives in the phone item's own metadata, so the tray follows the ITEM through
+---trades, drops and stashes.
+local tray = {}
+
+---@type string ox_inventory resource name (trays are ox-only).
+local OX = 'ox_inventory'
+
+---@type string Prefix on every tray id; the ox hook filters match against it.
+local PREFIX = 'simtray:'
+
+---@type integer Characters of randomness after the prefix.
+local ID_LEN = 16
+
+---@type table<string, true> Tray ids already registered with ox this session.
+local registered = {}
+
+---@type table<string, true> Configured phone item names.
+local phoneItems = {}
+for _, entry in ipairs(config.Phone.Items or {}) do phoneItems[entry.item] = true end
+
+-- Tray mode as CONFIGURED, reading the pre-rename `UseContainers` key when `SimTray` is absent.
+-- The LIVE mode additionally needs an ox backend; server/sim/init.lua folds that in as state.mode.
+local configured = config.Sim.SimTray
+if configured == nil then configured = config.Sim.UseContainers end
+
+---@type boolean True when the config asks for physical SIM trays.
+tray.configured = configured == true
+
+---True when `id` has the shape of one of our tray ids.
+---@param id any
+---@return boolean
+function tray.isTrayId(id)
+    return type(id) == 'string' and id:sub(1, #PREFIX) == PREFIX
+end
+
+---Registers a tray with ox, once per id per session. Registered UNOWNED so it travels with the
+---item rather than a character; holding the phone is what authorises access (see holderSlot).
+---@param id string tray id
+function tray.ensure(id)
+    if registered[id] then return end
+    registered[id] = true
+    pcall(function() exports[OX]:RegisterStash(id, 'SIM Tray', 1, 1000, false) end)
+end
+
+---The phone item row at `slot`, or nil when that slot holds anything else.
+---@param source number player server id
+---@param slot number|string|nil inventory slot
+---@return { slot: number, name: string, metadata: table }|nil
+local function phoneAt(source, slot)
+    slot = tonumber(slot)
+    if not slot then return nil end
+    local row = bridge.getSlot(source, slot)
+    if not row or not phoneItems[row.name] then return nil end
+    return row
+end
+
+---The tray id stamped on a phone item, minting and writing one the first time that phone's tray
+---is opened. Always resolved from the player's OWN slot; a client-supplied id is never trusted.
+---@param source number player server id
+---@param slot number|string|nil inventory slot holding a phone
+---@return string|nil id
+function tray.idFor(source, slot)
+    local row = phoneAt(source, slot)
+    if not row then return nil end
+    local id = row.metadata.simTray
+    if tray.isTrayId(id) then return id end
+    id = PREFIX .. util.newId(ID_LEN)
+    local metadata = row.metadata
+    metadata.simTray = id
+    if not bridge.setSlotMetadata(source, row.slot, metadata) then return nil end
+    return id
+end
+
+---Items inside a tray, keyed by slot. Nil when the id is not a tray or ox refuses the read.
+---@param id string tray id
+---@return table|nil items
+function tray.items(id)
+    if not tray.isTrayId(id) then return nil end
+    tray.ensure(id)
+    local ok, items = pcall(function() return exports[OX]:GetInventoryItems(id) end)
+    return (ok and type(items) == 'table') and items or nil
+end
+
+---The slot of the phone this player carries whose tray is `id`, or nil when they carry no such
+---phone. Backs the openInventory hook: a tray id is readable from the item's own metadata, so
+---possession of the phone has to be the gate, not knowledge of the id.
+---@param source number player server id
+---@param id any tray id
+---@return number|nil slot
+function tray.holderSlot(source, id)
+    if not tray.isTrayId(id) then return nil end
+    for item in pairs(phoneItems) do
+        for _, row in ipairs(bridge.searchSlots(source, item)) do
+            if row.metadata and row.metadata.simTray == id then return row.slot end
+        end
+    end
+    return nil
+end
+
+---Opens a phone's SIM tray for its holder. Force-opens because the item button is pressed from
+---inside the inventory UI, where a plain open would close the view instead of swapping it.
+---@param source number player server id
+---@param slot number|string|nil inventory slot holding a phone
+---@return boolean ok
+function tray.open(source, slot)
+    local id = tray.idFor(source, slot)
+    if not id then return false end
+    tray.ensure(id)
+    return (pcall(function() exports[OX]:forceOpenInventory(source, 'stash', id) end))
+end
+
+---Moves a phone off the legacy ox item-container tray onto its stash tray: any SIM inside the
+---old container follows, then `container` is stripped. Stripping is the load-bearing half - ox
+---keys its use-hijack off that metadata field, so a phone that keeps it never opens the phone UI.
+---@param source number player server id
+---@param row { slot: number, metadata: table } phone item row
+---@return boolean migrated
+local function migratePhone(source, row)
+    local containerId = row.metadata.container
+    if type(containerId) ~= 'string' or containerId == '' then return false end
+
+    local id = tray.idFor(source, row.slot)
+    local items = id and bridge.containerItems(source, row.slot)
+    if id and type(items) == 'table' then
+        tray.ensure(id)
+        for _, item in pairs(items) do
+            if item and item.name == config.Sim.SimItem then
+                -- Remove BEFORE add, deliberately: a failed add loses one SIM (an admin can
+                -- reissue it with /givesim bind), while a failed remove after a successful add
+                -- would leave two cards sharing one number.
+                local pulled = select(2, pcall(function()
+                    return exports[OX]:RemoveItem(containerId, item.name, 1, nil, item.slot)
+                end)) == true
+                local moved = pulled and select(2, pcall(function()
+                    return exports[OX]:AddItem(id, item.name, 1, item.metadata)
+                end)) == true
+                if not moved then
+                    print(('^3[sd-phone:sim]^0 could not move SIM %s out of legacy container %s (slot %s)')
+                        :format(tostring(item.metadata and item.metadata.number), containerId, tostring(row.slot)))
+                end
+                break
+            end
+        end
+    end
+
+    -- Re-read: idFor wrote the tray id, so the row captured above is stale.
+    local fresh = bridge.getSlot(source, row.slot)
+    local metadata = fresh and fresh.metadata or row.metadata
+    metadata.container = nil
+    metadata.size = nil
+    return bridge.setSlotMetadata(source, row.slot, metadata)
+end
+
+---Converts every legacy-container phone this player carries. Offline players hold their inventory
+---as a JSON blob, so there is no server-wide equivalent; this runs per player instead.
+---@param source number player server id
+---@return integer migrated phones converted
+function tray.migrate(source)
+    local count = 0
+    for item in pairs(phoneItems) do
+        for _, row in ipairs(bridge.searchSlots(source, item)) do
+            if row.metadata and row.metadata.container and migratePhone(source, row) then
+                count = count + 1
+            end
+        end
+    end
+    return count
+end
+
+---@type table<number, true> Players whose legacy sweep is already in flight.
+local sweeping = {}
+
+---Fires tray.migrate when any of `phones` still carries a legacy container. Hung off the phone
+---LOOKUP rather than character load so it also catches a legacy phone that arrives mid-session
+---from a drop or a trade. Deferred so a read path never turns into a write mid-call.
+---@param source number player server id
+---@param phones { metadata: table }[] rows from inv.findPhones
+function tray.sweepLegacy(source, phones)
+    if not tray.configured or sweeping[source] then return end
+    local legacy = false
+    for _, phone in ipairs(phones) do
+        if phone.metadata and phone.metadata.container then
+            legacy = true
+            break
+        end
+    end
+    if not legacy then return end
+
+    sweeping[source] = true
+    SetTimeout(0, function()
+        pcall(tray.migrate, source)
+        sweeping[source] = nil
+    end)
+end
+
+return tray

--- a/web/src/admin/pages/PlayerDetail.tsx
+++ b/web/src/admin/pages/PlayerDetail.tsx
@@ -310,7 +310,7 @@ function SimCard({ ov, toast, reload }: {
                 </div>
             }
         >
-            <InfoRow label="Mode">{sim.mode === 'container' ? 'SIM tray (containers)' : 'Item metadata'}</InfoRow>
+            <InfoRow label="Mode">{sim.mode === 'tray' ? 'SIM tray' : 'Item metadata'}</InfoRow>
             <InfoRow label="Active number">
                 {ov.online
                     ? (sim.activeNumber ? fmtPhone(sim.activeNumber) : <Badge tone="amber">No SIM / no phone</Badge>)

--- a/web/src/admin/types.ts
+++ b/web/src/admin/types.ts
@@ -68,7 +68,7 @@ export interface AdminOverview {
     downloadable: { id: string; label: string }[];
     /** Unique-phones footprint; absent while the SIM feature is off. */
     sim?: {
-        mode: 'container' | 'metadata';
+        mode: 'tray' | 'metadata';
         sims: AdminSimRow[];
         backup?: { profiles: number; enabled: boolean; hasPassword: boolean } | null;
         /** Only while the player is online. */

--- a/web/src/apps/settings/sim/SimBackupPage.tsx
+++ b/web/src/apps/settings/sim/SimBackupPage.tsx
@@ -25,7 +25,7 @@ interface BackupProfile {
 }
 
 interface SimInfo {
-    mode: 'container' | 'metadata';
+    mode: 'tray' | 'metadata';
     builtin: boolean;
     hasSim: boolean;
     /** Physical card in the active phone; hasSim = has service (character mode satisfies it
@@ -188,8 +188,8 @@ export function SimBackupPage({ onBack }: { onBack: () => void }) {
             <SubPage title={t('settings.simBackup', 'SIM & Backup')} onBack={onBack}>
                 <ListGroup footer={info?.builtin
                     ? t('settings.simFooterBuiltin', 'This phone\'s SIM is built in. Its number was assigned the first time the phone was used and stays with the phone.')
-                    : info?.mode === 'container'
-                        ? t('settings.simFooterContainer', 'Your number lives on the SIM card in this phone. Open the phone in your inventory to swap the SIM.')
+                    : info?.mode === 'tray'
+                        ? t('settings.simFooterTray', 'Your number lives on the SIM card in this phone. Right-click the phone in your inventory and pick SIM Tray to swap it.')
                         : t('settings.simFooterMetadata', 'Your number lives on the SIM card installed in this phone. Use a SIM card item to install it.')}>
                     <ListRow
                         label={t('settings.simStatus', 'SIM Status')}


### PR DESCRIPTION
## Why

With `UseContainers = true`, using a phone item opened the SIM tray instead of the phone, leaving the phone UI reachable only by keybind.

That is not a config mistake, it is hard-coded in ox. `ox_inventory/client.lua:501`, inside `useSlot`:

```lua
if item.metadata.container then
    return client.openInventory('container', item.slot)
end
```

Client-side, and it returns before `data.client`, `data.export` and the server usable callback, so sd-phone is never told the item was used. A container's existence *is* the `metadata.container` field, so there is no way to keep the container and free the use action.

Cancelling the open with the server `openInventory` hook was tried and rejected: the client then falls through to `lib.notify('inventory_right_access')` (`client.lua:249`), an error toast on every hotbar phone use.

## What

The tray is now a 1-slot ox **stash** whose id is minted by sd-phone and stamped into the phone item's metadata, so it still follows the item through trades, drops and stashes. Using the phone opens the phone; the tray gets its own inventory button.

- **`server/sim/tray.lua`** (new): mint/read `metadata.simTray`, register the stash, read its items, force-open it, resolve the holder, migrate legacy containers.
- **`server/sim/inv.lua`**: `getSimNumber` / `rewriteSimNumber` read the tray. `registerContainers` removed. Blank-SIM activation is unchanged, since `SetMetadata` takes any inventory id.
- **`server/sim/init.lua`**: `state.mode` is `'tray'`, plus the `openTray` event and two new hooks.
- **Config**: `UseContainers` is now `SimTray`, old key still read (same pattern as `DeviceIdentity` to `DataOwner`).

### Two guards containers gave us for free

- **`openInventory` hook** refuses a tray to anyone not carrying that phone. A stash id alone is enough to open a stash from anywhere, and the id ships to the client inside the phone's own metadata, so without this anyone who ever held the phone could lift its SIM remotely. Containers were gated on holding the item; a stash is not.
- **`swapItems` hook** keeps non-SIM items out. Containers had `whitelist`, stashes have no equivalent.

### Migration

Phones created under container mode convert on first lookup: the SIM moves into the new tray, then `container` and `size` are stripped. The strip is the load-bearing half, because ox keys its use-hijack off that field, so a phone that keeps it stays broken no matter what else changes. Hung off the phone lookup rather than character load so it also catches a legacy phone arriving mid-session from a drop or trade.

Remove runs before add deliberately: a failed add loses one SIM (reissuable with `/givesim bind`) while a failed remove after a successful add would leave two cards sharing one number. A console warning names the number if that happens.

## Install step

Tray mode needs a `buttons` entry on each phone item in `ox_inventory/data/items.lua`:

```lua
buttons = {
    { label = 'SIM Tray', action = function(slot) exports['sd-phone']:openSimTray(slot) end },
},
```

This cannot be injected at runtime. Cross-resource Lua exports serialize, so `exports.ox_inventory:Items(name)` returns a copy and writing to it never reaches ox, and ox exposes no runtime item-data registration API. README, installation docs and the client-exports page all cover it.

## Verification

| Gate | Result |
| --- | --- |
| Lua suite | 214 passed, 0 failed (was 161) |
| `luac -p`, changed Lua files | clean |
| `tsc --noEmit` | 0 errors |
| `eslint` | 0 errors |
| `vitest` | 142 passed |
| `knip` | clean |

New Lua coverage: tray id minting and stability, distinct ids per phone, non-phone and empty slots refused, `holderSlot` allow/deny, force-open path and stash properties, reading a SIM from a tray, blank-card activation (and refusal when `ActivateBlankSims = false`), `rewriteSimNumber`, legacy migration including the empty-container and stuck-SIM cases, and the legacy config key.

**Not verified in-game.** Everything above is static analysis plus unit tests against mocked ox exports, so hooks firing and `forceOpenInventory` landing are still unproven on a live server.
