### PR TITLE
fix(calls): fix mute button not silencing call voice target

### DIFF
--- a/client/apps/calls.lua
+++ b/client/apps/calls.lua
@@ -21,12 +21,20 @@ end
 ---@type boolean True while the local mic is muted for the active call.
 local micMuted = false
 
----Mutes/unmutes the local mic entirely (call AND proximity - a muted caller isn't talking).
----Mumble's audio input distance gates capture at the source; near-zero captures nothing.
+---Mutes/unmutes the local mic entirely (call AND proximity).
+---Switching the voice target to 0 (the default, which carries no call channels) prevents audio
+---from reaching the pma-voice call channel; zeroing the input distance silences proximity too.
+---pma-voice rebuilds target 1's channel list every ~200 ms, so unmuting restores it instantly.
 ---@param on boolean
 local function setMicMuted(on)
     micMuted = on == true
-    MumbleSetAudioInputDistance(micMuted and 0.05 or 9999.0)
+    if micMuted then
+        MumbleSetVoiceTarget(0)
+        MumbleSetAudioInputDistance(0.0)
+    else
+        MumbleSetVoiceTarget(1)
+        MumbleSetAudioInputDistance(9999.0)
+    end
 end
 
 ---React to Lua: the call UI's Mute button.


### PR DESCRIPTION
## Summary

Fixes an issue in `client/apps/calls.lua` where toggling the mute button during an active call failed to properly silence the voice target for the recipient.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

N/A

## Testing

Verified in a local multiplayer environment with two active clients:
- Initiated a call between two players.
- Toggled the mute button on and off during the call.
- Verified that voice target audio transmission mutes and unmutes correctly without breaking call state.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [x] Tested with latest ox_inventory
- [x] Multiplayer tested

## Breaking Changes

No breaking changes introduced.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.