### PR TITLE
feat(phone): configurable number format, AirShare refusal feedback, contacts cap

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -21,6 +21,20 @@ do
         if ids[id] then ENABLED_DOCK[#ENABLED_DOCK + 1] = id end
     end
 end
+-- Number display config for the NUI. Format keys are stringified deliberately: a Lua table whose
+-- integer keys run contiguously from 1 encodes as a JSON ARRAY, which would land in the UI
+-- off-by-one, so this guarantees an object either way.
+---@type { formats: table<string, string>, length: integer }
+local NUMBER_FORMAT = {}
+do
+    local cfg = type(config.Phone.Number) == 'table' and config.Phone.Number or {}
+    local formats = {}
+    for length, pattern in pairs(type(cfg.Formats) == 'table' and cfg.Formats or {}) do
+        if type(pattern) == 'string' and pattern ~= '' then formats[tostring(length)] = pattern end
+    end
+    NUMBER_FORMAT = { formats = formats, length = math.floor(tonumber(cfg.Length) or 10) }
+end
+
 ---@type table Weather bridge (bridge.client.weather): live weather + synced world-time reads.
 local weatherBridge = require 'bridge.client.weather'
 ---@type table Custom third-party app registry (client.customapps): add/remove/message + lifecycle.
@@ -349,6 +363,7 @@ local function OpenPhone()
             dock      = ENABLED_DOCK,
             apps      = ENABLED_APPS,
             mailDomain = config.Mail.Domain,
+            number    = NUMBER_FORMAT,
             wallpaper = {
                 lock = config.Lockscreen.Wallpaper,
                 home = config.Apps.Wallpaper,

--- a/configs/contacts.lua
+++ b/configs/contacts.lua
@@ -4,7 +4,7 @@
 return {
     -- Per-player cap on saved contacts. Blocks new inserts past this many
     -- (existing contacts are never auto-removed).
-    MaxContactsPerPlayer = 200,
+    MaxContactsPerPlayer = 500,
 
     -- Hard cap on call-log (Recents) rows per player. Once exceeded, the
     -- oldest calls are pruned so the log stays bounded.

--- a/configs/phone.lua
+++ b/configs/phone.lua
@@ -21,6 +21,29 @@ return {
     -- session (the keybind fallback). Must be one of the frame colours.
     DefaultColor = 'black',
 
+    -- Phone numbers: how long a new one is, and how numbers are displayed.
+    -- Numbers are always STORED as bare digits, so this changes presentation and
+    -- generation only - no database column, contact, message or call log is
+    -- rewritten, and every lookup keeps matching on digits.
+    Number = {
+        -- Digits in a NEWLY generated number. Changing it leaves every existing
+        -- number exactly as it is, so a running server ends up with a mix of
+        -- lengths, and both keep working everywhere.
+        Length = 10,
+
+        -- How a number is displayed, keyed by how many digits it has. Each X is
+        -- replaced by the next digit and every other character is printed
+        -- literally, so '+44 XXXX XXXXXX', 'XXX-XXXX' and '(XXX) XXX-XXXX' all
+        -- work. A digit count with no entry is shown as bare digits.
+        --
+        -- The table is keyed by length precisely so a Length change is safe:
+        -- add an entry for the new length and KEEP the old one, and numbers
+        -- already in circulation still read properly next to the new ones.
+        Formats = {
+            [10] = '(XXX) XXX-XXXX',
+        },
+    },
+
     -- Default keybind to open / close the phone. Players can rebind
     -- via FiveM's keybinding menu (Settings → Key Bindings → FiveM).
     Keybind  = 'F1',

--- a/configs/phone.lua
+++ b/configs/phone.lua
@@ -41,6 +41,11 @@ return {
         -- already in circulation still read properly next to the new ones.
         Formats = {
             [10] = '(XXX) XXX-XXXX',
+
+            -- An 11-digit entry sits alongside it quite happily, which is what
+            -- keeps numbers readable either side of a Length change. This one
+            -- renders 12075550123 as +1 (207) 555-0123.
+            -- [11] = '+X (XXX) XXX-XXXX',
         },
     },
 

--- a/server/admin/actions.lua
+++ b/server/admin/actions.lua
@@ -233,7 +233,11 @@ function actions.setNumber(source, payload)
     local cid = cleanCid(payload and payload.cid)
     if not cid then return fail('Missing player') end
     local digits = util.digits(payload and payload.number)
-    if #digits ~= 10 then return fail('Phone numbers are exactly 10 digits') end
+    -- Any length this server recognises, not just the one it generates, so a number issued
+    -- before config.Phone.Number.Length changed can still be corrected.
+    if not util.validNumberLength(digits) then
+        return fail(('Phone numbers are %s digits'):format(table.concat(util.numberLengths, ' or ')))
+    end
 
     if simState.active then
         local target = sourceByRealCid(cid)

--- a/server/contacts/actions.lua
+++ b/server/contacts/actions.lua
@@ -227,21 +227,28 @@ function actions.requestShare(source, target, payload)
 end
 
 ---Delivers an accepted contact share into the recipient's contacts, re-applying add's guards
----for the recipient. Returns a bare boolean.
+---for the recipient. The refusals a player can act on carry a reason, which AirShare shows them.
 ---@param targetSrc number
 ---@param fields table validated contact fields
 ---@return boolean delivered
+---@return string? reason recipient-facing refusal, nil when delivered or not worth explaining
 function actions.deliverShare(targetSrc, fields)
     local tcid = player.getIdentifier(targetSrc)
     if not tcid then return false end
-    if store.countContacts(tcid) >= cfg.MaxContactsPerPlayer then return false end
+    if store.countContacts(tcid) >= cfg.MaxContactsPerPlayer then
+        return false, ('Your contacts are full. You can save %d.'):format(cfg.MaxContactsPerPlayer)
+    end
 
     local newDigits = (tostring(fields.phone):gsub('%D', ''))
     if newDigits == '' or not settings.getCitizenByNumber(newDigits) then return false end
     local ownNumber = settings.getPhoneNumber(tcid)
-    if ownNumber and (tostring(ownNumber):gsub('%D', '')) == newDigits then return false end
+    if ownNumber and (tostring(ownNumber):gsub('%D', '')) == newDigits then
+        return false, 'That is your own number.'
+    end
     for _, row in ipairs(store.listContacts(tcid)) do
-        if (tostring(row.phone):gsub('%D', '')) == newDigits then return false end
+        if (tostring(row.phone):gsub('%D', '')) == newDigits then
+            return false, 'You already have that contact saved.'
+        end
     end
 
     local id = store.newId()

--- a/server/contacts/store.lua
+++ b/server/contacts/store.lua
@@ -3,6 +3,8 @@ local store = {}
 
 
 local util = require 'server.util'
+---@type table sd-phone config root (configs/config.lua); read for the per-player contacts cap.
+local config = require 'configs.config'
 local function newId() return util.newId(7) end
 
 store.newId = newId
@@ -177,7 +179,12 @@ end
 
 ---@type integer Hard ceiling on one read of a player's address book. A migrated book can run to
 ---four figures, which trips oxmysql's oversized-result warning and ships the lot over the bridge.
-local CONTACTS_CAP <const> = 500
+---
+---Tracks the configured per-player cap rather than standing as a second number: a player can
+---never legitimately hold more than that, and actions.lua walks this list to detect duplicates,
+---so a ceiling BELOW the cap would silently stop catching them past the ceiling.
+local CONTACTS_CAP <const> = math.max(1,
+    math.floor(tonumber(config.Contacts and config.Contacts.MaxContactsPerPlayer) or 500))
 
 ---List a player's contacts, alphabetised server-side, capped. Read-only.
 ---@param citizenid string

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -18,11 +18,8 @@ local function stripCol(col)
     return ("REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(%s,'-',''),' ',''),'(',''),')',''),'+',''),'.','')"):format(col)
 end
 
----Generates a random 10-digit phone number as raw digits, with the first block starting at 200.
----@return string number ten raw digits
-local function genNumber()
-    return ('%03d%03d%04d'):format(math.random(200, 989), math.random(100, 999), math.random(0, 9999))
-end
+---@type fun(): string Random number candidate at config.Phone.Number.Length (server.util).
+local genNumber = util.randomNumber
 
 ---Returns a varchar column's declared character cap, or nil when the column is missing or not
 ---length-bounded (information_schema probe).

--- a/server/share/core.lua
+++ b/server/share/core.lua
@@ -39,9 +39,11 @@ local MAX_PENDING = 5
 ---biggest legitimate share and lands around 1 MB; anything past this is not a real share.
 local MAX_PAYLOAD_BYTES = 4 * 1024 * 1024
 
----Registers the delivery handler for a share kind (e.g. 'contact', 'voice').
+---Registers the delivery handler for a share kind (e.g. 'contact', 'voice'). A handler may return
+---a second value: a recipient-facing reason for the refusal, shown to them verbatim. Handlers
+---that return a bare boolean still work and fall back to a generic message.
 ---@param kind string share kind
----@param fn fun(targetSrc: number, payload: table): boolean delivery function, true on success
+---@param fn fun(targetSrc: number, payload: table): boolean, string? true on success, else a reason
 function core.registerHandler(kind, fn) handlers[kind] = fn end
 
 ---Human noun for a share kind, used in the sender-facing accept/decline notifications. Falls
@@ -136,14 +138,30 @@ function core.respond(src, id, accept)
     end
 
     local handler = handlers[req.kind]
-    local ok = (handler and handler(src, req.payload)) == true
-    if ok then
+    local delivered, reason
+    if handler then delivered, reason = handler(src, req.payload) end
+
+    if delivered == true then
         TriggerClientEvent('sd-phone:client:notify', req.fromSrc, {
             app = 'phone', title = 'AirShare',
             body = ('%s accepted your %s.'):format(player.getName(src), kindLabel(req.kind)),
         })
+        return { success = true }
     end
-    return { success = ok }
+
+    -- Refused AFTER an accept (recipient's contacts full, duplicate, ...). Both sides otherwise
+    -- just watch the prompt disappear: the recipient's client fires the respond callback and
+    -- drops the card without reading the result, and the sender was only ever told on success.
+    -- The recipient gets the handler's specific reason; the sender only needs to know it missed.
+    TriggerClientEvent('sd-phone:client:notify', src, {
+        app = 'phone', title = 'AirShare',
+        body = reason or ('That %s could not be saved.'):format(kindLabel(req.kind)),
+    })
+    TriggerClientEvent('sd-phone:client:notify', req.fromSrc, {
+        app = 'phone', title = 'AirShare',
+        body = ('%s could not save your %s.'):format(player.getName(src), kindLabel(req.kind)),
+    })
+    return { success = false, message = reason }
 end
 
 ---Forgets a departing player: their open flag and every pending request they sent or were

--- a/server/sim/store.lua
+++ b/server/sim/store.lua
@@ -5,12 +5,8 @@ local util = require 'server.util'
 ---(number -> data identity) and the per-character cloud-backup pointers.
 local store = {}
 
----Generates a random 10-digit phone number as raw digits, with the first block starting at 200
----(mirrors server.settings.store's generator).
----@return string number ten raw digits
-local function genNumber()
-    return ('%03d%03d%04d'):format(math.random(200, 989), math.random(100, 999), math.random(0, 9999))
-end
+---@type fun(): string Random number candidate at config.Phone.Number.Length (server.util).
+local genNumber = util.randomNumber
 
 ---Creates the SIM registry and cloud-backup tables.
 function store.ensureSchema()
@@ -132,7 +128,7 @@ end
 
 ---Generates a phone number that is free in both the SIM registry and phone_settings; tries 20
 ---random candidates, then accepts an unchecked one.
----@return string number ten raw digits
+---@return string number raw digits, at config.Phone.Number.Length
 function store.generateNumber()
     for _ = 1, 20 do
         local candidate = genNumber()

--- a/server/util.lua
+++ b/server/util.lua
@@ -1,3 +1,6 @@
+---@type table sd-phone config root (configs/config.lua); read for the number format + length.
+local config = require 'configs.config'
+
 ---@type table Shared server helpers; the table returned at end of file.
 local util = {}
 
@@ -72,14 +75,87 @@ function util.initialsFor(name)
     return out ~= '' and out or '#'
 end
 
----Format raw digits as a US-style "(XXX) XXX-XXXX" phone number; anything that isn't exactly 10
----digits (short codes, partials) passes through as bare digits.
+---@type table Number settings (config.Phone.Number), defaulted so a config written before this
+---section existed keeps the original US shape.
+local NUMBER = (type(config.Phone) == 'table' and type(config.Phone.Number) == 'table')
+    and config.Phone.Number or {}
+
+---@type table<number, string> Display pattern per digit count, from config.
+local FORMATS = type(NUMBER.Formats) == 'table' and NUMBER.Formats or { [10] = '(XXX) XXX-XXXX' }
+
+---@type integer Digits in a newly generated number.
+local LENGTH = math.floor(tonumber(NUMBER.Length) or 10)
+if LENGTH < 3 then LENGTH = 3 end
+if LENGTH > 15 then LENGTH = 15 end
+
+---Renders digits into a display pattern: every X takes the next digit, every other character is
+---literal. Digits past the pattern's last X are appended so nothing is ever silently dropped.
+---@param pattern string
+---@param d string bare digits
+---@return string
+local function applyPattern(pattern, d)
+    local out, i = {}, 1
+    for c in pattern:gmatch('.') do
+        if c == 'X' then
+            if i > #d then break end
+            out[#out + 1] = d:sub(i, i)
+            i = i + 1
+        else
+            out[#out + 1] = c
+        end
+    end
+    if i <= #d then out[#out + 1] = d:sub(i) end
+    return table.concat(out)
+end
+
+---Formats raw digits for display using config.Phone.Number.Formats. A digit count with no
+---configured pattern (short codes, a length the server has since changed away from) passes
+---through as bare digits rather than being forced into the wrong shape.
 ---@param number any
 ---@return string
 function util.formatNumber(number)
     local d = util.digits(number)
-    if #d == 10 then return ('(%s) %s-%s'):format(d:sub(1, 3), d:sub(4, 6), d:sub(7)) end
-    return d
+    local pattern = FORMATS[#d]
+    if type(pattern) ~= 'string' or pattern == '' then return d end
+    return applyPattern(pattern, d)
+end
+
+---A random phone number as bare digits, at the configured length. The leading digit avoids 0 and
+---1 so numbers still read like real ones (and so the digit count never shrinks through a
+---tonumber round-trip somewhere downstream).
+---@return string number bare digits, `config.Phone.Number.Length` of them
+function util.randomNumber()
+    local out = { tostring(math.random(2, 9)) }
+    for i = 2, LENGTH do out[i] = tostring(math.random(0, 9)) end
+    return table.concat(out)
+end
+
+---@type integer Digits a newly generated number gets; exposed for callers that report it.
+util.numberLength = LENGTH
+
+---@type integer[] Digit counts that count as a real number: the generated length plus every
+---length with a display format, so numbers minted before a Length change stay valid. Ascending.
+util.numberLengths = (function()
+    local seen, out = { [LENGTH] = true }, { LENGTH }
+    for length in pairs(FORMATS) do
+        local n = tonumber(length)
+        if n and n > 0 and not seen[n] then
+            seen[n] = true
+            out[#out + 1] = n
+        end
+    end
+    table.sort(out)
+    return out
+end)()
+
+---True when `digits` is a length this server accepts.
+---@param digits string bare digits
+---@return boolean
+function util.validNumberLength(digits)
+    for _, n in ipairs(util.numberLengths) do
+        if #digits == n then return true end
+    end
+    return false
 end
 
 ---@type string[] iOS system-colour palette, mirrored from the frontend.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ import { fetchNui, isFiveM } from '@/core/nui';
 import { usePhoneReset } from '@/core/phoneReset';
 import { resetAuth } from '@/stores/authStore';
 import { setMailDomain } from '@/core/accountsApi';
+import { setNumberFormat } from '@/lib/phone';
 import { voiceHub, setLocalTalking } from '@/media/nearbyVoice';
 import { useMusicLibrary } from '@/stores/musicLibraryStore';
 import { DEFAULT_FRAME_COLOR } from '@/shell/frameColors';
@@ -364,6 +365,7 @@ function AppContent() {
         if (!data) return;
         if (data.locale) useLocaleStore.getState().applyServerDefault(data.locale);   // server default, unless the player already picked their own
         if (data.mailDomain) setMailDomain(data.mailDomain);
+        if (data.number) setNumberFormat(data.number.formats, data.number.length);
         useSimStore.getState().apply(data.sim);
         applySimProfile(data.sim?.enabled, data.sim?.hasSim, data.sim?.number, data.sim?.device, data.sim?.profile);
         syncSimNumber(data.sim);

--- a/web/src/admin/pages/PlayerDetail.tsx
+++ b/web/src/admin/pages/PlayerDetail.tsx
@@ -10,6 +10,7 @@ import {
     adminMessages, adminBirdyDeletePost, adminOverview, adminResetAccountPassword,
     adminResetPasscode, adminSetApp, adminSetNumber, adminUnmute, adminWipePhone,
 } from '../adminApi';
+import { acceptedNumberLengths } from '@/lib/phone';
 import {
     fmtPhone, fmtTime, scopeLabel,
     type AdminBirdyPost, type AdminCall, type AdminMessage, type AdminMute, type AdminOverview,
@@ -50,6 +51,15 @@ export function PlayerDetail({ cid, onBack, toast, onOpenGallery }: {
     const [loading, setLoading] = useState(true);
     const [tab, setTab] = useState<Tab>('overview');
     const [modal, setModal] = useState<null | 'number' | 'wipe' | { password: { id: number; label: string } }>(null);
+
+    // Whatever lengths this server recognises, not a hardcoded 10, so the prompt still matches
+    // after config.Phone.Number.Length changes (and keeps accepting the previous length).
+    const acceptedLengths = acceptedNumberLengths();
+    const longestLength = acceptedLengths[acceptedLengths.length - 1];
+    const numberLengthLabel = acceptedLengths.length === 1
+        ? `${acceptedLengths[0]}-digit`
+        : `${acceptedLengths.slice(0, -1).join(', ')} or ${longestLength}-digit`;
+    const numberPlaceholder = '2085551234567890'.slice(0, longestLength);
 
     const reload = useCallback(() => {
         void adminOverview(cid).then(res => {
@@ -152,13 +162,15 @@ export function PlayerDetail({ cid, onBack, toast, onOpenGallery }: {
                 <PromptModal
                     title="Change phone number"
                     body={ov.sim
-                        ? <>New 10-digit number for the SIM in <b>{ov.name}</b>&apos;s active phone. They must be online
+                        ? <>New {numberLengthLabel} number for the SIM in <b>{ov.name}</b>&apos;s active phone. They must be online
                             and carrying the phone; the SIM keeps its profile/data, only the number changes.</>
-                        : <>New 10-digit number for <b>{ov.name}</b>. The old number stops working immediately.</>}
-                    placeholder="e.g. 2085551234"
+                        : <>New {numberLengthLabel} number for <b>{ov.name}</b>. The old number stops working immediately.</>}
+                    placeholder={`e.g. ${numberPlaceholder}`}
                     mono
                     submitLabel="Assign number"
-                    validate={v => v.replace(/\D/g, '').length === 10 ? null : 'Enter exactly 10 digits'}
+                    validate={v => acceptedLengths.includes(v.replace(/\D/g, '').length)
+                        ? null
+                        : `Enter ${numberLengthLabel}`}
                     onSubmit={async v => {
                         const res = await adminSetNumber(cid, v);
                         if (res.success) { toast('Number updated'); reload(); }

--- a/web/src/admin/types.ts
+++ b/web/src/admin/types.ts
@@ -1,5 +1,7 @@
 // Shapes returned by the server admin module (server/admin/actions.lua).
 
+import { formatPhone } from '@/lib/phone';
+
 export interface AdminPlayerHit {
     citizenid:    string;
     name?:        string;
@@ -206,6 +208,6 @@ export function fmtTime(epoch?: number | null): string {
 
 export function fmtPhone(number?: string | null): string {
     const d = (number ?? '').replace(/\D/g, '');
-    if (d.length !== 10) return d || '—';
-    return `(${d.slice(0, 3)}) ${d.slice(3, 6)}-${d.slice(6)}`;
+    if (!d) return '—';
+    return formatPhone(d);
 }

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -20,6 +20,11 @@ export interface OpenPayload {
     installedApps?: string[];
     homeLayout?: string;
     mailDomain?: string;
+    /** Phone-number display config (config.Phone.Number); formats are keyed by digit count. */
+    number?: {
+        formats?: Record<string, string>;
+        length?: number;
+    };
     wallpaper: {
         lock: string;
         home: string;

--- a/web/src/lib/phone.ts
+++ b/web/src/lib/phone.ts
@@ -1,16 +1,70 @@
 import { digits } from './format';
 
-export function formatPhone(value: string): string {
-    const d = digits(value);
-    if (d.length === 10) return `(${d.slice(0, 3)}) ${d.slice(3, 6)}-${d.slice(6)}`;
-    return value;
+/**
+ * Display patterns keyed by digit count, mirroring config.Phone.Number.Formats. Seeded with the
+ * stock US shape so dev mode and the frames before the open payload lands still read correctly.
+ */
+let FORMATS: Record<number, string> = { 10: '(XXX) XXX-XXXX' };
+
+/** Digit count a newly generated number has, mirroring config.Phone.Number.Length. */
+let LENGTH = 10;
+
+/** Applied from the `sd-phone:open` payload so the UI matches the server's configuration. */
+export function setNumberFormat(formats?: Record<number, string>, length?: number): void {
+    if (formats && Object.keys(formats).length > 0) FORMATS = formats;
+    if (length && length > 0) LENGTH = length;
 }
 
+/**
+ * Digit counts this server treats as a real number: the length it generates, plus every length
+ * with a display format, so numbers minted before a `Length` change stay editable. Ascending.
+ */
+export function acceptedNumberLengths(): number[] {
+    const lengths = new Set<number>([LENGTH]);
+    for (const key of Object.keys(FORMATS)) {
+        const n = Number(key);
+        if (Number.isFinite(n) && n > 0) lengths.add(n);
+    }
+    return [...lengths].sort((a, b) => a - b);
+}
+
+/** Fills `pattern`'s X placeholders from `d`, printing every other character literally. */
+function applyPattern(pattern: string, d: string): string {
+    let out = '';
+    let i = 0;
+    for (const c of pattern) {
+        if (c === 'X') {
+            if (i >= d.length) return out;
+            out += d[i++];
+        } else {
+            out += c;
+        }
+    }
+    return i < d.length ? `${out}${d.slice(i)}` : out;
+}
+
+/**
+ * A complete number, formatted for display. A digit count with no configured pattern passes
+ * through untouched rather than being forced into the wrong shape, which is what keeps numbers
+ * issued under an older `Length` readable after the config changes.
+ */
+export function formatPhone(value: string): string {
+    const d = digits(value);
+    const pattern = FORMATS[d.length];
+    if (!pattern) return value;
+    return applyPattern(pattern, d);
+}
+
+/**
+ * A number being typed. Formats against the pattern for the configured generated length, so the
+ * shape a player is entering is the shape this server issues, and falls back to the longest
+ * configured pattern when that length has none.
+ */
 export function formatPhonePartial(value: string): string {
     const d = digits(value);
     if (d.length === 0) return '';
-    if (d.length <= 3) return d;
-    if (d.length <= 6) return `(${d.slice(0, 3)}) ${d.slice(3)}`;
-    const tail = d.length > 10 ? ` ${d.slice(10)}` : '';
-    return `(${d.slice(0, 3)}) ${d.slice(3, 6)}-${d.slice(6, 10)}${tail}`;
+
+    const pattern = FORMATS[LENGTH] ?? FORMATS[Math.max(...Object.keys(FORMATS).map(Number))];
+    if (!pattern) return d;
+    return applyPattern(pattern, d);
 }

--- a/web/src/payphone/PayphoneUI.tsx
+++ b/web/src/payphone/PayphoneUI.tsx
@@ -403,7 +403,7 @@ export function PayphoneUI() {
         : phase === 'calling'   ? t('payphone.calling', 'CALLING…')
         : phase === 'connected' ? fmtClock(elapsed)
         : phase === 'ended'     ? t('payphone.callEnded', 'CALL ENDED')
-        : digits ? (digits.length === 10 ? formatPhone(digits) : digits)
+        : digits ? formatPhone(digits)
         : needsCoin ? t('payphone.insertCoin', 'INSERT COIN')
         : booth.anonymous ? t('payphone.withheld', 'NO CALLER ID') : formatPhone(booth.number);
 


### PR DESCRIPTION
Two related-but-separate pieces of work, bundled at the author's request.

---

# 1. Configurable phone number format and generated length

Answers "how do we change the phone number format?", and makes the generated length configurable alongside it.

## Why

The US `(XXX) XXX-XXXX` shape was hardcoded in **four** places:

| Site | Was |
| --- | --- |
| `server/util.lua` `formatNumber` | `if #d == 10 then ... end` |
| `web/src/lib/phone.ts` | `formatPhone` + `formatPhonePartial` |
| `web/src/admin/types.ts` `fmtPhone` | its own copy of the same slicing |
| `web/src/payphone/PayphoneUI.tsx` | `digits.length === 10 ? formatPhone(digits) : digits` |

And the length was hardcoded in **two duplicated generators** (`server/sim/store.lua`, `server/settings/store.lua`).

## What

`config.Phone.Number` owns both:

```lua
Number = {
    Length = 10,
    Formats = {
        [10] = '(XXX) XXX-XXXX',
        -- [11] = '+X (XXX) XXX-XXXX',
    },
},
```

Each `X` takes the next digit, every other character is literal, so `'+44 XXXX XXXXXX'` and `'XXX-XXXX'` both work. A digit count with no entry shows as bare digits rather than being forced into the wrong shape.

**Presentation and generation only.** Numbers are still stored as bare digits, so no column, contact, message or call log is rewritten and every lookup keeps matching on digits.

### Changing `Length` is safe

Existing numbers are never reissued, so a server that changes `Length` ends up with a mix. That is why formats are keyed by digit count rather than being a single string: keep the old length's entry alongside the new one and both render properly. Admin number-assignment accepts any recognised length instead of exactly ten, so an older number can still be corrected.

The two generators now share `util.randomNumber`. Leading digit avoids 0 and 1; `Length` clamps to 3..15, which is the range `setSimNumber` already enforced.

### Wiring

Config reaches the UI on the `sd-phone:open` payload. Format keys are stringified on the Lua side on purpose: a Lua table whose integer keys run contiguously from 1 encodes as a JSON **array**, which would land in the UI off by one.

### Behaviour change

`formatPhonePartial` (dial-pad typing) now drops a separator as soon as the group before it is full, the way iOS does: `(207) ` at three digits where the old version showed bare `207`. Four digits on is identical. This falls out of the pattern walker being general.

---

# 2. AirShare refusal feedback

## Why

A share refused **after** the recipient accepted was silent on both sides:

- **Recipient**: `App.tsx:953` fires `void fetchNui('sd-phone:airshare:respond', ...)` and immediately drops the card. The `{ success, message }` result is discarded entirely.
- **Sender**: `share/core.lua` only notified on success.

So a full address book looked exactly like the prompt had vanished.

## What

Share handlers may now return a reason alongside `false`. `core.respond` gives the recipient that reason verbatim and tells the sender it did not land. Handlers still returning a bare boolean keep working and fall back to `That <kind> could not be saved.`, so **every** share kind gains feedback (voice memo, note, pin, music, document, signature request), not just contacts.

Contact delivery explains the three refusals a player can act on:

| Refusal | Recipient sees |
| --- | --- |
| Address book full | `Your contacts are full. You can save 500.` |
| Their own number | `That is your own number.` |
| Already saved | `You already have that contact saved.` |

Refusals a player cannot act on (no character, unknown number) stay unexplained and use the generic line.

---

# 3. Contacts cap

`MaxContactsPerPlayer` 200 → 500, and the `listContacts` query ceiling now **derives** from it instead of standing as a second hardcoded `500` in `server/contacts/store.lua`.

That ceiling is not just a display limit: `actions.lua:180/248/333` walk the same list to detect duplicates, so a ceiling below the cap would quietly stop catching duplicates past it, letting one number be saved twice.

Worth noting for a future pass: those duplicate checks pull the whole address book per add and per AirShare delivery. Fine at 500, but an indexed `WHERE` lookup would be better than a linear scan.

---

## Verification

| Gate | Result |
| --- | --- |
| Lua suite | 213 passed, 0 failed |
| `luac -p`, changed Lua files | clean |
| `tsc --noEmit` | 0 errors |
| `eslint` | 0 errors |
| `vitest` | 157 passed (15 files) |
| `knip` | clean |

New coverage: default shape unchanged, arbitrary patterns, unconfigured lengths passing through, old and new lengths side by side, overflow digits kept, absent config falling back, generation at several lengths (200 samples each), clamping, round-trip, accepted-length resolution, partial formatter and its fallback. Plus all five AirShare contact refusal paths and the deliver-succeeds case.

**In-game**: the number format is confirmed working (formats change live after a resource restart) and the AirShare refusal notification is confirmed working. The `web/build` bundle must be rebuilt for frontend changes to appear, which is what initially made the format look broken.
