### PR TITLE
feat: cell towers, degradable cellular service

### DIFF
--- a/client/apps/calls.lua
+++ b/client/apps/calls.lua
@@ -82,6 +82,13 @@ RegisterNetEvent('sd-phone:client:call:ended', function(data)
     pushCall('sd-phone:call:ended', data)
 end)
 
+---A call torn down because tower coverage went. `lost` marks whether it was this player's own
+---signal that dropped; the phone raises a dialog either way.
+---@param data { lost: boolean }
+RegisterNetEvent('sd-phone:client:call:dropped', function(data)
+    pushCall('sd-phone:call:dropped', data)
+end)
+
 ---Flips the active cell-cam between the rear and front (selfie) lens.
 ---The old raw hash (0x2491A93618B7D838) is stale on current builds and threw "invalid native";
 ---the name lets FiveM cross-map it, and a missing native no-ops quietly.

--- a/client/celltowerblips.lua
+++ b/client/celltowerblips.lua
@@ -1,0 +1,54 @@
+---@type table sd-phone config root (configs/config.lua).
+local config = require 'configs.config'
+
+---@type table Cell tower settings (configs/celltowers.lua).
+local cfg = config.CellTowers or {}
+---@type table Blip settings; nothing is drawn unless Enabled is explicitly true.
+local blipCfg = type(cfg.Blips) == 'table' and cfg.Blips or {}
+---@type table Coverage circle settings, on unless turned off.
+local radiusCfg = type(blipCfg.Radius) == 'table' and blipCfg.Radius or {}
+
+---@type integer[] Handles for every blip drawn here, kept so a resource stop can clear them.
+local created = {}
+
+---Draws a marker on each mast plus its coverage circle. The tower list is static config, so this
+---runs once rather than on a tick.
+local function drawTowerBlips()
+    for _, entry in ipairs(type(cfg.Towers) == 'table' and cfg.Towers or {}) do
+        local pos   = type(entry) == 'table' and entry.tower or nil
+        local range = tonumber(type(entry) == 'table' and entry.range or nil)
+        if pos and range and range > 0 then
+            -- Sized from the tower's own range rather than a separate setting, so what the map
+            -- shows can never disagree with the service the maths hands out.
+            if radiusCfg.Enabled ~= false then
+                local circle = AddBlipForRadius(pos.x, pos.y, pos.z, range + 0.0)
+                SetBlipHighDetail(circle, true)
+                SetBlipColour(circle, math.floor(tonumber(radiusCfg.Color) or 3))
+                SetBlipAlpha(circle, math.floor(tonumber(radiusCfg.Alpha) or 80))
+                created[#created + 1] = circle
+            end
+
+            local marker = AddBlipForCoord(pos.x, pos.y, pos.z)
+            SetBlipSprite(marker, math.floor(tonumber(blipCfg.Sprite) or 1))
+            SetBlipColour(marker, math.floor(tonumber(blipCfg.Color) or 3))
+            SetBlipScale(marker, tonumber(blipCfg.Scale) or 0.8)
+            SetBlipAsShortRange(marker, true)
+            BeginTextCommandSetBlipName('STRING')
+            AddTextComponentString(tostring(blipCfg.Label or 'Cell Tower'))
+            EndTextCommandSetBlipName(marker)
+            created[#created + 1] = marker
+        end
+    end
+end
+
+if blipCfg.Enabled == true then
+    CreateThread(drawTowerBlips)
+end
+
+---Clears the blips when sd-phone stops, so restarting the resource never stacks a second set of
+---circles on top of the first.
+AddEventHandler('onResourceStop', function(resource)
+    if resource ~= GetCurrentResourceName() then return end
+    for i = 1, #created do RemoveBlip(created[i]) end
+    created = {}
+end)

--- a/client/compat/lbphone.lua
+++ b/client/compat/lbphone.lua
@@ -23,11 +23,15 @@ if compatConvar == 'false' or compatConvar == '0' or realLbPhoneStarted() then r
 ---@type table Self-export proxy for the sd-phone client surface.
 local sd = exports['sd-phone']
 
----@type table sd-phone config root (configs/config.lua), read here only for the Debug flag.
+---@type table sd-phone config root (configs/config.lua), read here for the Debug flag and the
+---configured cell towers.
 local config = require 'configs.config'
 
 ---@type table Custom third-party app registry (client.customapps): identifier resolution + forwards.
 local customApps = require 'client.customapps'
+
+---@type table Cell service (client.service): level, bars + the SetServiceBars override.
+local service = require 'client.service'
 
 ---@type any[] AddEventHandler cookies for every registered export handler.
 local exportCookies = {}
@@ -328,12 +332,26 @@ eventCookies[#eventCookies + 1] = AddEventHandler('sd-phone:client:settingsUpdat
 
 -- Config and settings readers.
 stubLbExport('GetConfig', {})
-stubLbExport('GetCellTowers', {})
+---GetCellTowers() -> vector3[]. lb-phone's config is a bare coordinate list, so the per-tower
+---`range` sd-phone adds is dropped here; read it via exports['sd-phone']:getServiceLevel().
+registerLbExport('GetCellTowers', function()
+    local out = {}
+    for _, entry in ipairs(config.CellTowers and config.CellTowers.Towers or {}) do
+        if entry and entry.tower then out[#out + 1] = entry.tower end
+    end
+    return out
+end)
 ---GetSettings() -> table|nil, from the cache refreshed alongside lb-phone:settingsUpdated.
 registerLbExport('GetSettings', function()
     return settingsCache
 end)
 stubLbExport('GetStreamerMode', false)
+
+---SetServiceBars(bars): forces the displayed bars until called with nil. Display only; it never
+---changes what the server allows.
+registerLbExport('SetServiceBars', function(bars)
+    service.setBarsOverride(bars)
+end)
 
 -- Airplane mode reads as off.
 stubLbExport('GetAirplaneMode', false, 'state is server-side only in sd-phone; returning false')
@@ -363,7 +381,6 @@ stubLbExport('IsPhoneDead', false)
 
 -- Appearance and shell tweaks with no sd-phone counterpart.
 stubLbExport('SetPhoneVariation', nil)
-stubLbExport('SetServiceBars', nil)
 stubLbExport('ReloadPhone', nil)
 stubLbExport('ToggleHomeIndicator', nil)
 stubLbExport('ToggleLandscape', nil)

--- a/client/compat/lbphone.lua
+++ b/client/compat/lbphone.lua
@@ -332,6 +332,7 @@ eventCookies[#eventCookies + 1] = AddEventHandler('sd-phone:client:settingsUpdat
 
 -- Config and settings readers.
 stubLbExport('GetConfig', {})
+
 ---GetCellTowers() -> vector3[]. lb-phone's config is a bare coordinate list, so the per-tower
 ---`range` sd-phone adds is dropped here; read it via exports['sd-phone']:getServiceLevel().
 registerLbExport('GetCellTowers', function()
@@ -341,6 +342,7 @@ registerLbExport('GetCellTowers', function()
     end
     return out
 end)
+
 ---GetSettings() -> table|nil, from the cache refreshed alongside lb-phone:settingsUpdated.
 registerLbExport('GetSettings', function()
     return settingsCache

--- a/client/compat/lbphone.lua
+++ b/client/compat/lbphone.lua
@@ -334,10 +334,13 @@ eventCookies[#eventCookies + 1] = AddEventHandler('sd-phone:client:settingsUpdat
 stubLbExport('GetConfig', {})
 
 ---GetCellTowers() -> vector3[]. lb-phone's config is a bare coordinate list, so the per-tower
----`range` sd-phone adds is dropped here; read it via exports['sd-phone']:getServiceLevel().
+---`range` sd-phone adds is dropped here; read it via exports['sd-phone']:getServiceLevel(). A
+---switched-off system reports no masts, matching the full service every phone actually has.
 registerLbExport('GetCellTowers', function()
+    local cfg = config.CellTowers
+    if not cfg or cfg.Enabled ~= true then return {} end
     local out = {}
-    for _, entry in ipairs(config.CellTowers and config.CellTowers.Towers or {}) do
+    for _, entry in ipairs(type(cfg.Towers) == 'table' and cfg.Towers or {}) do
         if entry and entry.tower then out[#out + 1] = entry.tower end
     end
     return out

--- a/client/compat/lbphone.lua
+++ b/client/compat/lbphone.lua
@@ -337,12 +337,8 @@ stubLbExport('GetConfig', {})
 ---`range` sd-phone adds is dropped here; read it via exports['sd-phone']:getServiceLevel(). A
 ---switched-off system reports no masts, matching the full service every phone actually has.
 registerLbExport('GetCellTowers', function()
-    local cfg = config.CellTowers
-    if not cfg or cfg.Enabled ~= true then return {} end
     local out = {}
-    for _, entry in ipairs(type(cfg.Towers) == 'table' and cfg.Towers or {}) do
-        if entry and entry.tower then out[#out + 1] = entry.tower end
-    end
+    for _, mast in ipairs(service.towers()) do out[#out + 1] = mast.tower end
     return out
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -43,6 +43,8 @@ local customApps = require 'client.customapps'
 local pose = require 'client.pose'
 ---@type table Scripted phone camera (client.phonecam): owns the frame-a-shot movement lock.
 local phonecam = require 'client.phonecam'
+---@type table Cell service (client.service): live signal level, bars + capability gating.
+local service = require 'client.service'
 
 -- Loaded for side effects: each app module registers its own NUI callbacks, net events and
 -- server proxies.
@@ -356,7 +358,7 @@ local function OpenPhone()
             battery   = phoneState.battery,
             frameColor = currentFrameColor,
             carrier   = config.StatusBar.Carrier,
-            signal    = config.StatusBar.SignalBars,
+            signal    = service.active() and service.bars() or config.StatusBar.SignalBars,
             showWifi  = config.StatusBar.ShowWifi,
             use24h    = config.Lockscreen.Use24Hour,
             showDate  = config.Lockscreen.ShowDate,

--- a/client/main.lua
+++ b/client/main.lua
@@ -788,6 +788,11 @@ exports('getServiceLevel', function() return service.level() end)
 ---Current status bar bars, 0..4.
 exports('getServiceBars', function() return service.bars() end)
 
+---The configured masts as { tower = vector3, range = number }, mirroring configs/celltowers.lua.
+---Empty while the system is off. The lb-phone GetCellTowers export drops the ranges to match
+---their shape; this one keeps them.
+exports('getCellTowers', function() return service.towers() end)
+
 ---Whether a capability is currently possible: 'text', 'call' or 'data' (default 'data').
 ---@param capability string|nil
 exports('hasService', function(capability)

--- a/client/main.lua
+++ b/client/main.lua
@@ -93,6 +93,7 @@ require 'client.apps.settings'
 require 'client.apps.sim'
 require 'client.admin'
 require 'client.payphone'
+require 'client.celltowerblips'
 
 ---@type table Phone visibility state: open/locked flags + cosmetic battery percentage.
 local phoneState = {

--- a/client/main.lua
+++ b/client/main.lua
@@ -780,6 +780,19 @@ exports('open',     OpenPhone)
 exports('close',    ClosePhone)
 exports('openApp',  OpenApp)
 
+---Current cell service, 0 (dead zone) to 1 (standing at a mast). Always 1 when no towers are
+---configured.
+exports('getServiceLevel', function() return service.level() end)
+
+---Current status bar bars, 0..4.
+exports('getServiceBars', function() return service.bars() end)
+
+---Whether a capability is currently possible: 'text', 'call' or 'data' (default 'data').
+---@param capability string|nil
+exports('hasService', function(capability)
+    return service.allows(capability or 'data')
+end)
+
 ---Registers a third-party app - exports['sd-phone']:addCustomApp(data). Attribution is the calling
 ---resource; re-registering an identifier is only allowed from that same resource.
 ---@param data table lb-phone-shaped app definition

--- a/client/nui.lua
+++ b/client/nui.lua
@@ -32,19 +32,82 @@ local function reachable(serverEvent)
     return service.allows('data')
 end
 
+---@type table<string, boolean> Reads whose last good answer survives a dead zone.
+local CACHED = {}
+for _, name in ipairs(towerCfg.Cached or {}) do
+    CACHED[tostring(name)] = true
+end
+
+---@type integer Most remembered answers before the oldest is dropped.
+local CACHE_MAX = 80
+
+---@type table<string, table> Last good envelope, keyed by action plus the arguments it was for.
+local lastGood = {}
+---@type string[] Cache keys in insertion order, so the oldest can be evicted.
+local cacheOrder = {}
+
+---Key for one read. The arguments are part of it: a profile page and a DM thread are the same
+---action with different payloads, and handing one back for the other would show the wrong data.
+---@param action string '<app>:<action>'
+---@param payload any arguments the NUI sent
+---@return string
+local function cacheKey(action, payload)
+    local ok, encoded = pcall(json.encode, payload)
+    return action .. '|' .. ((ok and encoded) or tostring(payload))
+end
+
+---Remembers a successful read. Re-reading something moves it to the back of the queue, so a feed
+---the player keeps opening is not evicted ahead of a profile they looked at once.
+---@param key string
+---@param res table envelope
+local function remember(key, res)
+    if lastGood[key] ~= nil then
+        for i = 1, #cacheOrder do
+            if cacheOrder[i] == key then table.remove(cacheOrder, i) break end
+        end
+    end
+
+    cacheOrder[#cacheOrder + 1] = key
+    if #cacheOrder > CACHE_MAX then
+        local oldest = table.remove(cacheOrder, 1)
+        lastGood[oldest] = nil
+    end
+    lastGood[key] = res
+end
+
 ---Binds a NUI callback that forwards its payload to the matching server callback and returns the
 ---response envelope unchanged, falling back to a uniform failure when the server never answers.
 ---@param nuiAction string NUI action name the React app fetches
 ---@param serverEvent string server callback name to await
 ---@param onAccepted? fun() ran only when the server accepted the write, never on a rejection
 local function proxy(nuiAction, serverEvent, onAccepted)
+    ---@type string|nil '<app>:<action>', nil for anything not shaped like one
+    local action = serverEvent:match('^sd%-phone:server:(.+)$')
+    ---@type boolean Whether this action's answers are worth keeping.
+    local cacheable = action ~= nil and CACHED[action] == true
+
     RegisterNUICallback(nuiAction, function(payload, cb)
+        local key = cacheable and cacheKey(action, payload) or nil
+
         if not reachable(serverEvent) then
+            -- Out of coverage: hand back what this read last returned, so the app still shows the
+            -- feed the player already had rather than an empty screen. `cached` marks it as the
+            -- old answer for any UI that wants to say so.
+            local kept = key and lastGood[key]
+            if kept then
+                local copy = {}
+                for k, v in pairs(kept) do copy[k] = v end
+                copy.cached = true
+                cb(copy)
+                return
+            end
             cb({ success = false, message = 'No Service' })
             return
         end
+
         local res = lib.callback.await(serverEvent, false, payload)
         if onAccepted and type(res) == 'table' and res.success == true then onAccepted() end
+        if key and type(res) == 'table' and res.success == true then remember(key, res) end
         cb(res or { success = false, message = 'No response from server' })
     end)
 end

--- a/client/nui.lua
+++ b/client/nui.lua
@@ -3,21 +3,32 @@ local config = require 'configs.config'
 ---@type table Cell service (client.service): live level + capability gating.
 local service = require 'client.service'
 
----@type table<string, boolean> App namespaces that work with no signal (configs/celltowers.lua).
+---@type table Cell tower settings (configs/celltowers.lua).
+local towerCfg = type(config.CellTowers) == 'table' and config.CellTowers or {}
+
+---@type table<string, boolean> App namespaces that work with no signal.
 local OFFLINE_OK = {}
-for _, name in ipairs(type(config.CellTowers) == 'table' and config.CellTowers.Offline or {}) do
+for _, name in ipairs(towerCfg.Offline or {}) do
     OFFLINE_OK[tostring(name)] = true
+end
+
+---@type table<string, boolean> '<app>:<action>' pairs that need data despite an offline namespace.
+local GATED = {}
+for _, name in ipairs(towerCfg.Gated or {}) do
+    GATED[tostring(name)] = true
 end
 
 ---Whether a server callback may be reached right now. Every app talks to the server through
 ---this file, so one check covers the whole phone; namespaces in Offline are device-local, RF or
----landline and keep working in a dead zone.
+---landline and keep working in a dead zone, bar the individual actions listed in Gated.
 ---@param serverEvent string 'sd-phone:server:<namespace>:<action>'
 ---@return boolean
 local function reachable(serverEvent)
     if not service.active() then return true end
-    local namespace = serverEvent:match('^sd%-phone:server:([^:]+):')
-    if not namespace or OFFLINE_OK[namespace] then return true end
+    local action = serverEvent:match('^sd%-phone:server:(.+)$')
+    if not action then return true end
+    if GATED[action] then return service.allows('data') end
+    if OFFLINE_OK[action:match('^([^:]+)')] then return true end
     return service.allows('data')
 end
 

--- a/client/nui.lua
+++ b/client/nui.lua
@@ -1,3 +1,26 @@
+---@type table sd-phone config root (configs/config.lua).
+local config = require 'configs.config'
+---@type table Cell service (client.service): live level + capability gating.
+local service = require 'client.service'
+
+---@type table<string, boolean> App namespaces that work with no signal (configs/celltowers.lua).
+local OFFLINE_OK = {}
+for _, name in ipairs(type(config.CellTowers) == 'table' and config.CellTowers.Offline or {}) do
+    OFFLINE_OK[tostring(name)] = true
+end
+
+---Whether a server callback may be reached right now. Every app talks to the server through
+---this file, so one check covers the whole phone; namespaces in Offline are device-local, RF or
+---landline and keep working in a dead zone.
+---@param serverEvent string 'sd-phone:server:<namespace>:<action>'
+---@return boolean
+local function reachable(serverEvent)
+    if not service.active() then return true end
+    local namespace = serverEvent:match('^sd%-phone:server:([^:]+):')
+    if not namespace or OFFLINE_OK[namespace] then return true end
+    return service.allows('data')
+end
+
 ---Binds a NUI callback that forwards its payload to the matching server callback and returns the
 ---response envelope unchanged, falling back to a uniform failure when the server never answers.
 ---@param nuiAction string NUI action name the React app fetches
@@ -5,6 +28,10 @@
 ---@param onAccepted? fun() ran only when the server accepted the write, never on a rejection
 local function proxy(nuiAction, serverEvent, onAccepted)
     RegisterNUICallback(nuiAction, function(payload, cb)
+        if not reachable(serverEvent) then
+            cb({ success = false, message = 'No Service' })
+            return
+        end
         local res = lib.callback.await(serverEvent, false, payload)
         if onAccepted and type(res) == 'table' and res.success == true then onAccepted() end
         cb(res or { success = false, message = 'No response from server' })

--- a/client/service.lua
+++ b/client/service.lua
@@ -1,0 +1,109 @@
+---@type table sd-phone config root (configs/config.lua).
+local config = require 'configs.config'
+---@type table Pure cell-tower maths (shared.celltowers): level / bars / capability thresholds.
+local celltowers = require 'shared.celltowers'
+
+---@type table Cell tower settings (configs/celltowers.lua): towers, thresholds, bar cutoffs.
+local cfg = config.CellTowers or {}
+---@type table[] Configured masts; empty leaves the whole system inert.
+local TOWERS = type(cfg.Towers) == 'table' and cfg.Towers or {}
+---@type number[] Ascending level cutoffs for the 0..4 bars.
+local CUTOFFS = type(cfg.Bars) == 'table' and cfg.Bars or { 0.05, 0.25, 0.50, 0.75 }
+---@type table Minimum level per capability.
+local THRESHOLDS = type(cfg.Thresholds) == 'table' and cfg.Thresholds or {}
+---@type integer Milliseconds between recomputes while the phone is on screen.
+local TICK_MS = 1000
+
+---@type table Service module; the table returned at end of file.
+local service = {}
+
+---@type number Last computed level, 0..1.
+local currentLevel = 1.0
+---@type integer Last pushed bar count.
+local currentBars = celltowers.bars(1.0, CUTOFFS)
+---@type boolean Whether data-backed apps are currently reachable.
+local currentData = true
+---@type integer|nil Bars forced by another resource (lb-phone SetServiceBars), or nil.
+local barsOverride = nil
+---@type boolean True while the phone is on screen; gates the tick entirely.
+local phoneOpen = false
+
+---Whether any mast is configured. False means the feature is off and every reading is full.
+---@return boolean
+function service.active()
+    return #TOWERS > 0
+end
+
+---@return number level 0..1
+function service.level()
+    return currentLevel
+end
+
+---@return integer bars 0..4
+function service.bars()
+    return barsOverride or currentBars
+end
+
+---@param capability string 'text' | 'call' | 'data'
+---@return boolean
+function service.allows(capability)
+    return celltowers.allows(currentLevel, capability, THRESHOLDS)
+end
+
+---Forces the displayed bars until cleared with nil. Display only: it never changes what the
+---server allows.
+---@param bars integer|nil
+function service.setBarsOverride(bars)
+    local n = tonumber(bars)
+    barsOverride = n and math.floor(n) or nil
+    if phoneOpen then
+        SendNUIMessage({
+            action = 'sd-phone:service',
+            data   = { bars = service.bars(), level = currentLevel, data = currentData },
+        })
+    end
+end
+
+---Recomputes from the player's position and pushes to the NUI only when the displayed bars or
+---the data verdict actually changed, so a stationary player costs one distance check a second
+---and no messages at all.
+---@param force boolean|nil push even when nothing changed (used on open)
+local function refresh(force)
+    local pos = GetEntityCoords(PlayerPedId())
+    local level = celltowers.level(pos.x, pos.y, TOWERS)
+    local bars  = celltowers.bars(level, CUTOFFS)
+    local data  = celltowers.allows(level, 'data', THRESHOLDS)
+    local regained = currentBars == 0 and bars > 0
+
+    local changed = force or bars ~= currentBars or data ~= currentData
+    currentLevel, currentBars, currentData = level, bars, data
+    if not changed then return end
+
+    SendNUIMessage({
+        action = 'sd-phone:service',
+        data   = { bars = service.bars(), level = level, data = data },
+    })
+
+    -- Walking back into coverage is the client's cue to ask for anything held while it was out.
+    -- The server re-derives the level from its own coords before honouring this, so a forged
+    -- report drains nothing.
+    if regained or force then
+        TriggerServerEvent('sd-phone:server:service:report')
+    end
+end
+
+-- Only runs while the phone is on screen: a holstered phone costs nothing at all.
+AddEventHandler('sd-phone:client:openState', function(open)
+    phoneOpen = open == true
+    if phoneOpen and service.active() then refresh(true) end
+end)
+
+CreateThread(function()
+    if not service.active() then return end
+    while true do
+        Wait(TICK_MS)
+        if phoneOpen then refresh(false) end
+    end
+end)
+
+return service

--- a/client/service.lua
+++ b/client/service.lua
@@ -40,6 +40,13 @@ function service.level()
     return currentLevel
 end
 
+---The masts currently shaping service, as a fresh table. Empty while the system is switched off,
+---which matches the full service every phone then has.
+---@return table[] masts { tower: vector3, range: number }
+function service.towers()
+    return celltowers.list(TOWERS)
+end
+
 ---@return integer bars 0..4
 function service.bars()
     return barsOverride or currentBars

--- a/client/service.lua
+++ b/client/service.lua
@@ -5,8 +5,9 @@ local celltowers = require 'shared.celltowers'
 
 ---@type table Cell tower settings (configs/celltowers.lua): towers, thresholds, bar cutoffs.
 local cfg = config.CellTowers or {}
----@type table[] Configured masts; empty leaves the whole system inert.
-local TOWERS = type(cfg.Towers) == 'table' and cfg.Towers or {}
+---@type table[] Configured masts, empty while the system is switched off. Folding Enabled in
+---here means every reading downstream treats a disabled system as a server with no masts.
+local TOWERS = (cfg.Enabled == true and type(cfg.Towers) == 'table') and cfg.Towers or {}
 ---@type number[] Ascending level cutoffs for the 0..4 bars.
 local CUTOFFS = type(cfg.Bars) == 'table' and cfg.Bars or { 0.05, 0.25, 0.50, 0.75 }
 ---@type table Minimum level per capability.

--- a/configs/celltowers.lua
+++ b/configs/celltowers.lua
@@ -1,0 +1,44 @@
+-- Cell towers - degradable cellular service by location. Leave Towers empty and the whole
+-- system is inert: every phone always has full service and StatusBar.SignalBars keeps drawing
+-- the static bar count, exactly as before.
+return {
+    -- Each entry is a mast position and the flat radius it covers. Service at a point is the
+    -- BEST reading across every tower: 1 - distance / range. So a player 200 units from a
+    -- 250-range tower (20%) who is also 750 units from a 1000-range tower (25%) gets 25% - the
+    -- further mast wins because it reaches better.
+    --
+    -- Distance is horizontal only. The Z you put here is ignored by the maths, so you can paste
+    -- coordinates straight off an antenna prop without the height eating your coverage, and a
+    -- pilot at altitude keeps the same service as the ground below them.
+    Towers = {
+        -- { tower = vec3(2792.25, 5996.05, 355.19), range = 1000.0 },
+        -- { tower = vec3(1858.30, 3694.04,  37.91), range =  750.0 },
+    },
+
+    -- Minimum level each capability needs. Texts get through on a signal too weak to hold a
+    -- call, and data-backed apps need the most - the same order a real phone degrades in.
+    Thresholds = {
+        Text = 0.05,
+        Call = 0.15,
+        Data = 0.30,
+    },
+
+    -- Ascending cutoffs mapping level to the 0..4 status bar bars. Bar count is how many
+    -- cutoffs the level reaches, so anything under the first shows no bars at all. Keep the
+    -- first entry equal to Thresholds.Text: a phone that cannot manage a text should not be
+    -- claiming a bar.
+    Bars = { 0.05, 0.25, 0.50, 0.75 },
+
+    -- App namespaces that keep working on no signal whatsoever. Everything not listed needs
+    -- Thresholds.Data, so an app added later is covered by default.
+    --
+    -- contacts, calls and messages are here because reading your phone book, call log and
+    -- existing threads is on-device behaviour: the threads stay readable in a dead zone and it
+    -- is the SEND that fails, refused server-side. radio is RF, not cellular. payphone is a
+    -- landline, and being reachable on one in a dead zone is the entire point of it.
+    Offline = {
+        'settings', 'phone', 'apps', 'sim', 'admin', 'badges', 'compat',
+        'notes', 'documents', 'photos', 'albums', 'music', 'clock',
+        'contacts', 'calls', 'messages', 'payphone', 'share', 'airshare', 'radio',
+    },
+}

--- a/configs/celltowers.lua
+++ b/configs/celltowers.lua
@@ -110,4 +110,32 @@ return {
     Gated = {
         'apps:install',
     },
+
+    -- Reads whose last good answer is kept, so a data app in a dead zone shows what it was
+    -- showing before the signal went instead of an empty "nothing here yet" screen. The cache is
+    -- per phone session and is replaced by the real answer the moment coverage returns.
+    --
+    -- ONLY EVER LIST READS HERE. An action that changes something must not be cached: replaying
+    -- its old success would tell the player their post went out when it never left the phone.
+    -- Posting, liking, sending and buying all still fail in a dead zone, which is correct.
+    Cached = {
+        -- Squawk
+        'birdy:me', 'birdy:feed', 'birdy:profile', 'birdy:profilePosts', 'birdy:notifications',
+        'birdy:notificationCount', 'birdy:trending', 'birdy:hashtag', 'birdy:followList',
+        'birdy:dmList', 'birdy:dmThread',
+        -- Photogram
+        'photogram:feed', 'photogram:explore', 'photogram:profile', 'photogram:profilePosts',
+        'photogram:saved', 'photogram:comments', 'photogram:stories', 'photogram:activity',
+        'photogram:counts', 'photogram:followList', 'photogram:followRequests',
+        'photogram:dmList', 'photogram:dmThread',
+        -- Vibez
+        'vibez:feed', 'vibez:discover', 'vibez:profile', 'vibez:profilePosts', 'vibez:likedPosts',
+        'vibez:savedPosts', 'vibez:comments', 'vibez:activity', 'vibez:counts', 'vibez:followList',
+        -- Everything else that opens onto a list
+        'mail:list', 'mail:savedEmails', 'darkchat:rooms', 'darkchat:notifications',
+        'cherry:state', 'cherry:thread', 'marketplace:list', 'pages:list', 'review:list',
+        'review:business', 'weazelnews:feed', 'weazelnews:view', 'stocks:market',
+        'banking:overview', 'garages:list', 'homes:list', 'services:directory', 'services:inbox',
+        'ryde:history', 'ryde:leaderboard',
+    },
 }

--- a/configs/celltowers.lua
+++ b/configs/celltowers.lua
@@ -6,7 +6,7 @@ return {
     -- so a server can keep the mast list below intact while the system is parked. An empty
     -- Towers list does the same thing on its own, as does a list where every entry is malformed:
     -- a typo must never leave a whole server without phones.
-    Enabled = false,
+    Enabled = true,
 
     -- Each entry is a mast position and the flat radius it covers. Service at a point is the
     -- BEST reading across every tower: 1 - distance / range. So a player 200 units from a
@@ -32,6 +32,33 @@ return {
         { tower = vec3(  280.00,  2900.00,  44.00), range = 1800.0 },  -- Harmony, Route 68
         { tower = vec3( 1858.30,  3694.04,  37.91), range = 1700.0 },  -- Sandy Shores and the Alamo Sea
         { tower = vec3( -180.00,  6350.00,  31.00), range = 1600.0 },  -- Paleto Bay and the north coast
+    },
+
+    -- Map blips for the masts. This is a setup and debugging aid rather than something to run on
+    -- a live server: drawing the coverage circles is how you see where masts overlap and where
+    -- the gaps actually fall, which is hard to judge from coordinates alone. Off by default, and
+    -- deliberately independent of the Enabled switch above, so a network can be laid out and
+    -- looked at before the system is ever switched on.
+    Blips = {
+        Enabled = false,
+
+        -- The marker sitting on the mast itself. Sprite and colour are GTA's own ids; the full
+        -- lists live at https://docs.fivem.net/docs/game-references/blips/ Markers are drawn
+        -- short-range so eight of them do not crowd the minimap; open the pause map to see the
+        -- whole network and its circles at once.
+        Sprite = 1,
+        Color  = 3,
+        Scale  = 0.8,
+        Label  = 'Cell Tower',
+
+        -- The translucent circle showing what that mast reaches. Its size is always the tower's
+        -- own range, never a separate number, so the picture on the map cannot drift out of step
+        -- with the service the maths actually gives you. Alpha is 0 to 255.
+        Radius = {
+            Enabled = true,
+            Color   = 3,
+            Alpha   = 80,
+        },
     },
 
     -- Minimum level each capability needs. Texts get through on a signal too weak to hold a

--- a/configs/celltowers.lua
+++ b/configs/celltowers.lua
@@ -1,7 +1,13 @@
--- Cell towers - degradable cellular service by location. Leave Towers empty and the whole
--- system is inert: every phone always has full service and StatusBar.SignalBars keeps drawing
--- the static bar count, exactly as before.
+-- Cell towers - degradable cellular service by location. Turn Enabled off and the whole system
+-- is inert: every phone always has full service and StatusBar.SignalBars keeps drawing the
+-- static bar count, exactly as before, without you having to delete your tower list.
 return {
+    -- Master switch. False leaves every phone on full service no matter where its owner stands,
+    -- so a server can keep the mast list below intact while the system is parked. An empty
+    -- Towers list does the same thing on its own, as does a list where every entry is malformed:
+    -- a typo must never leave a whole server without phones.
+    Enabled = false,
+
     -- Each entry is a mast position and the flat radius it covers. Service at a point is the
     -- BEST reading across every tower: 1 - distance / range. So a player 200 units from a
     -- 250-range tower (20%) who is also 750 units from a 1000-range tower (25%) gets 25% - the
@@ -10,9 +16,22 @@ return {
     -- Distance is horizontal only. The Z you put here is ignored by the maths, so you can paste
     -- coordinates straight off an antenna prop without the height eating your coverage, and a
     -- pilot at altitude keeps the same service as the ground below them.
+    --
+    -- This curated eight-mast network covers the whole map. Every town and populated area holds
+    -- a usable signal, the back country thins out, and the far corners genuinely drop to nothing:
+    --   full service   Los Santos, LSIA, Vinewood, Chumash, Zancudo, Harmony, Sandy Shores, Paleto
+    --   fringe         Vespucci Beach, Grapeseed and Chiliad's summit sit around two bars
+    --   texts only     Raton Canyon
+    --   no service     Mount Gordo, the eastern desert and open ocean
     Towers = {
-        -- { tower = vec3(2792.25, 5996.05, 355.19), range = 1000.0 },
-        -- { tower = vec3(1858.30, 3694.04,  37.91), range =  750.0 },
+        { tower = vec3(  -75.00,  -818.00, 326.00), range = 2200.0 },  -- Downtown Los Santos
+        { tower = vec3(-1050.00, -2750.00,  20.00), range = 1800.0 },  -- LSIA and the south docks
+        { tower = vec3( -438.00,  1075.00, 352.00), range = 1800.0 },  -- Galileo Observatory, Vinewood Hills
+        { tower = vec3(-3050.00,  1250.00,  20.00), range = 1600.0 },  -- Chumash, Great Ocean Highway
+        { tower = vec3(-2050.00,  3200.00,  32.00), range = 1700.0 },  -- Fort Zancudo
+        { tower = vec3(  280.00,  2900.00,  44.00), range = 1800.0 },  -- Harmony, Route 68
+        { tower = vec3( 1858.30,  3694.04,  37.91), range = 1700.0 },  -- Sandy Shores and the Alamo Sea
+        { tower = vec3( -180.00,  6350.00,  31.00), range = 1600.0 },  -- Paleto Bay and the north coast
     },
 
     -- Minimum level each capability needs. Texts get through on a signal too weak to hold a

--- a/configs/celltowers.lua
+++ b/configs/celltowers.lua
@@ -61,6 +61,13 @@ return {
         },
     },
 
+    -- Seconds a caller may hold a live call without call-grade signal before it drops, with both
+    -- sides told they lost service. The grace period stops a call dying because someone clipped
+    -- the edge of a dead zone for a moment, and the countdown resets the instant signal returns.
+    -- Set 0 to cut the moment coverage goes, or false to let a connected call survive anywhere.
+    -- A payphone leg is never dropped: a booth is a landline and has no cell signal to lose.
+    DropCallsAfter = 6,
+
     -- Minimum level each capability needs. Texts get through on a signal too weak to hold a
     -- call, and data-backed apps need the most - the same order a real phone degrades in.
     Thresholds = {

--- a/configs/celltowers.lua
+++ b/configs/celltowers.lua
@@ -32,13 +32,19 @@ return {
     -- App namespaces that keep working on no signal whatsoever. Everything not listed needs
     -- Thresholds.Data, so an app added later is covered by default.
     --
-    -- contacts, calls and messages are here because reading your phone book, call log and
-    -- existing threads is on-device behaviour: the threads stay readable in a dead zone and it
-    -- is the SEND that fails, refused server-side. radio is RF, not cellular. payphone is a
-    -- landline, and being reachable on one in a dead zone is the entire point of it.
+    -- contacts, messages and call are here because reading your phone book and threads is
+    -- on-device behaviour: they stay readable in a dead zone and it is the SEND that fails,
+    -- refused server-side against Thresholds.Text and Thresholds.Call. Leaving `call` out would
+    -- also block hangup and decline, stranding a player whose signal drops mid-call in a session
+    -- they cannot end. radio is RF, not cellular. payphone is a landline, and being reachable on
+    -- one in a dead zone is the entire point of it. voice carries both the voice memo library
+    -- and the peer signalling a live call's audio runs on, so gating it would connect calls that
+    -- nobody can hear. cookie is a single-player clicker whose save is the player's own
+    -- progress; refusing it would lose their clicks rather than tell them anything useful.
     Offline = {
         'settings', 'phone', 'apps', 'sim', 'admin', 'badges', 'compat',
-        'notes', 'documents', 'photos', 'albums', 'music', 'clock',
-        'contacts', 'calls', 'messages', 'payphone', 'share', 'airshare', 'radio',
+        'notes', 'documents', 'photos', 'albums', 'music', 'clock', 'voice',
+        'contacts', 'call', 'calls', 'messages', 'payphone', 'share', 'airshare',
+        'radio', 'cookie',
     },
 }

--- a/configs/celltowers.lua
+++ b/configs/celltowers.lua
@@ -100,4 +100,14 @@ return {
         'contacts', 'call', 'calls', 'messages', 'payphone', 'share', 'airshare',
         'radio', 'cookie',
     },
+
+    -- Single actions that need Thresholds.Data even though the app around them is offline-safe,
+    -- written as '<app>:<action>'. These win over the Offline list above.
+    --
+    -- Downloading an app really is a download, while the rest of the App Store is the phone's own
+    -- state: the catalogue, the home layout and deleting something already on the device all keep
+    -- working with no signal, which is how a real phone behaves.
+    Gated = {
+        'apps:install',
+    },
 }

--- a/configs/celltowers.lua
+++ b/configs/celltowers.lua
@@ -40,7 +40,7 @@ return {
     -- deliberately independent of the Enabled switch above, so a network can be laid out and
     -- looked at before the system is ever switched on.
     Blips = {
-        Enabled = false,
+        Enabled = true,
 
         -- The marker sitting on the mast itself. Sprite and colour are GTA's own ids; the full
         -- lists live at https://docs.fivem.net/docs/game-references/blips/ Markers are drawn

--- a/configs/config.lua
+++ b/configs/config.lua
@@ -45,6 +45,7 @@ local config = {
     Streaks     = require 'configs.streaks',        -- photo-a-day streaks: milestone cash + global gallery
     Migrate     = require 'configs.migrate',         -- one-time lb-phone -> sd-phone data import
     Sim         = require 'configs.uniqueandsim',    -- unique phones + SIM cards (see its pick-your-setup header)
+    CellTowers  = require 'configs.celltowers',   -- degradable service by distance to a mast
 }
 
 -- Server-only secrets: third-party API keys live in configs/server/apikeys.lua, which is NOT in

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -45,6 +45,9 @@ ui_page 'web/build/index.html'
 -- exposed.
 files {
     'bridge/**.lua',
+    -- Pure maths shared by both sides (cell tower service levels); the client computes its own
+    -- bars from it, so it has to be fetchable.
+    'shared/**.lua',
     -- Only the flat client-shared configs ship (configs/*.lua). configs/server/ is deliberately
     -- excluded so configs/server/apikeys.lua (GIPHY + Fivemanage keys) never reaches a client -
     -- do NOT widen this to configs/**.lua.

--- a/server/calls/actions.lua
+++ b/server/calls/actions.lua
@@ -352,9 +352,6 @@ end
 
 actions.endCall = endCall
 
----@type table Phone notifications (server.notifications.init): the dropped-call banner.
-local notifications = require 'server.notifications.init'
-
 ---@type number|false Seconds a live call tolerates a signal too weak to hold it, false to never drop.
 local DROP_AFTER = (function()
     local cfg = config.CellTowers
@@ -382,8 +379,9 @@ local function legHasSignal(party, isPayphone)
     return service.allows(party.src, 'call')
 end
 
----Ends a call because coverage went, and tells each side what happened from their own point of
----view: the one who walked out of range lost service, the other simply lost the call.
+---Ends a call because coverage went and tells each side whose signal was the one that went, so
+---the phone can raise the dialog. Only that fact travels: the wording and its translation are the
+---NUI's business.
 ---@param channel number
 ---@param s table live session
 ---@param callerOk boolean caller still had signal
@@ -392,18 +390,12 @@ local function dropForNoService(channel, s, callerOk, calleeOk)
     local caller, callee = s.caller, s.callee
     endCall(channel, 'noservice')
 
-    local function tell(party, lostIt)
-        if not party or not party.cid then return end
-        notifications.notifyCid(party.cid, {
-            app   = 'Phone',
-            appId = 'phone',
-            title = 'Call Dropped',
-            body  = lostIt and 'You lost service.' or 'The other caller lost service.',
-        })
+    if caller and caller.src then
+        TriggerClientEvent('sd-phone:client:call:dropped', caller.src, { lost = not callerOk })
     end
-
-    tell(caller, not callerOk)
-    tell(callee, not calleeOk)
+    if callee and callee.src then
+        TriggerClientEvent('sd-phone:client:call:dropped', callee.src, { lost = not calleeOk })
+    end
 end
 
 -- Coverage watch. There is no event for "player walked out of range", so a live call has to be

--- a/server/calls/actions.lua
+++ b/server/calls/actions.lua
@@ -12,6 +12,8 @@ local badges   = require 'server.badges.init'
 local moderation = require 'server.admin.moderation'
 ---@type table Payphone persistence (server.payphone.store): booth number -> location lookups.
 local payphones = require 'server.payphone.store'
+---@type table Cell service (server.service): authoritative signal level per player.
+local service  = require 'server.service'
 
 ---@type table Actions module; the table returned at end of file.
 local actions = {}
@@ -372,6 +374,7 @@ function actions.dial(source, payload)
     if sessionForSource(source) or ringForSource(source) or boothRingForSource(source) then return fail('You are already on a call') end
     if not util.rateLimit(cid, 'call:dial', DIAL_WINDOW, DIAL_PER_WINDOW) then return fail('Slow down') end
     if settings.isAirplane(cid) then return fail('Airplane Mode is on') end
+    if not service.allows(source, 'call') then return fail('No Service') end
     local muted = moderation.guard(cid, 'calls'); if muted then return muted end
 
     local myNumber = settings.ensurePhoneNumber(cid)
@@ -423,6 +426,7 @@ function actions.dial(source, payload)
     if not targetSrc then return fail('This number is currently unavailable') end
     if not reachable(targetSrc) then return fail('This number is currently unavailable') end
     if settings.isAirplane(targetCid) then return fail('This number is currently unavailable') end
+    if not service.allows(targetSrc, 'call') then return fail('This number is currently unavailable') end
     if contacts.isBlocked(targetCid, digits(myNumber)) then return fail('This number is currently unavailable') end
     if sessionForSource(targetSrc) or ringForSource(targetSrc) then return fail('Line busy') end
 
@@ -483,6 +487,7 @@ function actions.dialPayphone(source, payload)
     if not targetSrc then return fail('This number is currently unavailable') end
     if not reachable(targetSrc) then return fail('This number is currently unavailable') end
     if settings.isAirplane(targetCid) then return fail('This number is currently unavailable') end
+    if not service.allows(targetSrc, 'call') then return fail('This number is currently unavailable') end
     if callerNumber ~= '' and contacts.isBlocked(targetCid, callerNumber) then return fail('This number is currently unavailable') end
     if sessionForSource(targetSrc) or ringForSource(targetSrc) then return fail('Line busy') end
 
@@ -557,6 +562,7 @@ function actions.callGroup(source, targets, displayName, displayNumber)
     if not cid then return fail('Player not found') end
     if sessionForSource(source) or ringForSource(source) then return fail('You are already on a call') end
     if settings.isAirplane(cid) then return fail('Airplane Mode is on') end
+    if not service.allows(source, 'call') then return fail('No Service') end
 
     local myNumber = digits(settings.ensurePhoneNumber(cid))
 
@@ -564,7 +570,8 @@ function actions.callGroup(source, targets, displayName, displayNumber)
     for _, t in ipairs(targets) do
         if t.src and t.src ~= source
             and not sessionForSource(t.src) and not ringForSource(t.src)
-            and not settings.isAirplane(t.cid) and reachable(t.src) then
+            and not settings.isAirplane(t.cid) and reachable(t.src)
+            and service.allows(t.src, 'call') then
             ringTargets[t.src] = {
                 src    = t.src,
                 cid    = t.cid,

--- a/server/calls/actions.lua
+++ b/server/calls/actions.lua
@@ -352,6 +352,94 @@ end
 
 actions.endCall = endCall
 
+---@type table Phone notifications (server.notifications.init): the dropped-call banner.
+local notifications = require 'server.notifications.init'
+
+---@type number|false Seconds a live call tolerates a signal too weak to hold it, false to never drop.
+local DROP_AFTER = (function()
+    local cfg = config.CellTowers
+    local n = cfg and cfg.DropCallsAfter
+    if n == false or n == nil then return false end
+    return math.max(0, tonumber(n) or 0)
+end)()
+
+---@type integer Milliseconds between coverage sweeps while at least one call is live.
+local COVERAGE_MS = 2000
+---@type integer Milliseconds between sweeps while nothing is connected.
+local COVERAGE_IDLE_MS = 5000
+
+---@type table<number, number> Channel -> os.time() a participant first fell below call signal.
+local losingSignal = {}
+
+---Whether one leg of a call still has the signal to hold it. A payphone leg is a landline, so it
+---always does; an unresolvable player is left alone rather than cut off.
+---@param party table session side, { src, cid, ... }
+---@param isPayphone boolean
+---@return boolean
+local function legHasSignal(party, isPayphone)
+    if isPayphone then return true end
+    if not party or not party.src then return true end
+    return service.allows(party.src, 'call')
+end
+
+---Ends a call because coverage went, and tells each side what happened from their own point of
+---view: the one who walked out of range lost service, the other simply lost the call.
+---@param channel number
+---@param s table live session
+---@param callerOk boolean caller still had signal
+---@param calleeOk boolean callee still had signal
+local function dropForNoService(channel, s, callerOk, calleeOk)
+    local caller, callee = s.caller, s.callee
+    endCall(channel, 'noservice')
+
+    local function tell(party, lostIt)
+        if not party or not party.cid then return end
+        notifications.notifyCid(party.cid, {
+            app   = 'Phone',
+            appId = 'phone',
+            title = 'Call Dropped',
+            body  = lostIt and 'You lost service.' or 'The other caller lost service.',
+        })
+    end
+
+    tell(caller, not callerOk)
+    tell(callee, not calleeOk)
+end
+
+-- Coverage watch. There is no event for "player walked out of range", so a live call has to be
+-- looked at; the sweep is bounded by the number of connected calls rather than players, and idles
+-- when nothing is up. Ringing calls are left alone: an unanswered ring ends on its own.
+CreateThread(function()
+    if DROP_AFTER == false then return end
+    while true do
+        if next(sessions) == nil then
+            losingSignal = {}
+            Wait(COVERAGE_IDLE_MS)
+        else
+            local now = os.time()
+            for channel, s in pairs(sessions) do
+                if s.state ~= 'active' then
+                    losingSignal[channel] = nil
+                else
+                    local callerOk = legHasSignal(s.caller, s.payphoneSide == 'caller')
+                    local calleeOk = legHasSignal(s.callee, s.payphoneSide == 'callee')
+                    if callerOk and calleeOk then
+                        losingSignal[channel] = nil
+                    else
+                        local since = losingSignal[channel] or now
+                        losingSignal[channel] = since
+                        if now - since >= DROP_AFTER then
+                            losingSignal[channel] = nil
+                            dropForNoService(channel, s, callerOk, calleeOk)
+                        end
+                    end
+                end
+            end
+            Wait(COVERAGE_MS)
+        end
+    end
+end)
+
 ---@type integer Dial budget window in ms.
 local DIAL_WINDOW = 30000
 ---@type integer Dials allowed per window, counted even when the dial fails. Redialling a busy

--- a/server/compat/lbphone/misc.lua
+++ b/server/compat/lbphone/misc.lua
@@ -6,8 +6,8 @@ local banking = require 'server.banking.actions'
 local settings = require 'server.settings.store'
 ---@type table Shared server helpers (server.util): digit/trim/finite guards at the shim boundary.
 local util = require 'server.util'
----@type table sd-phone config root (configs/config.lua): the configured cell towers.
-local config = require 'configs.config'
+---@type table Cell service (server.service): the configured masts behind GetCellTowers.
+local service = require 'server.service'
 
 local registerLbExport, stubLbExport = shim.registerLbExport, shim.stubLbExport
 
@@ -47,12 +47,8 @@ stubLbExport('GetConfig', {})
 ---per-tower `range` is dropped; read it via exports['sd-phone']:getServiceLevel(source). A
 ---switched-off system reports no masts, matching the full service every phone actually has.
 registerLbExport('GetCellTowers', function()
-    local cfg = config.CellTowers
-    if not cfg or cfg.Enabled ~= true then return {} end
     local out = {}
-    for _, entry in ipairs(type(cfg.Towers) == 'table' and cfg.Towers or {}) do
-        if entry and entry.tower then out[#out + 1] = entry.tower end
-    end
+    for _, mast in ipairs(service.towers()) do out[#out + 1] = mast.tower end
     return out
 end)
 

--- a/server/compat/lbphone/misc.lua
+++ b/server/compat/lbphone/misc.lua
@@ -44,10 +44,13 @@ end)
 stubLbExport('GetConfig', {})
 
 ---GetCellTowers() -> vector3[]. lb-phone's shape is a bare coordinate list, so sd-phone's
----per-tower `range` is dropped; read it via exports['sd-phone']:getServiceLevel(source).
+---per-tower `range` is dropped; read it via exports['sd-phone']:getServiceLevel(source). A
+---switched-off system reports no masts, matching the full service every phone actually has.
 registerLbExport('GetCellTowers', function()
+    local cfg = config.CellTowers
+    if not cfg or cfg.Enabled ~= true then return {} end
     local out = {}
-    for _, entry in ipairs(config.CellTowers and config.CellTowers.Towers or {}) do
+    for _, entry in ipairs(type(cfg.Towers) == 'table' and cfg.Towers or {}) do
         if entry and entry.tower then out[#out + 1] = entry.tower end
     end
     return out

--- a/server/compat/lbphone/misc.lua
+++ b/server/compat/lbphone/misc.lua
@@ -6,6 +6,8 @@ local banking = require 'server.banking.actions'
 local settings = require 'server.settings.store'
 ---@type table Shared server helpers (server.util): digit/trim/finite guards at the shim boundary.
 local util = require 'server.util'
+---@type table sd-phone config root (configs/config.lua): the configured cell towers.
+local config = require 'configs.config'
 
 local registerLbExport, stubLbExport = shim.registerLbExport, shim.stubLbExport
 
@@ -38,9 +40,19 @@ registerLbExport('AddTransaction', function(phoneNumber, amount, company, logo)
     })
 end)
 
--- Misc surfaces with no sd-phone equivalent; GetConfig/GetCellTowers answer with empty tables.
+-- Misc surfaces with no sd-phone equivalent; GetConfig answers with an empty table.
 stubLbExport('GetConfig', {})
-stubLbExport('GetCellTowers', {})
+
+---GetCellTowers() -> vector3[]. lb-phone's shape is a bare coordinate list, so sd-phone's
+---per-tower `range` is dropped; read it via exports['sd-phone']:getServiceLevel(source).
+registerLbExport('GetCellTowers', function()
+    local out = {}
+    for _, entry in ipairs(config.CellTowers and config.CellTowers.Towers or {}) do
+        if entry and entry.tower then out[#out + 1] = entry.tower end
+    end
+    return out
+end)
+
 stubLbExport('AirShare', nil)
 stubLbExport('AddCheck', 0, 'is not supported; use exports["sd-phone"]:setDisabled(true) on the client instead')
 stubLbExport('RemoveCheck', false, 'is not supported; use exports["sd-phone"]:setDisabled(false) on the client instead')

--- a/server/main.lua
+++ b/server/main.lua
@@ -16,6 +16,7 @@ local inv       = require 'bridge.server.inventory'
 -- clarity - the wrapper must also be live before the boot-time registrations below).
 require 'server.sim.init'
 require 'server.settings.init'
+require 'server.service'
 require 'server.apps.init'
 require 'server.groups.init'
 require 'server.mail.init'

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -18,6 +18,8 @@ local store         = require 'server.messages.store'
 local badges        = require 'server.badges.init'
 ---@type table Admin mute registry (server.admin.moderation): scope guards for sending texts.
 local moderation    = require 'server.admin.moderation'
+---@type table Cell service (server.service): authoritative signal level per player.
+local service       = require 'server.service'
 
 ---@type table Messages knobs (configs/messages.lua): body / thread / group caps.
 local cfg = config.Messages
@@ -452,12 +454,12 @@ local function sendDirect(source, cid, myNumber, target, kind, body, meta, ts, m
     if not targetCid then
         queueForNumber(target, mid, myNumber, kind, body, meta, ts)
     elseif targetCid ~= cid and not contactsStore.isBlocked(targetCid, myNumber) then
-        withheld = settings.isAirplane(targetCid)
+        targetSrc = player.getSourceByIdentifier(targetCid)
+        withheld = settings.isAirplane(targetCid) or not service.allows(targetSrc, 'text')
         inId = store.newId()
         store.insertMessage(inId, mid, targetCid, myNumber, myNumber, 'incoming', kind, body, meta, false, ts, withheld)
         store.pruneThread(targetCid, myNumber, cfg.MessagesPerThread)
 
-        targetSrc = player.getSourceByIdentifier(targetCid)
         if targetSrc and not withheld then
             -- No character-name fallback: an unsaved sender shows as their number, matching
             -- the buildConversation reload path (and not leaking identities).
@@ -603,11 +605,11 @@ function actions.systemText(senderNumber, senderName, targetNumber, body, opts)
     local ts   = os.time()
     local mid  = store.newId()
     local inId = store.newId()
-    local withheld = settings.isAirplane(targetCid)
+    local targetSrc = player.getSourceByIdentifier(targetCid)
+    local withheld = settings.isAirplane(targetCid) or not service.allows(targetSrc, 'text')
     store.insertMessage(inId, mid, targetCid, senderNumber, senderNumber, 'incoming', kind, body, meta, false, ts, withheld)
     store.pruneThread(targetCid, senderNumber, cfg.MessagesPerThread)
 
-    local targetSrc = player.getSourceByIdentifier(targetCid)
     if targetSrc and not withheld then
         local participant = resolveParticipant(senderNumber, nil, senderName)
         local msg = buildMessage(inId, senderNumber, kind, body, meta, ts, false, digits(settings.getPhoneNumber(targetCid)))
@@ -741,6 +743,7 @@ function actions.send(source, payload)
         return fail('Slow down')
     end
     if settings.isAirplane(cid) then return fail('Airplane Mode is on') end
+    if not service.allows(source, 'text') then return fail('No Service') end
     local muted = moderation.guard(cid, 'sms'); if muted then return muted end
 
     local conversation = tostring(payload.conversation or '')

--- a/server/messages/init.lua
+++ b/server/messages/init.lua
@@ -44,6 +44,13 @@ AddEventHandler('sd-phone:server:airplane:released', function(source)
     actions.releaseWithheld(source)
 end)
 
+---Delivers everything held back while the player was outside tower coverage, when the service
+---module verifies a client's back-in-range report.
+---@param source number player server id
+AddEventHandler('sd-phone:server:service:regained', function(source)
+    actions.releaseWithheld(source)
+end)
+
 ---Delivers texts queued while a number was out of service, when the SIM session attaches the
 ---number to an identity (SIM installed or moved). Threaded: the attach fires mid-resolve.
 ---@param source number player server id

--- a/server/service.lua
+++ b/server/service.lua
@@ -36,6 +36,13 @@ function service.levelFor(source)
     return celltowers.level(pos.x, pos.y, TOWERS)
 end
 
+---The masts currently shaping service, as a fresh table. Empty while the system is switched off,
+---which matches the full service every phone then has.
+---@return table[] masts { tower: vector3, range: number }
+function service.towers()
+    return celltowers.list(TOWERS)
+end
+
 ---@param source number|nil player server id
 ---@param capability string 'text' | 'call' | 'data'
 ---@return boolean
@@ -59,6 +66,11 @@ end)
 ---Authoritative service level for a player, 0..1.
 ---@param source number player server id
 exports('getServiceLevel', function(source) return service.levelFor(source) end)
+
+---The configured masts as { tower = vector3, range = number }, mirroring configs/celltowers.lua.
+---Empty while the system is off. The lb-phone GetCellTowers export drops the ranges to match
+---their shape; this one keeps them.
+exports('getCellTowers', function() return service.towers() end)
 
 ---Whether a player can currently use a capability: 'text', 'call' or 'data' (default 'data').
 ---@param source number player server id

--- a/server/service.lua
+++ b/server/service.lua
@@ -1,0 +1,58 @@
+---@type table sd-phone config root (configs/config.lua).
+local config = require 'configs.config'
+---@type table Pure cell-tower maths (shared.celltowers): level + capability thresholds.
+local celltowers = require 'shared.celltowers'
+---@type table Shared server helpers (server.util): rate limiting for the reported edge.
+local util = require 'server.util'
+---@type table Player bridge (bridge.server.player): citizenid lookup for the rate-limit key.
+local player = require 'bridge.server.player'
+
+---@type table Cell tower settings (configs/celltowers.lua).
+local cfg = config.CellTowers or {}
+---@type table[] Configured masts; empty leaves every reading full.
+local TOWERS = type(cfg.Towers) == 'table' and cfg.Towers or {}
+---@type table Minimum level per capability.
+local THRESHOLDS = type(cfg.Thresholds) == 'table' and cfg.Thresholds or {}
+---@type integer Milliseconds a player must wait between honoured back-in-range reports.
+local REPORT_WINDOW = 10000
+---@type integer Reports honoured per window.
+local REPORTS_PER_WINDOW = 1
+
+---@type table Service module; the table returned at end of file.
+local service = {}
+
+---Authoritative service level for a player, from the server's own view of where they are. An
+---unresolvable player reads as full service so an offline or mid-spawn target is never treated
+---as being in a dead zone.
+---@param source number|nil player server id
+---@return number level 0..1
+function service.levelFor(source)
+    if #TOWERS == 0 or not source then return 1.0 end
+    local ped = GetPlayerPed(source)
+    if not ped or ped == 0 then return 1.0 end
+    local pos = GetEntityCoords(ped)
+    if not pos then return 1.0 end
+    return celltowers.level(pos.x, pos.y, TOWERS)
+end
+
+---@param source number|nil player server id
+---@param capability string 'text' | 'call' | 'data'
+---@return boolean
+function service.allows(source, capability)
+    if #TOWERS == 0 then return true end
+    return celltowers.allows(service.levelFor(source), capability, THRESHOLDS)
+end
+
+---A client reporting it walked back into coverage. The level is re-derived here before anything
+---acts on it, so a forged report releases nothing; the rate limit keeps a spamming client from
+---driving repeated drains.
+RegisterNetEvent('sd-phone:server:service:report', function()
+    local source = source
+    if not service.allows(source, 'text') then return end
+    local cid = player.getIdentifier(source)
+    if not cid then return end
+    if not util.rateLimit(cid, 'service:report', REPORT_WINDOW, REPORTS_PER_WINDOW) then return end
+    TriggerEvent('sd-phone:server:service:regained', source)
+end)
+
+return service

--- a/server/service.lua
+++ b/server/service.lua
@@ -55,4 +55,15 @@ RegisterNetEvent('sd-phone:server:service:report', function()
     TriggerEvent('sd-phone:server:service:regained', source)
 end)
 
+---Authoritative service level for a player, 0..1.
+---@param source number player server id
+exports('getServiceLevel', function(source) return service.levelFor(source) end)
+
+---Whether a player can currently use a capability: 'text', 'call' or 'data' (default 'data').
+---@param source number player server id
+---@param capability string|nil
+exports('hasService', function(source, capability)
+    return service.allows(source, capability or 'data')
+end)
+
 return service

--- a/server/service.lua
+++ b/server/service.lua
@@ -9,8 +9,9 @@ local player = require 'bridge.server.player'
 
 ---@type table Cell tower settings (configs/celltowers.lua).
 local cfg = config.CellTowers or {}
----@type table[] Configured masts; empty leaves every reading full.
-local TOWERS = type(cfg.Towers) == 'table' and cfg.Towers or {}
+---@type table[] Configured masts, empty while the system is switched off. Folding Enabled in
+---here means every reading downstream treats a disabled system as a server with no masts.
+local TOWERS = (cfg.Enabled == true and type(cfg.Towers) == 'table') and cfg.Towers or {}
 ---@type table Minimum level per capability.
 local THRESHOLDS = type(cfg.Thresholds) == 'table' and cfg.Thresholds or {}
 ---@type integer Milliseconds a player must wait between honoured back-in-range reports.

--- a/shared/celltowers.lua
+++ b/shared/celltowers.lua
@@ -32,6 +32,24 @@ function celltowers.level(x, y, towers)
     return best
 end
 
+---The usable masts as a fresh table, so an export handing this out cannot be used to reach into
+---the running config. Malformed entries are dropped, matching what the level maths counts.
+---@param towers table[]|nil
+---@return table[] masts { tower: vector3, range: number }
+function celltowers.list(towers)
+    local out = {}
+    if type(towers) ~= 'table' then return out end
+    for i = 1, #towers do
+        local entry = towers[i]
+        local pos   = type(entry) == 'table' and entry.tower or nil
+        local range = tonumber(type(entry) == 'table' and entry.range or nil)
+        if pos and range and range > 0 then
+            out[#out + 1] = { tower = pos, range = range }
+        end
+    end
+    return out
+end
+
 ---Status bar bars for a level: how many ascending cutoffs it meets or exceeds.
 ---@param level number 0..1
 ---@param cutoffs number[] ascending

--- a/shared/celltowers.lua
+++ b/shared/celltowers.lua
@@ -1,0 +1,65 @@
+---@type table Pure cell-tower maths; no natives, no state, so both sides and the test harness
+---can load it unchanged.
+local celltowers = {}
+
+---Best service level across every tower, 0 (nothing) to 1 (standing on a mast). Distance is
+---horizontal: `range` is a flat radius and a tower's Z is documentation, not maths.
+---@param x number player world X
+---@param y number player world Y
+---@param towers table[]|nil { tower = vector3, range = number }
+---@return number level 0..1
+function celltowers.level(x, y, towers)
+    if type(towers) ~= 'table' then return 1.0 end
+
+    local best, valid = 0.0, 0
+    for i = 1, #towers do
+        local entry = towers[i]
+        local pos   = type(entry) == 'table' and entry.tower or nil
+        local range = tonumber(type(entry) == 'table' and entry.range or nil)
+        local px    = pos and tonumber(pos.x)
+        local py    = pos and tonumber(pos.y)
+        if px and py and range and range > 0 then
+            valid = valid + 1
+            local dx, dy = x - px, y - py
+            local pct = 1.0 - (math.sqrt(dx * dx + dy * dy) / range)
+            if pct > best then best = pct end
+        end
+    end
+
+    -- No usable entry means the feature is not configured (or is misconfigured). Fail open: a
+    -- typo in one server's config must never leave every phone on it dead.
+    if valid == 0 then return 1.0 end
+    return best
+end
+
+---Status bar bars for a level: how many ascending cutoffs it meets or exceeds.
+---@param level number 0..1
+---@param cutoffs number[] ascending
+---@return integer bars 0..#cutoffs
+function celltowers.bars(level, cutoffs)
+    if type(cutoffs) ~= 'table' then return 0 end
+    local n = 0
+    for i = 1, #cutoffs do
+        if level >= cutoffs[i] then n = i else break end
+    end
+    return n
+end
+
+---@type table<string, string> Capability name to its Thresholds key.
+local THRESHOLD_KEY = { text = 'Text', call = 'Call', data = 'Data' }
+
+---Whether a level clears the minimum for a capability. An unrecognised capability is permitted,
+---so a caller asking about something this module does not model is never silently blocked.
+---@param level number 0..1
+---@param capability string 'text' | 'call' | 'data'
+---@param thresholds table { Text: number, Call: number, Data: number }
+---@return boolean
+function celltowers.allows(level, capability, thresholds)
+    local key = THRESHOLD_KEY[capability]
+    if not key then return true end
+    local min = tonumber(type(thresholds) == 'table' and thresholds[key] or nil)
+    if not min then return true end
+    return level >= min
+end
+
+return celltowers

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -47,6 +47,7 @@ import { customToAppDef, installedCustomIds, isCustomApp, setCustomInstalled, us
 import { resolveWallpaper } from '@/shell/wallpapers';
 import { NoSimScreen } from '@/shell/NoSimScreen';
 import { useNoService, useNoSim, useSimStore } from '@/stores/simStore';
+import { useNoServiceArea, useServiceBars, useServiceStore } from '@/stores/serviceStore';
 import { resetContacts, syncSimNumber } from '@/stores/contactsStore';
 import { playOnce } from '@/apps/settings/tonePlayer';
 import { resolveTone, toneUrl } from '@/apps/settings/tones';
@@ -230,6 +231,8 @@ function AppContent() {
     // status bar shows "No Service" and only number-dependent actions (call/text) are refused
     // server-side. (In legacy mode useNoSim drives the full-screen wall instead.)
     const noService = useNoService();
+    // A configured dead zone reads as No Service too, from location rather than a missing SIM.
+    const noServiceArea = useNoServiceArea();
     // A pulled SIM drops the phone straight back to the (blocked) lock state: no app stays
     // foregrounded and the switcher/control-center close.
     useEffect(() => {
@@ -712,6 +715,10 @@ function AppContent() {
         if (typeof pct === 'number') { setBattery(pct); useBatteryStore.getState().setLevel(pct); }
     }, []));
 
+    useNuiEvent('sd-phone:service', useCallback((data) => {
+        useServiceStore.getState().apply(data);
+    }, []));
+
     // Home screen widgets render while their app is closed, so the pushes those apps listen for
     // are mirrored into a store here, the same way the battery level is above.
     useNuiEvent('sd-phone:weather', useCallback((data) => {
@@ -796,6 +803,10 @@ function AppContent() {
     ringingAlarmRef.current = ringingAlarm;
     const [ringingSince, setRingingSince] = useState(0);
     const lastViewRef  = useRef<ViewState | null>(null);
+    // Live bars from the cell tower push, falling back to the static value the open payload
+    // carried. Both status bars sit past an early return, so these hooks are read here instead.
+    const peekBars = useServiceBars(lastViewRef.current?.signal ?? 4);
+    const liveBars = useServiceBars(view?.signal ?? 4);
     const phoneOpenRef = useRef(false);
     phoneOpenRef.current = !!view;
     const lockedRef = useRef(locked);
@@ -1238,12 +1249,12 @@ function AppContent() {
                         <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/30 via-black/5 to-transparent" />
                         <StatusBar
                             use24h={hour24}
-                            signal={(airplaneMode || noSim || noService) ? 0 : (lv?.signal ?? 4)}
+                            signal={(airplaneMode || noSim || noService) ? 0 : peekBars}
                             showWifi={(airplaneMode || noSim) ? false : ((lv?.showWifi ?? true) && ccWifi)}
                             battery={battery}
                             airplane={airplaneMode}
                             noSim={noSim}
-                            noService={noService}
+                            noService={noService || noServiceArea}
                             light
                         />
                         {ringingAlarm ? (
@@ -1341,12 +1352,12 @@ function AppContent() {
                 {!(showSetup && setupHello && !noSim) && (
                     <StatusBar
                         use24h={hour24}
-                        signal={(airplaneMode || noSim || noService) ? 0 : view.signal}
+                        signal={(airplaneMode || noSim || noService) ? 0 : liveBars}
                         showWifi={(airplaneMode || noSim) ? false : (view.showWifi && ccWifi)}
                         battery={battery}
                         airplane={airplaneMode}
                         noSim={noSim}
-                        noService={noService}
+                        noService={noService || noServiceArea}
                         light={noSim ? true : (showSetup ? false : (cameraMode ? true : (statusLightOverride ?? statusBarAutoLight ?? statusLight)))}
                         controlHint={!showSetup && !cameraMode && !ccOpen && !homeEditing && !noSim}
                         editing={homeEditing && onHomescreen}

--- a/web/src/apps/appstore/AppDetail.tsx
+++ b/web/src/apps/appstore/AppDetail.tsx
@@ -19,13 +19,15 @@ function appSize(id: string): string {
     return t('appstore.appSize', '{size} MB', { size: mb.toFixed(1) });
 }
 
-export function AppDetail({ app, desc, installed, downloadProgress, onBack, onInstall, onOpen }: {
+export function AppDetail({ app, desc, installed, downloadProgress, onBack, onInstall, canDownload = true, onOpen }: {
     app:               AppDef;
     desc:              string;
     installed:         boolean;
     downloadProgress?: number;
     onBack:            () => void;
     onInstall:         (id: string) => void;
+    /** False in a dead zone: the Get button dims, and onInstall raises the No Service dialog. */
+    canDownload?:      boolean;
     onOpen:            (id: string) => void;
 }) {
     const [shown, setShown] = useState(false);
@@ -79,7 +81,7 @@ export function AppDetail({ app, desc, installed, downloadProgress, onBack, onIn
                                 <button
                                     type="button"
                                     onClick={() => (installed ? onOpen(app.id) : onInstall(app.id))}
-                                    className="rounded-full bg-ios-blue px-7 py-1.5 text-[15px] font-bold uppercase tracking-wide text-white active:opacity-70"
+                                    className={`rounded-full bg-ios-blue px-7 py-1.5 text-[15px] font-bold uppercase tracking-wide text-white active:opacity-70 ${!installed && !canDownload ? 'opacity-40' : ''}`}
                                 >
                                     {installed ? t('appstore.open', 'Open') : t('appstore.get', 'Get')}
                                 </button>

--- a/web/src/apps/appstore/AppStore.tsx
+++ b/web/src/apps/appstore/AppStore.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react';
+
 import { useSessionState } from '@/hooks/useSessionState';
 import { useDownloads } from '@/stores/downloadStore';
+import { useHasData } from '@/stores/serviceStore';
+import { AlertDialog } from '@/ui/AlertDialog';
 import { AppIconSVG } from '@/shell/AppIconSVG';
 import { SearchBar } from '@/ui/SearchBar';
 import { SegmentedControl } from '@/ui/SegmentedControl';
@@ -66,6 +70,14 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
     onOpenApp: (id: string) => void;
 }) {
     const downloading = useDownloads();
+    // Downloading an app needs a real connection. Both Get buttons go through installGuarded, so
+    // the dead-zone case is handled once rather than at each button.
+    const hasData = useHasData();
+    const [noServiceOpen, setNoServiceOpen] = useState(false);
+    const installGuarded = (id: string) => {
+        if (!hasData) { setNoServiceOpen(true); return; }
+        onInstall(id);
+    };
     const [q, setQ] = useSessionState('appstore:search', '');
     const [filter, setFilter] = useSessionState<'all' | 'notInstalled'>('appstore:filter', 'all');
     const [selectedId, setSelectedId] = useSessionState<string | null>('appstore:selected', null);
@@ -129,8 +141,8 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
                                         ) : (
                                             <button
                                                 type="button"
-                                                onClick={() => (isInstalled ? onOpenApp(a.id) : onInstall(a.id))}
-                                                className="shrink-0 rounded-full bg-black/[0.08] px-5 py-2 text-[15px] font-bold uppercase tracking-wide text-ios-blue dark:bg-white/15 active:opacity-60"
+                                                onClick={() => (isInstalled ? onOpenApp(a.id) : installGuarded(a.id))}
+                                                className={`shrink-0 rounded-full bg-black/[0.08] px-5 py-2 text-[15px] font-bold uppercase tracking-wide text-ios-blue dark:bg-white/15 active:opacity-60 ${!isInstalled && !hasData ? 'opacity-40' : ''}`}
                                             >
                                                 {isInstalled ? t('appstore.open', 'Open') : t('appstore.get', 'Get')}
                                             </button>
@@ -152,8 +164,20 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
                     installed={!!selected.base || installed.has(selected.id)}
                     downloadProgress={downloading[selected.id]}
                     onBack={() => setSelectedId(null)}
-                    onInstall={onInstall}
+                    onInstall={installGuarded}
+                    canDownload={hasData}
                     onOpen={onOpenApp}
+                />
+            )}
+
+            {noServiceOpen && (
+                <AlertDialog
+                    title={t('appstore.noServiceTitle', 'No Service')}
+                    message={t('appstore.noServiceBody', 'You need a signal to download apps. Try again once you are back in coverage.')}
+                    confirmLabel={t('appstore.ok', 'OK')}
+                    hideCancel
+                    onCancel={() => setNoServiceOpen(false)}
+                    onConfirm={() => setNoServiceOpen(false)}
                 />
             )}
         </div>

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Bell, ChevronLeft, House, Mail, Pen, Search as SearchIcon } from 'lucide-react';
 
 import { t } from '@/i18n';
+import { useRefreshOnReconnect } from '@/hooks/useRefreshOnReconnect';
 import { useAppAuth } from '@/hooks/useAppAuth';
 import { useIosPush } from '@/hooks/useIosPush';
 import { useDidEnter } from '@/hooks/useDidEnter';
@@ -62,6 +63,9 @@ export function Birdy({ onClose }: { onClose: () => void }) {
         if (deckActive && !wasActive.current) refreshFeed();
         wasActive.current = deckActive;
     }, [deckActive, refreshFeed]);
+
+    // The same refresh for someone who never left the screen while driving back into coverage.
+    useRefreshOnReconnect(refreshFeed);
 
     // feedChanged reaches only the phones showing Birdy, so the subscription follows the
     // foreground. The refresh above covers anything pushed while this one was not listening.

--- a/web/src/apps/mail/Mail.tsx
+++ b/web/src/apps/mail/Mail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 
 import { t } from '@/i18n';
+import { useRefreshOnReconnect } from '@/hooks/useRefreshOnReconnect';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { useSessionState } from '@/hooks/useSessionState';
 import { takeMailTarget } from '@/shell/deeplink';
@@ -57,6 +58,9 @@ export function Mail({ onClose }: { onClose: () => void }) {
     }, []);
 
     useEffect(() => { void refresh(); }, [refresh]);
+
+    // Pull the mailbox again once coverage returns, for someone who never left the screen.
+    useRefreshOnReconnect(useCallback(() => { void refresh(); }, [refresh]));
     useEffect(() => { void accountsMyNumber().then(setMyNumber); }, []);
     useEffect(() => { void listSavedEmails().then(applySavedState); }, [applySavedState]);
 

--- a/web/src/apps/phone/CallLayer.tsx
+++ b/web/src/apps/phone/CallLayer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { Mic, MicOff, Phone, Plus, User, Video, Volume2 } from 'lucide-react';
 
+import { AlertDialog } from '@/ui/AlertDialog';
 import { resolveWallpaper } from '@/shell/wallpapers';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { fetchNui } from '@/core/nui';
@@ -36,6 +37,8 @@ export function CallLayer({ wallpaper }: { wallpaper?: string }) {
     const [keypadOpen, setKeypadOpen]     = useState(false);
     const [contactsOpen, setContactsOpen] = useState(false);
     const [dtmfDialed, setDtmfDialed]     = useState('');
+    // null while there is nothing to report; true when this player's own signal was the one lost.
+    const [droppedLost, setDroppedLost]   = useState<boolean | null>(null);
     const [now, setNow]         = useState(() => Date.now());
     const [videoPhase, setVideoPhase]         = useState<'off' | 'requesting' | 'incoming' | 'active'>('off');
     const [videoInitiator, setVideoInitiator] = useState(false);
@@ -68,6 +71,12 @@ export function CallLayer({ wallpaper }: { wallpaper?: string }) {
         resetControls();
     }, [resetControls]));
 
+    // Coverage went mid-call. `lost` is true for whoever's own signal dropped, false for the
+    // other side, which is the only difference between the two messages.
+    useNuiEvent('sd-phone:call:dropped', useCallback((data) => {
+        setDroppedLost(data?.lost === true);
+    }, []));
+
     useNuiEvent('sd-phone:video:request', useCallback(() => setVideoPhase('incoming'), []));
     useNuiEvent('sd-phone:video:accept',  useCallback(() => { setVideoInitiator(true); setVideoPhase('active'); }, []));
     useNuiEvent('sd-phone:video:stop',    useCallback(() => setVideoPhase('off'), []));
@@ -95,7 +104,22 @@ export function CallLayer({ wallpaper }: { wallpaper?: string }) {
         return () => window.clearInterval(id);
     }, [phase]);
 
-    if (!phase) return null;
+    // Rendered past the phase guard below: a dropped call has already cleared the call UI by the
+    // time this lands, so the dialog is the only thing left on screen.
+    const dropNotice = droppedLost === null ? null : (
+        <AlertDialog
+            title={t('phone.callDropped','Call Dropped')}
+            message={droppedLost
+                ? t('phone.youLostService','You lost service.')
+                : t('phone.peerLostService','The other caller lost service.')}
+            confirmLabel={t('phone.ok','OK')}
+            hideCancel
+            onCancel={() => setDroppedLost(null)}
+            onConfirm={() => setDroppedLost(null)}
+        />
+    );
+
+    if (!phase) return dropNotice;
 
     const title    = name || formatPhone(number) || t('phone.unknown','Unknown');
     const elapsed  = startedAt ? Math.max(0, Math.floor((now - startedAt) / 1000)) : 0;

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { t } from '@/i18n';
 import { useStatusBarLight } from '@/shell/useStatusBarLight';
 import { useDeckActive } from '@/shell/deckActive';
+import { useRefreshOnReconnect } from '@/hooks/useRefreshOnReconnect';
 import { clearSessionState, useSessionState } from '@/hooks/useSessionState';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { useAppAuth } from '@/hooks/useAppAuth';
@@ -128,6 +129,9 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
         wasActive.current = deckActive;
         if (returning) setSyncNonce(n => n + 1);
     }, [deckActive]);
+
+    // The same refresh for someone who never left the screen while driving back into coverage.
+    useRefreshOnReconnect(useCallback(() => setSyncNonce(n => n + 1), []));
 
     useEffect(() => {
         if (!authed) return;

--- a/web/src/apps/vibez/Vibez.tsx
+++ b/web/src/apps/vibez/Vibez.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, Home, Inbox as InboxIcon, Plus, Search, User } from 'lucid
 import { useStatusBarLight } from '@/shell/useStatusBarLight';
 import { useDeckActive } from '@/shell/deckActive';
 import { setLaunchIntent } from '@/shell/launchIntent';
+import { useRefreshOnReconnect } from '@/hooks/useRefreshOnReconnect';
 import { useSessionState } from '@/hooks/useSessionState';
 import { isVideoUrl } from '@/core/photosApi';
 import { useAsyncData } from '@/hooks/useAsyncData';
@@ -97,6 +98,9 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
         wasActive.current = deckActive;
         if (returning) bumpRefresh();
     }, [deckActive, bumpRefresh]);
+
+    // The same refresh for someone who never left the screen while driving back into coverage.
+    useRefreshOnReconnect(bumpRefresh);
 
     useNuiEvent('sd-phone:vibez:notification', useCallback(() => {
         void apiCounts().then(setUnread);

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -208,6 +208,7 @@ export type NuiMessage =
     | { action: 'sd-phone:client:characterLoaded' }
     | { action: 'sd-phone:launchApp'; data: { id: string; link?: Record<string, unknown> } }
     | { action: 'sd-phone:battery'; data: number }
+    | { action: 'sd-phone:service'; data: { bars: number; level: number; data: boolean } }
     | { action: 'sd-phone:weather'; data: WeatherPayload }
     | { action: 'sd-phone:session'; data: SessionPayload }
     | { action: 'sd-phone:health';  data: HealthPayload }

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -257,6 +257,7 @@ export type NuiMessage =
     | { action: 'sd-phone:call:outgoing';  data: CallPush }
     | { action: 'sd-phone:call:connected'; data: { channel: number } }
     | { action: 'sd-phone:call:ended';     data: CallEndedPush }
+    | { action: 'sd-phone:call:dropped';   data: { lost: boolean } }
     | { action: 'sd-phone:payphone:open';     data: { number: string; anonymous: boolean; myNumber?: string | null; favorites: { name: string; phone: string }[]; connected?: boolean; callerName?: string; coin?: { enabled: boolean; cost: number }; credited?: boolean } }
     | { action: 'sd-phone:payphone:outgoing'; data: { channel: number; number: string } }
     | { action: 'sd-phone:payphone:ended';    data: { channel: number; reason: string } }

--- a/web/src/hooks/useRefreshOnReconnect.ts
+++ b/web/src/hooks/useRefreshOnReconnect.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+import { useServiceStore } from '@/stores/serviceStore';
+
+/**
+ * Runs `refresh` when data service comes back after being lost.
+ *
+ * Apps already refetch on the deck-active rising edge, which covers leaving an app and returning,
+ * reopening the phone, and switching tabs. This covers the one case that misses: a player who
+ * stays on the same screen, untouched, across the whole trip out of coverage and back. Without it
+ * they keep looking at the cached feed the proxy served them until they touch something.
+ *
+ * Refetching rather than replaying queued events is deliberate. A feed has no per-event value the
+ * way a message does: what you want is its current state, and one fetch cannot arrive out of order
+ * or drift from what the server actually holds.
+ */
+export function useRefreshOnReconnect(refresh: () => void): void {
+    const hasData = useServiceStore(s => s.data);
+    const had = useRef(hasData);
+
+    useEffect(() => {
+        // Only the rising edge fires. A changing `refresh` identity re-runs this effect, but `had`
+        // is already true by then, so it cannot cause a second fetch.
+        if (hasData && !had.current) refresh();
+        had.current = hasData;
+    }, [hasData, refresh]);
+}

--- a/web/src/lib/signal.ts
+++ b/web/src/lib/signal.ts
@@ -1,0 +1,16 @@
+/** Bars the cellular icon draws. */
+const BAR_COUNT = 4;
+
+/** Opacity of a bar the current signal does not reach. Dimmed rather than hidden, as iOS draws it. */
+const DIM = 0.28;
+
+/**
+ * Opacity for each cellular bar, left to right, for a 0..4 signal level. Bars up to the level are
+ * solid and the rest stay visible but dimmed, so the icon keeps its shape while the strength
+ * changes. An unusable level reads as no signal rather than full, so a missing value can never
+ * flatter the connection.
+ */
+export function signalBarOpacities(bars: number): number[] {
+    const level = Number.isFinite(bars) ? Math.max(0, Math.min(BAR_COUNT, Math.round(bars))) : 0;
+    return Array.from({ length: BAR_COUNT }, (_, i) => (i < level ? 1 : DIM));
+}

--- a/web/src/shell/StatusBar.tsx
+++ b/web/src/shell/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { formatClockTime, useClock } from '@/hooks/useClock';
 import { t } from '@/i18n';
+import { signalBarOpacities } from '@/lib/signal';
 
 export interface StatusBarProps {
     use24h: boolean;
@@ -38,7 +39,7 @@ export function StatusBar({ use24h, signal, showWifi, battery, airplane = false,
                     <span className="font-sf text-[13px] font-semibold leading-none opacity-80">{t('shell.noService', 'No Service')}</span>
                 ) : (
                     <>
-                        {signal > 0 && <Cellular size={21} />}
+                        {signal > 0 && <Cellular size={21} bars={signal} />}
                         {showWifi && <Wifi size={21} />}
                     </>
                 )}
@@ -57,10 +58,20 @@ export function StatusBar({ use24h, signal, showWifi, battery, airplane = false,
 }
 
 
-function Cellular({ size }: { size: number }) {
+const BAR_PATHS = [
+    'M88 432H40a24 24 0 01-24-24v-96a24 24 0 0124-24h48a24 24 0 0124 24v96a24 24 0 01-24 24z',
+    'M216 432h-48a24 24 0 01-24-24V248a24 24 0 0124-24h48a24 24 0 0124 24v160a24 24 0 01-24 24z',
+    'M344 432h-48a24 24 0 01-24-24V184a24 24 0 0124-24h48a24 24 0 0124 24v224a24 24 0 01-24 24z',
+    'M472 432h-48a24 24 0 01-24-24V104a24 24 0 0124-24h48a24 24 0 0124 24v304a24 24 0 01-24 24z',
+];
+
+function Cellular({ size, bars }: { size: number; bars: number }) {
+    const opacities = signalBarOpacities(bars);
     return (
         <svg width={size} height={size} viewBox="0 0 512 512" fill="currentColor" aria-hidden>
-            <path d="M472 432h-48a24 24 0 01-24-24V104a24 24 0 0124-24h48a24 24 0 0124 24v304a24 24 0 01-24 24zM344 432h-48a24 24 0 01-24-24V184a24 24 0 0124-24h48a24 24 0 0124 24v224a24 24 0 01-24 24zM216 432h-48a24 24 0 01-24-24V248a24 24 0 0124-24h48a24 24 0 0124 24v160a24 24 0 01-24 24zM88 432H40a24 24 0 01-24-24v-96a24 24 0 0124-24h48a24 24 0 0124 24v96a24 24 0 01-24 24z" />
+            {BAR_PATHS.map((d, i) => (
+                <path key={d} d={d} opacity={opacities[i]} />
+            ))}
         </svg>
     );
 }

--- a/web/src/stores/serviceStore.ts
+++ b/web/src/stores/serviceStore.ts
@@ -33,6 +33,11 @@ export function useServiceBars(fallback: number): number {
     return useServiceStore(s => (s.active ? s.bars : fallback));
 }
 
+/** True when data-backed features can reach the server: app downloads, social apps, and the like. */
+export function useHasData(): boolean {
+    return useServiceStore(s => s.data);
+}
+
 /** True when the player is inside a configured dead zone (no bars from any tower). */
 export function useNoServiceArea(): boolean {
     return useServiceStore(s => s.active && s.bars === 0);

--- a/web/src/stores/serviceStore.ts
+++ b/web/src/stores/serviceStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+
+/**
+ * Live cellular service, fed by the `sd-phone:service` push. `active` stays false until the
+ * first push arrives, which is what keeps a server with no towers configured on its static
+ * `StatusBar.SignalBars` value instead of snapping to a computed one.
+ */
+interface ServiceState {
+    bars: number;
+    level: number;
+    data: boolean;
+    active: boolean;
+    apply: (push: { bars?: number; level?: number; data?: boolean }) => void;
+}
+
+const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
+
+export const useServiceStore = create<ServiceState>()(set => ({
+    bars: 4,
+    level: 1,
+    data: true,
+    active: false,
+    apply: push => set({
+        bars:   clamp(Math.round(push?.bars ?? 4), 0, 4),
+        level:  clamp(push?.level ?? 1, 0, 1),
+        data:   push?.data !== false,
+        active: true,
+    }),
+}));
+
+/** Bars to draw: the live value once towers are configured, else the static config fallback. */
+export function useServiceBars(fallback: number): number {
+    return useServiceStore(s => (s.active ? s.bars : fallback));
+}
+
+/** True when the player is inside a configured dead zone (no bars from any tower). */
+export function useNoServiceArea(): boolean {
+    return useServiceStore(s => s.active && s.bars === 0);
+}


### PR DESCRIPTION
Adds a configurable cell tower system. Service level is the best reading across every tower,
`1 - distance / range`, so a player 200 units from a 250-range tower (20%) who is also 750 units
from a 1000-range tower (25%) gets 25%: the further mast wins because it reaches better.

Distance is horizontal only. A tower's Z is documentation, not maths, so coordinates can be
pasted straight off an antenna prop without the height eating coverage, and a pilot at altitude
keeps the service of the ground below them.

## What it does

- `shared/celltowers.lua` holds the formula for both sides. Pure, native-free, 24 unit assertions.
- The client recomputes on a 1s tick **only while the phone is open**, and pushes to the NUI only
  when the displayed bars or the data verdict actually change. A holstered phone costs nothing.
- Capabilities degrade in tiers: texts survive the weakest signal, then calls, then data-backed
  apps. Calls and texts are enforced **server-side**, recomputed from the server's own coords at
  the moment of the attempt, with no polling thread anywhere.
- Texts to someone in a dead zone are withheld and replay when they walk back into coverage,
  reusing the pipeline airplane mode already had. The client reports the transition, the server
  re-derives the level before honouring it, so a forged report drains nothing.
- lb-phone's `GetCellTowers` (client and server) and `SetServiceBars` stop being stubs.

## Config

`configs/celltowers.lua` ships a curated eight-mast network covering the whole map, behind an
`Enabled` master switch. The mast list stays intact whichever way the switch is set, so a server
can park the system without deleting its towers.

`Enabled` folds into the internal tower constant, which means a switched-off system reads
identically to one with no masts configured, including through the lb-phone exports. A list where
every entry is malformed fails open the same way: a config typo must never leave a whole server
without phones.

| Mast | Range | Covers |
|---|---|---|
| Downtown Los Santos | 2200 | the city core |
| LSIA | 1800 | airport and south docks |
| Galileo Observatory | 1800 | Vinewood and the hills |
| Chumash | 1600 | Great Ocean Highway |
| Fort Zancudo | 1700 | the base and west Blaine |
| Harmony | 1800 | Route 68 and the central desert |
| Sandy Shores | 1700 | the town and Alamo Sea |
| Paleto Bay | 1600 | the north coast |

### Map blips (off by default)

`Blips` draws a marker on each mast plus a translucent circle showing what it reaches. It is a
setup aid rather than something to run live, so it sits behind its own switch, deliberately
independent of `Enabled` so a network can be laid out and looked at before service gating is ever
switched on. Circle size is read from each tower's own `range` rather than a separate setting, so
the picture on the map cannot drift out of step with the maths. Markers are short-range to keep
eight of them off the minimap; the pause map shows the whole network. Blips are cleared on
resource stop so restarting sd-phone never stacks a second set.

### Resulting coverage

Measured against the shipped list:

| Area | Level | Bars | Text | Call | Data |
|---|---|---|---|---|---|
| Legion Square | 0.87 | 4 | yes | yes | yes |
| Sandy Shores | 0.93 | 4 | yes | yes | yes |
| Vespucci Beach | 0.40 | 2 | yes | yes | yes |
| Grapeseed | 0.34 | 2 | yes | yes | yes |
| Chiliad summit | 0.37 | 2 | yes | yes | yes |
| Raton Canyon | 0.11 | 1 | yes | no | no |
| Mount Gordo | 0.00 | 0 | no | no | no |
| Open ocean | 0.00 | 0 | no | no | no |

## Notes for review

Two deliberate properties worth not "fixing":

1. Target-side call refusals reuse the existing "This number is currently unavailable" rather
   than saying "No Service". Distinct wording would let a caller use the error as an oracle to
   tell a dead zone apart from being blocked. Caller-side refusals say "No Service" because the
   caller already knows their own signal.
2. The offline allow-list names `call` (singular), which is the live-call namespace. Leaving it
   gated would block `hangup` and `decline`, stranding a player whose signal drops mid-call in a
   session they cannot end. `voice` is listed because it carries a live call's audio signalling
   as well as the memo library, and `cookie` because its save is single-player progress.

An in-progress call is deliberately **not** dropped when a player drives out of range; that would
mean touching the voice bridge and is out of scope.

## Gates

- Lua suite: 298 passed, 2 failed. Both failures are pre-existing on `main` (`battery_store_test`
  and `battery_tick_test` reference files from the unmerged `feat/battery-system` branch).
  Baseline before this work was 274 passed / 2 failed, so this is +24 passing, no new failures.
- eslint: 0 errors (29 pre-existing warnings, none in new code)
- tsc: clean
- vitest: 161 passed / 16 files
- knip: clean

Not verified in a running server: this was validated by unit tests and simulation against the
real config, not by starting FXServer. The blip layer in particular is untested in-game.