### PR TITLE
feat(lb-compat): emit lb-phone:settingsUpdated and implement GetSettings

### DIFF
--- a/client/apps/settings.lua
+++ b/client/apps/settings.lua
@@ -1,31 +1,43 @@
----@type fun(nuiAction: string, serverEvent: string) NUI->server pass-through registrar (client.nui).
+---@type fun(nuiAction: string, serverEvent: string, onAccepted?: fun()) NUI->server pass-through registrar (client.nui).
 local proxyCallback = require 'client.nui'
 
+---Announces an accepted settings write, so listeners can re-read the snapshot.
+local function announce()
+    TriggerEvent('sd-phone:client:settingsUpdated')
+end
+
+---Registers a settings write: the read pass-through plus the announcement.
+---@param nuiAction string
+---@param serverEvent string
+local function writeCallback(nuiAction, serverEvent)
+    proxyCallback(nuiAction, serverEvent, announce)
+end
+
 -- Thin delegates into server/settings: per-player setting reads/writes persisted to the
--- phone_settings table.
+-- phone_settings table. Writes go through writeCallback so they announce afterwards.
 proxyCallback('sd-phone:settings:get',      'sd-phone:server:settings:get')
-proxyCallback('sd-phone:settings:setTones', 'sd-phone:server:settings:setTones')
-proxyCallback('sd-phone:settings:tones:add',    'sd-phone:server:settings:tones:add')
-proxyCallback('sd-phone:settings:tones:remove', 'sd-phone:server:settings:tones:remove')
-proxyCallback('sd-phone:settings:setAirplane',  'sd-phone:server:settings:setAirplane')
-proxyCallback('sd-phone:settings:setHour24',    'sd-phone:server:settings:setHour24')
-proxyCallback('sd-phone:settings:setReopenApp', 'sd-phone:server:settings:setReopenApp')
-proxyCallback('sd-phone:settings:setSetupDone', 'sd-phone:server:settings:setSetupDone')
-proxyCallback('sd-phone:settings:setTheme',     'sd-phone:server:settings:setTheme')
-proxyCallback('sd-phone:settings:setDarkTheme', 'sd-phone:server:settings:setDarkTheme')
-proxyCallback('sd-phone:settings:setLockClock', 'sd-phone:server:settings:setLockClock')
-proxyCallback('sd-phone:settings:setSecurity',  'sd-phone:server:settings:setSecurity')
-proxyCallback('sd-phone:settings:setWallpaper', 'sd-phone:server:settings:setWallpaper')
-proxyCallback('sd-phone:settings:setBlur',      'sd-phone:server:settings:setBlur')
-proxyCallback('sd-phone:settings:wallpapers:add',    'sd-phone:server:settings:wallpapers:add')
-proxyCallback('sd-phone:settings:wallpapers:remove', 'sd-phone:server:settings:wallpapers:remove')
-proxyCallback('sd-phone:settings:setChatTextScale', 'sd-phone:server:settings:setChatTextScale')
-proxyCallback('sd-phone:settings:setPhoneScale',    'sd-phone:server:settings:setPhoneScale')
-proxyCallback('sd-phone:settings:setBrightness',    'sd-phone:server:settings:setBrightness')
-proxyCallback('sd-phone:settings:setPhoneAlign',    'sd-phone:server:settings:setPhoneAlign')
-proxyCallback('sd-phone:settings:setVolumes',       'sd-phone:server:settings:setVolumes')
-proxyCallback('sd-phone:settings:setLocale',        'sd-phone:server:settings:setLocale')
+writeCallback('sd-phone:settings:setTones', 'sd-phone:server:settings:setTones')
+writeCallback('sd-phone:settings:tones:add',    'sd-phone:server:settings:tones:add')
+writeCallback('sd-phone:settings:tones:remove', 'sd-phone:server:settings:tones:remove')
+writeCallback('sd-phone:settings:setAirplane',  'sd-phone:server:settings:setAirplane')
+writeCallback('sd-phone:settings:setHour24',    'sd-phone:server:settings:setHour24')
+writeCallback('sd-phone:settings:setReopenApp', 'sd-phone:server:settings:setReopenApp')
+writeCallback('sd-phone:settings:setSetupDone', 'sd-phone:server:settings:setSetupDone')
+writeCallback('sd-phone:settings:setTheme',     'sd-phone:server:settings:setTheme')
+writeCallback('sd-phone:settings:setDarkTheme', 'sd-phone:server:settings:setDarkTheme')
+writeCallback('sd-phone:settings:setLockClock', 'sd-phone:server:settings:setLockClock')
+writeCallback('sd-phone:settings:setSecurity',  'sd-phone:server:settings:setSecurity')
+writeCallback('sd-phone:settings:setWallpaper', 'sd-phone:server:settings:setWallpaper')
+writeCallback('sd-phone:settings:setBlur',      'sd-phone:server:settings:setBlur')
+writeCallback('sd-phone:settings:wallpapers:add',    'sd-phone:server:settings:wallpapers:add')
+writeCallback('sd-phone:settings:wallpapers:remove', 'sd-phone:server:settings:wallpapers:remove')
+writeCallback('sd-phone:settings:setChatTextScale', 'sd-phone:server:settings:setChatTextScale')
+writeCallback('sd-phone:settings:setPhoneScale',    'sd-phone:server:settings:setPhoneScale')
+writeCallback('sd-phone:settings:setBrightness',    'sd-phone:server:settings:setBrightness')
+writeCallback('sd-phone:settings:setPhoneAlign',    'sd-phone:server:settings:setPhoneAlign')
+writeCallback('sd-phone:settings:setVolumes',       'sd-phone:server:settings:setVolumes')
+writeCallback('sd-phone:settings:setLocale',        'sd-phone:server:settings:setLocale')
 proxyCallback('sd-phone:settings:versionInfo',  'sd-phone:server:settings:versionInfo')
 proxyCallback('sd-phone:settings:getNotifPref', 'sd-phone:server:settings:getNotifPref')
-proxyCallback('sd-phone:settings:setNotifPref', 'sd-phone:server:settings:setNotifPref')
-proxyCallback('sd-phone:settings:factoryReset', 'sd-phone:server:settings:factoryReset')
+writeCallback('sd-phone:settings:setNotifPref', 'sd-phone:server:settings:setNotifPref')
+writeCallback('sd-phone:settings:factoryReset', 'sd-phone:server:settings:factoryReset')

--- a/client/compat/lbphone.lua
+++ b/client/compat/lbphone.lua
@@ -242,13 +242,73 @@ end)
 eventCookies[#eventCookies + 1] = RegisterNetEvent('lb-phone:itemAdded', function() end)
 eventCookies[#eventCookies + 1] = RegisterNetEvent('lb-phone:itemRemoved', function() end)
 
+---Converts an sd-phone 0-100 slider to the 0-1 fraction lb-phone published. nil stays nil.
+---@param v number|nil
+---@return number|nil
+local function slider01(v)
+    local n = tonumber(v)
+    if not n then return nil end
+    return n / 100
+end
+
+---Projects an sd-phone settings snapshot onto lb-phone's settings object. Shape and ranges follow
+---lb-phone's config/defaultSettings.json; settings it never published are left out.
+---@param s table snapshot from sd-phone:server:settings:get
+---@return table settings
+local function lbSettings(s)
+    return {
+        display = {
+            theme      = s.theme,
+            brightness = slider01(s.brightness),
+            size       = slider01(s.phoneScale),
+        },
+        sound = {
+            ringtone   = s.ringtone,
+            texttone   = s.notificationTone,
+            volume     = slider01(s.ringtoneVol),
+            callVolume = slider01(s.callVol),
+        },
+        wallpaper = {
+            background = s.wallpaper,
+            blur       = s.blurLock,
+        },
+        time = {
+            twelveHourClock = not s.hour24,
+        },
+    }
+end
+
+---@type table|nil Last known lb-phone-shaped settings. Cached so GetSettings answers without yielding.
+local settingsCache
+
+---Re-reads the snapshot into settingsCache. Yields, so never called from the export.
+---@return table|nil settings nil when the read failed
+local function refreshSettings()
+    local res = lib.callback.await('sd-phone:server:settings:get', false)
+    if type(res) ~= 'table' or res.success ~= true or type(res.data) ~= 'table' then return nil end
+    settingsCache = lbSettings(res.data)
+    return settingsCache
+end
+
+-- Primed at load; not retried, since every accepted write refreshes it below.
+CreateThread(refreshSettings)
+
+---Mirrors an accepted sd-phone settings write as lb-phone's settingsUpdated.
+eventCookies[#eventCookies + 1] = AddEventHandler('sd-phone:client:settingsUpdated', function()
+    local settings = refreshSettings()
+    if settings then TriggerEvent('lb-phone:settingsUpdated', settings) end
+end)
+
 -- Stubs: the rest of lb-phone's client surface, grouped by family; each warns once and returns
 -- a safe default.
 
 -- Config and settings readers.
 stubLbExport('GetConfig', {})
 stubLbExport('GetCellTowers', {})
-stubLbExport('GetSettings', nil)
+---GetSettings() -> table|nil, from the cache refreshed alongside lb-phone:settingsUpdated.
+registerLbExport('GetSettings', function()
+    return settingsCache
+end)
 stubLbExport('GetStreamerMode', false)
 
 -- Airplane mode reads as off.

--- a/client/nui.lua
+++ b/client/nui.lua
@@ -2,9 +2,12 @@
 ---response envelope unchanged, falling back to a uniform failure when the server never answers.
 ---@param nuiAction string NUI action name the React app fetches
 ---@param serverEvent string server callback name to await
-local function proxy(nuiAction, serverEvent)
+---@param onAccepted? fun() ran only when the server accepted the write, never on a rejection
+local function proxy(nuiAction, serverEvent, onAccepted)
     RegisterNUICallback(nuiAction, function(payload, cb)
-        cb(lib.callback.await(serverEvent, false, payload) or { success = false, message = 'No response from server' })
+        local res = lib.callback.await(serverEvent, false, payload)
+        if onAccepted and type(res) == 'table' and res.success == true then onAccepted() end
+        cb(res or { success = false, message = 'No response from server' })
     end)
 end
 


### PR DESCRIPTION
## Summary

sd-phone never announced when a player changed a setting, so a resource ported from lb-phone had no way to follow the phone's appearance.

The `vivum-billing` resource is the visible case. It registers its billing app inside the phone via `AddCustomApp`, listens for `lb-phone:settingsUpdated`, and forwards the payload into its own NUI so the app can match the phone's theme. Under sd-phone that event never fired, so the embedded app never tracked the phone's theme. `GetSettings` was also a `nil` stub, so a consumer could not read the current settings on init either. As a result of both of these, the settings half of the lb-phone client API was unavailable.

This adds:

- **`sd-phone:client:settingsUpdated`** - a first-party client event fired by the settings app after any write the server accepted. Payload-free by design: each write carries a different partial shape, and a listener that cares about settings wants all of them, not the one field that changed.
- **`lb-phone:settingsUpdated`** - mirrored in the lb-phone compat layer, carrying lb-phone's nested settings object.
- **`GetSettings()`** - promoted from a `nil` stub to a real export.

### Notes for review

**Where the payload shape came from.** The projection is derived from `server/migrate/port/settings.lua`, which already reads real lb-phone settings rows. So `display.theme`, `display.brightness`, `display.size`, `sound.ringtone`, `sound.texttone`, `sound.volume`, `sound.callVolume`, `wallpaper.background`, `wallpaper.blur` and `time.twelveHourClock` are the field names the importer expects to find, rather than names I invented. sd-phone-only settings are deliberately left out rather than added, so a consumer reading anything else gets `nil` exactly as it would have under lb-phone.

**Scales are converted, verified against lb-phone's own defaults.** `config/defaultSettings.json` in lb-phone publishes `display.brightness` as `1.0`, `display.size` as `0.7`, and both `sound.volume` and `sound.callVolume` as `0.5` - 0–1 fractions. sd-phone stores the same four as 0–100 sliders, so the projection divides them through a `slider01` helper. Passing them raw would have handed every consumer a value 100× too high; `nil` stays `nil`, so a never-set slider is still omitted rather than becoming `0`. Everything else - theme, tones, wallpaper, blur, clock format - is the same type and domain on both sides and passes straight through.

**Absent fields are omitted, not nulled - and distinct from zero.** A setting the player has never set is simply missing from its group: the samples below show `"wallpaper":{"blur":false}` with no `background` until one is chosen. An explicit `0` is still emitted, so a muted volume or a slider at its floor is distinguishable from "never set". That is ordinary Lua table behaviour and both read correctly to a consumer, but it is worth knowing the groups are not fixed-shape.

**The event tracks writes, not deltas.** sd-phone has settings lb-phone had no field for, and stores wallpaper and blur *per screen* (lock and home) where lb-phone had one of each. The projection maps the lock-screen variants, so a home-screen wallpaper or blur write fires an event whose lb-shaped payload is byte-identical to the previous one - visible as event 6 in the test log below. Since consumers re-read the settings on the event rather than diffing it, this is harmless, and suppressing it would mean field-comparing every projection on a path that is already user-paced. Flagging it so it is not mistaken for a double-fire. The same applies to `darkTheme`, `locale`, `chatTextScale` and `phoneAlign`, which have no lb-phone equivalent at all.

**`background` carries sd-phone's identifier.** It is whatever sd-phone stored - a built-in wallpaper key such as `background12.jpg`, or a custom URL - so a consumer cannot assume it resolves against lb-phone's own asset set. This mirrors the constraint `server/migrate/port/settings.lua` already documents in the other direction, where lb-phone's built-in names are deliberately dropped on import because sd-phone does not ship those images.

**Why `GetSettings` is cached rather than reading through.** It answers from a cache primed at load and refreshed alongside the event. Doing a live `lib.callback.await` inside the export would make it yield, which breaks any caller invoking it from a non-yieldable context - lb-phone's was a synchronous read of local state, so this keeps the same contract. The cache is `nil` until the first successful read, which reads the same as lb-phone would for a player whose settings had not loaded yet.

**Cost when nobody is listening.** The snapshot is read in the compat layer, not carried on the first-party event. Everything here sits below the `realLbPhoneStarted()` / `sd_phone_lbcompat` guard, so a server with no lb-phone consumer registers none of it and pays nothing. Settings writes are user-paced, so the extra round trip is not on any hot path.

**The one shared file.** `client/nui.lua`'s `proxy()` takes an optional third argument, `onAccepted`, fired only when the server returned `success == true` - never for a rejected write or an unanswered call, so a listener cannot read a failure as a change. Existing two-argument calls are unaffected. In `client/apps/settings.lua` the mutating callbacks now register through a `writeCallback` wrapper; the three genuine reads (`get`, `versionInfo`, `getNotifPref`) still use `proxyCallback` unchanged.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [x] Compatibility
- [ ] Other

## Related Issues

None found while migrating a server from lb-phone to sd-phone.

## Testing

Tested on a live QBox server running sd-phone alongside vivum-billing. A temporary client resource listened for `lb-phone:settingsUpdated` and exposed a command calling `exports['lb-phone']:GetSettings()`. Two runs: the first for field coverage and event mechanics, the second - after the scale conversion landed - across a resource restart.

### Run 1 - coverage and event mechanics

> Captured before the `slider01` conversion, so the four numeric fields appear here as sd-phone's raw 0–100. Run 2 below shows the same settings emitted as fractions. Nothing else in this run is affected.

`GetSettings()` called before touching any setting, confirming the load-time priming path answers rather than returning `nil`:

```
{"sound":{"texttone":"default","callVolume":50,"volume":50,"ringtone":"marimba"},
 "wallpaper":{"blur":false},"time":{"twelveHourClock":false},
 "display":{"brightness":100,"size":100,"theme":"dark"}}
```

Then 22 writes covering every field the projection maps, each producing exactly one event. Reduced here to the field that moved:

```
 1  display.brightness    100 -> 43
 2  display.theme         dark -> light
 3  display.brightness    43 -> 100
 4  sound.ringtone        marimba -> signal
 5  wallpaper.blur        false -> true
 6  (no mapped field changed)
 7  wallpaper.background  absent -> background12.jpg
 8  sound.texttone        default -> glimmer
 9  sound.texttone        glimmer -> bloom
10  sound.texttone        bloom -> glimmer
11  sound.volume          50 -> 95
12  sound.volume          95 -> 0
13  sound.callVolume      50 -> 100
14  sound.callVolume      100 -> 0
15  sound.callVolume      0 -> 15
16  sound.volume          0 -> 23
17  (no mapped field changed)
18  (no mapped field changed)
19  display.size          100 -> 0
20  display.size          0 -> 91
21  time.twelveHourClock  false -> true
22  time.twelveHourClock  true -> false
```

What that establishes:

- The cache primes at load and answers correctly before anything is touched.
- **Every field in the projection is exercised** - theme, brightness, size, ringtone, texttone, both volumes, wallpaper background and blur, and the clock format.
- 22 accepted writes produced 22 events, one each: no double-fires, none missing, and exactly one field moving per event with the rest carrying through untouched.
- **Zero is emitted, not omitted.** Events 12, 14 and 19 carry `volume: 0`, `callVolume: 0` and `size: 0`. Absent means never set, `0` means explicitly zero, and a consumer can tell them apart. (`size: 0` is the legitimate floor of sd-phone's own 0–100 slider clamp, not an artifact.)
- `background` appears on first use rather than being sent as an empty value.

**Events 6, 17 and 18 are not double-fires** - they are writes to settings the lb-phone shape has no field for, so they are covered by the "tracks writes, not deltas" note above. Event 6 is a home-screen blur write; the projection maps the lock-screen variant.

### Run 2 - scale conversion, verified across a restart

`restart sd-phone`, then `GetSettings()` before any interaction. Every value is the one run 1 left behind, now converted:

```
{"time":{"twelveHourClock":false},"wallpaper":{"blur":true,"background":"background12.jpg"},
 "display":{"brightness":1.0,"theme":"light","size":0.91},
 "sound":{"callVolume":0.15,"ringtone":"signal","volume":0.23,"texttone":"glimmer"}}
```

Checked field by field against run 1's final state - `brightness 100 → 1.0`, `size 91 → 0.91`, `volume 23 → 0.23`, `callVolume 15 → 0.15`, and the five string/boolean fields byte-identical. That establishes two things beyond the conversion itself: the cache primes correctly at load, and **every setting written in run 1 survived a resource restart**, which exercises the write path of the ~20 rerouted callbacks end to end rather than just their announcement.

Then seven slider writes:

```
1  display.brightness  1.0 -> 0.73
2  sound.volume        0.23 -> 0.15
3  sound.callVolume    0.15 -> 0.09
4  sound.volume        0.15 -> 0.0
5  sound.callVolume    0.09 -> 0.0
6  sound.callVolume    0.0 -> 0.25
7  sound.volume        0.0 -> 0.22
```

All four converted fields emit 0–1 throughout. Events 4 and 5 cover the edge the conversion could most plausibly have broken: an explicit zero still arrives as `0.0` rather than being dropped, because `nil` and `0` take different paths through `slider01`.

Environment: QBox, ox_lib 3.37.2, single player on a live server. Branch rebased onto current `main` before testing.

Also ran the full CI set locally against the rebased branch: `npm run build`, `lint`, `test` and `knip` all exit 0.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

None.

`proxy()`'s new third parameter is optional and every existing call site is unchanged. `GetSettings` previously returned `nil` unconditionally, so anything depending on it already handled `nil`; it now returns a table once settings have loaded. No schema, config or NUI changes. This is Lua only, which is why the web CI is unaffected.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.
