### PR TITLE
feat: home screen customisation

### DIFF
--- a/client/apps/settings.lua
+++ b/client/apps/settings.lua
@@ -26,6 +26,8 @@ writeCallback('sd-phone:settings:setSetupDone', 'sd-phone:server:settings:setSet
 writeCallback('sd-phone:settings:setTheme',     'sd-phone:server:settings:setTheme')
 writeCallback('sd-phone:settings:setDarkTheme', 'sd-phone:server:settings:setDarkTheme')
 writeCallback('sd-phone:settings:setIconTheme',    'sd-phone:server:settings:setIconTheme')
+writeCallback('sd-phone:settings:saveCustomIconTheme',   'sd-phone:server:settings:saveCustomIconTheme')
+writeCallback('sd-phone:settings:deleteCustomIconTheme', 'sd-phone:server:settings:deleteCustomIconTheme')
 writeCallback('sd-phone:settings:setShowAppNames', 'sd-phone:server:settings:setShowAppNames')
 writeCallback('sd-phone:settings:setLockClock', 'sd-phone:server:settings:setLockClock')
 writeCallback('sd-phone:settings:setSecurity',  'sd-phone:server:settings:setSecurity')

--- a/client/apps/settings.lua
+++ b/client/apps/settings.lua
@@ -25,6 +25,8 @@ writeCallback('sd-phone:settings:setReopenApp', 'sd-phone:server:settings:setReo
 writeCallback('sd-phone:settings:setSetupDone', 'sd-phone:server:settings:setSetupDone')
 writeCallback('sd-phone:settings:setTheme',     'sd-phone:server:settings:setTheme')
 writeCallback('sd-phone:settings:setDarkTheme', 'sd-phone:server:settings:setDarkTheme')
+writeCallback('sd-phone:settings:setIconTheme',    'sd-phone:server:settings:setIconTheme')
+writeCallback('sd-phone:settings:setShowAppNames', 'sd-phone:server:settings:setShowAppNames')
 writeCallback('sd-phone:settings:setLockClock', 'sd-phone:server:settings:setLockClock')
 writeCallback('sd-phone:settings:setSecurity',  'sd-phone:server:settings:setSecurity')
 writeCallback('sd-phone:settings:setWallpaper', 'sd-phone:server:settings:setWallpaper')

--- a/client/customapps.lua
+++ b/client/customapps.lua
@@ -28,6 +28,24 @@ local FIELD_TYPES = {
     landscape   = 'boolean',
 }
 
+---@type table<string, string> Fields of one entry in a def's optional `widgets` array, and the Lua
+---type each must have. `ui` is the page the home screen frames; `id` defaults to a slug of `name`.
+local WIDGET_FIELD_TYPES = {
+    id   = 'string',
+    name = 'string',
+    ui   = 'string',
+}
+
+---@type table<string, true> Sizes a declared widget may claim, matching the home screen's grid.
+local WIDGET_SIZES = { sm = true, md = true, lg = true }
+
+---@type string[] Sizes a widget is offered at when it declares none.
+local WIDGET_SIZES_DEFAULT = { 'sm', 'md', 'lg' }
+
+---@type string This resource, which no widget may point its frame at: a page served from the
+---phone's own origin would be same-origin with the shell, and framing the shell nests it in a tile.
+local PHONE_RESOURCE = GetCurrentResourceName():lower()
+
 ---@type table Public module surface; the table returned at end of file.
 local M = {}
 
@@ -37,6 +55,102 @@ local function debugPrint(...)
     if config.Debug then
         print('[sd-phone:client]', ...)
     end
+end
+
+---Reduces a widget name to an identifier the saved home-screen layout can key a placement on.
+---@param value string
+---@return string
+local function slug(value)
+    return (value:lower():gsub('%s+', '_'):gsub('[^%w_%-]', ''))
+end
+
+---The resource a widget's ui is served from, or nil for an outside url. A cfx-nui host is read back
+---to its resource so the absolute form of a local page cannot dodge the checks below.
+---@param ui string
+---@return string?
+local function uiResource(ui)
+    local path = (ui:lower():gsub('^nui://', ''))
+    local host = path:match('^https?://([^/]+)')
+    if host then return (host:gsub(':%d+$', '')):match('^cfx%-nui%-(.+)') end
+    if path:find('http') then return nil end
+    return path:gsub('^/', ''):match('^[^/]+')
+end
+
+---Sanitizes one declared widget, or refuses it with the reason. Refusing an entry never refuses
+---the app: the caller drops this widget and keeps the rest.
+---@param entry any
+---@param index integer position in the declared array, used when the entry has no usable name
+---@return table? widget, string? err
+local function readWidget(entry, index)
+    if type(entry) ~= 'table' then
+        return nil, ('widget #%d must be a table'):format(index)
+    end
+
+    local widget = {}
+    for field, expected in pairs(WIDGET_FIELD_TYPES) do
+        if type(entry[field]) == expected then widget[field] = entry[field] end
+    end
+    if not widget.name or widget.name == '' then
+        return nil, ('widget #%d needs a non-empty name'):format(index)
+    end
+    if not widget.ui or widget.ui == '' then
+        return nil, ('widget %s needs a ui to render'):format(widget.name)
+    end
+    if uiResource(widget.ui) == PHONE_RESOURCE then
+        return nil, ('widget %s cannot frame %s itself'):format(widget.name, PHONE_RESOURCE)
+    end
+
+    widget.id = slug(widget.id or widget.name)
+    if widget.id == '' then
+        return nil, ('widget %s needs an id of letters, numbers, - or _'):format(widget.name)
+    end
+
+    local sizes = {}
+    if entry.sizes == nil then
+        for i = 1, #WIDGET_SIZES_DEFAULT do sizes[i] = WIDGET_SIZES_DEFAULT[i] end
+    elseif type(entry.sizes) == 'table' then
+        local seen = {}
+        for _, size in ipairs(entry.sizes) do
+            if WIDGET_SIZES[size] and not seen[size] then
+                seen[size] = true
+                sizes[#sizes + 1] = size
+            end
+        end
+    end
+    if #sizes == 0 then
+        return nil, ('widget %s declares no usable size'):format(widget.name)
+    end
+    widget.sizes = sizes
+
+    return widget
+end
+
+---Reads a def's optional `widgets` array, keeping every entry that validates and reporting the
+---rest. Returns an empty list when nothing was declared or nothing survived.
+---@param list any
+---@param identifier string owning app, named in refusal reasons
+---@return table[] widgets
+local function readWidgets(list, identifier)
+    local widgets = {}
+    if list == nil then return widgets end
+    if type(list) ~= 'table' then
+        debugPrint(('%s: widgets must be an array, ignoring it'):format(identifier))
+        return widgets
+    end
+
+    local claimed = {}
+    for index = 1, #list do
+        local widget, err = readWidget(list[index], index)
+        if not widget then
+            debugPrint(('%s: %s'):format(identifier, err))
+        elseif claimed[widget.id] then
+            debugPrint(('%s: widget id %s is declared twice'):format(identifier, widget.id))
+        else
+            claimed[widget.id] = true
+            widgets[#widgets + 1] = widget
+        end
+    end
+    return widgets
 end
 
 ---Records an identifier in the order list once.
@@ -123,6 +237,8 @@ function M.add(data, resource)
         end
         def.images = images
     end
+    local widgets = readWidgets(data.widgets, identifier)
+    if #widgets > 0 then def.widgets = widgets end
 
     local onOpen = data.onOpen
     if type(onOpen) ~= 'function' then onOpen = data.onUse end

--- a/server/migrations.lua
+++ b/server/migrations.lua
@@ -27,6 +27,8 @@ local COLUMNS = {
         phone_scale       = 'phone_scale TINYINT UNSIGNED NULL',
         phone_align       = 'phone_align VARCHAR(16) NULL',
         brightness        = 'brightness TINYINT UNSIGNED NULL',
+        icon_theme        = 'icon_theme VARCHAR(16) NULL',
+        show_app_names    = 'show_app_names TINYINT(1) NULL',
     },
 
     phone_documents = {

--- a/server/migrations.lua
+++ b/server/migrations.lua
@@ -28,6 +28,7 @@ local COLUMNS = {
         phone_align       = 'phone_align VARCHAR(16) NULL',
         brightness        = 'brightness TINYINT UNSIGNED NULL',
         icon_theme        = 'icon_theme VARCHAR(16) NULL',
+        icon_custom       = 'icon_custom LONGTEXT NULL',
         show_app_names    = 'show_app_names TINYINT(1) NULL',
     },
 

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -360,6 +360,31 @@ lib.callback.register('sd-phone:server:settings:setIconTheme', function(source, 
     return { success = true }
 end)
 
+---Saves one of the caller's own icon themes, keyed by its id; the store validates every field
+---and refuses past the per-character cap.
+lib.callback.register('sd-phone:server:settings:saveCustomIconTheme', function(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    if not writeAllowed(cid, 'iconThemeSave') then return BUSY end
+    payload = type(payload) == 'table' and payload or {}
+    local ok, reason = store.saveCustomIconTheme(cid, payload.theme)
+    if ok then return { success = true } end
+    if reason == 'limit' then
+        return { success = false, message = 'You have saved as many icon themes as this phone holds' }
+    end
+    return { success = false, message = 'Could not save that icon theme' }
+end)
+
+---Removes one of the caller's own icon themes; a caller using it falls back to Default.
+lib.callback.register('sd-phone:server:settings:deleteCustomIconTheme', function(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    if not writeAllowed(cid, 'iconThemeDelete') then return BUSY end
+    payload = type(payload) == 'table' and payload or {}
+    store.deleteCustomIconTheme(cid, payload.id)
+    return { success = true }
+end)
+
 ---Persists whether the caller wants app names under their home-screen icons.
 lib.callback.register('sd-phone:server:settings:setShowAppNames', function(source, payload)
     local cid = player.getIdentifier(source)

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -350,6 +350,26 @@ lib.callback.register('sd-phone:server:settings:setDarkTheme', function(source, 
     return { success = true }
 end)
 
+---Persists the caller's home-screen icon theme (default/mono/pastel/tinted).
+lib.callback.register('sd-phone:server:settings:setIconTheme', function(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    if not writeAllowed(cid, 'iconTheme') then return BUSY end
+    payload = type(payload) == 'table' and payload or {}
+    store.setIconTheme(cid, payload.iconTheme)
+    return { success = true }
+end)
+
+---Persists whether the caller wants app names under their home-screen icons.
+lib.callback.register('sd-phone:server:settings:setShowAppNames', function(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    if not writeAllowed(cid, 'showAppNames') then return BUSY end
+    payload = type(payload) == 'table' and payload or {}
+    store.setShowAppNames(cid, payload.on == true)
+    return { success = true }
+end)
+
 ---Persists the caller's tone selections; a missing or invalid field is left unchanged.
 lib.callback.register('sd-phone:server:settings:setTones', function(source, payload)
     local cid = player.getIdentifier(source)

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -350,7 +350,7 @@ lib.callback.register('sd-phone:server:settings:setDarkTheme', function(source, 
     return { success = true }
 end)
 
----Persists the caller's home-screen icon theme (default/mono/pastel/tinted).
+---Persists the caller's home-screen icon theme, whitelisted by the store.
 lib.callback.register('sd-phone:server:settings:setIconTheme', function(source, payload)
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -1021,6 +1021,11 @@ local CUSTOM_ICON_MIN, CUSTOM_ICON_MAX = 4, 8
 local MAX_CUSTOM_ICON_THEMES = 12
 ---@type integer Cap on a player-designed theme's display name, in characters.
 local CUSTOM_ICON_NAME_MAX = 24
+-- Mirrors IconTexture in web/src/stores/iconThemeStore.ts.
+---@type table<string, boolean> Whitelist of tile textures a theme may name.
+local ICON_TEXTURES = { none = true, noise = true, dots = true, stripes = true }
+---@type integer Cap on per-app overrides inside one theme.
+local MAX_ICON_OVERRIDES = 40
 ---@type table|nil Lua 5.4 utf8 library, so a name is bounded in characters rather than bytes.
 local utf8lib = _G.utf8
 
@@ -1100,10 +1105,200 @@ local function sanitizeRecipe(v)
     return clean
 end
 
+---A finite number inside [lo, hi], or nil. The type test drops NaN, and both infinities fall out
+---of the bounds compare.
+---@param v any client-supplied number
+---@param lo number inclusive lower bound
+---@param hi number inclusive upper bound
+---@return number|nil value
+local function boundedNumber(v, lo, hi)
+    if type(v) ~= 'number' or v ~= v then return nil end
+    if v < lo or v > hi then return nil end
+    return v
+end
+
+---True for a plausible app or glyph id: at most 32 characters of [a-z0-9_-] behind an
+---alphanumeric first one, which is also what keeps '__proto__' out of the overrides map.
+---@param v any client-supplied id
+---@return boolean
+local function isAppId(v)
+    if type(v) ~= 'string' or #v > 32 then return false end
+    return v:match('^[a-z0-9][a-z0-9_%-]*$') ~= nil
+end
+
+---Validates a theme's per-app overrides, capped at MAX_ICON_OVERRIDES entries. An empty table is
+---a legal no-op; nil refuses the whole theme.
+---@param v any client-supplied override map
+---@return table|nil overrides appId -> { background: table|nil, glyph: table|nil, icon: string|nil }
+local function sanitizeIconOverrides(v)
+    if type(v) ~= 'table' then return nil end
+    local out, count = {}, 0
+    for key, entry in pairs(v) do
+        if not isAppId(key) or type(entry) ~= 'table' then return nil end
+        local clean, fields = {}, 0
+        if entry.background ~= nil then
+            clean.background = sanitizeRecipe(entry.background)
+            if not clean.background then return nil end
+            fields = fields + 1
+        end
+        if entry.glyph ~= nil then
+            clean.glyph = sanitizeRecipe(entry.glyph)
+            if not clean.glyph then return nil end
+            fields = fields + 1
+        end
+        if entry.icon ~= nil then
+            if not isAppId(entry.icon) then return nil end
+            clean.icon = entry.icon
+            fields = fields + 1
+        end
+        if fields == 0 then return nil end
+        count = count + 1
+        if count > MAX_ICON_OVERRIDES then return nil end
+        out[key] = clean
+    end
+    return out
+end
+
+---Validates one label style block: colour recipe, CSS font weight and the show flag.
+---@param v any client-supplied label block
+---@return table|nil label { color: table|nil, weight: number|nil, show: boolean|nil }
+local function sanitizeIconLabel(v)
+    if type(v) ~= 'table' then return nil end
+    local clean = {}
+    if v.color ~= nil then
+        clean.color = sanitizeRecipe(v.color)
+        if not clean.color then return nil end
+    end
+    if v.weight ~= nil then
+        clean.weight = boundedNumber(v.weight, 100, 900)
+        if not clean.weight then return nil end
+    end
+    if v.show ~= nil then
+        if type(v.show) ~= 'boolean' then return nil end
+        clean.show = v.show
+    end
+    return clean
+end
+
+---Validates a tile border: the colour recipe is required, the width is 0-4 pixels.
+---@param v any client-supplied border block
+---@return table|nil border { color: table, width: number }
+local function sanitizeIconBorder(v)
+    if type(v) ~= 'table' then return nil end
+    local color = sanitizeRecipe(v.color)
+    local width = boundedNumber(v.width, 0, 4)
+    if not color or not width then return nil end
+    return { color = color, width = width }
+end
+
+---Validates a theme's wallpaper exactly as the wallpaper setting does, but refusing anything
+---sanitizeWallpaper would have had to rewrite: a theme is stored whole or not at all.
+---@param v any client-supplied wallpaper key or URL
+---@return string|nil wallpaper
+local function sanitizeThemeWallpaper(v)
+    local clean = sanitizeWallpaper(v)
+    if clean ~= v then return nil end
+    return clean
+end
+
+---Writes the optional look fields a theme shares with its dark variant onto `clean`. False when a
+---field that IS present is malformed, which drops the whole theme.
+---@param v table client-supplied theme or variant
+---@param clean table destination, mutated in place
+---@return boolean ok
+local function applyIconTraits(v, clean)
+    if v.radius ~= nil then
+        clean.radius = boundedNumber(v.radius, 0, 0.5)
+        if not clean.radius then return false end
+    end
+    if v.background2 ~= nil then
+        clean.background2 = sanitizeRecipe(v.background2)
+        if not clean.background2 then return false end
+    end
+    if v.angle ~= nil then
+        clean.angle = boundedNumber(v.angle, 0, 360)
+        if not clean.angle then return false end
+    end
+    if v.gloss ~= nil then
+        clean.gloss = boundedNumber(v.gloss, 0, 1)
+        if not clean.gloss then return false end
+    end
+    if v.texture ~= nil then
+        if type(v.texture) ~= 'string' or not ICON_TEXTURES[v.texture] then return false end
+        clean.texture = v.texture
+    end
+    if v.glyphScale ~= nil then
+        clean.glyphScale = boundedNumber(v.glyphScale, 0.6, 1.4)
+        if not clean.glyphScale then return false end
+    end
+    if v.glyphWeight ~= nil then
+        clean.glyphWeight = boundedNumber(v.glyphWeight, 1, 3)
+        if not clean.glyphWeight then return false end
+    end
+    if v.hue ~= nil then
+        clean.hue = boundedNumber(v.hue, -180, 180)
+        if not clean.hue then return false end
+    end
+    if v.saturation ~= nil then
+        clean.saturation = boundedNumber(v.saturation, 0, 2)
+        if not clean.saturation then return false end
+    end
+    if v.border ~= nil then
+        clean.border = sanitizeIconBorder(v.border)
+        if not clean.border then return false end
+    end
+    if v.bevel ~= nil then
+        if type(v.bevel) ~= 'boolean' then return false end
+        if v.bevel then clean.bevel = true end
+    end
+    if v.glow ~= nil then
+        clean.glow = boundedNumber(v.glow, 0, 1)
+        if not clean.glow then return false end
+    end
+    if v.label ~= nil then
+        local label = sanitizeIconLabel(v.label)
+        if not label then return false end
+        if next(label) ~= nil then clean.label = label end
+    end
+    if v.overrides ~= nil then
+        local overrides = sanitizeIconOverrides(v.overrides)
+        if not overrides then return false end
+        if next(overrides) ~= nil then clean.overrides = overrides end
+    end
+    if v.wallpaper ~= nil then
+        clean.wallpaper = sanitizeThemeWallpaper(v.wallpaper)
+        if not clean.wallpaper then return false end
+    end
+    return true
+end
+
+---Validates a theme's dark-mode variant: every field the theme itself carries, minus a nested
+---variant of its own.
+---@param v any client-supplied variant
+---@return table|nil variant
+local function sanitizeIconVariant(v)
+    if type(v) ~= 'table' or v.dark ~= nil then return nil end
+    local clean = {}
+    if v.background ~= nil then
+        clean.background = sanitizeRecipe(v.background)
+        if not clean.background then return nil end
+    end
+    if v.glyph ~= nil then
+        clean.glyph = sanitizeRecipe(v.glyph)
+        if not clean.glyph then return nil end
+    end
+    if v.depth ~= nil then
+        if type(v.depth) ~= 'boolean' then return nil end
+        if v.depth then clean.depth = true end
+    end
+    if not applyIconTraits(v, clean) then return nil end
+    return clean
+end
+
 ---Validates one player-designed icon theme, rebuilding it from only the sanitised fields so no
 ---client JSON is ever stored verbatim. Nil when any field is malformed.
 ---@param v any client-supplied theme
----@return table|nil theme { id: string, name: string, background: table, glyph: table, depth: boolean|nil }
+---@return table|nil theme { id: string, name: string, background: table, glyph: table, ... }
 local function sanitizeCustomIconTheme(v)
     if type(v) ~= 'table' or not isCustomIconId(v.id) then return nil end
     if type(v.name) ~= 'string' then return nil end
@@ -1116,6 +1311,12 @@ local function sanitizeCustomIconTheme(v)
     if not background or not glyph then return nil end
     local clean = { id = v.id, name = name, background = background, glyph = glyph }
     if v.depth == true then clean.depth = true end
+    if not applyIconTraits(v, clean) then return nil end
+    if v.dark ~= nil then
+        local dark = sanitizeIconVariant(v.dark)
+        if not dark then return nil end
+        if next(dark) ~= nil then clean.dark = dark end
+    end
     return clean
 end
 

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -80,6 +80,8 @@ function store.ensureSchema()
             setup_done         TINYINT(1)   NULL,
             theme              VARCHAR(8)   NULL,
             dark_theme         VARCHAR(16)  NULL,
+            icon_theme         VARCHAR(16)  NULL,
+            show_app_names     TINYINT(1)   NULL,
             ringtone_volume    TINYINT UNSIGNED NULL,
             call_volume        TINYINT UNSIGNED NULL,
             locale             VARCHAR(8)   NULL,
@@ -1002,6 +1004,59 @@ function store.setDarkTheme(citizenid, theme)
     ]], { citizenid, theme })
 end
 
+-- Mirrors the IconThemeId union in web/src/stores/iconThemeStore.ts.
+---@type table<string, boolean> Whitelist of storable home-screen icon themes.
+local ICON_THEMES = {
+    default = true, mono = true, pastel = true, tinted = true,
+}
+
+---Returns a player's home-screen icon theme, defaulting to 'default'. Read-only.
+---@param citizenid string framework per-character id
+---@return string iconTheme 'default' | 'mono' | 'pastel' | 'tinted'
+function store.getIconTheme(citizenid)
+    if not citizenid or citizenid == '' then return 'default' end
+    local row = MySQL.single.await('SELECT icon_theme FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local v = row and row.icon_theme
+    if type(v) == 'string' and ICON_THEMES[v] then return v end
+    return 'default'
+end
+
+---Persists a player's home-screen icon theme (upsert), whitelisted to the known values.
+---@param citizenid string framework per-character id
+---@param theme any client-supplied icon theme id
+function store.setIconTheme(citizenid, theme)
+    if not citizenid or citizenid == '' then return end
+    if type(theme) ~= 'string' or not ICON_THEMES[theme] then return end
+    MySQL.update.await([[
+        INSERT INTO phone_settings (citizenid, icon_theme) VALUES (?, ?)
+        ON DUPLICATE KEY UPDATE icon_theme = VALUES(icon_theme)
+    ]], { citizenid, theme })
+end
+
+---Returns true if a player wants app names printed under their home-screen icons, defaulting to
+---true when the show_app_names column is NULL. Read-only.
+---@param citizenid string framework per-character id
+---@return boolean showAppNames
+function store.getShowAppNames(citizenid)
+    if not citizenid or citizenid == '' then return true end
+    local row = MySQL.single.await('SELECT show_app_names FROM phone_settings WHERE citizenid = ?', { citizenid })
+    if row and row.show_app_names ~= nil then
+        return isTruthy(row.show_app_names)
+    end
+    return true
+end
+
+---Persists a player's show-app-names preference (upsert), coerced to a strict boolean.
+---@param citizenid string framework per-character id
+---@param on boolean print app names under the home-screen icons
+function store.setShowAppNames(citizenid, on)
+    if not citizenid or citizenid == '' then return end
+    MySQL.update.await([[
+        INSERT INTO phone_settings (citizenid, show_app_names) VALUES (?, ?)
+        ON DUPLICATE KEY UPDATE show_app_names = VALUES(show_app_names)
+    ]], { citizenid, on == true and 1 or 0 })
+end
+
 ---Persists a player's tone selections, leaving any other settings intact; a nil or invalid
 ---field is left unchanged.
 ---@param citizenid string framework per-character id
@@ -1125,6 +1180,14 @@ function store.snapshot(citizenid)
     end
     local dark = row and row.dark_theme
     if dark ~= 'graphite' and dark ~= 'black' and dark ~= 'warm' then dark = 'graphite' end
+    local icons = row and row.icon_theme
+    if type(icons) ~= 'string' or not ICON_THEMES[icons] then icons = 'default' end
+    local showAppNames
+    if row and row.show_app_names ~= nil then
+        showAppNames = isTruthy(row.show_app_names)
+    else
+        showAppNames = true
+    end
 
     return {
         ringtone         = row and row.ringtone or nil,
@@ -1135,6 +1198,8 @@ function store.snapshot(citizenid)
         setupDone        = row ~= nil and (row.setup_done == true or tonumber(row.setup_done) == 1),
         theme            = (row and row.theme == 'dark') and 'dark' or 'light',
         darkTheme        = dark,
+        iconTheme        = icons,
+        showAppNames     = showAppNames,
         lockClock        = row and decodeColumn(row.lock_clock, nil) or nil,
         wallpaper        = (row and row.wallpaper ~= '') and row.wallpaper or nil,
         wallpaperHome    = (row and row.wallpaper_home ~= '') and row.wallpaper_home or nil,

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -1007,12 +1007,14 @@ end
 -- Mirrors the IconThemeId union in web/src/stores/iconThemeStore.ts.
 ---@type table<string, boolean> Whitelist of storable home-screen icon themes.
 local ICON_THEMES = {
-    default = true, mono = true, pastel = true, tinted = true,
+    default = true, glass  = true, flat = true, light = true, pastel   = true,
+    sand    = true, slate  = true, tinted = true, noir = true, mono    = true,
+    contrast = true,
 }
 
 ---Returns a player's home-screen icon theme, defaulting to 'default'. Read-only.
 ---@param citizenid string framework per-character id
----@return string iconTheme 'default' | 'mono' | 'pastel' | 'tinted'
+---@return string iconTheme one of the ICON_THEMES keys
 function store.getIconTheme(citizenid)
     if not citizenid or citizenid == '' then return 'default' end
     local row = MySQL.single.await('SELECT icon_theme FROM phone_settings WHERE citizenid = ?', { citizenid })

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -81,6 +81,7 @@ function store.ensureSchema()
             theme              VARCHAR(8)   NULL,
             dark_theme         VARCHAR(16)  NULL,
             icon_theme         VARCHAR(16)  NULL,
+            icon_custom        LONGTEXT     NULL,
             show_app_names     TINYINT(1)   NULL,
             ringtone_volume    TINYINT UNSIGNED NULL,
             call_volume        TINYINT UNSIGNED NULL,
@@ -1012,27 +1013,184 @@ local ICON_THEMES = {
     contrast = true,
 }
 
+-- Mirrors CUSTOM_ID / MAX_CUSTOM_ICON_THEMES in web/src/stores/iconThemeStore.ts.
+---@type integer Bounds on the slug after the 'custom:' prefix. 8 keeps the longest id at 15
+---characters, which is what lets a player-designed theme share icon_theme VARCHAR(16).
+local CUSTOM_ICON_MIN, CUSTOM_ICON_MAX = 4, 8
+---@type integer Cap on player-designed icon themes per character.
+local MAX_CUSTOM_ICON_THEMES = 12
+---@type integer Cap on a player-designed theme's display name, in characters.
+local CUSTOM_ICON_NAME_MAX = 24
+---@type table|nil Lua 5.4 utf8 library, so a name is bounded in characters rather than bytes.
+local utf8lib = _G.utf8
+
+---True for a well-formed player-designed icon theme id, whether or not that theme exists. The
+---UI applies before it saves, so an id is accepted here and falls back to Default at render.
+---@param v any client-supplied icon theme id
+---@return boolean
+local function isCustomIconId(v)
+    if type(v) ~= 'string' or not v:match('^custom:[a-z0-9]+$') then return false end
+    local slug = #v - #'custom:'
+    return slug >= CUSTOM_ICON_MIN and slug <= CUSTOM_ICON_MAX
+end
+
+---True for any icon theme id this server will store: a built-in, or a well-formed custom one.
+---@param v any client-supplied icon theme id
+---@return boolean
+local function isStorableIconTheme(v)
+    return (type(v) == 'string' and ICON_THEMES[v] == true) or isCustomIconId(v)
+end
+
 ---Returns a player's home-screen icon theme, defaulting to 'default'. Read-only.
 ---@param citizenid string framework per-character id
----@return string iconTheme one of the ICON_THEMES keys
+---@return string iconTheme a built-in id or a 'custom:' one
 function store.getIconTheme(citizenid)
     if not citizenid or citizenid == '' then return 'default' end
     local row = MySQL.single.await('SELECT icon_theme FROM phone_settings WHERE citizenid = ?', { citizenid })
     local v = row and row.icon_theme
-    if type(v) == 'string' and ICON_THEMES[v] then return v end
+    if isStorableIconTheme(v) then return v end
     return 'default'
 end
 
----Persists a player's home-screen icon theme (upsert), whitelisted to the known values.
+---Persists a player's home-screen icon theme (upsert), whitelisted to the built-ins plus any
+---well-formed custom id.
 ---@param citizenid string framework per-character id
 ---@param theme any client-supplied icon theme id
 function store.setIconTheme(citizenid, theme)
     if not citizenid or citizenid == '' then return end
-    if type(theme) ~= 'string' or not ICON_THEMES[theme] then return end
+    if not isStorableIconTheme(theme) then return end
     MySQL.update.await([[
         INSERT INTO phone_settings (citizenid, icon_theme) VALUES (?, ?)
         ON DUPLICATE KEY UPDATE icon_theme = VALUES(icon_theme)
     ]], { citizenid, theme })
+end
+
+---A trimmed name's length in characters, or nil when the string is not valid UTF-8.
+---@param s string trimmed display name
+---@return integer|nil chars
+local function nameLength(s)
+    if utf8lib then return utf8lib.len(s) end
+    return #s
+end
+
+---Validates one colour recipe: the source, the base colour a 'fixed' source needs, and the
+---optional toward/amount mix pair, which is all-or-nothing. Nil for anything malformed.
+---@param v any client-supplied recipe
+---@return table|nil recipe { from: string, color: string|nil, toward: string|nil, amount: number|nil }
+local function sanitizeRecipe(v)
+    if type(v) ~= 'table' then return nil end
+    if v.from ~= 'accent' and v.from ~= 'fixed' then return nil end
+    local clean = { from = v.from }
+    if v.color ~= nil then
+        local hex = sanitizeHex(v.color)
+        if not hex then return nil end
+        clean.color = hex
+    elseif v.from == 'fixed' then
+        return nil
+    end
+    if (v.toward ~= nil) ~= (v.amount ~= nil) then return nil end
+    if v.toward ~= nil then
+        local hex = sanitizeHex(v.toward)
+        if not hex then return nil end
+        if type(v.amount) ~= 'number' or v.amount ~= v.amount then return nil end
+        if v.amount < 0 or v.amount > 1 then return nil end
+        clean.toward = hex
+        clean.amount = v.amount
+    end
+    return clean
+end
+
+---Validates one player-designed icon theme, rebuilding it from only the sanitised fields so no
+---client JSON is ever stored verbatim. Nil when any field is malformed.
+---@param v any client-supplied theme
+---@return table|nil theme { id: string, name: string, background: table, glyph: table, depth: boolean|nil }
+local function sanitizeCustomIconTheme(v)
+    if type(v) ~= 'table' or not isCustomIconId(v.id) then return nil end
+    if type(v.name) ~= 'string' then return nil end
+    local name = (v.name:gsub('^%s+', ''):gsub('%s+$', ''))
+    local chars = nameLength(name)
+    if not chars or chars < 1 or chars > CUSTOM_ICON_NAME_MAX then return nil end
+    if v.depth ~= nil and type(v.depth) ~= 'boolean' then return nil end
+    local background = sanitizeRecipe(v.background)
+    local glyph      = sanitizeRecipe(v.glyph)
+    if not background or not glyph then return nil end
+    local clean = { id = v.id, name = name, background = background, glyph = glyph }
+    if v.depth == true then clean.depth = true end
+    return clean
+end
+
+---Decodes an icon_custom column into validated themes; an unparseable column, a malformed entry
+---or a duplicate id is dropped rather than served.
+---@param raw any stored column value
+---@return table[] themes
+local function decodeCustomIconThemes(raw)
+    if not raw or raw == '' then return {} end
+    local ok, decoded = pcall(json.decode, raw)
+    if not ok or type(decoded) ~= 'table' then return {} end
+    local out, seen = {}, {}
+    for i = 1, #decoded do
+        local clean = sanitizeCustomIconTheme(decoded[i])
+        if clean and not seen[clean.id] and #out < MAX_CUSTOM_ICON_THEMES then
+            seen[clean.id] = true
+            out[#out + 1] = clean
+        end
+    end
+    return out
+end
+
+---Reads a player's player-designed icon themes (JSON array column); an unparseable column or a
+---malformed entry yields nothing for that entry. Read-only.
+---@param citizenid string framework per-character id
+---@return table[] themes
+function store.getCustomIconThemes(citizenid)
+    if not citizenid or citizenid == '' then return {} end
+    local row = MySQL.single.await('SELECT icon_custom FROM phone_settings WHERE citizenid = ?', { citizenid })
+    if not row then return {} end
+    return decodeCustomIconThemes(row.icon_custom)
+end
+
+---Upserts one player-designed icon theme by id, capped at MAX_CUSTOM_ICON_THEMES per character.
+---@param citizenid string framework per-character id
+---@param theme any client-supplied theme definition
+---@return boolean ok, string|nil reason 'invalid' or 'limit' when refused
+function store.saveCustomIconTheme(citizenid, theme)
+    if not citizenid or citizenid == '' then return false, 'invalid' end
+    local clean = sanitizeCustomIconTheme(theme)
+    if not clean then return false, 'invalid' end
+    local list = store.getCustomIconThemes(citizenid)
+    local at
+    for i = 1, #list do
+        if list[i].id == clean.id then at = i break end
+    end
+    if not at and #list >= MAX_CUSTOM_ICON_THEMES then return false, 'limit' end
+    list[at or (#list + 1)] = clean
+    MySQL.update.await([[
+        INSERT INTO phone_settings (citizenid, icon_custom) VALUES (?, ?)
+        ON DUPLICATE KEY UPDATE icon_custom = VALUES(icon_custom)
+    ]], { citizenid, json.encode(list) })
+    return true, nil
+end
+
+---Removes one player-designed icon theme; a character using it falls back to Default in the same
+---statement, so no row is ever left pointing at a theme that no longer exists.
+---@param citizenid string framework per-character id
+---@param id any theme id to remove
+---@return boolean removed
+function store.deleteCustomIconTheme(citizenid, id)
+    if not citizenid or citizenid == '' or not isCustomIconId(id) then return false end
+    local list = store.getCustomIconThemes(citizenid)
+    local kept, removed = {}, false
+    for i = 1, #list do
+        if list[i].id == id then removed = true else kept[#kept + 1] = list[i] end
+    end
+    if not removed then return false end
+    MySQL.update.await([[
+        UPDATE phone_settings
+        SET icon_custom = ?,
+            icon_theme  = CASE WHEN icon_theme = ? THEN 'default' ELSE icon_theme END
+        WHERE citizenid = ?
+    ]], { json.encode(kept), id, citizenid })
+    return true
 end
 
 ---Returns true if a player wants app names printed under their home-screen icons, defaulting to
@@ -1183,7 +1341,7 @@ function store.snapshot(citizenid)
     local dark = row and row.dark_theme
     if dark ~= 'graphite' and dark ~= 'black' and dark ~= 'warm' then dark = 'graphite' end
     local icons = row and row.icon_theme
-    if type(icons) ~= 'string' or not ICON_THEMES[icons] then icons = 'default' end
+    if not isStorableIconTheme(icons) then icons = 'default' end
     local showAppNames
     if row and row.show_app_names ~= nil then
         showAppNames = isTruthy(row.show_app_names)
@@ -1201,6 +1359,7 @@ function store.snapshot(citizenid)
         theme            = (row and row.theme == 'dark') and 'dark' or 'light',
         darkTheme        = dark,
         iconTheme        = icons,
+        customIconThemes = row and decodeCustomIconThemes(row.icon_custom) or {},
         showAppNames     = showAppNames,
         lockClock        = row and decodeColumn(row.lock_clock, nil) or nil,
         wallpaper        = (row and row.wallpaper ~= '') and row.wallpaper or nil,

--- a/server/sim/backup.lua
+++ b/server/sim/backup.lua
@@ -138,7 +138,7 @@ local SETTINGS_COLS = {
     'card_email', 'card_address', 'installed_apps', 'home_layout', 'lock_clock',
     'wallpaper', 'wallpaper_home', 'blur_lock', 'blur_home', 'custom_wallpapers', 'passcode',
     'face_id', 'chat_text_scale', 'phone_scale', 'phone_align', 'hour24', 'ringtone_volume',
-    'call_volume', 'locale', 'dark_theme', 'theme', 'icon_theme', 'show_app_names',
+    'call_volume', 'locale', 'dark_theme', 'theme', 'icon_theme', 'icon_custom', 'show_app_names',
 }
 
 ---Overwrites `toId`'s phone_settings preference columns with `fromId`'s, creating the target

--- a/server/sim/backup.lua
+++ b/server/sim/backup.lua
@@ -138,7 +138,7 @@ local SETTINGS_COLS = {
     'card_email', 'card_address', 'installed_apps', 'home_layout', 'lock_clock',
     'wallpaper', 'wallpaper_home', 'blur_lock', 'blur_home', 'custom_wallpapers', 'passcode',
     'face_id', 'chat_text_scale', 'phone_scale', 'phone_align', 'hour24', 'ringtone_volume',
-    'call_volume', 'locale', 'dark_theme', 'theme',
+    'call_volume', 'locale', 'dark_theme', 'theme', 'icon_theme', 'show_app_names',
 }
 
 ---Overwrites `toId`'s phone_settings preference columns with `fromId`'s, creating the target

--- a/web/src/apps/appstore/appsApi.ts
+++ b/web/src/apps/appstore/appsApi.ts
@@ -67,7 +67,7 @@ export interface WidgetPlacement {
  * of pages, which passes Array.isArray while being the wrong shape). A separate optional key
  * leaves that guard intact and lets an older build ignore widgets instead of choking on them.
  */
-export interface SavedLayout { slots: (string | null)[]; folders: FolderDef[]; widgets?: WidgetPlacement[] }
+export interface SavedLayout { slots: (string | null)[]; folders: FolderDef[]; widgets?: WidgetPlacement[]; dock?: string[] }
 
 /** Every slot must be an app id or an empty slot; anything else cannot be rendered. */
 function isSlotArray(v: unknown): v is (string | null)[] {
@@ -134,6 +134,7 @@ export function parseLayout(raw: string | null | undefined): SavedLayout | null 
                 slots: o.slots,
                 folders: Array.isArray(o.folders) ? o.folders : [],
                 ...(widgets.length ? { widgets } : {}),
+                ...(Array.isArray(o.dock) ? { dock: o.dock.filter((x): x is string => typeof x === 'string') } : {}),
             };
         }
     } catch { /* ignore */ }

--- a/web/src/apps/settings/Settings.tsx
+++ b/web/src/apps/settings/Settings.tsx
@@ -1,5 +1,6 @@
 import { t } from '@/i18n';
 import { useSessionState } from '@/hooks/useSessionState';
+import { AppIconsPage } from './appearance/AppIconsPage';
 import { DisplayBrightnessPage } from './appearance/DisplayBrightnessPage';
 import { FaceUnlockPage } from './security/FaceUnlockPage';
 import { BatteryPage } from './general/BatteryPage';
@@ -20,7 +21,7 @@ import { useSimStore } from '@/stores/simStore';
 import { WifiPage } from './wifi/WifiPage';
 import { useWifiConnected } from '@/stores/wifiStore';
 
-type SubPage = 'general' | 'display' | 'wallpaper' | 'notifications' | 'sound-haptics' | 'face-unlock' | 'phone' | 'battery' | 'privacy' | 'sim' | 'wifi' | null;
+type SubPage = 'general' | 'display' | 'wallpaper' | 'app-icons' | 'notifications' | 'sound-haptics' | 'face-unlock' | 'phone' | 'battery' | 'privacy' | 'sim' | 'wifi' | null;
 
 export function Settings({ onClose }: { onClose: () => void }) {
     const [subPage, setSubPage] = useSessionState<SubPage>('settings:subPage', null);
@@ -53,6 +54,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
         if (id === 'general')       setSubPage('general');
         if (id === 'display')       setSubPage('display');
         if (id === 'wallpaper')     setSubPage('wallpaper');
+        if (id === 'app-icons')     setSubPage('app-icons');
         if (id === 'notifications') setSubPage('notifications');
         if (id === 'sound-haptics') setSubPage('sound-haptics');
         if (id === 'face-unlock')   setSubPage('face-unlock');
@@ -67,6 +69,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
         subPage === 'general'         ? <GeneralPage           onBack={handleBack} />
         : subPage === 'display'       ? <DisplayBrightnessPage onBack={handleBack} />
         : subPage === 'wallpaper'     ? <WallpaperPage         onBack={handleBack} />
+        : subPage === 'app-icons'     ? <AppIconsPage          onBack={handleBack} />
         : subPage === 'notifications' ? <NotificationsPage     onBack={handleBack} />
         : subPage === 'sound-haptics' ? <SoundHapticsPage      onBack={handleBack} />
         : subPage === 'face-unlock'   ? <FaceUnlockPage        onBack={handleBack} />

--- a/web/src/apps/settings/appearance/AppIconsPage.tsx
+++ b/web/src/apps/settings/appearance/AppIconsPage.tsx
@@ -1,34 +1,28 @@
+import { useState } from 'react';
 import { Plus } from 'lucide-react';
 
 import { t } from '@/i18n';
 import { useSessionState } from '@/hooks/useSessionState';
-import { AppGlyph } from '@/shell/AppGlyphs';
 import { AppIconSVG } from '@/shell/AppIconSVG';
+import { resolveWallpaper } from '@/shell/wallpapers';
+import { useTheme } from '@/stores/themeStore';
 import {
-    ICON_THEMES, MAX_CUSTOM_ICON_THEMES, resolveIconAppearance,
+    ICON_THEMES, iconThemeWallpaper, MAX_CUSTOM_ICON_THEMES, resolveIconAppearance,
     useCustomIconThemes, useIconTheme, useIconThemeStore, useShowAppNames,
 } from '@/stores/iconThemeStore';
 import type { CustomIconTheme, IconThemeDef, IconThemeId } from '@/stores/iconThemeStore';
+import { AlertDialog } from '@/ui/AlertDialog';
 import { ListGroup, ListRow } from '@/ui/ListGroup';
 import { Toggle } from '@/ui/Toggle';
 import { SubPage } from '../SettingsSubPage';
+import { PREVIEW_APPS, SWATCH_PREVIEW_APPS } from './iconThemeCatalog';
+import type { ThemeApp } from './iconThemeCatalog';
+import type { DraftState } from './iconThemeDraft';
+import { ThemeTile, ThemeTileLabel } from './IconThemePreview';
 import { IconThemeEditorPage } from './IconThemeEditorPage';
+import { IconThemeStartPage } from './IconThemeStartPage';
 
-interface PreviewApp {
-    id:     string;
-    icon:   string;
-    label:  string;
-    accent: string;
-}
-
-const PREVIEW_APPS: PreviewApp[] = [
-    { id: 'phone',   icon: 'phone',   label: 'Phone',   accent: '#34c759' },
-    { id: 'maps',    icon: 'maps',    label: 'Maps',    accent: '#f0c43a' },
-    { id: 'music',   icon: 'music',   label: 'Music',   accent: '#fa233b' },
-    { id: 'weather', icon: 'weather', label: 'Weather', accent: '#5ac8fa' },
-];
-
-const SWATCH_APPS = PREVIEW_APPS.slice(0, 3);
+const STRIP_APPS = PREVIEW_APPS.slice(0, 4);
 
 export function AppIconsPage({ onBack }: { onBack: () => void }) {
     const theme           = useIconTheme();
@@ -36,22 +30,45 @@ export function AppIconsPage({ onBack }: { onBack: () => void }) {
     const custom          = useCustomIconThemes();
     const setIconTheme    = useIconThemeStore(s => s.setIconTheme);
     const setShowAppNames = useIconThemeStore(s => s.setShowAppNames);
+    const { wallpaperHome, setWallpaper } = useTheme('wallpaperHome', 'setWallpaper');
+
     const [editing, setEditing] = useSessionState<string | null>('settings:iconThemeEditor', null);
+    const [seed,    setSeed]    = useSessionState<DraftState | null>('settings:iconThemeSeed', null);
+    const [pairing, setPairing] = useState<string | null>(null);
 
     const editTarget = editing === null ? null : custom.find(c => c.id === editing) ?? null;
+
+    function choose(id: IconThemeId) {
+        setIconTheme(id);
+        const paired = iconThemeWallpaper(id);
+        if (paired && resolveWallpaper(paired) !== resolveWallpaper(wallpaperHome)) setPairing(paired);
+    }
+
+    function closeEditor() {
+        setSeed(null);
+        setEditing(null);
+    }
+
+    const sub =
+        seed !== null ? (
+            <IconThemeEditorPage existing={null} seed={seed} onBack={closeEditor} />
+        ) : editing === 'new' ? (
+            <IconThemeStartPage onStart={setSeed} onBack={() => setEditing(null)} />
+        ) : editing !== null ? (
+            <IconThemeEditorPage
+                key={editing}
+                existing={editTarget}
+                seed={null}
+                onBack={() => setEditing(null)}
+            />
+        ) : null;
 
     return (
         <SubPage
             title={t('settings.appIcons', 'App Icons')}
             backLabel={t('settings.settings', 'Settings')}
             onBack={onBack}
-            sub={editing !== null ? (
-                <IconThemeEditorPage
-                    key={editing}
-                    existing={editTarget}
-                    onBack={() => setEditing(null)}
-                />
-            ) : null}
+            sub={sub}
         >
 
             <div className="mx-4">
@@ -60,17 +77,10 @@ export function AppIconsPage({ onBack }: { onBack: () => void }) {
                     style={{ background: 'linear-gradient(165deg, #40404a 0%, #17171a 100%)' }}
                 >
                     <div className="flex items-start justify-between">
-                        {PREVIEW_APPS.map(app => (
+                        {STRIP_APPS.map(app => (
                             <div key={app.id} className="flex flex-col items-center gap-[6px]" style={{ width: 62 }}>
                                 <Tile theme={theme} app={app} size={62} />
-                                {showAppNames && (
-                                    <span
-                                        className="w-full truncate text-center font-sf text-[11px] font-semibold tracking-[0.01em] text-white"
-                                        style={{ textShadow: '0 1px 3px rgba(0,0,0,0.95)' }}
-                                    >
-                                        {app.label}
-                                    </span>
-                                )}
+                                <StripLabel theme={theme} app={app} showAppNames={showAppNames} />
                             </div>
                         ))}
                     </div>
@@ -87,21 +97,21 @@ export function AppIconsPage({ onBack }: { onBack: () => void }) {
                         def={def}
                         selected={def.id === theme}
                         divider={i < ICON_THEMES.length - 1}
-                        onSelect={() => setIconTheme(def.id)}
+                        onSelect={() => choose(def.id)}
                     />
                 ))}
             </ListGroup>
 
             <ListGroup
                 header={t('settings.iconThemeMine', 'My Themes')}
-                footer={t('settings.iconThemeMineHint', 'Design your own tile and symbol colours.')}
+                footer={t('settings.iconThemeMineHint', 'Build a theme from a starting point, a built-in theme or a code someone shared.')}
             >
                 {custom.map(def => (
                     <CustomRow
                         key={def.id}
                         def={def}
                         selected={def.id === theme}
-                        onSelect={() => setIconTheme(def.id)}
+                        onSelect={() => choose(def.id)}
                         onEdit={() => setEditing(def.id)}
                     />
                 ))}
@@ -127,6 +137,21 @@ export function AppIconsPage({ onBack }: { onBack: () => void }) {
                 />
             </ListGroup>
 
+            {pairing !== null && (
+                <AlertDialog
+                    title={t('settings.iconThemePairTitle', 'Use the Paired Wallpaper?')}
+                    message={t('settings.iconThemePairBody', 'This theme comes with a wallpaper. Your Home Screen can change to match it.')}
+                    confirmLabel={t('settings.iconThemePairConfirm', 'Use It')}
+                    cancelLabel={t('settings.iconThemePairSkip', 'Keep Mine')}
+                    onCancel={() => setPairing(null)}
+                    onConfirm={() => {
+                        const paired = pairing;
+                        setPairing(null);
+                        if (paired) setWallpaper(resolveWallpaper(paired), 'home');
+                    }}
+                />
+            )}
+
         </SubPage>
     );
 }
@@ -145,7 +170,7 @@ function ThemeRow({ def, selected, divider, onSelect }: {
             divider={divider}
             left={(
                 <span className="flex gap-[3px]">
-                    {SWATCH_APPS.map(app => <Tile key={app.id} theme={def.id} app={app} size={24} />)}
+                    {SWATCH_PREVIEW_APPS.map(app => <Tile key={app.id} theme={def.id} app={app} size={24} />)}
                 </span>
             )}
             onPress={onSelect}
@@ -159,21 +184,32 @@ function CustomRow({ def, selected, onSelect, onEdit }: {
     onSelect: () => void;
     onEdit:   () => void;
 }) {
+    const notes: string[] = [];
+    if (def.dark) notes.push(t('settings.iconThemeHasDark', 'Dark design'));
+    if (def.wallpaper) notes.push(t('settings.iconThemeHasWallpaper', 'Wallpaper'));
+    if (def.overrides) notes.push(t('settings.iconThemeHasOverrides', 'Custom app icons'));
+
+    const sub = notes.length > 0
+        ? notes.join(', ')
+        : selected
+            ? t('settings.iconThemeInUse', 'In use')
+            : t('settings.iconThemeTapToUse', 'Tap to use');
+
     return (
         <div className="relative flex items-center pr-4">
-            <ListRow
-                label={def.name}
-                sub={selected
-                    ? t('settings.iconThemeInUse', 'In use')
-                    : t('settings.iconThemeTapToUse', 'Tap to use')}
-                selected={selected}
-                left={(
-                    <span className="flex gap-[3px]">
-                        {SWATCH_APPS.map(app => <Tile key={app.id} theme={def.id} app={app} size={24} />)}
-                    </span>
-                )}
-                onPress={onSelect}
-            />
+            <div className="min-w-0 flex-1">
+                <ListRow
+                    label={def.name}
+                    sub={sub}
+                    selected={selected}
+                    left={(
+                        <span className="flex gap-[3px]">
+                            {SWATCH_PREVIEW_APPS.map(app => <Tile key={app.id} theme={def.id} app={app} size={24} />)}
+                        </span>
+                    )}
+                    onPress={onSelect}
+                />
+            </div>
             <button
                 type="button"
                 onClick={onEdit}
@@ -189,25 +225,27 @@ function CustomRow({ def, selected, onSelect, onEdit }: {
     );
 }
 
-function Tile({ theme, app, size }: { theme: IconThemeId; app: PreviewApp; size: number }) {
-    const { background, glyph, art } = resolveIconAppearance(theme, app.id, app.accent);
-    return (
-        <span
-            className="relative block shrink-0 overflow-hidden"
-            style={{
-                width:        size,
-                height:       size,
-                borderRadius: '27.6%',
-                boxShadow:    '0 1px 4px rgba(0,0,0,0.28), inset 0 0 0 0.5px rgba(255,255,255,0.12)',
-            }}
-        >
-            {art === 'native' ? (
+function Tile({ theme, app, size }: { theme: IconThemeId; app: ThemeApp; size: number }) {
+    const look = resolveIconAppearance(theme, app.id, app.accent);
+    if (look.art === 'native') {
+        return (
+            <span
+                className="relative block shrink-0 overflow-hidden"
+                style={{
+                    width:        size,
+                    height:       size,
+                    borderRadius: `${look.radius * 100}%`,
+                    boxShadow:    '0 1px 4px rgba(0,0,0,0.28), inset 0 0 0 0.5px rgba(255,255,255,0.12)',
+                }}
+            >
                 <AppIconSVG icon={app.icon} size={size} />
-            ) : (
-                <span className="flex h-full w-full items-center justify-center" style={{ background }}>
-                    <AppGlyph icon={app.icon} label={app.label} color={glyph} size={Math.round(size * 0.52)} />
-                </span>
-            )}
-        </span>
-    );
+            </span>
+        );
+    }
+    return <ThemeTile look={look} icon={look.icon ?? app.icon} label={app.label} size={size} />;
+}
+
+function StripLabel({ theme, app, showAppNames }: { theme: IconThemeId; app: ThemeApp; showAppNames: boolean }) {
+    const look = resolveIconAppearance(theme, app.id, app.accent);
+    return <ThemeTileLabel look={look} label={app.label} fallbackShow={showAppNames} />;
 }

--- a/web/src/apps/settings/appearance/AppIconsPage.tsx
+++ b/web/src/apps/settings/appearance/AppIconsPage.tsx
@@ -1,11 +1,18 @@
+import { Plus } from 'lucide-react';
+
 import { t } from '@/i18n';
+import { useSessionState } from '@/hooks/useSessionState';
 import { AppGlyph } from '@/shell/AppGlyphs';
 import { AppIconSVG } from '@/shell/AppIconSVG';
-import { ICON_THEMES, resolveIconAppearance, useIconTheme, useIconThemeStore, useShowAppNames } from '@/stores/iconThemeStore';
-import type { IconThemeDef, IconThemeId } from '@/stores/iconThemeStore';
+import {
+    ICON_THEMES, MAX_CUSTOM_ICON_THEMES, resolveIconAppearance,
+    useCustomIconThemes, useIconTheme, useIconThemeStore, useShowAppNames,
+} from '@/stores/iconThemeStore';
+import type { CustomIconTheme, IconThemeDef, IconThemeId } from '@/stores/iconThemeStore';
 import { ListGroup, ListRow } from '@/ui/ListGroup';
 import { Toggle } from '@/ui/Toggle';
 import { SubPage } from '../SettingsSubPage';
+import { IconThemeEditorPage } from './IconThemeEditorPage';
 
 interface PreviewApp {
     id:     string;
@@ -26,14 +33,25 @@ const SWATCH_APPS = PREVIEW_APPS.slice(0, 3);
 export function AppIconsPage({ onBack }: { onBack: () => void }) {
     const theme           = useIconTheme();
     const showAppNames    = useShowAppNames();
+    const custom          = useCustomIconThemes();
     const setIconTheme    = useIconThemeStore(s => s.setIconTheme);
     const setShowAppNames = useIconThemeStore(s => s.setShowAppNames);
+    const [editing, setEditing] = useSessionState<string | null>('settings:iconThemeEditor', null);
+
+    const editTarget = editing === null ? null : custom.find(c => c.id === editing) ?? null;
 
     return (
         <SubPage
             title={t('settings.appIcons', 'App Icons')}
             backLabel={t('settings.settings', 'Settings')}
             onBack={onBack}
+            sub={editing !== null ? (
+                <IconThemeEditorPage
+                    key={editing}
+                    existing={editTarget}
+                    onBack={() => setEditing(null)}
+                />
+            ) : null}
         >
 
             <div className="mx-4">
@@ -74,6 +92,31 @@ export function AppIconsPage({ onBack }: { onBack: () => void }) {
                 ))}
             </ListGroup>
 
+            <ListGroup
+                header={t('settings.iconThemeMine', 'My Themes')}
+                footer={t('settings.iconThemeMineHint', 'Design your own tile and symbol colours.')}
+            >
+                {custom.map(def => (
+                    <CustomRow
+                        key={def.id}
+                        def={def}
+                        selected={def.id === theme}
+                        onSelect={() => setIconTheme(def.id)}
+                        onEdit={() => setEditing(def.id)}
+                    />
+                ))}
+                <ListRow
+                    label={t('settings.iconThemeCreate', 'Create Icon Theme')}
+                    sub={t('settings.iconThemeCount', '{used} of {max} used', { used: custom.length, max: MAX_CUSTOM_ICON_THEMES })}
+                    left={(
+                        <span className="flex h-[24px] w-[24px] items-center justify-center rounded-[7px] bg-ios-blue">
+                            <Plus className="h-[15px] w-[15px] text-white" strokeWidth={3} />
+                        </span>
+                    )}
+                    onPress={() => { if (custom.length < MAX_CUSTOM_ICON_THEMES) setEditing('new'); }}
+                />
+            </ListGroup>
+
             <ListGroup>
                 <ListRow
                     label={t('settings.appNames', 'App Names')}
@@ -107,6 +150,42 @@ function ThemeRow({ def, selected, divider, onSelect }: {
             )}
             onPress={onSelect}
         />
+    );
+}
+
+function CustomRow({ def, selected, onSelect, onEdit }: {
+    def:      CustomIconTheme;
+    selected: boolean;
+    onSelect: () => void;
+    onEdit:   () => void;
+}) {
+    return (
+        <div className="relative flex items-center pr-4">
+            <ListRow
+                label={def.name}
+                sub={selected
+                    ? t('settings.iconThemeInUse', 'In use')
+                    : t('settings.iconThemeTapToUse', 'Tap to use')}
+                selected={selected}
+                left={(
+                    <span className="flex gap-[3px]">
+                        {SWATCH_APPS.map(app => <Tile key={app.id} theme={def.id} app={app} size={24} />)}
+                    </span>
+                )}
+                onPress={onSelect}
+            />
+            <button
+                type="button"
+                onClick={onEdit}
+                className="shrink-0 pl-3 text-[15px] font-normal text-ios-blue active:opacity-60"
+            >
+                {t('common.edit', 'Edit')}
+            </button>
+            <div
+                className="pointer-events-none absolute inset-x-0 bottom-0 bg-ios-gray4 dark:bg-control"
+                style={{ height: '0.5px' }}
+            />
+        </div>
     );
 }
 

--- a/web/src/apps/settings/appearance/AppIconsPage.tsx
+++ b/web/src/apps/settings/appearance/AppIconsPage.tsx
@@ -1,0 +1,134 @@
+import { t } from '@/i18n';
+import { AppGlyph } from '@/shell/AppGlyphs';
+import { AppIconSVG } from '@/shell/AppIconSVG';
+import { ICON_THEMES, resolveIconAppearance, useIconTheme, useIconThemeStore, useShowAppNames } from '@/stores/iconThemeStore';
+import type { IconThemeDef, IconThemeId } from '@/stores/iconThemeStore';
+import { ListGroup, ListRow } from '@/ui/ListGroup';
+import { Toggle } from '@/ui/Toggle';
+import { SubPage } from '../SettingsSubPage';
+
+interface PreviewApp {
+    id:     string;
+    icon:   string;
+    label:  string;
+    accent: string;
+}
+
+const PREVIEW_APPS: PreviewApp[] = [
+    { id: 'phone',   icon: 'phone',   label: 'Phone',   accent: '#34c759' },
+    { id: 'maps',    icon: 'maps',    label: 'Maps',    accent: '#f0c43a' },
+    { id: 'music',   icon: 'music',   label: 'Music',   accent: '#fa233b' },
+    { id: 'weather', icon: 'weather', label: 'Weather', accent: '#5ac8fa' },
+];
+
+const SWATCH_APPS = PREVIEW_APPS.slice(0, 3);
+
+export function AppIconsPage({ onBack }: { onBack: () => void }) {
+    const theme           = useIconTheme();
+    const showAppNames    = useShowAppNames();
+    const setIconTheme    = useIconThemeStore(s => s.setIconTheme);
+    const setShowAppNames = useIconThemeStore(s => s.setShowAppNames);
+
+    return (
+        <SubPage
+            title={t('settings.appIcons', 'App Icons')}
+            backLabel={t('settings.settings', 'Settings')}
+            onBack={onBack}
+        >
+
+            <div className="mx-4">
+                <div
+                    className="overflow-hidden rounded-[12px] px-4 py-5"
+                    style={{ background: 'linear-gradient(165deg, #40404a 0%, #17171a 100%)' }}
+                >
+                    <div className="flex items-start justify-between">
+                        {PREVIEW_APPS.map(app => (
+                            <div key={app.id} className="flex flex-col items-center gap-[6px]" style={{ width: 62 }}>
+                                <Tile theme={theme} app={app} size={62} />
+                                {showAppNames && (
+                                    <span
+                                        className="w-full truncate text-center font-sf text-[11px] font-semibold tracking-[0.01em] text-white"
+                                        style={{ textShadow: '0 1px 3px rgba(0,0,0,0.95)' }}
+                                    >
+                                        {app.label}
+                                    </span>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+                <p className="px-3 pt-2 text-[13px] font-normal text-ios-gray">
+                    {t('settings.appIconsPreviewHint', 'A preview of your Home Screen icons.')}
+                </p>
+            </div>
+
+            <ListGroup header={t('settings.iconTheme', 'Icon Theme')}>
+                {ICON_THEMES.map((def, i) => (
+                    <ThemeRow
+                        key={def.id}
+                        def={def}
+                        selected={def.id === theme}
+                        divider={i < ICON_THEMES.length - 1}
+                        onSelect={() => setIconTheme(def.id)}
+                    />
+                ))}
+            </ListGroup>
+
+            <ListGroup>
+                <ListRow
+                    label={t('settings.appNames', 'App Names')}
+                    sub={t('settings.appNamesSub', 'Show names on the Home Screen')}
+                    chevron={false}
+                    right={<div className="pointer-events-none -my-1"><Toggle on={showAppNames} /></div>}
+                    onPress={() => setShowAppNames(!showAppNames)}
+                />
+            </ListGroup>
+
+        </SubPage>
+    );
+}
+
+function ThemeRow({ def, selected, divider, onSelect }: {
+    def:      IconThemeDef;
+    selected: boolean;
+    divider:  boolean;
+    onSelect: () => void;
+}) {
+    return (
+        <ListRow
+            label={def.label()}
+            sub={def.hint()}
+            selected={selected}
+            divider={divider}
+            left={(
+                <span className="flex gap-[3px]">
+                    {SWATCH_APPS.map(app => <Tile key={app.id} theme={def.id} app={app} size={24} />)}
+                </span>
+            )}
+            onPress={onSelect}
+        />
+    );
+}
+
+function Tile({ theme, app, size }: { theme: IconThemeId; app: PreviewApp; size: number }) {
+    const { background, glyph, art } = resolveIconAppearance(theme, app.id, app.accent);
+    return (
+        <span
+            className="relative block shrink-0 overflow-hidden"
+            style={{
+                width:        size,
+                height:       size,
+                borderRadius: '27.6%',
+                boxShadow:    '0 1px 4px rgba(0,0,0,0.28), inset 0 0 0 0.5px rgba(255,255,255,0.12)',
+            }}
+        >
+            {art === 'native' ? (
+                <AppIconSVG icon={app.icon} size={size} />
+            ) : (
+                <span className="flex h-full w-full items-center justify-center" style={{ background }}>
+                    <AppGlyph icon={app.icon} label={app.label} color={glyph} size={Math.round(size * 0.52)} />
+                </span>
+            )}
+        </span>
+    );
+}

--- a/web/src/apps/settings/appearance/GlyphPickerSheet.tsx
+++ b/web/src/apps/settings/appearance/GlyphPickerSheet.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Check } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { resolveDraftAppearance } from '@/stores/iconThemeStore';
+import type { IconThemeDraft } from '@/stores/iconThemeStore';
+import { SearchBar } from '@/ui/SearchBar';
+import { Sheet } from '@/ui/Sheet';
+import { GLYPH_NAMES, glyphLabel } from './iconThemeCatalog';
+import { ThemeTile } from './IconThemePreview';
+
+export function GlyphPickerSheet({ draft, appId, accent, ownIcon, current, onSelect, onClear, onClose }: {
+    draft:    IconThemeDraft;
+    appId:    string;
+    accent:   string;
+    ownIcon:  string;
+    current:  string | undefined;
+    onSelect: (name: string) => void;
+    onClear:  () => void;
+    onClose:  () => void;
+}) {
+    const [query, setQuery] = useState('');
+    const look = resolveDraftAppearance(draft, appId, accent);
+
+    const needle = query.trim().toLowerCase();
+    const matches = needle === ''
+        ? GLYPH_NAMES
+        : GLYPH_NAMES.filter(name => name.includes(needle) || glyphLabel(name).toLowerCase().includes(needle));
+
+    return (
+        <Sheet
+            onClose={onClose}
+            fit="full"
+            top={30}
+            title={t('settings.iconOverrideSymbol', 'Symbol')}
+            className="bg-[#d4d4d4] dark:bg-base"
+        >
+            {({ close }) => (
+                <>
+                    <div className="shrink-0 px-4 pb-3">
+                        <SearchBar
+                            value={query}
+                            onChange={setQuery}
+                            placeholder={t('settings.iconOverrideSymbolSearch', 'Search symbols')}
+                        />
+                    </div>
+
+                    <div className="flex-1 overflow-y-auto no-scrollbar px-4 pb-10">
+                        <button
+                            type="button"
+                            onClick={() => { onClear(); close(); }}
+                            className="mb-4 flex w-full items-center gap-3 rounded-[12px] bg-[#e5e5e5] px-3 py-3 text-left active:opacity-70 dark:bg-surface"
+                        >
+                            <ThemeTile look={look} icon={ownIcon} label={ownIcon} size={40} />
+                            <span className="min-w-0 flex-1">
+                                <span className="block text-[17px] font-normal text-black dark:text-white">
+                                    {t('settings.iconOverrideOwnSymbol', "App's Own Symbol")}
+                                </span>
+                                <span className="block truncate text-[13px] text-ios-gray">
+                                    {glyphLabel(ownIcon)}
+                                </span>
+                            </span>
+                            {current === undefined && (
+                                <Check className="h-[17px] w-[17px] shrink-0 text-ios-blue" strokeWidth={2.5} />
+                            )}
+                        </button>
+
+                        {matches.length === 0 ? (
+                            <p className="py-10 text-center text-[15px] text-ios-gray">
+                                {t('settings.iconOverrideNoSymbols', 'No symbols match that search.')}
+                            </p>
+                        ) : (
+                            <div className="grid grid-cols-4 gap-y-4">
+                                {matches.map(name => {
+                                    const on = current === name;
+                                    return (
+                                        <button
+                                            key={name}
+                                            type="button"
+                                            onClick={() => { onSelect(name); close(); }}
+                                            className="flex flex-col items-center gap-1.5 active:opacity-70"
+                                        >
+                                            <span
+                                                className="flex items-center justify-center rounded-[14px] p-[3px]"
+                                                style={{ boxShadow: on ? '0 0 0 2px #0a84ff' : undefined }}
+                                            >
+                                                <ThemeTile look={look} icon={name} label={name} size={54} />
+                                            </span>
+                                            <span className={`w-full truncate px-1 text-center text-[11px] ${on ? 'font-semibold text-ios-blue' : 'text-ios-gray'}`}>
+                                                {glyphLabel(name)}
+                                            </span>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
+                </>
+            )}
+        </Sheet>
+    );
+}

--- a/web/src/apps/settings/appearance/IconOverrideEditorPage.tsx
+++ b/web/src/apps/settings/appearance/IconOverrideEditorPage.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { useIosPush } from '@/hooks/useIosPush';
+import { resolveDraftAppearance } from '@/stores/iconThemeStore';
+import type { ColorRecipe, IconThemeDraft, IconThemeOverride } from '@/stores/iconThemeStore';
+import { NavBar } from '@/ui/NavBar';
+import { glyphLabel } from './iconThemeCatalog';
+import type { ThemeApp } from './iconThemeCatalog';
+import { ActionRow, Hairline, RecipeEditor, Section, SwitchRow } from './IconThemeControls';
+import { ThemeStage, ThemeTile, ThemeTileLabel } from './IconThemePreview';
+import { GlyphPickerSheet } from './GlyphPickerSheet';
+import { WHITE } from './iconThemeDraft';
+
+export function IconOverrideEditorPage({ app, draft, override, wallpaper, showAppNames, pinned, onTogglePin, onChange, onBack }: {
+    app:          ThemeApp;
+    draft:        IconThemeDraft;
+    override:     IconThemeOverride | undefined;
+    wallpaper:    string;
+    showAppNames: boolean;
+    pinned:       boolean;
+    onTogglePin:  () => void;
+    onChange:     (next: IconThemeOverride | undefined) => void;
+    onBack:       () => void;
+}) {
+    const { goBack, pageStyle } = useIosPush(onBack);
+    const [picking, setPicking] = useState(false);
+
+    const look = resolveDraftAppearance(draft, app.id, app.accent);
+    const icon = override?.icon ?? app.icon;
+
+    function patch(next: IconThemeOverride) {
+        const clean: IconThemeOverride = {};
+        if (next.background) clean.background = next.background;
+        if (next.glyph) clean.glyph = next.glyph;
+        if (next.icon) clean.icon = next.icon;
+        onChange(Object.keys(clean).length === 0 ? undefined : clean);
+    }
+
+    function setBackground(recipe: ColorRecipe | undefined) {
+        patch({ ...override, background: recipe });
+    }
+
+    function setGlyph(recipe: ColorRecipe | undefined) {
+        patch({ ...override, glyph: recipe });
+    }
+
+    function setIcon(name: string | undefined) {
+        patch({ ...override, icon: name });
+    }
+
+    return (
+        <div className="absolute inset-0 z-40 flex flex-col bg-[#d4d4d4] text-black dark:bg-base dark:text-white" style={pageStyle}>
+            <div className="h-11 shrink-0" aria-hidden />
+
+            <NavBar
+                backLabel={t('settings.iconOverrides', 'App Icons')}
+                onBack={goBack}
+                title={app.label}
+                hairline
+            />
+
+            <div className="flex-1 overflow-y-auto no-scrollbar">
+                <div className="mt-6 flex flex-col gap-6 pb-12">
+
+                    <ThemeStage
+                        wallpaper={wallpaper}
+                        pinned={pinned}
+                        onTogglePin={onTogglePin}
+                        hint={t('settings.iconOverridePreviewHint', 'How {app} looks with this theme.', { app: app.label })}
+                    >
+                        <div className={`flex flex-col items-center gap-[6px] ${pinned ? 'pb-3 pt-1' : 'pb-7 pt-4'}`}>
+                            <ThemeTile look={look} icon={icon} label={app.label} size={pinned ? 48 : 92} />
+                            <ThemeTileLabel look={look} label={app.label} fallbackShow={showAppNames} small={pinned} />
+                        </div>
+                    </ThemeStage>
+
+                    <Section
+                        header={t('settings.iconOverrideTile', 'Tile Colour')}
+                        footer={override?.background
+                            ? t('settings.iconOverrideTileOnHint', 'This app ignores the theme tile colour.')
+                            : t('settings.iconOverrideTileOffHint', 'This app follows the theme tile colour.')}
+                    >
+                        <SwitchRow
+                            label={t('settings.iconOverrideCustomTile', 'Custom Tile Colour')}
+                            on={override?.background !== undefined}
+                            divider={override?.background !== undefined}
+                            onToggle={() => setBackground(
+                                override?.background ? undefined : { from: 'fixed', color: '#26262a' },
+                            )}
+                        />
+                        {override?.background && (
+                            <RecipeEditor
+                                recipe={override.background}
+                                onChange={setBackground}
+                                label={t('settings.iconOverrideTile', 'Tile Colour')}
+                            />
+                        )}
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconOverrideGlyph', 'Symbol Colour')}
+                        footer={override?.glyph
+                            ? undefined
+                            : t('settings.iconOverrideGlyphOffHint', 'This app follows the theme symbol colour.')}
+                    >
+                        <SwitchRow
+                            label={t('settings.iconOverrideCustomGlyph', 'Custom Symbol Colour')}
+                            on={override?.glyph !== undefined}
+                            divider={override?.glyph !== undefined}
+                            onToggle={() => setGlyph(
+                                override?.glyph ? undefined : { from: 'fixed', color: WHITE },
+                            )}
+                        />
+                        {override?.glyph && (
+                            <RecipeEditor
+                                recipe={override.glyph}
+                                onChange={setGlyph}
+                                label={t('settings.iconOverrideGlyph', 'Symbol Colour')}
+                                fallbackColour={WHITE}
+                            />
+                        )}
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconOverrideSymbol', 'Symbol')}
+                        footer={t('settings.iconOverrideSymbolHint', 'Swap the drawing on this tile for any other app symbol.')}
+                    >
+                        <button
+                            type="button"
+                            onClick={() => setPicking(true)}
+                            className="relative flex w-full items-center px-4 py-3 text-left active:bg-black/5 dark:active:bg-white/5"
+                        >
+                            <span className="mr-3 flex shrink-0 items-center">
+                                <ThemeTile look={look} icon={icon} label={app.label} size={30} />
+                            </span>
+                            <span className="min-w-0 flex-1">
+                                <span className="block truncate text-[17px] font-normal text-black dark:text-white">
+                                    {glyphLabel(icon)}
+                                </span>
+                                <span className="block truncate text-[13px] text-ios-gray">
+                                    {override?.icon
+                                        ? t('settings.iconOverrideSwapped', 'Swapped symbol')
+                                        : t('settings.iconOverrideOwnSymbol', "App's Own Symbol")}
+                                </span>
+                            </span>
+                            <ChevronRight className="h-[17px] w-[17px] shrink-0 text-ios-gray3" strokeWidth={2.5} />
+                        </button>
+                        {override?.icon && (
+                            <>
+                                <Hairline />
+                                <ActionRow
+                                    label={t('settings.iconOverrideResetSymbol', 'Use the App’s Own Symbol')}
+                                    onPress={() => setIcon(undefined)}
+                                />
+                            </>
+                        )}
+                    </Section>
+
+                    <Section>
+                        <ActionRow
+                            label={t('settings.iconOverrideClear', 'Reset This App')}
+                            destructive
+                            disabled={override === undefined}
+                            onPress={() => { onChange(undefined); goBack(); }}
+                        />
+                    </Section>
+
+                </div>
+            </div>
+
+            {picking && (
+                <GlyphPickerSheet
+                    draft={draft}
+                    appId={app.id}
+                    accent={app.accent}
+                    ownIcon={app.icon}
+                    current={override?.icon}
+                    onSelect={name => setIcon(name === app.icon ? undefined : name)}
+                    onClear={() => setIcon(undefined)}
+                    onClose={() => setPicking(false)}
+                />
+            )}
+        </div>
+    );
+}

--- a/web/src/apps/settings/appearance/IconOverridesPage.tsx
+++ b/web/src/apps/settings/appearance/IconOverridesPage.tsx
@@ -1,0 +1,207 @@
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { useIosPush } from '@/hooks/useIosPush';
+import { PushLayer } from '@/shell/PushLayer';
+import { customAccent, useCustomApps } from '@/stores/customAppsStore';
+import { MAX_ICON_OVERRIDES, resolveDraftAppearance } from '@/stores/iconThemeStore';
+import type { IconThemeDraft, IconThemeOverride } from '@/stores/iconThemeStore';
+import { NavBar } from '@/ui/NavBar';
+import { SearchBar } from '@/ui/SearchBar';
+import { APP_ID_PATTERN, glyphLabel, THEME_APPS } from './iconThemeCatalog';
+import type { ThemeApp } from './iconThemeCatalog';
+import { ActionRow, Section, SectionAction } from './IconThemeControls';
+import { ThemeTile } from './IconThemePreview';
+import { IconOverrideEditorPage } from './IconOverrideEditorPage';
+
+type Overrides = Record<string, IconThemeOverride>;
+
+function summarise(override: IconThemeOverride): string {
+    const parts: string[] = [];
+    if (override.background) parts.push(t('settings.iconOverridePartTile', 'Tile'));
+    if (override.glyph) parts.push(t('settings.iconOverridePartGlyph', 'Symbol colour'));
+    if (override.icon) parts.push(glyphLabel(override.icon));
+    return parts.join(', ');
+}
+
+export function IconOverridesPage({ draft, wallpaper, showAppNames, pinned, onTogglePin, onChange, onBack }: {
+    draft:        IconThemeDraft;
+    wallpaper:    string;
+    showAppNames: boolean;
+    pinned:       boolean;
+    onTogglePin:  () => void;
+    onChange:     (next: Overrides | undefined) => void;
+    onBack:       () => void;
+}) {
+    const { goBack, pageStyle } = useIosPush(onBack);
+    const customApps = useCustomApps();
+    const [query,   setQuery]   = useState('');
+    const [openApp, setOpenApp] = useState<string | null>(null);
+
+    const overrides = draft.overrides ?? {};
+    const used  = Object.keys(overrides).length;
+    const atCap = used >= MAX_ICON_OVERRIDES;
+
+    const extra: ThemeApp[] = customApps
+        .filter(app => APP_ID_PATTERN.test(app.id) && !THEME_APPS.some(known => known.id === app.id))
+        .map(app => ({ id: app.id, label: app.name, icon: app.id, accent: customAccent(app.id) }));
+
+    const apps = [...THEME_APPS, ...extra].sort((a, b) => a.label.localeCompare(b.label));
+
+    const needle  = query.trim().toLowerCase();
+    const visible = needle === '' ? apps : apps.filter(app => app.label.toLowerCase().includes(needle));
+    const custom  = visible.filter(app => overrides[app.id] !== undefined);
+    const plain   = visible.filter(app => overrides[app.id] === undefined);
+
+    function write(next: Overrides) {
+        onChange(Object.keys(next).length === 0 ? undefined : next);
+    }
+
+    function setOverride(id: string, value: IconThemeOverride | undefined) {
+        const next = { ...overrides };
+        if (value === undefined) delete next[id];
+        else next[id] = value;
+        write(next);
+    }
+
+    const target = openApp === null ? null : apps.find(app => app.id === openApp) ?? null;
+
+    return (
+        <PushLayer
+            pageStyle={pageStyle}
+            className="z-30"
+            sub={target && (
+                <IconOverrideEditorPage
+                    key={target.id}
+                    app={target}
+                    draft={draft}
+                    override={overrides[target.id]}
+                    wallpaper={wallpaper}
+                    showAppNames={showAppNames}
+                    pinned={pinned}
+                    onTogglePin={onTogglePin}
+                    onChange={value => setOverride(target.id, value)}
+                    onBack={() => setOpenApp(null)}
+                />
+            )}
+        >
+            <div className="h-11 shrink-0" aria-hidden />
+
+            <NavBar
+                backLabel={t('settings.iconThemeEditBack', 'Theme')}
+                onBack={goBack}
+                title={t('settings.iconOverrides', 'App Icons')}
+                hairline
+            />
+
+            <div className="flex-1 overflow-y-auto no-scrollbar">
+                <div className="mt-4 flex flex-col gap-6 pb-12">
+
+                    <div className="px-4">
+                        <SearchBar
+                            value={query}
+                            onChange={setQuery}
+                            placeholder={t('settings.iconOverridesSearch', 'Search apps')}
+                        />
+                    </div>
+
+                    {custom.length > 0 && (
+                        <Section
+                            header={t('settings.iconOverridesCustomised', 'Customised')}
+                            footer={t('settings.iconOverridesCount', '{used} of {max} apps customised', { used, max: MAX_ICON_OVERRIDES })}
+                            action={(
+                                <SectionAction
+                                    label={t('settings.iconOverridesResetAll', 'Reset All')}
+                                    onPress={() => write({})}
+                                />
+                            )}
+                        >
+                            {custom.map((app, i) => (
+                                <AppRow
+                                    key={app.id}
+                                    app={app}
+                                    draft={draft}
+                                    override={overrides[app.id]}
+                                    divider={i < custom.length - 1}
+                                    onPress={() => setOpenApp(app.id)}
+                                />
+                            ))}
+                        </Section>
+                    )}
+
+                    {atCap && (
+                        <Section footer={t('settings.iconOverridesFullHint', 'Reset an app above to make room for another one.')}>
+                            <ActionRow
+                                label={t('settings.iconOverridesFull', 'All {max} slots are used', { max: MAX_ICON_OVERRIDES })}
+                                disabled
+                                onPress={() => {}}
+                            />
+                        </Section>
+                    )}
+
+                    <Section
+                        header={t('settings.iconOverridesAll', 'All Apps')}
+                        footer={custom.length === 0
+                            ? t('settings.iconOverridesEmptyHint', 'Give one app its own tile colour, symbol colour or symbol. Up to {max} apps.', { max: MAX_ICON_OVERRIDES })
+                            : undefined}
+                    >
+                        {plain.length === 0 ? (
+                            <div className="px-4 py-6 text-center text-[15px] text-ios-gray">
+                                {needle === ''
+                                    ? t('settings.iconOverridesAllDone', 'Every app has its own look.')
+                                    : t('settings.iconOverridesNoMatch', 'No apps match that search.')}
+                            </div>
+                        ) : plain.map((app, i) => (
+                            <AppRow
+                                key={app.id}
+                                app={app}
+                                draft={draft}
+                                override={undefined}
+                                divider={i < plain.length - 1}
+                                disabled={atCap}
+                                onPress={() => setOpenApp(app.id)}
+                            />
+                        ))}
+                    </Section>
+
+                </div>
+            </div>
+        </PushLayer>
+    );
+}
+
+function AppRow({ app, draft, override, divider, disabled = false, onPress }: {
+    app:       ThemeApp;
+    draft:     IconThemeDraft;
+    override:  IconThemeOverride | undefined;
+    divider:   boolean;
+    disabled?: boolean;
+    onPress:   () => void;
+}) {
+    const look = resolveDraftAppearance(draft, app.id, app.accent);
+    return (
+        <button
+            type="button"
+            onClick={() => { if (!disabled) onPress(); }}
+            className={`relative flex w-full items-center px-4 py-2.5 text-left ${disabled ? 'opacity-40' : 'active:bg-black/5 dark:active:bg-white/5'}`}
+        >
+            <span className="mr-3 flex shrink-0 items-center">
+                <ThemeTile look={look} icon={look.icon ?? app.icon} label={app.label} size={32} />
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className="block truncate text-[17px] font-normal text-black dark:text-white">{app.label}</span>
+                {override && (
+                    <span className="block truncate text-[13px] text-ios-blue">{summarise(override)}</span>
+                )}
+            </span>
+            <ChevronRight className="h-[17px] w-[17px] shrink-0 text-ios-gray3" strokeWidth={2.5} />
+            {divider && (
+                <div
+                    className="pointer-events-none absolute inset-x-0 bottom-0 bg-ios-gray4 dark:bg-control"
+                    style={{ height: '0.5px' }}
+                />
+            )}
+        </button>
+    );
+}

--- a/web/src/apps/settings/appearance/IconThemeControls.tsx
+++ b/web/src/apps/settings/appearance/IconThemeControls.tsx
@@ -1,0 +1,238 @@
+import type { ReactNode } from 'react';
+
+import { t } from '@/i18n';
+import type { ColorRecipe, IconAppearance } from '@/stores/iconThemeStore';
+import { GroupCard } from '@/ui/ListGroup';
+import { SegmentedControl } from '@/ui/SegmentedControl';
+import { SliderRow } from '@/ui/SliderRow';
+import { Toggle } from '@/ui/Toggle';
+import { SWATCHES } from './iconThemeCatalog';
+import { LIGHTEN, mixAmount } from './iconThemeDraft';
+import { ThemeTile } from './IconThemePreview';
+
+const MIX_SWATCHES = [
+    '#ffffff', '#f4f4f6', '#e8dcc4', '#8e8e93', '#39414f', '#1f3a5f', '#1b1b1f', '#0f0f12',
+];
+
+export function Hairline() {
+    return <div className="h-[0.5px] bg-ios-gray4 dark:bg-control" />;
+}
+
+export function Section({ header, footer, action, children }: {
+    header?:  string;
+    footer?:  string;
+    action?:  ReactNode;
+    children: ReactNode;
+}) {
+    return (
+        <div>
+            {(header || action) && (
+                <div className="flex items-end justify-between gap-3 px-7 pb-1.5 pt-1">
+                    <span className="min-w-0 truncate text-[13px] font-normal uppercase tracking-wider text-ios-gray">
+                        {header ?? ''}
+                    </span>
+                    {action}
+                </div>
+            )}
+            <GroupCard className="mx-4">{children}</GroupCard>
+            {footer && (
+                <div className="px-7 pt-2 text-[13px] font-normal text-ios-gray">{footer}</div>
+            )}
+        </div>
+    );
+}
+
+export function SectionAction({ label, onPress }: { label: string; onPress: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onPress}
+            className="shrink-0 pb-[1px] text-[13px] font-semibold uppercase tracking-wider text-ios-blue active:opacity-60"
+        >
+            {label}
+        </button>
+    );
+}
+
+export function ActionRow({ label, destructive = false, disabled = false, divider = false, right, onPress }: {
+    label:        string;
+    destructive?: boolean;
+    disabled?:    boolean;
+    divider?:     boolean;
+    right?:       ReactNode;
+    onPress:      () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onPress}
+            disabled={disabled}
+            className={`relative flex w-full items-center px-4 py-3 text-[17px] font-normal active:bg-black/5 disabled:opacity-40 dark:active:bg-white/5 ${destructive ? 'text-ios-red' : 'text-ios-blue'}`}
+        >
+            <span className="flex-1 text-left">{label}</span>
+            {right}
+            {divider && <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[0.5px] bg-ios-gray4 dark:bg-control" />}
+        </button>
+    );
+}
+
+export function SwitchRow({ label, sub, on, disabled = false, divider = false, onToggle }: {
+    label:     string;
+    sub?:      string;
+    on:        boolean;
+    disabled?: boolean;
+    divider?:  boolean;
+    onToggle:  () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={() => { if (!disabled) onToggle(); }}
+            className={`relative flex w-full items-center px-4 py-3 text-left ${disabled ? 'opacity-45' : 'active:bg-black/5 dark:active:bg-white/5'}`}
+        >
+            <span className="min-w-0 flex-1">
+                <span className="block truncate text-[17px] font-normal text-black dark:text-white">{label}</span>
+                {sub && <span className="block truncate text-[13px] text-ios-gray">{sub}</span>}
+            </span>
+            <span className="pointer-events-none -my-1 ml-3 shrink-0">
+                <Toggle on={on} disabled={disabled} />
+            </span>
+            {divider && <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[0.5px] bg-ios-gray4 dark:bg-control" />}
+        </button>
+    );
+}
+
+function SwatchGrid({ value, onChange, label, swatches = SWATCHES }: {
+    value:     string | undefined;
+    onChange:  (v: string) => void;
+    label:     string;
+    swatches?: string[];
+}) {
+    return (
+        <div className="grid grid-cols-8 gap-2 px-4 py-4" role="group" aria-label={label}>
+            {swatches.map(colour => {
+                const on = colour === value;
+                return (
+                    <button
+                        key={colour}
+                        type="button"
+                        aria-label={colour}
+                        aria-pressed={on}
+                        onClick={() => onChange(colour)}
+                        className="relative aspect-square w-full rounded-full active:opacity-70"
+                        style={{
+                            background: colour,
+                            boxShadow: on
+                                ? 'inset 0 0 0 2px rgba(255,255,255,0.92), inset 0 0 0 2.5px rgba(0,0,0,0.14), 0 0 0 2px #0a84ff'
+                                : 'inset 0 0 0 0.5px rgba(0,0,0,0.20)',
+                        }}
+                    />
+                );
+            })}
+        </div>
+    );
+}
+
+export function RecipeEditor({ recipe, onChange, label, title, fallbackColour }: {
+    recipe:          ColorRecipe;
+    onChange:        (next: ColorRecipe) => void;
+    label:           string;
+    title?:          string;
+    fallbackColour?: string;
+}) {
+    const mix     = mixAmount(recipe);
+    const mixWith = recipe.toward ?? LIGHTEN;
+
+    function build(from: 'accent' | 'fixed', colour: string | undefined, amount: number, toward: string): ColorRecipe {
+        const next: ColorRecipe = { from };
+        if (from === 'fixed') next.color = colour ?? fallbackColour ?? '#26262a';
+        if (amount > 0) {
+            next.toward = toward;
+            next.amount = amount / 100;
+        }
+        return next;
+    }
+
+    return (
+        <>
+            {title && (
+                <div className="px-4 pt-3 text-[17px] font-normal text-black dark:text-white">{title}</div>
+            )}
+            <div className="px-4 py-3">
+                <SegmentedControl
+                    value={recipe.from}
+                    onChange={from => onChange(build(from, recipe.color, mix, mixWith))}
+                    options={[
+                        { value: 'accent', label: t('settings.iconThemeAppColour', 'App Colour') },
+                        { value: 'fixed',  label: t('settings.iconThemeOneColour', 'One Colour') },
+                    ]}
+                />
+            </div>
+
+            {recipe.from === 'fixed' && (
+                <>
+                    <Hairline />
+                    <SwatchGrid
+                        value={recipe.color}
+                        onChange={colour => onChange(build('fixed', colour, mix, mixWith))}
+                        label={label}
+                    />
+                </>
+            )}
+
+            <Hairline />
+            <SliderRow
+                label={t('settings.iconThemeMix', 'Mix')}
+                value={mix}
+                display={mix === 0 ? t('settings.iconThemeMixNone', 'None') : `${mix}%`}
+                onChange={amount => onChange(build(recipe.from, recipe.color, amount, mixWith))}
+            />
+
+            {mix > 0 && (
+                <>
+                    <Hairline />
+                    <SwatchGrid
+                        value={mixWith}
+                        onChange={toward => onChange(build(recipe.from, recipe.color, mix, toward))}
+                        label={t('settings.iconThemeMixWith', 'Mix with')}
+                        swatches={MIX_SWATCHES}
+                    />
+                </>
+            )}
+        </>
+    );
+}
+
+export function TilePicker<T extends string | number>({ value, options, onChange, label }: {
+    value:    T;
+    options:  { value: T; label: string; look: IconAppearance; icon: string }[];
+    onChange: (v: T) => void;
+    label:    string;
+}) {
+    return (
+        <div className="flex items-start justify-between gap-2 px-4 py-4" role="group" aria-label={label}>
+            {options.map(opt => {
+                const on = opt.value === value;
+                return (
+                    <button
+                        key={String(opt.value)}
+                        type="button"
+                        aria-pressed={on}
+                        onClick={() => onChange(opt.value)}
+                        className="flex min-w-0 flex-1 flex-col items-center gap-1.5 active:opacity-70"
+                    >
+                        <span
+                            className="flex items-center justify-center rounded-[12px] p-[3px]"
+                            style={{ boxShadow: on ? '0 0 0 2px #0a84ff' : undefined }}
+                        >
+                            <ThemeTile look={opt.look} icon={opt.icon} label={opt.label} size={46} />
+                        </span>
+                        <span className={`w-full truncate text-center text-[12px] ${on ? 'font-semibold text-ios-blue' : 'text-ios-gray'}`}>
+                            {opt.label}
+                        </span>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/web/src/apps/settings/appearance/IconThemeEditorPage.tsx
+++ b/web/src/apps/settings/appearance/IconThemeEditorPage.tsx
@@ -1,0 +1,406 @@
+import { useState } from 'react';
+import { Check } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { useIosPush } from '@/hooks/useIosPush';
+import { AppGlyph } from '@/shell/AppGlyphs';
+import { resolveWallpaper } from '@/shell/wallpapers';
+import { useTheme } from '@/stores/themeStore';
+import {
+    newCustomIconThemeId, resolveDraftAppearance, sanitizeCustomIconTheme,
+    useIconTheme, useIconThemeStore, useShowAppNames,
+} from '@/stores/iconThemeStore';
+import type { ColorRecipe, CustomIconTheme, CustomIconThemeId } from '@/stores/iconThemeStore';
+import { AlertDialog } from '@/ui/AlertDialog';
+import { ListGroup, ListRow } from '@/ui/ListGroup';
+import { NavBar } from '@/ui/NavBar';
+import { SegmentedControl } from '@/ui/SegmentedControl';
+import { Slider } from '@/ui/Slider';
+import { Toggle } from '@/ui/Toggle';
+
+const LIGHTEN = '#ffffff';
+const DARKEN  = '#0f0f12';
+
+const WHITE = '#ffffff';
+const BLACK = '#000000';
+
+const SWATCHES = [
+    '#ffffff', '#f4f4f6', '#d1d1d6', '#8e8e93', '#48484a', '#26262a', '#0a0a0c', '#000000',
+    '#ff453a', '#ff6482', '#ff9f0a', '#ffd60a', '#e8dcc4', '#ac8e68', '#8b5e3c', '#5c3d2e',
+    '#34c759', '#00c7be', '#5ac8fa', '#0a84ff', '#5e5ce6', '#bf5af2', '#39414f', '#1f3a5f',
+];
+
+const PREVIEW_APPS = [
+    { id: 'phone',    icon: 'phone',    label: 'Phone',    accent: '#34c759' },
+    { id: 'mail',     icon: 'mail',     label: 'Mail',     accent: '#0a84ff' },
+    { id: 'maps',     icon: 'maps',     label: 'Maps',     accent: '#f0c43a' },
+    { id: 'music',    icon: 'music',    label: 'Music',    accent: '#fa233b' },
+    { id: 'weather',  icon: 'weather',  label: 'Weather',  accent: '#5ac8fa' },
+    { id: 'notes',    icon: 'notes',    label: 'Notes',    accent: '#ffd60a' },
+    { id: 'photos',   icon: 'photos',   label: 'Photos',   accent: '#bf5af2' },
+    { id: 'settings', icon: 'settings', label: 'Settings', accent: '#8e8e93' },
+];
+
+type TileSource = 'accent' | 'fixed';
+type BlendDir   = 'light' | 'dark';
+type GlyphMode  = 'white' | 'black' | 'accent' | 'fixed';
+
+function readBlend(recipe: ColorRecipe): { dir: BlendDir; amount: number } {
+    if (recipe.toward === undefined || recipe.amount === undefined) return { dir: 'dark', amount: 0 };
+    return {
+        dir:    recipe.toward === LIGHTEN ? 'light' : 'dark',
+        amount: Math.round(recipe.amount * 100),
+    };
+}
+
+function readGlyphMode(recipe: ColorRecipe): GlyphMode {
+    if (recipe.from === 'accent') return 'accent';
+    if (recipe.color === WHITE) return 'white';
+    if (recipe.color === BLACK) return 'black';
+    return 'fixed';
+}
+
+export function IconThemeEditorPage({ existing, onBack }: {
+    existing: CustomIconTheme | null;
+    onBack:   () => void;
+}) {
+    const { goBack, pageStyle } = useIosPush(onBack);
+    const applied      = useIconTheme();
+    const showAppNames = useShowAppNames();
+    const { wallpaperHome }    = useTheme('wallpaperHome');
+    const setIconTheme         = useIconThemeStore(s => s.setIconTheme);
+    const saveCustomIconTheme  = useIconThemeStore(s => s.saveCustomIconTheme);
+    const deleteCustomIconTheme = useIconThemeStore(s => s.deleteCustomIconTheme);
+
+    const [origin] = useState(existing);
+    const [id] = useState<CustomIconThemeId>(() => origin?.id ?? newCustomIconThemeId());
+    const [name, setName] = useState(origin?.name ?? t('settings.iconThemeNewName', 'My Theme'));
+
+    const startTile:  ColorRecipe = origin?.background ?? { from: 'accent' };
+    const startGlyph: ColorRecipe = origin?.glyph ?? { from: 'fixed', color: WHITE };
+    const startBlend = readBlend(startTile);
+
+    const [tileSource, setTileSource] = useState<TileSource>(startTile.from);
+    const [tileColor,  setTileColor]  = useState(startTile.color ?? '#26262a');
+    const [blendDir,   setBlendDir]   = useState<BlendDir>(startBlend.dir);
+    const [blend,      setBlend]      = useState(startBlend.amount);
+    const [glyphMode,  setGlyphMode]  = useState<GlyphMode>(readGlyphMode(startGlyph));
+    const [glyphColor, setGlyphColor] = useState(startGlyph.color ?? '#f4f4f6');
+    const [gloss,      setGloss]      = useState(origin?.depth === true);
+
+    const [failure,  setFailure]  = useState<string | null>(null);
+    const [confirmDelete, setConfirmDelete] = useState(false);
+    const [busy, setBusy] = useState(false);
+
+    const background: ColorRecipe = {
+        from: tileSource,
+        ...(tileSource === 'fixed' ? { color: tileColor } : {}),
+        ...(blend > 0 ? { toward: blendDir === 'light' ? LIGHTEN : DARKEN, amount: blend / 100 } : {}),
+    };
+
+    const glyph: ColorRecipe =
+        glyphMode === 'accent' ? { from: 'accent' }
+        : { from: 'fixed', color: glyphMode === 'white' ? WHITE : glyphMode === 'black' ? BLACK : glyphColor };
+
+    const trimmed = name.trim();
+    const draft: CustomIconTheme = { id, name: trimmed, background, glyph, ...(gloss ? { depth: true } : {}) };
+    const valid = sanitizeCustomIconTheme(draft) !== null;
+
+    async function persist(): Promise<boolean> {
+        if (!valid || busy) return false;
+        setBusy(true);
+        const message = await saveCustomIconTheme(draft);
+        setBusy(false);
+        if (message) { setFailure(message); return false; }
+        return true;
+    }
+
+    async function save() {
+        if (await persist()) goBack();
+    }
+
+    async function apply() {
+        if (!await persist()) return;
+        setIconTheme(id);
+        goBack();
+    }
+
+    function remove() {
+        setConfirmDelete(false);
+        deleteCustomIconTheme(id);
+        goBack();
+    }
+
+    return (
+        <div className="absolute inset-0 z-30 flex flex-col bg-[#d4d4d4] text-black dark:bg-base dark:text-white" style={pageStyle}>
+            <div className="h-11 shrink-0" aria-hidden />
+
+            <NavBar
+                backLabel={t('settings.appIcons', 'App Icons')}
+                onBack={goBack}
+                title={origin ? t('settings.iconThemeEdit', 'Edit Theme') : t('settings.iconThemeNew', 'New Theme')}
+                hairline
+                right={(
+                    <button
+                        type="button"
+                        onClick={() => { void save(); }}
+                        disabled={!valid || busy}
+                        className="text-[17px] font-semibold text-ios-blue active:opacity-60 disabled:opacity-40"
+                    >
+                        {t('common.save', 'Save')}
+                    </button>
+                )}
+            />
+
+            <div className="flex-1 overflow-y-auto no-scrollbar">
+                <div className="mt-6 flex flex-col gap-6 pb-12">
+
+                    <div className="mx-4">
+                        <div
+                            className="overflow-hidden rounded-[14px]"
+                            style={{
+                                backgroundImage:    `url(${resolveWallpaper(wallpaperHome)})`,
+                                backgroundSize:     'cover',
+                                backgroundPosition: 'center',
+                            }}
+                        >
+                            <div className="grid grid-cols-4 gap-y-5 bg-black/25 px-3 py-6">
+                                {PREVIEW_APPS.map(app => (
+                                    <div key={app.id} className="flex flex-col items-center gap-[6px]">
+                                        <PreviewTile
+                                            background={background}
+                                            glyph={glyph}
+                                            gloss={gloss}
+                                            app={app}
+                                            size={68}
+                                        />
+                                        {showAppNames && (
+                                            <span
+                                                className="w-full truncate px-0.5 text-center font-sf text-[11px] font-semibold tracking-[0.01em] text-white"
+                                                style={{ textShadow: '0 1px 3px rgba(0,0,0,0.95)' }}
+                                            >
+                                                {app.label}
+                                            </span>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                        <p className="px-3 pt-2 text-[13px] font-normal text-ios-gray">
+                            {t('settings.iconThemePreviewHint', 'Your theme on the Home Screen, updating as you go.')}
+                        </p>
+                    </div>
+
+                    <ListGroup header={t('settings.iconThemeNameHeader', 'Name')}>
+                        <div className="px-4 py-3">
+                            <input
+                                value={name}
+                                maxLength={24}
+                                onChange={e => setName(e.target.value)}
+                                placeholder={t('settings.iconThemeNewName', 'My Theme')}
+                                aria-label={t('settings.iconThemeNameHeader', 'Name')}
+                                className="w-full bg-transparent text-[17px] font-normal text-black outline-none placeholder:text-ios-gray dark:text-white"
+                            />
+                        </div>
+                    </ListGroup>
+
+                    <ListGroup
+                        header={t('settings.iconThemeTile', 'Tile')}
+                        footer={tileSource === 'accent'
+                            ? t('settings.iconThemeTileAppHint', 'Every tile keeps its own app colour.')
+                            : t('settings.iconThemeTileFixedHint', 'One colour for every app.')}
+                    >
+                        <div className="px-4 py-3">
+                            <SegmentedControl
+                                value={tileSource}
+                                onChange={setTileSource}
+                                options={[
+                                    { value: 'accent', label: t('settings.iconThemeAppColour', 'App Colour') },
+                                    { value: 'fixed',  label: t('settings.iconThemeOneColour', 'One Colour') },
+                                ]}
+                            />
+                        </div>
+                        {tileSource === 'fixed' && (
+                            <>
+                                <Hairline />
+                                <SwatchGrid value={tileColor} onChange={setTileColor} label={t('settings.iconThemeTile', 'Tile')} />
+                            </>
+                        )}
+                    </ListGroup>
+
+                    <ListGroup
+                        header={t('settings.iconThemeBlend', 'Blend')}
+                        footer={t('settings.iconThemeBlendHint', 'Pulls the tile toward a lighter or darker tone.')}
+                    >
+                        <div className="px-4 py-3">
+                            <SegmentedControl
+                                value={blendDir}
+                                onChange={setBlendDir}
+                                options={[
+                                    { value: 'light', label: t('settings.iconThemeLighter', 'Lighter') },
+                                    { value: 'dark',  label: t('settings.iconThemeDarker', 'Darker') },
+                                ]}
+                            />
+                        </div>
+                        <Hairline />
+                        <div className="flex items-center gap-4 px-4 py-2">
+                            <Slider
+                                className="flex-1"
+                                value={blend}
+                                onChange={setBlend}
+                                ariaLabel={t('settings.iconThemeBlend', 'Blend')}
+                            />
+                            <span className="w-9 shrink-0 text-right text-[15px] tabular-nums text-ios-gray">{blend}</span>
+                        </div>
+                    </ListGroup>
+
+                    <ListGroup header={t('settings.iconThemeSymbol', 'Symbol')}>
+                        <div className="px-4 py-3">
+                            <SegmentedControl
+                                value={glyphMode}
+                                onChange={setGlyphMode}
+                                options={[
+                                    { value: 'white',  label: t('settings.iconThemeWhite', 'White') },
+                                    { value: 'black',  label: t('settings.iconThemeBlack', 'Black') },
+                                    { value: 'accent', label: t('settings.iconThemeApp', 'App') },
+                                    { value: 'fixed',  label: t('settings.iconThemeColour', 'Colour') },
+                                ]}
+                            />
+                        </div>
+                        {glyphMode === 'fixed' && (
+                            <>
+                                <Hairline />
+                                <SwatchGrid value={glyphColor} onChange={setGlyphColor} label={t('settings.iconThemeSymbol', 'Symbol')} />
+                            </>
+                        )}
+                    </ListGroup>
+
+                    <ListGroup footer={t('settings.iconThemeGlossHint', 'The lit, glassy sheen the Glass theme uses.')}>
+                        <ListRow
+                            label={t('settings.iconThemeGloss', 'Gloss')}
+                            chevron={false}
+                            right={<div className="pointer-events-none -my-1"><Toggle on={gloss} /></div>}
+                            onPress={() => setGloss(!gloss)}
+                        />
+                    </ListGroup>
+
+                    <ListGroup>
+                        <ActionRow
+                            label={t('settings.iconThemeApply', 'Save and Use')}
+                            disabled={!valid || busy}
+                            divider
+                            right={applied === id ? <Check className="h-[17px] w-[17px] text-ios-blue" strokeWidth={2.5} /> : undefined}
+                            onPress={() => { void apply(); }}
+                        />
+                        <ActionRow
+                            label={t('settings.iconThemeDelete', 'Delete Theme')}
+                            destructive
+                            disabled={!origin}
+                            onPress={() => setConfirmDelete(true)}
+                        />
+                    </ListGroup>
+
+                </div>
+            </div>
+
+            {confirmDelete && (
+                <AlertDialog
+                    title={t('settings.iconThemeDeleteTitle', 'Delete “{name}”?', { name: origin?.name ?? trimmed })}
+                    message={t('settings.iconThemeDeleteBody', 'This theme is removed from your phone. If it is the one in use, your icons go back to Default.')}
+                    confirmLabel={t('common.delete', 'Delete')}
+                    destructive
+                    onCancel={() => setConfirmDelete(false)}
+                    onConfirm={remove}
+                />
+            )}
+
+            {failure && (
+                <AlertDialog
+                    title={t('settings.iconThemeSaveTitle', 'Not Saved')}
+                    message={failure}
+                    confirmLabel={t('common.ok', 'OK')}
+                    hideCancel
+                    onCancel={() => setFailure(null)}
+                    onConfirm={() => setFailure(null)}
+                />
+            )}
+        </div>
+    );
+}
+
+function Hairline() {
+    return <div className="h-[0.5px] bg-ios-gray4 dark:bg-control" />;
+}
+
+function ActionRow({ label, destructive = false, disabled = false, divider = false, right, onPress }: {
+    label:        string;
+    destructive?: boolean;
+    disabled?:    boolean;
+    divider?:     boolean;
+    right?:       React.ReactNode;
+    onPress:      () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onPress}
+            disabled={disabled}
+            className={`relative flex w-full items-center px-4 py-3 text-[17px] font-normal active:bg-black/5 disabled:opacity-40 dark:active:bg-white/5 ${destructive ? 'text-ios-red' : 'text-ios-blue'}`}
+        >
+            <span className="flex-1 text-left">{label}</span>
+            {right}
+            {divider && <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[0.5px] bg-ios-gray4 dark:bg-control" />}
+        </button>
+    );
+}
+
+function SwatchGrid({ value, onChange, label }: { value: string; onChange: (v: string) => void; label: string }) {
+    return (
+        <div className="grid grid-cols-8 gap-2 px-4 py-4" role="group" aria-label={label}>
+            {SWATCHES.map(colour => {
+                const on = colour === value;
+                return (
+                    <button
+                        key={colour}
+                        type="button"
+                        aria-label={colour}
+                        aria-pressed={on}
+                        onClick={() => onChange(colour)}
+                        className="relative aspect-square w-full rounded-full active:opacity-70"
+                        style={{
+                            background: colour,
+                            boxShadow: on
+                                ? '0 0 0 2px #0a84ff, inset 0 0 0 0.5px rgba(0,0,0,0.20)'
+                                : 'inset 0 0 0 0.5px rgba(0,0,0,0.20)',
+                        }}
+                    />
+                );
+            })}
+        </div>
+    );
+}
+
+function PreviewTile({ background, glyph, gloss, app, size }: {
+    background: ColorRecipe;
+    glyph:      ColorRecipe;
+    gloss:      boolean;
+    app:        { icon: string; label: string; accent: string; id: string };
+    size:       number;
+}) {
+    const look = resolveDraftAppearance({ background, glyph, depth: gloss }, app.id, app.accent);
+    return (
+        <span
+            className="relative block shrink-0 overflow-hidden"
+            style={{
+                width:        size,
+                height:       size,
+                borderRadius: '27.6%',
+                boxShadow:    '0 2px 8px rgba(0,0,0,0.34), inset 0 0 0 0.5px rgba(255,255,255,0.12)',
+            }}
+        >
+            <span className="flex h-full w-full items-center justify-center" style={{ background: look.background }}>
+                <AppGlyph icon={app.icon} label={app.label} color={look.glyph} size={Math.round(size * 0.52)} />
+            </span>
+        </span>
+    );
+}

--- a/web/src/apps/settings/appearance/IconThemeEditorPage.tsx
+++ b/web/src/apps/settings/appearance/IconThemeEditorPage.tsx
@@ -1,115 +1,150 @@
 import { useState } from 'react';
-import { Check } from 'lucide-react';
+import { Check, Copy } from 'lucide-react';
 
 import { t } from '@/i18n';
+import { apiCall } from '@/core/api';
+import { isFiveM } from '@/core/nui';
 import { useIosPush } from '@/hooks/useIosPush';
-import { AppGlyph } from '@/shell/AppGlyphs';
+import { useSessionState } from '@/hooks/useSessionState';
+import { encodeThemeCode } from '@/lib/themeCode';
+import { PushLayer } from '@/shell/PushLayer';
 import { resolveWallpaper } from '@/shell/wallpapers';
+import { ShareAction, ShareSheet } from '@/shared/ShareSheet';
 import { useTheme } from '@/stores/themeStore';
 import {
-    newCustomIconThemeId, resolveDraftAppearance, sanitizeCustomIconTheme,
-    useIconTheme, useIconThemeStore, useShowAppNames,
+    iconThemeWallpaper, MAX_ICON_OVERRIDES, newCustomIconThemeId, resolveDraftAppearance,
+    sanitizeCustomIconTheme, useIconTheme, useIconThemeStore, useShowAppNames,
 } from '@/stores/iconThemeStore';
-import type { ColorRecipe, CustomIconTheme, CustomIconThemeId } from '@/stores/iconThemeStore';
+import type {
+    CustomIconTheme, CustomIconThemeId, IconThemeLabel, IconThemeVariant,
+} from '@/stores/iconThemeStore';
 import { AlertDialog } from '@/ui/AlertDialog';
-import { ListGroup, ListRow } from '@/ui/ListGroup';
+import { ListRow } from '@/ui/ListGroup';
 import { NavBar } from '@/ui/NavBar';
 import { SegmentedControl } from '@/ui/SegmentedControl';
-import { Slider } from '@/ui/Slider';
-import { Toggle } from '@/ui/Toggle';
+import { SliderRow } from '@/ui/SliderRow';
+import {
+    PREVIEW_APPS, RADIUS_SQUIRCLE, radiusChoices, textureChoices, themePresets,
+} from './iconThemeCatalog';
+import {
+    activeLook, DARKEN, draftFromTheme, dropTraits, hasOwnTraits, isLockedInDark, previewDraft,
+    seedDraft, toTheme, writeTrait, WHITE,
+} from './iconThemeDraft';
+import type { DraftState, TraitKey, VariantKey } from './iconThemeDraft';
+import {
+    ActionRow, Hairline, RecipeEditor, Section, SectionAction, SwitchRow, TilePicker,
+} from './IconThemeControls';
+import { StageBadge, ThemePreviewGrid, ThemeStage } from './IconThemePreview';
+import { IconOverridesPage } from './IconOverridesPage';
+import { ThemeWallpaperPage } from './ThemeWallpaperPage';
+import { ThemeCodeSheet } from './ThemeCodeSheet';
 
-const LIGHTEN = '#ffffff';
-const DARKEN  = '#0f0f12';
+const DEFAULT_ANGLE  = 166;
+const DEFAULT_WEIGHT = 600;
+const SHAPE_SAMPLE   = PREVIEW_APPS[0];
+const TEXTURE_SAMPLE = PREVIEW_APPS[1];
 
-const WHITE = '#ffffff';
-const BLACK = '#000000';
-
-const SWATCHES = [
-    '#ffffff', '#f4f4f6', '#d1d1d6', '#8e8e93', '#48484a', '#26262a', '#0a0a0c', '#000000',
-    '#ff453a', '#ff6482', '#ff9f0a', '#ffd60a', '#e8dcc4', '#ac8e68', '#8b5e3c', '#5c3d2e',
-    '#34c759', '#00c7be', '#5ac8fa', '#0a84ff', '#5e5ce6', '#bf5af2', '#39414f', '#1f3a5f',
-];
-
-const PREVIEW_APPS = [
-    { id: 'phone',    icon: 'phone',    label: 'Phone',    accent: '#34c759' },
-    { id: 'mail',     icon: 'mail',     label: 'Mail',     accent: '#0a84ff' },
-    { id: 'maps',     icon: 'maps',     label: 'Maps',     accent: '#f0c43a' },
-    { id: 'music',    icon: 'music',    label: 'Music',    accent: '#fa233b' },
-    { id: 'weather',  icon: 'weather',  label: 'Weather',  accent: '#5ac8fa' },
-    { id: 'notes',    icon: 'notes',    label: 'Notes',    accent: '#ffd60a' },
-    { id: 'photos',   icon: 'photos',   label: 'Photos',   accent: '#bf5af2' },
-    { id: 'settings', icon: 'settings', label: 'Settings', accent: '#8e8e93' },
-];
-
-type TileSource = 'accent' | 'fixed';
-type BlendDir   = 'light' | 'dark';
-type GlyphMode  = 'white' | 'black' | 'accent' | 'fixed';
-
-function readBlend(recipe: ColorRecipe): { dir: BlendDir; amount: number } {
-    if (recipe.toward === undefined || recipe.amount === undefined) return { dir: 'dark', amount: 0 };
-    return {
-        dir:    recipe.toward === LIGHTEN ? 'light' : 'dark',
-        amount: Math.round(recipe.amount * 100),
-    };
+async function shareTheme(target: number, name: string, code: string): Promise<boolean> {
+    if (!isFiveM) return true;
+    const body = [
+        t('settings.iconThemeShareTitle', 'Icon theme: {name}', { name }),
+        code,
+        t('settings.iconThemeShareFooter', 'Paste this code into Settings, App Icons, New Theme.'),
+    ].join('\n\n');
+    const r = await apiCall<void>('sd-phone:notes:share', { target, body, sketches: [], images: [] });
+    return r.success;
 }
 
-function readGlyphMode(recipe: ColorRecipe): GlyphMode {
-    if (recipe.from === 'accent') return 'accent';
-    if (recipe.color === WHITE) return 'white';
-    if (recipe.color === BLACK) return 'black';
-    return 'fixed';
-}
-
-export function IconThemeEditorPage({ existing, onBack }: {
+export function IconThemeEditorPage({ existing, seed, onBack }: {
     existing: CustomIconTheme | null;
+    seed:     DraftState | null;
     onBack:   () => void;
 }) {
     const { goBack, pageStyle } = useIosPush(onBack);
     const applied      = useIconTheme();
     const showAppNames = useShowAppNames();
-    const { wallpaperHome }    = useTheme('wallpaperHome');
-    const setIconTheme         = useIconThemeStore(s => s.setIconTheme);
-    const saveCustomIconTheme  = useIconThemeStore(s => s.saveCustomIconTheme);
+    const { wallpaperHome, setWallpaper } = useTheme('wallpaperHome', 'setWallpaper');
+    const setIconTheme          = useIconThemeStore(s => s.setIconTheme);
+    const saveCustomIconTheme   = useIconThemeStore(s => s.saveCustomIconTheme);
     const deleteCustomIconTheme = useIconThemeStore(s => s.deleteCustomIconTheme);
 
     const [origin] = useState(existing);
     const [id] = useState<CustomIconThemeId>(() => origin?.id ?? newCustomIconThemeId());
-    const [name, setName] = useState(origin?.name ?? t('settings.iconThemeNewName', 'My Theme'));
+    const [state, setState] = useState<DraftState>(() => {
+        if (origin) return draftFromTheme(origin);
+        if (seed) return seed;
+        const first = themePresets()[0];
+        return seedDraft(t('settings.iconThemeNewName', 'My Theme'), first.seed);
+    });
 
-    const startTile:  ColorRecipe = origin?.background ?? { from: 'accent' };
-    const startGlyph: ColorRecipe = origin?.glyph ?? { from: 'fixed', color: WHITE };
-    const startBlend = readBlend(startTile);
-
-    const [tileSource, setTileSource] = useState<TileSource>(startTile.from);
-    const [tileColor,  setTileColor]  = useState(startTile.color ?? '#26262a');
-    const [blendDir,   setBlendDir]   = useState<BlendDir>(startBlend.dir);
-    const [blend,      setBlend]      = useState(startBlend.amount);
-    const [glyphMode,  setGlyphMode]  = useState<GlyphMode>(readGlyphMode(startGlyph));
-    const [glyphColor, setGlyphColor] = useState(startGlyph.color ?? '#f4f4f6');
-    const [gloss,      setGloss]      = useState(origin?.depth === true);
-
-    const [failure,  setFailure]  = useState<string | null>(null);
+    const [pinned, setPinned] = useSessionState<boolean>('settings:iconThemePinned', false);
+    const [variant, setVariant] = useState<VariantKey>('base');
+    const [sub,     setSub]     = useState<'overrides' | 'wallpaper' | null>(null);
+    const [sheet,   setSheet]   = useState<'code' | 'share' | null>(null);
+    const [pairing, setPairing] = useState<string | null>(null);
+    const [failure, setFailure] = useState<string | null>(null);
     const [confirmDelete, setConfirmDelete] = useState(false);
     const [busy, setBusy] = useState(false);
 
-    const background: ColorRecipe = {
-        from: tileSource,
-        ...(tileSource === 'fixed' ? { color: tileColor } : {}),
-        ...(blend > 0 ? { toward: blendDir === 'light' ? LIGHTEN : DARKEN, amount: blend / 100 } : {}),
-    };
+    const look  = activeLook(state, variant);
+    const draft = previewDraft(state, variant);
+    const dark  = variant === 'dark';
 
-    const glyph: ColorRecipe =
-        glyphMode === 'accent' ? { from: 'accent' }
-        : { from: 'fixed', color: glyphMode === 'white' ? WHITE : glyphMode === 'black' ? BLACK : glyphColor };
+    function set<K extends TraitKey>(key: K, value: NonNullable<IconThemeVariant[K]>) {
+        setState(s => writeTrait(s, variant, key, value));
+    }
 
-    const trimmed = name.trim();
-    const draft: CustomIconTheme = { id, name: trimmed, background, glyph, ...(gloss ? { depth: true } : {}) };
-    const valid = sanitizeCustomIconTheme(draft) !== null;
+    function drop(...keys: TraitKey[]) {
+        setState(s => dropTraits(s, variant, keys));
+    }
+
+    function darkAction(keys: TraitKey[]) {
+        if (!hasOwnTraits(state, variant, keys)) return undefined;
+        return (
+            <SectionAction
+                label={t('settings.iconThemeFollowBase', 'Follow Base')}
+                onPress={() => drop(...keys)}
+            />
+        );
+    }
+
+    function footerFor(keys: TraitKey[], base?: string): string | undefined {
+        if (!dark) return base;
+        return hasOwnTraits(state, variant, keys)
+            ? t('settings.iconThemeDarkOwn', 'Set for Dark Mode only.')
+            : t('settings.iconThemeDarkFollows', 'Following your base design. Change anything here to set it for Dark Mode only.');
+    }
+
+    function setLabelStyle(patch: Partial<IconThemeLabel>) {
+        const merged: IconThemeLabel = { ...(look.label ?? {}), ...patch };
+        const clean: IconThemeLabel = {};
+        if (merged.color) clean.color = merged.color;
+        if (merged.weight !== undefined) clean.weight = merged.weight;
+        if (merged.show !== undefined) clean.show = merged.show;
+        if (Object.keys(clean).length === 0) drop('label');
+        else set('label', clean);
+    }
+
+    function setBorderWidth(width: number) {
+        if (width <= 0) { drop('border'); return; }
+        set('border', { color: look.border?.color ?? { from: 'fixed', color: WHITE }, width });
+    }
+
+    const trimmed  = state.name.trim();
+    const theme    = toTheme(id, state);
+    const valid    = trimmed.length > 0 && sanitizeCustomIconTheme(theme) !== null;
+    const code     = valid ? encodeThemeCode(theme) : '';
+    const overrides = Object.keys(look.overrides ?? {}).length;
+
+    const gloss   = Math.round((look.gloss ?? (look.depth === true ? 1 : 0)) * 100);
+    const shapes  = radiusChoices();
+    const radius  = look.radius ?? RADIUS_SQUIRCLE;
+    const texture = look.texture ?? 'none';
 
     async function persist(): Promise<boolean> {
         if (!valid || busy) return false;
         setBusy(true);
-        const message = await saveCustomIconTheme(draft);
+        const message = await saveCustomIconTheme(theme);
         setBusy(false);
         if (message) { setFailure(message); return false; }
         return true;
@@ -122,6 +157,18 @@ export function IconThemeEditorPage({ existing, onBack }: {
     async function apply() {
         if (!await persist()) return;
         setIconTheme(id);
+        const paired = iconThemeWallpaper(id);
+        if (paired && resolveWallpaper(paired) !== resolveWallpaper(wallpaperHome)) {
+            setPairing(paired);
+            return;
+        }
+        goBack();
+    }
+
+    function finishPairing(accept: boolean) {
+        const paired = pairing;
+        setPairing(null);
+        if (accept && paired) setWallpaper(resolveWallpaper(paired), 'home');
         goBack();
     }
 
@@ -131,8 +178,31 @@ export function IconThemeEditorPage({ existing, onBack }: {
         goBack();
     }
 
+    const subNode =
+        sub === 'overrides' ? (
+            <IconOverridesPage
+                draft={draft}
+                wallpaper={look.wallpaper ?? wallpaperHome}
+                showAppNames={showAppNames}
+                pinned={pinned}
+                onTogglePin={() => setPinned(!pinned)}
+                onChange={next => { if (next) set('overrides', next); else drop('overrides'); }}
+                onBack={() => setSub(null)}
+            />
+        ) : sub === 'wallpaper' ? (
+            <ThemeWallpaperPage
+                draft={draft}
+                showAppNames={showAppNames}
+                wallpaper={look.wallpaper}
+                pinned={pinned}
+                onTogglePin={() => setPinned(!pinned)}
+                onChange={next => { if (next) set('wallpaper', next); else drop('wallpaper'); }}
+                onBack={() => setSub(null)}
+            />
+        ) : null;
+
     return (
-        <div className="absolute inset-0 z-30 flex flex-col bg-[#d4d4d4] text-black dark:bg-base dark:text-white" style={pageStyle}>
+        <PushLayer pageStyle={pageStyle} className="z-30" sub={subNode}>
             <div className="h-11 shrink-0" aria-hidden />
 
             <NavBar
@@ -155,136 +225,366 @@ export function IconThemeEditorPage({ existing, onBack }: {
             <div className="flex-1 overflow-y-auto no-scrollbar">
                 <div className="mt-6 flex flex-col gap-6 pb-12">
 
-                    <div className="mx-4">
-                        <div
-                            className="overflow-hidden rounded-[14px]"
-                            style={{
-                                backgroundImage:    `url(${resolveWallpaper(wallpaperHome)})`,
-                                backgroundSize:     'cover',
-                                backgroundPosition: 'center',
-                            }}
-                        >
-                            <div className="grid grid-cols-4 gap-y-5 bg-black/25 px-3 py-6">
-                                {PREVIEW_APPS.map(app => (
-                                    <div key={app.id} className="flex flex-col items-center gap-[6px]">
-                                        <PreviewTile
-                                            background={background}
-                                            glyph={glyph}
-                                            gloss={gloss}
-                                            app={app}
-                                            size={68}
-                                        />
-                                        {showAppNames && (
-                                            <span
-                                                className="w-full truncate px-0.5 text-center font-sf text-[11px] font-semibold tracking-[0.01em] text-white"
-                                                style={{ textShadow: '0 1px 3px rgba(0,0,0,0.95)' }}
-                                            >
-                                                {app.label}
-                                            </span>
-                                        )}
-                                    </div>
-                                ))}
+                    <ThemeStage
+                        wallpaper={look.wallpaper ?? wallpaperHome}
+                        badge={dark ? <StageBadge label={t('settings.iconThemeDarkBadge', 'Dark Mode')} /> : undefined}
+                        pinned={pinned}
+                        onTogglePin={() => setPinned(!pinned)}
+                        hint={dark
+                            ? t('settings.iconThemeDarkPreviewHint', 'Your Dark Mode design, shown here whatever your phone is set to.')
+                            : t('settings.iconThemePreviewHint', 'Your theme on the Home Screen, updating as you go.')}
+                    >
+                        <ThemePreviewGrid draft={draft} showAppNames={showAppNames} pinned={pinned} />
+                    </ThemeStage>
+
+                    <Section
+                        footer={dark
+                            ? t('settings.iconThemeVariantDarkHint', 'A Dark Mode design only replaces the parts you change here.')
+                            : state.dark !== null
+                                ? t('settings.iconThemeVariantHasDark', 'This theme also has a Dark Mode design.')
+                                : t('settings.iconThemeVariantBaseHint', 'Your base design is used everywhere, including Dark Mode until you add one.')}
+                    >
+                        <div className="px-4 py-3">
+                            <SegmentedControl
+                                value={variant}
+                                onChange={setVariant}
+                                options={[
+                                    { value: 'base', label: t('settings.iconThemeVariantBase', 'Base') },
+                                    { value: 'dark', label: t('settings.iconThemeVariantDark', 'Dark Mode') },
+                                ]}
+                            />
+                        </div>
+                        {dark && state.dark !== null && (
+                            <>
+                                <Hairline />
+                                <ActionRow
+                                    label={t('settings.iconThemeDarkClear', 'Remove Dark Design')}
+                                    destructive
+                                    onPress={() => setState(s => ({ ...s, dark: null }))}
+                                />
+                            </>
+                        )}
+                    </Section>
+
+                    {!dark && (
+                        <Section header={t('settings.iconThemeNameHeader', 'Name')}>
+                            <div className="px-4 py-3">
+                                <input
+                                    value={state.name}
+                                    maxLength={24}
+                                    onChange={e => setState(s => ({ ...s, name: e.target.value }))}
+                                    placeholder={t('settings.iconThemeNewName', 'My Theme')}
+                                    aria-label={t('settings.iconThemeNameHeader', 'Name')}
+                                    className="w-full bg-transparent text-[17px] font-normal text-black outline-none placeholder:text-ios-gray dark:text-white"
+                                />
                             </div>
-                        </div>
-                        <p className="px-3 pt-2 text-[13px] font-normal text-ios-gray">
-                            {t('settings.iconThemePreviewHint', 'Your theme on the Home Screen, updating as you go.')}
-                        </p>
-                    </div>
+                        </Section>
+                    )}
 
-                    <ListGroup header={t('settings.iconThemeNameHeader', 'Name')}>
-                        <div className="px-4 py-3">
-                            <input
-                                value={name}
-                                maxLength={24}
-                                onChange={e => setName(e.target.value)}
-                                placeholder={t('settings.iconThemeNewName', 'My Theme')}
-                                aria-label={t('settings.iconThemeNameHeader', 'Name')}
-                                className="w-full bg-transparent text-[17px] font-normal text-black outline-none placeholder:text-ios-gray dark:text-white"
-                            />
-                        </div>
-                    </ListGroup>
-
-                    <ListGroup
-                        header={t('settings.iconThemeTile', 'Tile')}
-                        footer={tileSource === 'accent'
-                            ? t('settings.iconThemeTileAppHint', 'Every tile keeps its own app colour.')
-                            : t('settings.iconThemeTileFixedHint', 'One colour for every app.')}
+                    <Section
+                        header={t('settings.iconThemeShape', 'Shape')}
+                        action={darkAction(['radius'])}
+                        footer={footerFor(['radius'])}
                     >
-                        <div className="px-4 py-3">
-                            <SegmentedControl
-                                value={tileSource}
-                                onChange={setTileSource}
-                                options={[
-                                    { value: 'accent', label: t('settings.iconThemeAppColour', 'App Colour') },
-                                    { value: 'fixed',  label: t('settings.iconThemeOneColour', 'One Colour') },
-                                ]}
-                            />
-                        </div>
-                        {tileSource === 'fixed' && (
-                            <>
-                                <Hairline />
-                                <SwatchGrid value={tileColor} onChange={setTileColor} label={t('settings.iconThemeTile', 'Tile')} />
-                            </>
-                        )}
-                    </ListGroup>
-
-                    <ListGroup
-                        header={t('settings.iconThemeBlend', 'Blend')}
-                        footer={t('settings.iconThemeBlendHint', 'Pulls the tile toward a lighter or darker tone.')}
-                    >
-                        <div className="px-4 py-3">
-                            <SegmentedControl
-                                value={blendDir}
-                                onChange={setBlendDir}
-                                options={[
-                                    { value: 'light', label: t('settings.iconThemeLighter', 'Lighter') },
-                                    { value: 'dark',  label: t('settings.iconThemeDarker', 'Darker') },
-                                ]}
-                            />
-                        </div>
-                        <Hairline />
-                        <div className="flex items-center gap-4 px-4 py-2">
-                            <Slider
-                                className="flex-1"
-                                value={blend}
-                                onChange={setBlend}
-                                ariaLabel={t('settings.iconThemeBlend', 'Blend')}
-                            />
-                            <span className="w-9 shrink-0 text-right text-[15px] tabular-nums text-ios-gray">{blend}</span>
-                        </div>
-                    </ListGroup>
-
-                    <ListGroup header={t('settings.iconThemeSymbol', 'Symbol')}>
-                        <div className="px-4 py-3">
-                            <SegmentedControl
-                                value={glyphMode}
-                                onChange={setGlyphMode}
-                                options={[
-                                    { value: 'white',  label: t('settings.iconThemeWhite', 'White') },
-                                    { value: 'black',  label: t('settings.iconThemeBlack', 'Black') },
-                                    { value: 'accent', label: t('settings.iconThemeApp', 'App') },
-                                    { value: 'fixed',  label: t('settings.iconThemeColour', 'Colour') },
-                                ]}
-                            />
-                        </div>
-                        {glyphMode === 'fixed' && (
-                            <>
-                                <Hairline />
-                                <SwatchGrid value={glyphColor} onChange={setGlyphColor} label={t('settings.iconThemeSymbol', 'Symbol')} />
-                            </>
-                        )}
-                    </ListGroup>
-
-                    <ListGroup footer={t('settings.iconThemeGlossHint', 'The lit, glassy sheen the Glass theme uses.')}>
-                        <ListRow
-                            label={t('settings.iconThemeGloss', 'Gloss')}
-                            chevron={false}
-                            right={<div className="pointer-events-none -my-1"><Toggle on={gloss} /></div>}
-                            onPress={() => setGloss(!gloss)}
+                        <TilePicker
+                            value={radius}
+                            label={t('settings.iconThemeShape', 'Shape')}
+                            options={shapes.map(choice => ({
+                                value: choice.value,
+                                label: choice.label,
+                                icon:  SHAPE_SAMPLE.icon,
+                                look:  resolveDraftAppearance({ ...draft, radius: choice.value }, SHAPE_SAMPLE.id, SHAPE_SAMPLE.accent),
+                            }))}
+                            onChange={value => set('radius', value)}
                         />
-                    </ListGroup>
+                    </Section>
 
-                    <ListGroup>
+                    <Section
+                        header={t('settings.iconThemeTile', 'Tile Colour')}
+                        action={darkAction(['background'])}
+                        footer={footerFor(['background'], look.background.from === 'accent'
+                            ? t('settings.iconThemeTileAppHint', 'Every tile keeps its own app colour.')
+                            : t('settings.iconThemeTileFixedHint', 'One colour for every app.'))}
+                    >
+                        <RecipeEditor
+                            recipe={look.background}
+                            onChange={recipe => set('background', recipe)}
+                            label={t('settings.iconThemeTile', 'Tile Colour')}
+                        />
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeGradient', 'Gradient')}
+                        action={darkAction(['background2', 'angle'])}
+                        footer={footerFor(['background2', 'angle'], t('settings.iconThemeGradientHint', 'A second colour the tile fades into. The angle also turns the depth shading.'))}
+                    >
+                        <SwitchRow
+                            label={t('settings.iconThemeSecondColour', 'Second Colour')}
+                            on={look.background2 !== undefined}
+                            disabled={isLockedInDark(state, variant, 'background2')}
+                            divider
+                            onToggle={() => {
+                                if (look.background2) drop('background2');
+                                else set('background2', { from: 'accent', toward: DARKEN, amount: 0.55 });
+                            }}
+                        />
+                        {look.background2 && (
+                            <>
+                                <RecipeEditor
+                                    recipe={look.background2}
+                                    onChange={recipe => set('background2', recipe)}
+                                    label={t('settings.iconThemeSecondColour', 'Second Colour')}
+                                    title={t('settings.iconThemeColour', 'Colour')}
+                                />
+                                <Hairline />
+                            </>
+                        )}
+                        {(look.background2 !== undefined || look.depth === true) && (
+                            <SliderRow
+                                label={t('settings.iconThemeAngle', 'Angle')}
+                                value={look.angle ?? DEFAULT_ANGLE}
+                                display={`${Math.round(look.angle ?? DEFAULT_ANGLE)}°`}
+                                max={360}
+                                onChange={value => set('angle', value)}
+                            />
+                        )}
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeTexture', 'Texture')}
+                        action={darkAction(['texture'])}
+                        footer={footerFor(['texture'], t('settings.iconThemeTextureHint', 'A fine pattern printed over the tile.'))}
+                    >
+                        <TilePicker
+                            value={texture}
+                            label={t('settings.iconThemeTexture', 'Texture')}
+                            options={textureChoices().map(choice => ({
+                                value: choice.value,
+                                label: choice.label,
+                                icon:  TEXTURE_SAMPLE.icon,
+                                look:  resolveDraftAppearance({ ...draft, texture: choice.value }, TEXTURE_SAMPLE.id, TEXTURE_SAMPLE.accent),
+                            }))}
+                            onChange={value => set('texture', value)}
+                        />
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeSymbol', 'Symbol')}
+                        action={darkAction(['glyph', 'glyphScale', 'glyphWeight'])}
+                        footer={footerFor(['glyph', 'glyphScale', 'glyphWeight'])}
+                    >
+                        <RecipeEditor
+                            recipe={look.glyph}
+                            onChange={recipe => set('glyph', recipe)}
+                            label={t('settings.iconThemeSymbol', 'Symbol')}
+                            title={t('settings.iconThemeColour', 'Colour')}
+                            fallbackColour={WHITE}
+                        />
+                        <Hairline />
+                        <SliderRow
+                            label={t('settings.iconThemeSymbolSize', 'Size')}
+                            value={Math.round((look.glyphScale ?? 1) * 100)}
+                            display={`${Math.round((look.glyphScale ?? 1) * 100)}%`}
+                            min={60}
+                            max={140}
+                            step={2}
+                            divider
+                            onChange={value => set('glyphScale', value / 100)}
+                        />
+                        <SliderRow
+                            label={t('settings.iconThemeSymbolWeight', 'Thickness')}
+                            value={Math.round((look.glyphWeight ?? 1.9) * 10)}
+                            display={(Math.round((look.glyphWeight ?? 1.9) * 10) / 10).toFixed(1)}
+                            min={10}
+                            max={30}
+                            onChange={value => set('glyphWeight', value / 10)}
+                        />
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeDepth', 'Depth and Shine')}
+                        action={darkAction(['depth', 'gloss', 'bevel', 'glow'])}
+                        footer={footerFor(['depth', 'gloss', 'bevel', 'glow'], t('settings.iconThemeDepthHint', 'Depth lights the tile from the top. Gloss is the sheen over it.'))}
+                    >
+                        <SwitchRow
+                            label={t('settings.iconThemeDepthOn', 'Depth')}
+                            on={look.depth === true}
+                            disabled={isLockedInDark(state, variant, 'depth')}
+                            divider
+                            onToggle={() => { if (look.depth === true) drop('depth'); else set('depth', true); }}
+                        />
+                        <SliderRow
+                            label={t('settings.iconThemeGloss', 'Gloss')}
+                            value={gloss}
+                            display={gloss === 0 ? t('settings.iconThemeMixNone', 'None') : `${gloss}%`}
+                            divider
+                            onChange={value => set('gloss', value / 100)}
+                        />
+                        <SwitchRow
+                            label={t('settings.iconThemeBevel', 'Bevel')}
+                            sub={t('settings.iconThemeBevelSub', 'A lit top edge and a shaded bottom one')}
+                            on={look.bevel === true}
+                            disabled={isLockedInDark(state, variant, 'bevel')}
+                            divider
+                            onToggle={() => { if (look.bevel === true) drop('bevel'); else set('bevel', true); }}
+                        />
+                        <SliderRow
+                            label={t('settings.iconThemeGlow', 'Glow')}
+                            value={Math.round((look.glow ?? 0) * 100)}
+                            display={(look.glow ?? 0) === 0 ? t('settings.iconThemeMixNone', 'None') : `${Math.round((look.glow ?? 0) * 100)}%`}
+                            onChange={value => { if (value === 0) drop('glow'); else set('glow', value / 100); }}
+                        />
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeOutline', 'Outline')}
+                        action={darkAction(['border'])}
+                        footer={footerFor(['border'], t('settings.iconThemeOutlineHint', 'A line drawn just inside the tile edge.'))}
+                    >
+                        <SliderRow
+                            label={t('settings.iconThemeOutlineWidth', 'Thickness')}
+                            value={look.border?.width ?? 0}
+                            display={(look.border?.width ?? 0) === 0
+                                ? t('settings.iconThemeMixNone', 'None')
+                                : `${look.border?.width ?? 0}px`}
+                            max={4}
+                            step={0.5}
+                            divider={look.border !== undefined && look.border.width > 0}
+                            onChange={setBorderWidth}
+                        />
+                        {look.border && look.border.width > 0 && (
+                            <RecipeEditor
+                                recipe={look.border.color}
+                                onChange={recipe => set('border', { color: recipe, width: look.border?.width ?? 1 })}
+                                label={t('settings.iconThemeOutline', 'Outline')}
+                                title={t('settings.iconThemeColour', 'Colour')}
+                                fallbackColour={WHITE}
+                            />
+                        )}
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeShift', 'App Colours')}
+                        action={darkAction(['hue', 'saturation'])}
+                        footer={footerFor(['hue', 'saturation'], t('settings.iconThemeShiftHint', 'Turns and drains every app colour before the tile is drawn.'))}
+                    >
+                        <SliderRow
+                            label={t('settings.iconThemeHue', 'Hue')}
+                            value={look.hue ?? 0}
+                            display={`${look.hue ?? 0}°`}
+                            min={-180}
+                            max={180}
+                            divider
+                            onChange={value => { if (value === 0) drop('hue'); else set('hue', value); }}
+                        />
+                        <SliderRow
+                            label={t('settings.iconThemeSaturation', 'Saturation')}
+                            value={Math.round((look.saturation ?? 1) * 100)}
+                            display={`${Math.round((look.saturation ?? 1) * 100)}%`}
+                            max={200}
+                            step={5}
+                            divider={look.hue !== undefined || look.saturation !== undefined}
+                            onChange={value => { if (value === 100) drop('saturation'); else set('saturation', value / 100); }}
+                        />
+                        {(look.hue !== undefined || look.saturation !== undefined) && (
+                            <ActionRow
+                                label={t('settings.iconThemeShiftReset', 'Keep the Original Colours')}
+                                onPress={() => drop('hue', 'saturation')}
+                            />
+                        )}
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeLabels', 'Names')}
+                        action={darkAction(['label'])}
+                        footer={footerFor(['label'], t('settings.iconThemeLabelsHint', 'How this theme draws the app name under each icon.'))}
+                    >
+                        <SwitchRow
+                            label={t('settings.appNames', 'App Names')}
+                            sub={look.label?.show === undefined
+                                ? t('settings.iconThemeLabelFollow', 'Following the Home Screen setting')
+                                : undefined}
+                            on={look.label?.show ?? showAppNames}
+                            divider
+                            onToggle={() => setLabelStyle({ show: !(look.label?.show ?? showAppNames) })}
+                        />
+                        <SliderRow
+                            label={t('settings.iconThemeLabelWeight', 'Weight')}
+                            value={look.label?.weight ?? DEFAULT_WEIGHT}
+                            display={String(look.label?.weight ?? DEFAULT_WEIGHT)}
+                            min={100}
+                            max={900}
+                            step={100}
+                            divider
+                            onChange={value => setLabelStyle({ weight: value })}
+                        />
+                        <RecipeEditor
+                            recipe={look.label?.color ?? { from: 'fixed', color: WHITE }}
+                            onChange={recipe => setLabelStyle({ color: recipe })}
+                            label={t('settings.iconThemeLabelColour', 'Name Colour')}
+                            title={t('settings.iconThemeColour', 'Colour')}
+                            fallbackColour={WHITE}
+                        />
+                        {look.label !== undefined && (
+                            <>
+                                <Hairline />
+                                <ActionRow
+                                    label={t('settings.iconThemeLabelReset', 'Use the Standard Names')}
+                                    onPress={() => drop('label')}
+                                />
+                            </>
+                        )}
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeExtras', 'This Theme')}
+                        action={darkAction(['overrides', 'wallpaper'])}
+                        footer={footerFor(['overrides', 'wallpaper'])}
+                    >
+                        <ListRow
+                            label={t('settings.iconOverrides', 'App Icons')}
+                            sub={overrides === 0
+                                ? t('settings.iconOverridesNone', 'Every app follows the theme')
+                                : t('settings.iconOverridesCount', '{used} of {max} apps customised', { used: overrides, max: MAX_ICON_OVERRIDES })}
+                            divider
+                            onPress={() => setSub('overrides')}
+                        />
+                        <ListRow
+                            label={t('settings.iconThemeWallpaper', 'Paired Wallpaper')}
+                            sub={look.wallpaper
+                                ? t('settings.iconThemeWallpaperSet', 'Offered when this theme is applied')
+                                : t('settings.iconThemeWallpaperNone', 'No Paired Wallpaper')}
+                            chevron
+                            right={look.wallpaper ? (
+                                <img
+                                    src={resolveWallpaper(look.wallpaper)}
+                                    alt=""
+                                    draggable={false}
+                                    className="h-[34px] w-[20px] rounded-[4px] object-cover"
+                                />
+                            ) : undefined}
+                            onPress={() => setSub('wallpaper')}
+                        />
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeShare', 'Share')}
+                        footer={t('settings.iconThemeShareHint', 'A theme code carries the whole design, both variants included.')}
+                    >
+                        <ActionRow
+                            label={t('settings.iconThemeCode', 'Theme Code')}
+                            disabled={!valid}
+                            divider
+                            onPress={() => setSheet('code')}
+                        />
+                        <ActionRow
+                            label={t('settings.iconThemeAirShare', 'Send to a Nearby Phone')}
+                            disabled={!valid}
+                            onPress={() => setSheet('share')}
+                        />
+                    </Section>
+
+                    <Section>
                         <ActionRow
                             label={t('settings.iconThemeApply', 'Save and Use')}
                             disabled={!valid || busy}
@@ -298,10 +598,38 @@ export function IconThemeEditorPage({ existing, onBack }: {
                             disabled={!origin}
                             onPress={() => setConfirmDelete(true)}
                         />
-                    </ListGroup>
+                    </Section>
 
                 </div>
             </div>
+
+            {sheet === 'code' && (
+                <ThemeCodeSheet code={code} onClose={() => setSheet(null)} />
+            )}
+
+            {sheet === 'share' && (
+                <ShareSheet
+                    onClose={() => setSheet(null)}
+                    onShare={target => shareTheme(target.id, trimmed, code)}
+                >
+                    <ShareAction
+                        icon={<Copy className="h-[19px] w-[19px]" strokeWidth={2.2} />}
+                        label={t('settings.iconThemeCopyCode', 'Copy Code')}
+                        onClick={() => setSheet('code')}
+                    />
+                </ShareSheet>
+            )}
+
+            {pairing !== null && (
+                <AlertDialog
+                    title={t('settings.iconThemePairTitle', 'Use the Paired Wallpaper?')}
+                    message={t('settings.iconThemePairBody', 'This theme comes with a wallpaper. Your Home Screen can change to match it.')}
+                    confirmLabel={t('settings.iconThemePairConfirm', 'Use It')}
+                    cancelLabel={t('settings.iconThemePairSkip', 'Keep Mine')}
+                    onCancel={() => finishPairing(false)}
+                    onConfirm={() => finishPairing(true)}
+                />
+            )}
 
             {confirmDelete && (
                 <AlertDialog
@@ -324,83 +652,6 @@ export function IconThemeEditorPage({ existing, onBack }: {
                     onConfirm={() => setFailure(null)}
                 />
             )}
-        </div>
-    );
-}
-
-function Hairline() {
-    return <div className="h-[0.5px] bg-ios-gray4 dark:bg-control" />;
-}
-
-function ActionRow({ label, destructive = false, disabled = false, divider = false, right, onPress }: {
-    label:        string;
-    destructive?: boolean;
-    disabled?:    boolean;
-    divider?:     boolean;
-    right?:       React.ReactNode;
-    onPress:      () => void;
-}) {
-    return (
-        <button
-            type="button"
-            onClick={onPress}
-            disabled={disabled}
-            className={`relative flex w-full items-center px-4 py-3 text-[17px] font-normal active:bg-black/5 disabled:opacity-40 dark:active:bg-white/5 ${destructive ? 'text-ios-red' : 'text-ios-blue'}`}
-        >
-            <span className="flex-1 text-left">{label}</span>
-            {right}
-            {divider && <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[0.5px] bg-ios-gray4 dark:bg-control" />}
-        </button>
-    );
-}
-
-function SwatchGrid({ value, onChange, label }: { value: string; onChange: (v: string) => void; label: string }) {
-    return (
-        <div className="grid grid-cols-8 gap-2 px-4 py-4" role="group" aria-label={label}>
-            {SWATCHES.map(colour => {
-                const on = colour === value;
-                return (
-                    <button
-                        key={colour}
-                        type="button"
-                        aria-label={colour}
-                        aria-pressed={on}
-                        onClick={() => onChange(colour)}
-                        className="relative aspect-square w-full rounded-full active:opacity-70"
-                        style={{
-                            background: colour,
-                            boxShadow: on
-                                ? '0 0 0 2px #0a84ff, inset 0 0 0 0.5px rgba(0,0,0,0.20)'
-                                : 'inset 0 0 0 0.5px rgba(0,0,0,0.20)',
-                        }}
-                    />
-                );
-            })}
-        </div>
-    );
-}
-
-function PreviewTile({ background, glyph, gloss, app, size }: {
-    background: ColorRecipe;
-    glyph:      ColorRecipe;
-    gloss:      boolean;
-    app:        { icon: string; label: string; accent: string; id: string };
-    size:       number;
-}) {
-    const look = resolveDraftAppearance({ background, glyph, depth: gloss }, app.id, app.accent);
-    return (
-        <span
-            className="relative block shrink-0 overflow-hidden"
-            style={{
-                width:        size,
-                height:       size,
-                borderRadius: '27.6%',
-                boxShadow:    '0 2px 8px rgba(0,0,0,0.34), inset 0 0 0 0.5px rgba(255,255,255,0.12)',
-            }}
-        >
-            <span className="flex h-full w-full items-center justify-center" style={{ background: look.background }}>
-                <AppGlyph icon={app.icon} label={app.label} color={look.glyph} size={Math.round(size * 0.52)} />
-            </span>
-        </span>
+        </PushLayer>
     );
 }

--- a/web/src/apps/settings/appearance/IconThemePreview.tsx
+++ b/web/src/apps/settings/appearance/IconThemePreview.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from 'react';
+import { Pin } from 'lucide-react';
+import type { CSSProperties, ReactNode } from 'react';
+
+import { t } from '@/i18n';
+import { AppGlyph } from '@/shell/AppGlyphs';
+import { resolveWallpaper } from '@/shell/wallpapers';
+import { resolveDraftAppearance } from '@/stores/iconThemeStore';
+import type { IconAppearance, IconThemeDraft } from '@/stores/iconThemeStore';
+import { PREVIEW_APPS } from './iconThemeCatalog';
+import type { ThemeApp } from './iconThemeCatalog';
+
+const REFERENCE_TILE = 78;
+
+export function ThemeTile({ look, icon, label, size }: {
+    look:  IconAppearance;
+    icon:  string;
+    label: string;
+    size:  number;
+}) {
+    const shadow = look.boxShadow
+        ? `${look.boxShadow}, 0 2px 8px rgba(0,0,0,0.34)`
+        : '0 2px 8px rgba(0,0,0,0.34), inset 0 0 0 0.5px rgba(255,255,255,0.12)';
+
+    const style = {
+        width:        size,
+        height:       size,
+        borderRadius: `${look.radius * 100}%`,
+        boxShadow:    shadow,
+        '--sd-glyph-weight': String(look.glyphWeight),
+    } as CSSProperties;
+
+    return (
+        <span
+            className="relative block shrink-0 overflow-hidden [&_svg]:[stroke-width:var(--sd-glyph-weight)]"
+            style={style}
+        >
+            <span className="flex h-full w-full items-center justify-center" style={{ background: look.background }}>
+                <AppGlyph
+                    icon={icon}
+                    label={label}
+                    color={look.glyph}
+                    size={Math.max(8, Math.round(look.glyphSize * (size / REFERENCE_TILE)))}
+                />
+            </span>
+        </span>
+    );
+}
+
+function StagePin({ pinned, onToggle }: { pinned: boolean; onToggle: () => void }) {
+    return (
+        <button
+            type="button"
+            aria-pressed={pinned}
+            aria-label={pinned
+                ? t('settings.iconThemeUnpin', 'Unpin the preview')
+                : t('settings.iconThemePin', 'Pin the preview')}
+            onClick={onToggle}
+            className={`flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors active:scale-90 ${
+                pinned ? 'bg-white/90 ring-black/[0.06]' : 'bg-black/35 ring-white/[0.16]'
+            }`}
+            style={{ boxShadow: '0 1px 4px rgba(0,0,0,0.28)' }}
+        >
+            <Pin
+                className={`h-[15px] w-[15px] ${pinned ? 'text-ios-blue' : 'text-white'}`}
+                fill="none"
+                strokeWidth={2.2}
+            />
+        </button>
+    );
+}
+
+export function ThemeStage({ wallpaper, badge, hint, pinned = false, onTogglePin, children }: {
+    wallpaper:    string;
+    badge?:       ReactNode;
+    hint?:        string;
+    pinned?:      boolean;
+    onTogglePin?: () => void;
+    children:     ReactNode;
+}) {
+    const inner = useRef<HTMLDivElement>(null);
+    const [height, setHeight] = useState<number>();
+
+    useEffect(() => {
+        const el = inner.current;
+        if (!el || typeof ResizeObserver === 'undefined') return;
+        const observer = new ResizeObserver(() => setHeight(el.offsetHeight));
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
+    return (
+        <div className={pinned ? 'sticky top-0 z-20 bg-[#d4d4d4] dark:bg-base' : ''}>
+            <div className="mx-4">
+                <div
+                    className="relative overflow-hidden rounded-[14px]"
+                    style={{
+                        backgroundImage:    `url(${resolveWallpaper(wallpaper)})`,
+                        backgroundSize:     'cover',
+                        backgroundPosition: 'center',
+                        height,
+                        transition:         'height 240ms cubic-bezier(0.32,0.72,0,1)',
+                    }}
+                >
+                    <div ref={inner} className="bg-black/25">
+                        <div className="flex items-center justify-between gap-2 px-2.5 pt-2.5">
+                            <span className="min-w-0">{badge}</span>
+                            {onTogglePin && <StagePin pinned={pinned} onToggle={onTogglePin} />}
+                        </div>
+                        {children}
+                    </div>
+                </div>
+                {hint && !pinned && (
+                    <p className="px-3 pt-2 text-[13px] font-normal text-ios-gray">{hint}</p>
+                )}
+            </div>
+            {pinned && <div className="mt-2 h-[0.5px] bg-ios-gray4 dark:bg-control" />}
+        </div>
+    );
+}
+
+export function StageBadge({ label }: { label: string }) {
+    return (
+        <span className="block truncate rounded-full bg-black/55 px-2.5 py-[3px] text-[11px] font-semibold uppercase tracking-wider text-white">
+            {label}
+        </span>
+    );
+}
+
+export function ThemeTileLabel({ look, label, fallbackShow, small = false }: {
+    look:         IconAppearance;
+    label:        string;
+    fallbackShow: boolean;
+    small?:       boolean;
+}) {
+    if (!(look.labelShow ?? fallbackShow)) return null;
+    return (
+        <span
+            className={`w-full truncate px-0.5 text-center font-sf tracking-[0.01em] ${small ? 'text-[10px]' : 'text-[11px]'}`}
+            style={{
+                color:      look.labelColor ?? '#ffffff',
+                fontWeight: look.labelWeight ?? 600,
+                textShadow: '0 1px 3px rgba(0,0,0,0.95)',
+            }}
+        >
+            {label}
+        </span>
+    );
+}
+
+export function ThemePreviewGrid({ draft, showAppNames, pinned = false, apps = PREVIEW_APPS }: {
+    draft:        IconThemeDraft;
+    showAppNames: boolean;
+    pinned?:      boolean;
+    apps?:        ThemeApp[];
+}) {
+    const shown = pinned ? apps.slice(0, 5) : apps;
+    const size  = pinned ? 44 : 66;
+
+    return (
+        <div className={pinned
+            ? 'flex items-start justify-around px-3 pb-3 pt-2'
+            : 'grid grid-cols-4 gap-y-5 px-3 pb-6 pt-3'}
+        >
+            {shown.map(app => {
+                const look = resolveDraftAppearance(draft, app.id, app.accent);
+                return (
+                    <div
+                        key={app.id}
+                        className="flex flex-col items-center gap-[5px]"
+                        style={pinned ? { width: 62 } : undefined}
+                    >
+                        <ThemeTile look={look} icon={look.icon ?? app.icon} label={app.label} size={size} />
+                        <ThemeTileLabel look={look} label={app.label} fallbackShow={showAppNames} small={pinned} />
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/web/src/apps/settings/appearance/IconThemeStartPage.tsx
+++ b/web/src/apps/settings/appearance/IconThemeStartPage.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { useIosPush } from '@/hooks/useIosPush';
+import { decodeThemeCode } from '@/lib/themeCode';
+import {
+    ICON_THEMES, resolveDraftAppearance, resolveIconAppearance, useCustomIconThemes,
+} from '@/stores/iconThemeStore';
+import type { IconThemeDraft, IconThemeId } from '@/stores/iconThemeStore';
+import { NavBar } from '@/ui/NavBar';
+import { PromptDialog } from '@/ui/PromptDialog';
+import { SWATCH_PREVIEW_APPS, themePresets } from './iconThemeCatalog';
+import { draftFromBuiltin, draftFromTheme, seedDraft } from './iconThemeDraft';
+import type { DraftState } from './iconThemeDraft';
+import { Section } from './IconThemeControls';
+import { ThemeTile } from './IconThemePreview';
+
+const NAME_MAX = 24;
+
+function copyName(name: string): string {
+    const suffix = t('settings.iconThemeCopySuffix', 'Copy');
+    const joined = `${name} ${suffix}`;
+    if (joined.length <= NAME_MAX) return joined;
+    return `${name.slice(0, Math.max(1, NAME_MAX - suffix.length - 1)).trimEnd()} ${suffix}`;
+}
+
+export function IconThemeStartPage({ onStart, onBack }: {
+    onStart: (seed: DraftState) => void;
+    onBack:  () => void;
+}) {
+    const { goBack, pageStyle } = useIosPush(onBack);
+    const custom = useCustomIconThemes();
+    const [importing, setImporting] = useState(false);
+
+    const presets  = themePresets();
+    const builtins = ICON_THEMES.filter(def => def.art === 'glyph');
+
+    return (
+        <div className="absolute inset-0 z-30 flex flex-col bg-[#d4d4d4] text-black dark:bg-base dark:text-white" style={pageStyle}>
+            <div className="h-11 shrink-0" aria-hidden />
+
+            <NavBar
+                backLabel={t('settings.appIcons', 'App Icons')}
+                onBack={goBack}
+                title={t('settings.iconThemeNew', 'New Theme')}
+                hairline
+            />
+
+            <div className="flex-1 overflow-y-auto no-scrollbar">
+                <div className="mt-6 flex flex-col gap-6 pb-12">
+
+                    <Section
+                        header={t('settings.iconThemeStartPresets', 'Start With')}
+                        footer={t('settings.iconThemeStartPresetsHint', 'Every part of a starting point can be changed afterwards.')}
+                    >
+                        {presets.map((preset, i) => (
+                            <SeedRow
+                                key={preset.id}
+                                label={preset.label}
+                                hint={preset.hint}
+                                draft={preset.seed}
+                                divider={i < presets.length - 1}
+                                onPress={() => onStart(seedDraft(preset.label, preset.seed))}
+                            />
+                        ))}
+                    </Section>
+
+                    <Section
+                        header={t('settings.iconThemeStartBuiltin', 'From a Built-in Theme')}
+                        footer={t('settings.iconThemeStartBuiltinHint', 'Takes a copy. The built-in theme itself is never changed.')}
+                    >
+                        {builtins.map((def, i) => (
+                            <SeedRow
+                                key={def.id}
+                                label={def.label()}
+                                hint={def.hint()}
+                                theme={def.id}
+                                divider={i < builtins.length - 1}
+                                onPress={() => onStart(draftFromBuiltin(def))}
+                            />
+                        ))}
+                    </Section>
+
+                    {custom.length > 0 && (
+                        <Section header={t('settings.iconThemeStartMine', 'Duplicate One of Mine')}>
+                            {custom.map((def, i) => (
+                                <SeedRow
+                                    key={def.id}
+                                    label={def.name}
+                                    hint={t('settings.iconThemeStartDuplicate', 'Start from a copy of this theme')}
+                                    theme={def.id}
+                                    divider={i < custom.length - 1}
+                                    onPress={() => {
+                                        const seed = draftFromTheme(def);
+                                        onStart({ ...seed, name: copyName(def.name) });
+                                    }}
+                                />
+                            ))}
+                        </Section>
+                    )}
+
+                    <Section footer={t('settings.iconThemeImportHint', 'A theme code starts with SDTHEME1. Importing always adds a new theme.')}>
+                        <button
+                            type="button"
+                            onClick={() => setImporting(true)}
+                            className="relative flex w-full items-center px-4 py-3 text-left active:bg-black/5 dark:active:bg-white/5"
+                        >
+                            <span className="flex-1 text-[17px] font-normal text-ios-blue">
+                                {t('settings.iconThemePasteCode', 'Paste a Theme Code')}
+                            </span>
+                            <ChevronRight className="h-[17px] w-[17px] shrink-0 text-ios-gray3" strokeWidth={2.5} />
+                        </button>
+                    </Section>
+
+                </div>
+            </div>
+
+            {importing && (
+                <PromptDialog
+                    title={t('settings.iconThemeImport', 'Import a Theme')}
+                    message={t('settings.iconThemeImportBody', 'Paste the code someone shared with you.')}
+                    placeholder="SDTHEME1:"
+                    confirmLabel={t('settings.iconThemeImportAction', 'Import')}
+                    onCancel={() => setImporting(false)}
+                    onConfirm={value => {
+                        const theme = decodeThemeCode(value);
+                        if (!theme) return t('settings.iconThemeImportBad', 'That code could not be read. Check it was copied in full.');
+                        setImporting(false);
+                        onStart(draftFromTheme(theme));
+                        return undefined;
+                    }}
+                />
+            )}
+        </div>
+    );
+}
+
+function SeedRow({ label, hint, draft, theme, divider, onPress }: {
+    label:   string;
+    hint:    string;
+    draft?:  IconThemeDraft;
+    theme?:  IconThemeId;
+    divider: boolean;
+    onPress: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onPress}
+            className="relative flex w-full items-center px-4 py-3 text-left active:bg-black/5 dark:active:bg-white/5"
+        >
+            <span className="mr-3 flex shrink-0 gap-[3px]">
+                {SWATCH_PREVIEW_APPS.map(app => {
+                    const look = draft
+                        ? resolveDraftAppearance(draft, app.id, app.accent)
+                        : resolveIconAppearance(theme ?? 'default', app.id, app.accent);
+                    return (
+                        <ThemeTile key={app.id} look={look} icon={look.icon ?? app.icon} label={app.label} size={26} />
+                    );
+                })}
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className="block truncate text-[17px] font-normal text-black dark:text-white">{label}</span>
+                <span className="block truncate text-[13px] text-ios-gray">{hint}</span>
+            </span>
+            <ChevronRight className="h-[17px] w-[17px] shrink-0 text-ios-gray3" strokeWidth={2.5} />
+            {divider && (
+                <div
+                    className="pointer-events-none absolute inset-x-0 bottom-0 bg-ios-gray4 dark:bg-control"
+                    style={{ height: '0.5px' }}
+                />
+            )}
+        </button>
+    );
+}

--- a/web/src/apps/settings/appearance/ThemeCodeSheet.tsx
+++ b/web/src/apps/settings/appearance/ThemeCodeSheet.tsx
@@ -1,0 +1,43 @@
+import { Check, Copy } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { useCopied } from '@/hooks/useCopied';
+import { Sheet } from '@/ui/Sheet';
+
+export function ThemeCodeSheet({ code, onClose }: { code: string; onClose: () => void }) {
+    const [copied, copy] = useCopied();
+
+    return (
+        <Sheet
+            onClose={onClose}
+            fit="content"
+            title={t('settings.iconThemeCode', 'Theme Code')}
+            className="bg-[#d4d4d4] dark:bg-base"
+        >
+            {() => (
+                <div className="px-4 pb-2 pt-1">
+                    <p className="pb-4 text-[13px] leading-snug text-ios-gray">
+                        {t('settings.iconThemeCodeHint', 'Anyone can paste this code into App Icons to get a copy of this theme. Importing never overwrites a theme they already have.')}
+                    </p>
+
+                    <div className="max-h-[168px] overflow-y-auto rounded-[12px] bg-[#e5e5e5] px-3 py-3 no-scrollbar dark:bg-surface">
+                        <code className="block break-all font-mono text-[12px] leading-[1.45] text-black dark:text-white">
+                            {code}
+                        </code>
+                    </div>
+
+                    <button
+                        type="button"
+                        onClick={() => copy(code)}
+                        className="mt-4 flex w-full items-center justify-center gap-2 rounded-[12px] bg-ios-blue py-3 text-[17px] font-semibold text-white active:opacity-80"
+                    >
+                        {copied
+                            ? <Check className="h-[18px] w-[18px]" strokeWidth={2.5} />
+                            : <Copy className="h-[17px] w-[17px]" strokeWidth={2.2} />}
+                        {copied ? t('common.copied', 'Copied') : t('settings.iconThemeCopyCode', 'Copy Code')}
+                    </button>
+                </div>
+            )}
+        </Sheet>
+    );
+}

--- a/web/src/apps/settings/appearance/ThemeWallpaperPage.tsx
+++ b/web/src/apps/settings/appearance/ThemeWallpaperPage.tsx
@@ -1,0 +1,119 @@
+import { Check } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { useIosPush } from '@/hooks/useIosPush';
+import { PHOTO_SOURCES } from '@/apps/photos/data';
+import { resolveWallpaper, wallpaperKey } from '@/shell/wallpapers';
+import { useTheme } from '@/stores/themeStore';
+import type { IconThemeDraft } from '@/stores/iconThemeStore';
+import { NavBar } from '@/ui/NavBar';
+import { ListRow } from '@/ui/ListGroup';
+import { Section } from './IconThemeControls';
+import { ThemePreviewGrid, ThemeStage } from './IconThemePreview';
+
+const BUILT_IN = ['homescreen.jpg', 'lockscreen.jpg', ...PHOTO_SOURCES.map((_, i) => `background${i + 3}.jpg`)];
+
+export function ThemeWallpaperPage({ draft, showAppNames, wallpaper, pinned, onTogglePin, onChange, onBack }: {
+    draft:        IconThemeDraft;
+    showAppNames: boolean;
+    wallpaper:    string | undefined;
+    pinned:       boolean;
+    onTogglePin:  () => void;
+    onChange:     (next: string | undefined) => void;
+    onBack:       () => void;
+}) {
+    const { goBack, pageStyle } = useIosPush(onBack);
+    const { wallpaperHome, customWallpapers } = useTheme('wallpaperHome', 'customWallpapers');
+
+    const shown = wallpaper ?? wallpaperHome;
+
+    function isOn(src: string): boolean {
+        return wallpaper !== undefined && resolveWallpaper(wallpaper) === src;
+    }
+
+    return (
+        <div className="absolute inset-0 z-30 flex flex-col bg-[#d4d4d4] text-black dark:bg-base dark:text-white" style={pageStyle}>
+            <div className="h-11 shrink-0" aria-hidden />
+
+            <NavBar
+                backLabel={t('settings.iconThemeEditBack', 'Theme')}
+                onBack={goBack}
+                title={t('settings.iconThemeWallpaper', 'Wallpaper')}
+                hairline
+            />
+
+            <div className="flex-1 overflow-y-auto no-scrollbar">
+                <div className="mt-6 flex flex-col gap-6 pb-12">
+
+                    <ThemeStage
+                        wallpaper={shown}
+                        pinned={pinned}
+                        onTogglePin={onTogglePin}
+                        hint={wallpaper === undefined
+                            ? t('settings.iconThemeWallpaperNoneHint', 'Shown over your current wallpaper.')
+                            : t('settings.iconThemeWallpaperPairHint', 'Offered whenever this theme is applied.')}
+                    >
+                        <ThemePreviewGrid draft={draft} showAppNames={showAppNames} pinned={pinned} />
+                    </ThemeStage>
+
+                    <Section footer={t('settings.iconThemeWallpaperFooter', 'A paired wallpaper is never forced. Applying the theme asks first.')}>
+                        <ListRow
+                            label={t('settings.iconThemeWallpaperNone', 'No Paired Wallpaper')}
+                            selected={wallpaper === undefined}
+                            onPress={() => onChange(undefined)}
+                        />
+                    </Section>
+
+                    {customWallpapers.length > 0 && (
+                        <Section header={t('settings.wallpaperMine', 'My Wallpapers')}>
+                            <WallGrid
+                                sources={customWallpapers}
+                                isOn={isOn}
+                                onPick={src => onChange(wallpaperKey(src))}
+                            />
+                        </Section>
+                    )}
+
+                    <Section header={t('settings.wallpaperSuggested', 'Suggested Wallpapers')}>
+                        <WallGrid
+                            sources={BUILT_IN.map(resolveWallpaper)}
+                            isOn={isOn}
+                            onPick={src => onChange(wallpaperKey(src))}
+                        />
+                    </Section>
+
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function WallGrid({ sources, isOn, onPick }: {
+    sources: readonly string[];
+    isOn:    (src: string) => boolean;
+    onPick:  (src: string) => void;
+}) {
+    return (
+        <div className="grid grid-cols-3 gap-2 px-4 py-4">
+            {sources.map(src => {
+                const on = isOn(src);
+                return (
+                    <button
+                        key={src}
+                        type="button"
+                        onClick={() => onPick(src)}
+                        className="relative block w-full overflow-hidden rounded-[10px] active:opacity-80"
+                        style={{ boxShadow: on ? '0 0 0 3px #0a84ff' : '0 1px 4px rgba(0,0,0,0.18)' }}
+                    >
+                        <img src={src} alt="" draggable={false} className="block aspect-[9/16] w-full object-cover" />
+                        {on && (
+                            <span className="absolute right-1.5 top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-ios-blue">
+                                <Check className="h-[11px] w-[11px] text-white" strokeWidth={3} />
+                            </span>
+                        )}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/web/src/apps/settings/appearance/iconThemeCatalog.ts
+++ b/web/src/apps/settings/appearance/iconThemeCatalog.ts
@@ -1,0 +1,197 @@
+import { t } from '@/i18n';
+import type { IconTexture, IconThemeDraft } from '@/stores/iconThemeStore';
+
+export interface ThemeApp {
+    id:     string;
+    label:  string;
+    icon:   string;
+    accent: string;
+}
+
+export const THEME_APPS: ThemeApp[] = [
+    { id: 'phone',       label: 'Phone',        icon: 'phone',       accent: '#34c759' },
+    { id: 'messages',    label: 'Messages',     icon: 'messages',    accent: '#34c759' },
+    { id: 'mail',        label: 'Mail',         icon: 'mail',        accent: '#0a84ff' },
+    { id: 'maps',        label: 'Maps',         icon: 'maps',        accent: '#f0c43a' },
+    { id: 'compass',     label: 'Compass',      icon: 'compass',     accent: '#1c1c1e' },
+    { id: 'camera',      label: 'Camera',       icon: 'camera',      accent: '#1c1c1e' },
+    { id: 'photos',      label: 'Photos',       icon: 'photos',      accent: '#ffffff' },
+    { id: 'music',       label: 'Music',        icon: 'music',       accent: '#fa233b' },
+    { id: 'weather',     label: 'Weather',      icon: 'weather',     accent: '#5ac8fa' },
+    { id: 'clock',       label: 'Clock',        icon: 'clock',       accent: '#1c1c1e' },
+    { id: 'calendar',    label: 'Calendar',     icon: 'calendar',    accent: '#ffffff' },
+    { id: 'notes',       label: 'Notes',        icon: 'notes',       accent: '#fec547' },
+    { id: 'voicememos',  label: 'Voice Memos',  icon: 'voicememos',  accent: '#ff3b30' },
+    { id: 'bank',        label: 'Bank',         icon: 'bank',        accent: '#00b894' },
+    { id: 'health',      label: 'Health',       icon: 'health',      accent: '#ff2d55' },
+    { id: 'documents',   label: 'Files',        icon: 'documents',   accent: '#3478f6' },
+    { id: 'groups',      label: 'Groups',       icon: 'groups',      accent: '#6c63ff' },
+    { id: 'birdy',       label: 'Squawk',       icon: 'birdy',       accent: '#1d9bf0' },
+    { id: 'services',    label: 'Services',     icon: 'services',    accent: '#16b8a6' },
+    { id: 'pages',       label: 'Pages',        icon: 'pages',       accent: '#fbc02d' },
+    { id: 'review',      label: 'Review',       icon: 'review',      accent: '#e03131' },
+    { id: 'marketplace', label: 'Marketplace',  icon: 'marketplace', accent: '#0a84ff' },
+    { id: 'darkchat',    label: 'Dark Chat',    icon: 'darkchat',    accent: '#1c1c1e' },
+    { id: 'cherry',      label: 'Cherry',       icon: 'cherry',      accent: '#f0285a' },
+    { id: 'photogram',   label: 'Photogram',    icon: 'photogram',   accent: '#d62976' },
+    { id: 'garages',     label: 'Garages',      icon: 'garages',     accent: '#6e5cf2' },
+    { id: 'homes',       label: 'Homes',        icon: 'homes',       accent: '#12b866' },
+    { id: 'ryde',        label: 'Ryde',         icon: 'ryde',        accent: '#1c1c1e' },
+    { id: 'radio',       label: 'Radio',        icon: 'radio',       accent: '#30b0c7' },
+    { id: 'stocks',      label: 'Stocks',       icon: 'stocks',      accent: '#16c784' },
+    { id: 'settings',    label: 'Settings',     icon: 'settings',    accent: '#8e8e93' },
+    { id: 'appstore',    label: 'App Store',    icon: 'appstore',    accent: '#0a84ff' },
+    { id: 'calculator',  label: 'Calculator',   icon: 'calculator',  accent: '#333335' },
+    { id: 'passwords',   label: 'Passwords',    icon: 'passwords',   accent: '#1c1c1e' },
+    { id: 'cookie',      label: 'Cookie',       icon: 'cookie',      accent: '#c77d2e' },
+    { id: 'wordle',      label: 'Wordle',       icon: 'wordle',      accent: '#6aaa64' },
+    { id: 'flappy',      label: 'Flappy',       icon: 'flappy',      accent: '#4ec0ca' },
+    { id: 'blocks',      label: 'Blocks',       icon: 'blocks',      accent: '#7c4dff' },
+    { id: 'blackjack',   label: 'Blackjack',    icon: 'blackjack',   accent: '#157347' },
+    { id: 'climber',     label: 'Climber',      icon: 'climber',     accent: '#8bc34a' },
+    { id: 'railrunner',  label: 'Rail Runner',  icon: 'railrunner',  accent: '#3c5290' },
+    { id: 'connectfour', label: 'Connect 4',    icon: 'connectfour', accent: '#1e66d0' },
+    { id: 'chess',       label: 'Chess',        icon: 'chess',       accent: '#3b3b3b' },
+    { id: 'battleship',  label: 'Battleship',   icon: 'battleship',  accent: '#17a0b5' },
+    { id: 'vibez',       label: 'Vibez',        icon: 'vibez',       accent: '#a855f7' },
+    { id: 'weazelnews',  label: 'Weazel News',  icon: 'weazelnews',  accent: '#c8102e' },
+    { id: 'streaks',     label: 'Streaks',      icon: 'streaks',     accent: '#ff7a1a' },
+].sort((a, b) => a.label.localeCompare(b.label));
+
+const PREVIEW_IDS = ['phone', 'mail', 'maps', 'music', 'weather', 'notes', 'photogram', 'settings'];
+
+export const PREVIEW_APPS: ThemeApp[] = PREVIEW_IDS
+    .map(id => THEME_APPS.find(app => app.id === id))
+    .filter((app): app is ThemeApp => app !== undefined);
+
+export const SWATCH_PREVIEW_APPS: ThemeApp[] = PREVIEW_APPS.slice(0, 3);
+
+export const GLYPH_NAMES: string[] = [
+    'appstore', 'bank', 'battleship', 'birdy', 'blackjack', 'blocks', 'calculator', 'calendar',
+    'camera', 'cherry', 'chess', 'climber', 'clock', 'compass', 'connectfour', 'cookie',
+    'darkchat', 'documents', 'findfriends', 'flappy', 'garages', 'groups', 'health', 'homes',
+    'mail', 'maps', 'marketplace', 'messages', 'music', 'notes', 'pages', 'passwords',
+    'phone', 'photogram', 'photos', 'radio', 'railrunner', 'review', 'ryde', 'safari',
+    'services', 'settings', 'stocks', 'streaks', 'vibez', 'voicememos', 'wallet', 'weather',
+    'weazelnews', 'wordle',
+];
+
+const GLYPH_LABELS: Record<string, string> = {
+    findfriends: 'Find Friends',
+    safari:      'Safari',
+    wallet:      'Wallet',
+};
+
+export function glyphLabel(name: string): string {
+    const known = THEME_APPS.find(app => app.icon === name);
+    if (known) return known.label;
+    return GLYPH_LABELS[name] ?? name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+export const APP_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+export const RADIUS_SQUIRCLE = 0.276;
+
+export function radiusChoices(): { value: number; label: string }[] {
+    return [
+        { value: RADIUS_SQUIRCLE, label: t('settings.iconShapeSquircle', 'Squircle') },
+        { value: 0.14,            label: t('settings.iconShapeRounded', 'Rounded') },
+        { value: 0.5,             label: t('settings.iconShapeCircle', 'Circle') },
+        { value: 0.04,            label: t('settings.iconShapeSquared', 'Squared') },
+    ];
+}
+
+export function textureChoices(): { value: IconTexture; label: string }[] {
+    return [
+        { value: 'none',    label: t('settings.iconTextureNone', 'None') },
+        { value: 'noise',   label: t('settings.iconTextureNoise', 'Grain') },
+        { value: 'dots',    label: t('settings.iconTextureDots', 'Dots') },
+        { value: 'stripes', label: t('settings.iconTextureStripes', 'Lines') },
+    ];
+}
+
+export const SWATCHES = [
+    '#ffffff', '#f4f4f6', '#d1d1d6', '#8e8e93', '#48484a', '#26262a', '#0a0a0c', '#000000',
+    '#ff453a', '#ff6482', '#ff9f0a', '#ffd60a', '#e8dcc4', '#ac8e68', '#8b5e3c', '#5c3d2e',
+    '#34c759', '#00c7be', '#5ac8fa', '#0a84ff', '#5e5ce6', '#bf5af2', '#39414f', '#1f3a5f',
+];
+
+export interface ThemePreset {
+    id:    string;
+    label: string;
+    hint:  string;
+    seed:  IconThemeDraft;
+}
+
+export function themePresets(): ThemePreset[] {
+    return [
+        {
+            id:    'flat',
+            label: t('settings.iconPresetFlat', 'Flat'),
+            hint:  t('settings.iconPresetFlatHint', 'A plain tile in each app colour'),
+            seed:  {
+                background: { from: 'accent' },
+                glyph:      { from: 'fixed', color: '#ffffff' },
+            },
+        },
+        {
+            id:    'glass',
+            label: t('settings.iconPresetGlass', 'Glass'),
+            hint:  t('settings.iconPresetGlassHint', 'Lit and glossy, the classic look'),
+            seed:  {
+                background: { from: 'accent' },
+                glyph:      { from: 'fixed', color: '#ffffff' },
+                depth:      true,
+            },
+        },
+        {
+            id:    'gradient',
+            label: t('settings.iconPresetGradient', 'Gradient'),
+            hint:  t('settings.iconPresetGradientHint', 'Each colour fading into shadow'),
+            seed:  {
+                background:  { from: 'accent' },
+                background2: { from: 'accent', toward: '#0f0f12', amount: 0.55 },
+                angle:       160,
+                gloss:       0.35,
+                glyph:       { from: 'fixed', color: '#ffffff' },
+            },
+        },
+        {
+            id:    'neon',
+            label: t('settings.iconPresetNeon', 'Neon'),
+            hint:  t('settings.iconPresetNeonHint', 'Black tiles with a lit outline'),
+            seed:  {
+                background: { from: 'fixed', color: '#0a0a0c' },
+                glyph:      { from: 'accent', toward: '#ffffff', amount: 0.24 },
+                border:     { color: { from: 'accent' }, width: 1 },
+                glow:       0.7,
+                saturation: 1.3,
+            },
+        },
+        {
+            id:    'paper',
+            label: t('settings.iconPresetPaper', 'Paper'),
+            hint:  t('settings.iconPresetPaperHint', 'Off-white cards with a printed grain'),
+            seed:  {
+                background: { from: 'fixed', color: '#f4f4f6' },
+                glyph:      { from: 'accent', toward: '#1b1b1f', amount: 0.36 },
+                radius:     0.14,
+                texture:    'dots',
+                border:     { color: { from: 'fixed', color: '#d1d1d6' }, width: 1 },
+                glyphScale: 0.92,
+            },
+        },
+        {
+            id:    'ink',
+            label: t('settings.iconPresetInk', 'Ink'),
+            hint:  t('settings.iconPresetInkHint', 'Every app colour drained to graphite'),
+            seed:  {
+                background:  { from: 'accent', toward: '#141418', amount: 0.5 },
+                glyph:       { from: 'fixed', color: '#f5f5f7' },
+                saturation:  0,
+                radius:      0.04,
+                glyphWeight: 2.2,
+            },
+        },
+    ];
+}

--- a/web/src/apps/settings/appearance/iconThemeDraft.ts
+++ b/web/src/apps/settings/appearance/iconThemeDraft.ts
@@ -1,0 +1,108 @@
+import type {
+    ColorRecipe, CustomIconTheme, CustomIconThemeId, IconThemeDef, IconThemeDraft, IconThemeVariant,
+} from '@/stores/iconThemeStore';
+
+export type BaseLook = IconThemeVariant & { background: ColorRecipe; glyph: ColorRecipe };
+
+export type VariantKey = 'base' | 'dark';
+
+export type TraitKey = keyof IconThemeVariant;
+
+export interface DraftState {
+    name: string;
+    base: BaseLook;
+    dark: IconThemeVariant | null;
+}
+
+export const LIGHTEN = '#ffffff';
+export const DARKEN  = '#0f0f12';
+export const WHITE   = '#ffffff';
+
+const NEGATION_LOCKED: TraitKey[] = ['background2', 'depth', 'bevel'];
+
+export function seedDraft(name: string, seed: IconThemeDraft): DraftState {
+    const { dark, ...base } = seed;
+    return { name, base: { ...base }, dark: dark ? { ...dark } : null };
+}
+
+export function draftFromTheme(theme: CustomIconTheme): DraftState {
+    const { id, name, dark, ...base } = theme;
+    void id;
+    return { name, base: { ...base }, dark: dark ? { ...dark } : null };
+}
+
+export function draftFromBuiltin(def: IconThemeDef): DraftState {
+    const { id, art, label, hint, minContrast, dark, ...base } = def;
+    void id;
+    void art;
+    void hint;
+    void minContrast;
+    return { name: label(), base: { ...base }, dark: dark ? { ...dark } : null };
+}
+
+export function toTheme(id: CustomIconThemeId, state: DraftState): CustomIconTheme {
+    const dark = state.dark && Object.keys(state.dark).length > 0 ? { ...state.dark } : undefined;
+    return { id, name: state.name.trim(), ...state.base, ...(dark ? { dark } : {}) };
+}
+
+export function activeLook(state: DraftState, variant: VariantKey): BaseLook {
+    if (variant === 'base' || !state.dark) return state.base;
+    const merged = { ...state.base, ...state.dark };
+    return {
+        ...merged,
+        background: merged.background ?? state.base.background,
+        glyph:      merged.glyph      ?? state.base.glyph,
+    };
+}
+
+export function previewDraft(state: DraftState, variant: VariantKey): IconThemeDraft {
+    return activeLook(state, variant);
+}
+
+export function writeTrait<K extends TraitKey>(
+    state: DraftState, variant: VariantKey, key: K, value: NonNullable<IconThemeVariant[K]>,
+): DraftState {
+    if (variant === 'dark') {
+        const dark = { ...(state.dark ?? {}) } as Record<string, unknown>;
+        dark[key] = value;
+        return { ...state, dark: dark as IconThemeVariant };
+    }
+    const base = { ...state.base } as Record<string, unknown>;
+    base[key] = value;
+    return { ...state, base: base as unknown as BaseLook };
+}
+
+export function dropTraits(state: DraftState, variant: VariantKey, keys: TraitKey[]): DraftState {
+    if (variant === 'dark') {
+        if (!state.dark) return state;
+        const dark = { ...state.dark } as Record<string, unknown>;
+        for (const key of keys) delete dark[key];
+        const left = Object.keys(dark).length > 0 ? dark as IconThemeVariant : null;
+        return { ...state, dark: left };
+    }
+    const base = { ...state.base } as Record<string, unknown>;
+    for (const key of keys) {
+        if (key === 'background' || key === 'glyph') continue;
+        delete base[key];
+    }
+    return { ...state, base: base as unknown as BaseLook };
+}
+
+export function hasOwnTraits(state: DraftState, variant: VariantKey, keys: TraitKey[]): boolean {
+    if (variant === 'base') return false;
+    if (!state.dark) return false;
+    const dark = state.dark;
+    return keys.some(key => dark[key] !== undefined);
+}
+
+export function isLockedInDark(state: DraftState, variant: VariantKey, key: TraitKey): boolean {
+    if (variant === 'base') return false;
+    if (!NEGATION_LOCKED.includes(key)) return false;
+    const inherited = state.base[key];
+    return inherited !== undefined && inherited !== false;
+}
+
+export function mixAmount(recipe: ColorRecipe): number {
+    if (recipe.toward === undefined || recipe.amount === undefined) return 0;
+    return Math.round(recipe.amount * 100);
+}

--- a/web/src/apps/settings/data.ts
+++ b/web/src/apps/settings/data.ts
@@ -55,6 +55,7 @@ export function getSettingsGroups(): SettingsGroup[] {
                 { id: 'general',      icon: 'Settings2',   iconBg: '#8e8e93', label: t('settings.general', 'General'),              subtitle: t('settings.generalSub', 'Device info, storage and language') },
                 { id: 'display',      icon: 'Sun',         iconBg: '#0a84ff', label: t('settings.displayBrightness', 'Display & Brightness'),  subtitle: t('settings.displayBrightnessSub', 'Wallpaper, theme and brightness') },
                 { id: 'wallpaper',    icon: 'Image',       iconBg: '#64d2ff', label: t('settings.wallpaper', 'Wallpaper'),             subtitle: t('settings.wallpaperSub', 'Wallpaper & background') },
+                { id: 'app-icons',    icon: 'LayoutGrid',  iconBg: '#5e5ce6', label: t('settings.appIcons', 'App Icons'),              subtitle: t('settings.appIconsSub', 'Icon theme and Home Screen names') },
                 { id: 'face-unlock',  icon: 'Fingerprint', iconBg: '#34c759', label: t('settings.faceUnlockPasscode', 'Face Unlock & Passcode'), subtitle: t('settings.faceUnlockPasscodeSub', 'Lock and unlock options') },
                 { id: 'battery',      icon: 'BatteryFull', iconBg: '#34c759', label: t('settings.battery', 'Battery'),               subtitle: t('settings.batterySub', 'Manage battery usage') },
                 { id: 'privacy',      icon: 'ShieldCheck', iconBg: '#0a84ff', label: t('settings.privacySecurity', 'Privacy & Security'),    subtitle: t('settings.privacySecuritySub', 'Control app permissions') },

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -78,6 +78,13 @@ export interface AppDef {
     wifi?: string;
 }
 
+export interface CustomWidgetDef {
+    id:    string;
+    name:  string;
+    ui:    string;
+    sizes: ('sm' | 'md' | 'lg')[];
+}
+
 export interface CustomAppDef {
     id:          string;
     name:        string;
@@ -95,6 +102,7 @@ export interface CustomAppDef {
     landscape?:  boolean;
     /** Wi-Fi network id (configs/wifi.lua) the phone must be joined to before this app downloads. */
     wifi?:       string;
+    widgets?:    CustomWidgetDef[];
     resource:    string;
 }
 

--- a/web/src/lib/themeCode.ts
+++ b/web/src/lib/themeCode.ts
@@ -1,0 +1,47 @@
+import { newCustomIconThemeId, sanitizeCustomIconTheme } from '@/stores/iconThemeStore';
+import type { CustomIconTheme } from '@/stores/iconThemeStore';
+
+const PREFIX = 'SDTHEME1:';
+const MAX_CODE = 8192;
+
+function toBase64(text: string): string {
+    const bytes = new TextEncoder().encode(text);
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary);
+}
+
+function fromBase64(token: string): string {
+    const padded = token.length % 4 === 0 ? token : token + '='.repeat(4 - (token.length % 4));
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder().decode(bytes);
+}
+
+export function encodeThemeCode(theme: CustomIconTheme): string {
+    const clean = sanitizeCustomIconTheme(theme);
+    if (!clean) return '';
+    const { id, ...shared } = clean;
+    try {
+        return PREFIX + toBase64(JSON.stringify(shared));
+    } catch {
+        return '';
+    }
+}
+
+export function decodeThemeCode(code: unknown): CustomIconTheme | null {
+    if (typeof code !== 'string' || code.length > MAX_CODE) return null;
+    const at = code.indexOf(PREFIX);
+    if (at < 0) return null;
+    const word = code.slice(at + PREFIX.length).trim().split(/\s/)[0];
+    const token = word.replace(/-/g, '+').replace(/_/g, '/');
+    if (token === '') return null;
+    try {
+        const parsed: unknown = JSON.parse(fromBase64(token));
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+        return sanitizeCustomIconTheme({ ...parsed, id: newCustomIconThemeId() });
+    } catch {
+        return null;
+    }
+}

--- a/web/src/shell/AppGlyphs.tsx
+++ b/web/src/shell/AppGlyphs.tsx
@@ -68,9 +68,16 @@ function initials(label: string): string {
     return (words[0][0] + words[1][0]).toUpperCase();
 }
 
-export function AppGlyph({ icon, label, color, size }: { icon: string; label: string; color: string; size: number }) {
-    const Glyph = APP_GLYPHS[icon];
-    if (Glyph) return <Glyph size={size} color={color} strokeWidth={1.9} aria-hidden />;
+export function AppGlyph({ icon, override, label, color, size = 40, strokeWidth = 1.9 }: {
+    icon:         string;
+    override?:    string;
+    label:        string;
+    color:        string;
+    size?:        number;
+    strokeWidth?: number;
+}) {
+    const Glyph = (override ? APP_GLYPHS[override] : undefined) ?? APP_GLYPHS[icon];
+    if (Glyph) return <Glyph size={size} color={color} strokeWidth={strokeWidth} aria-hidden />;
     return (
         <span
             style={{

--- a/web/src/shell/AppGlyphs.tsx
+++ b/web/src/shell/AppGlyphs.tsx
@@ -1,3 +1,91 @@
+import {
+    Aperture, BookOpen, Bird, Blocks, Briefcase, Calculator, CalendarDays, Camera,
+    Car, Clock, CloudSun, Compass, Cookie, Crown, Flame, Folder, Gamepad2, Globe,
+    Heart, HeartPulse, House, Image as ImageIcon, KeyRound, Landmark, LayoutGrid,
+    Mail, Map, MessageCircle, MessagesSquare, Mic, Mountain, Music, Newspaper,
+    Phone, Radar, Radio, Settings, Ship, ShoppingBag, Spade, Star, StickyNote,
+    Store, TrainFront, TrendingUp, Users, Video, Wallet, Warehouse,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+const APP_GLYPHS: Record<string, LucideIcon> = {
+    phone:       Phone,
+    messages:    MessageCircle,
+    services:    Briefcase,
+    pages:       BookOpen,
+    review:      Star,
+    marketplace: Store,
+    radio:       Radio,
+    mail:        Mail,
+    safari:      Globe,
+    compass:     Compass,
+    maps:        Map,
+    findfriends: Radar,
+    stocks:      TrendingUp,
+    ryde:        Car,
+    camera:      Camera,
+    photos:      ImageIcon,
+    music:       Music,
+    wallet:      Wallet,
+    weather:     CloudSun,
+    clock:       Clock,
+    calendar:    CalendarDays,
+    notes:       StickyNote,
+    documents:   Folder,
+    voicememos:  Mic,
+    bank:        Landmark,
+    settings:    Settings,
+    appstore:    ShoppingBag,
+    health:      HeartPulse,
+    groups:      Users,
+    calculator:  Calculator,
+    birdy:       Bird,
+    darkchat:    MessagesSquare,
+    cherry:      Heart,
+    photogram:   Aperture,
+    garages:     Warehouse,
+    homes:       House,
+    cookie:      Cookie,
+    passwords:   KeyRound,
+    wordle:      LayoutGrid,
+    flappy:      Gamepad2,
+    blocks:      Blocks,
+    blackjack:   Spade,
+    climber:     Mountain,
+    railrunner:  TrainFront,
+    connectfour: Gamepad2,
+    chess:       Crown,
+    battleship:  Ship,
+    vibez:       Video,
+    weazelnews:  Newspaper,
+    streaks:     Flame,
+};
+
+function initials(label: string): string {
+    const words = label.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+    if (words.length === 0) return '?';
+    if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+    return (words[0][0] + words[1][0]).toUpperCase();
+}
+
+export function AppGlyph({ icon, label, color, size }: { icon: string; label: string; color: string; size: number }) {
+    const Glyph = APP_GLYPHS[icon];
+    if (Glyph) return <Glyph size={size} color={color} strokeWidth={1.9} aria-hidden />;
+    return (
+        <span
+            style={{
+                color,
+                fontFamily:    'var(--font-sf, system-ui, sans-serif)',
+                fontWeight:    700,
+                fontSize:      size * 0.62,
+                letterSpacing: '-0.03em',
+                lineHeight:    1,
+            }}
+        >
+            {initials(label)}
+        </span>
+    );
+}
 
 interface GlyphProps {
     className?: string;

--- a/web/src/shell/AppIcon.tsx
+++ b/web/src/shell/AppIcon.tsx
@@ -2,12 +2,18 @@ import { useRef } from 'react';
 
 import type { AppDef } from '@/core/types';
 import { useDownloadProgress } from '@/stores/downloadStore';
-import { useIconAppearance } from '@/stores/iconThemeStore';
+import { useIconAppearance, useShowAppNames } from '@/stores/iconThemeStore';
 import { AppIconSVG } from './AppIconSVG';
 import { AppGlyph } from './AppGlyphs';
 import { AppBadge } from './AppBadge';
 import { launchOriginFrom } from './launchOrigin';
 import { CircularProgress } from '@/ui/CircularProgress';
+
+export const TILE_SHADOW = '0 2px 10px rgba(0,0,0,0.38), 0 0 0 0.5px rgba(0,0,0,0.12)';
+
+export function radiusPct(fraction: number): string {
+    return `${Math.round(fraction * 1000) / 10}%`;
+}
 
 export interface AppIconProps {
     app:    AppDef;
@@ -18,7 +24,12 @@ export interface AppIconProps {
 
 export function AppIcon({ app, label = true, onOpen, badge }: AppIconProps) {
     const btnRef = useRef<HTMLButtonElement>(null);
-    const { background, glyph, art } = useIconAppearance(app.id, app.accent);
+    const {
+        background, glyph, art, radius, glyphSize, glyphWeight, boxShadow,
+        labelColor, labelWeight, labelShow, icon: glyphOverride,
+    } = useIconAppearance(app.id, app.accent);
+    const showAppNames = useShowAppNames();
+    const showLabel = label && (labelShow ?? showAppNames);
     const downloadProgress = useDownloadProgress(app.id);
     const downloading = downloadProgress !== undefined;
     const queued = downloading && downloadProgress < 0;
@@ -39,10 +50,8 @@ export function AppIcon({ app, label = true, onOpen, badge }: AppIconProps) {
                 <div
                     className={`relative h-[78px] w-[78px] overflow-hidden transition-transform duration-150 ease-out ${downloading ? '' : 'group-active:scale-[0.96]'}`}
                     style={{
-                        borderRadius: '27.6%',
-                        boxShadow:
-                            '0 2px 10px rgba(0,0,0,0.38), ' +
-                            '0 0 0 0.5px rgba(0,0,0,0.12)',
+                        borderRadius: radiusPct(radius),
+                        boxShadow:    [TILE_SHADOW, boxShadow].filter(Boolean).join(', '),
                     }}
                 >
                     {art === 'native' ? (
@@ -58,8 +67,22 @@ export function AppIcon({ app, label = true, onOpen, badge }: AppIconProps) {
                         </div>
                     ) : (
                         <div className="flex h-full w-full items-center justify-center" style={{ background }}>
-                            <AppGlyph icon={app.icon} label={app.label} color={glyph} size={40} />
+                            <AppGlyph
+                                icon={app.icon}
+                                override={glyphOverride}
+                                label={app.label}
+                                color={glyph}
+                                size={glyphSize}
+                                strokeWidth={glyphWeight}
+                            />
                         </div>
+                    )}
+
+                    {boxShadow !== '' && (
+                        <div
+                            className="pointer-events-none absolute inset-0"
+                            style={{ borderRadius: radiusPct(radius), boxShadow }}
+                        />
                     )}
 
                     {/* Hover/press dim as a background-color overlay rather than filter: brightness.
@@ -85,10 +108,14 @@ export function AppIcon({ app, label = true, onOpen, badge }: AppIconProps) {
                 {!downloading && <AppBadge count={badge} />}
             </div>
 
-            {label && (
+            {showLabel && (
                 <span
                     className="w-full truncate text-center font-sf text-[13px] font-semibold tracking-[0.01em] text-white"
-                    style={{ textShadow: '0 0 2px rgba(0,0,0,0.9), 0 1px 3px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.5)' }}
+                    style={{
+                        textShadow: '0 0 2px rgba(0,0,0,0.9), 0 1px 3px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.5)',
+                        color:      labelColor,
+                        fontWeight: labelWeight,
+                    }}
                 >
                     {app.label}
                 </span>

--- a/web/src/shell/AppIcon.tsx
+++ b/web/src/shell/AppIcon.tsx
@@ -2,7 +2,9 @@ import { useRef } from 'react';
 
 import type { AppDef } from '@/core/types';
 import { useDownloadProgress } from '@/stores/downloadStore';
+import { useIconAppearance } from '@/stores/iconThemeStore';
 import { AppIconSVG } from './AppIconSVG';
+import { AppGlyph } from './AppGlyphs';
 import { AppBadge } from './AppBadge';
 import { launchOriginFrom } from './launchOrigin';
 import { CircularProgress } from '@/ui/CircularProgress';
@@ -16,6 +18,7 @@ export interface AppIconProps {
 
 export function AppIcon({ app, label = true, onOpen, badge }: AppIconProps) {
     const btnRef = useRef<HTMLButtonElement>(null);
+    const { background, glyph, art } = useIconAppearance(app.id, app.accent);
     const downloadProgress = useDownloadProgress(app.id);
     const downloading = downloadProgress !== undefined;
     const queued = downloading && downloadProgress < 0;
@@ -42,16 +45,22 @@ export function AppIcon({ app, label = true, onOpen, badge }: AppIconProps) {
                             '0 0 0 0.5px rgba(0,0,0,0.12)',
                     }}
                 >
-                    <div
-                        style={{
-                            width:           60,
-                            height:          60,
-                            transform:       'scale(1.3)',
-                            transformOrigin: '0 0',
-                        }}
-                    >
-                        <AppIconSVG icon={app.icon} />
-                    </div>
+                    {art === 'native' ? (
+                        <div
+                            style={{
+                                width:           60,
+                                height:          60,
+                                transform:       'scale(1.3)',
+                                transformOrigin: '0 0',
+                            }}
+                        >
+                            <AppIconSVG icon={app.icon} />
+                        </div>
+                    ) : (
+                        <div className="flex h-full w-full items-center justify-center" style={{ background }}>
+                            <AppGlyph icon={app.icon} label={app.label} color={glyph} size={40} />
+                        </div>
+                    )}
 
                     {/* Hover/press dim as a background-color overlay rather than filter: brightness.
                         A filter promotes/demotes the icon's compositing layer on hover, which forces

--- a/web/src/shell/CustomAppFrame.tsx
+++ b/web/src/shell/CustomAppFrame.tsx
@@ -17,6 +17,7 @@ import { ContactPickerSheet } from '@/shared/ContactPickerSheet';
 import { formatPhone } from '@/apps/phone/data';
 import { AppIconSVG } from './AppIconSVG';
 import { useDeckActive } from './deckActive';
+import { resolveCustomUi } from './widgets/customUrl';
 import type { Contact } from '@/apps/phone/data';
 
 const COMPONENTS_URL = 'https://cfx-nui-sd-phone/web/build/components.js';
@@ -378,11 +379,7 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
 
     if (!def) return null;
 
-    const src = def.ui
-        ? (def.ui.startsWith('nui://')
-            ? `https://cfx-nui-${def.ui.slice(6)}`
-            : def.ui.includes('http') ? def.ui : `https://cfx-nui-${def.ui.replace(/^\//, '')}`)
-        : '';
+    const src = resolveCustomUi(def.ui);
 
     return (
         <div className="absolute inset-0 overflow-hidden bg-white dark:bg-base">

--- a/web/src/shell/Homescreen.tsx
+++ b/web/src/shell/Homescreen.tsx
@@ -5,7 +5,7 @@ import { LayoutGrid, Minus, Plus } from 'lucide-react';
 import type { AppDef } from '@/core/types';
 import { useTheme } from '@/stores/themeStore';
 import { resolveWallpaper } from './wallpapers';
-import { AppIcon } from './AppIcon';
+import { AppIcon, TILE_SHADOW, radiusPct } from './AppIcon';
 import { AppIconSVG } from './AppIconSVG';
 import { AppGlyph } from './AppGlyphs';
 import { AppBadge } from './AppBadge';
@@ -143,7 +143,6 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     const appMap   = useMemo(() => new Map(apps.map(a => [a.id, a])), [apps]);
-    const showAppNames = useShowAppNames();
 
     const [dockIds, setDockIds] = useState<string[]>(() => savedLayout?.dock ?? dock);
     const dockApps = useMemo(
@@ -923,7 +922,7 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                                             <div style={bloom ? { animation: 'home-icon-in 0.38s cubic-bezier(0.34,1.3,0.64,1) both', animationDelay: `${li * 20}ms` } : undefined}>
                                                 {folder
                                                     ? <FolderTile label={def!.name} apps={folderApps(fkey)} badge={folderBadge(fkey)} onOpen={() => setOpenFolder(fkey)} />
-                                                    : <AppIcon app={app!} label={showAppNames} onOpen={launch} badge={badges?.[app!.id]} />}
+                                                    : <AppIcon app={app!} onOpen={launch} badge={badges?.[app!.id]} />}
                                             </div>
                                         </div>
                                     );
@@ -1118,20 +1117,27 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
 
 function EditTile({ app, dragging, swapTarget, plopping, removable, merging, badge, onRemove }: { app: AppDef; dragging: boolean; swapTarget: boolean; plopping: boolean; removable: boolean; merging: boolean; badge?: number; onRemove: () => void }): ReactNode {
     const showNames = useShowAppNames();
-    const { background, glyph, art } = useIconAppearance(app.id, app.accent);
+    const {
+        background, glyph, art, radius, glyphSize, glyphWeight, boxShadow,
+        labelColor, labelWeight, labelShow, icon: glyphOverride,
+    } = useIconAppearance(app.id, app.accent);
+    const showLabel = labelShow ?? showNames;
     return (
         <div className={dragging ? '' : 'animate-app-jiggle'} style={{ animationDelay: `${jiggleDelay(app.id)}ms` }}>
             <div className="relative">
                 {merging && <div className="pointer-events-none absolute -inset-[8px] rounded-[30%] bg-white/25 backdrop-blur-sm" />}
-                <div className={`relative h-[78px] w-[78px] overflow-hidden transition-[box-shadow,transform] duration-150 ${plopping ? 'animate-plop' : ''}`} style={{ borderRadius: '27.6%', boxShadow: swapTarget ? '0 2px 12px rgba(0,0,0,0.42), 0 0 0 3.5px rgba(255,255,255,0.92)' : '0 2px 10px rgba(0,0,0,0.38), 0 0 0 0.5px rgba(0,0,0,0.12)', transform: dragging || merging ? 'scale(1.12)' : undefined }}>
+                <div className={`relative h-[78px] w-[78px] overflow-hidden transition-[box-shadow,transform] duration-150 ${plopping ? 'animate-plop' : ''}`} style={{ borderRadius: radiusPct(radius), boxShadow: [swapTarget ? '0 2px 12px rgba(0,0,0,0.42), 0 0 0 3.5px rgba(255,255,255,0.92)' : TILE_SHADOW, boxShadow].filter(Boolean).join(', '), transform: dragging || merging ? 'scale(1.12)' : undefined }}>
                     {art === 'native' ? (
                         <div style={{ width: 60, height: 60, transform: 'scale(1.3)', transformOrigin: '0 0' }}>
                             <AppIconSVG icon={app.icon} />
                         </div>
                     ) : (
                         <div className="flex h-full w-full items-center justify-center" style={{ background }}>
-                            <AppGlyph icon={app.icon} label={app.label} color={glyph} size={40} />
+                            <AppGlyph icon={app.icon} override={glyphOverride} label={app.label} color={glyph} size={glyphSize} strokeWidth={glyphWeight} />
                         </div>
+                    )}
+                    {boxShadow !== '' && (
+                        <div className="pointer-events-none absolute inset-0" style={{ borderRadius: radiusPct(radius), boxShadow }} />
                     )}
                 </div>
                 {!dragging && <AppBadge count={badge} />}
@@ -1141,22 +1147,34 @@ function EditTile({ app, dragging, swapTarget, plopping, removable, merging, bad
                     </button>
                 )}
             </div>
-            {showNames && <span className="mt-[7px] block w-full truncate text-center font-sf text-[13px] font-semibold tracking-[0.01em] text-white" style={{ textShadow: '0 0 2px rgba(0,0,0,0.9), 0 1px 3px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.5)' }}>{app.label}</span>}
+            {showLabel && <span className="mt-[7px] block w-full truncate text-center font-sf text-[13px] font-semibold tracking-[0.01em] text-white" style={{ textShadow: '0 0 2px rgba(0,0,0,0.9), 0 1px 3px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.5)', color: labelColor, fontWeight: labelWeight }}>{app.label}</span>}
         </div>
     );
 }
 
+const TILE_RADIUS = 0.276;
+const MINI_RADIUS = 0.30;
+const TILE_GLYPH  = 40;
+const MINI_GLYPH  = 10;
+
 function FolderMini({ app }: { app: AppDef }): ReactNode {
-    const { background, glyph, art } = useIconAppearance(app.id, app.accent);
+    const { background, glyph, art, radius, glyphSize, glyphWeight, icon: glyphOverride } = useIconAppearance(app.id, app.accent);
     return (
-        <div className="overflow-hidden" style={{ borderRadius: '30%' }}>
+        <div className="overflow-hidden" style={{ borderRadius: radiusPct(radius * (MINI_RADIUS / TILE_RADIUS)) }}>
             {art === 'native' ? (
                 <div style={{ width: 60, height: 60, transform: 'scale(0.3)', transformOrigin: '0 0' }}>
                     <AppIconSVG icon={app.icon} />
                 </div>
             ) : (
                 <div className="flex h-full w-full items-center justify-center" style={{ background }}>
-                    <AppGlyph icon={app.icon} label={app.label} color={glyph} size={10} />
+                    <AppGlyph
+                        icon={app.icon}
+                        override={glyphOverride}
+                        label={app.label}
+                        color={glyph}
+                        size={Math.round(glyphSize * (MINI_GLYPH / TILE_GLYPH))}
+                        strokeWidth={glyphWeight}
+                    />
                 </div>
             )}
         </div>
@@ -1202,7 +1220,6 @@ function FolderOverlay({ name, apps, badges, editing: homeEditing, autoEdit, wal
     onClose: () => void;
 }): ReactNode {
     const panelRef = useRef<HTMLDivElement>(null);
-    const showNames = useShowAppNames();
     const [localEdit, setLocalEdit] = useState(false);
     const editing = homeEditing || localEdit;
     const editingRef = useRef(editing);
@@ -1372,7 +1389,7 @@ function FolderOverlay({ name, apps, badges, editing: homeEditing, autoEdit, wal
                                     className={plopIds.has(a.id) ? 'animate-plop' : (jiggle ? 'animate-app-jiggle' : '')}
                                     style={jiggle ? { animationDelay: `${jiggleDelay(a.id)}ms` } : undefined}
                                 >
-                                    <AppIcon app={a} label={showNames} badge={badges?.[a.id]} onOpen={() => { /* launch handled by the cell gesture */ }} />
+                                    <AppIcon app={a} badge={badges?.[a.id]} onOpen={() => { /* launch handled by the cell gesture */ }} />
                                 </div>
                                 {editing && (
                                     <button

--- a/web/src/shell/Homescreen.tsx
+++ b/web/src/shell/Homescreen.tsx
@@ -7,10 +7,13 @@ import { useTheme } from '@/stores/themeStore';
 import { resolveWallpaper } from './wallpapers';
 import { AppIcon } from './AppIcon';
 import { AppIconSVG } from './AppIconSVG';
+import { AppGlyph } from './AppGlyphs';
 import { AppBadge } from './AppBadge';
 import { useBadges } from '@/stores/badgeStore';
+import { useIconAppearance, useShowAppNames } from '@/stores/iconThemeStore';
 import { AlertDialog } from '@/ui/AlertDialog';
 import type { SavedLayout, WidgetAlign, WidgetPlacement, WidgetSize, WidgetTheme } from '@/apps/appstore/appsApi';
+import { DOCK_MAX, freeCellNear, insertIntoDock } from './dockMoves';
 import { SPAN, coveredCells, firstFit, jiggleDeg, pageMoves, reflowAround, trySwap, widgetPx } from './widgets/geometry';
 import { widgetByKind } from './widgets/registry';
 import { launchOriginFrom } from './launchOrigin';
@@ -45,6 +48,14 @@ function cellFromCenter(cx: number, cy: number) {
     const c = Math.max(0, Math.min(COLS - 1, Math.round((cx - PAD_X - ICON / 2) / COL_STRIDE)));
     const r = Math.max(0, Math.min(ROWS - 1, Math.round((cy - ROW_Y0 - ICON / 2) / ROW_STRIDE)));
     return r * COLS + c;
+}
+function offsetWithin(el: HTMLElement | null, root: HTMLElement | null): { x: number; y: number } {
+    let x = 0, y = 0;
+    for (let n: HTMLElement | null = el; n && n !== root; n = n.offsetParent as HTMLElement | null) {
+        x += n.offsetLeft;
+        y += n.offsetTop;
+    }
+    return { x, y };
 }
 function ancestorZoom(el: HTMLElement | null): number {
     let z = 1;
@@ -132,10 +143,16 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     const appMap   = useMemo(() => new Map(apps.map(a => [a.id, a])), [apps]);
+    const showAppNames = useShowAppNames();
+
+    const [dockIds, setDockIds] = useState<string[]>(() => savedLayout?.dock ?? dock);
     const dockApps = useMemo(
-        () => dock.map(id => apps.find(a => a.id === id)).filter((a): a is AppDef => !!a),
-        [apps, dock],
+        () => dockIds.map(id => apps.find(a => a.id === id)).filter((a): a is AppDef => !!a),
+        [apps, dockIds],
     );
+    const dockShown = useMemo(() => dockApps.map(a => a.id), [dockApps]);
+    const dockShownRef = useRef(dockShown);
+    dockShownRef.current = dockShown;
 
     const [folders, setFolders] = useState<Record<string, { name: string; appIds: string[] }>>(() => {
         const out: Record<string, { name: string; appIds: string[] }> = {};
@@ -147,7 +164,7 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
     const [slots, setSlots] = useState<(string | null)[]>(() => {
         if (savedLayout && savedLayout.slots.length) return normalize(savedLayout.slots);
         const seeded = new Set(Object.values(folders).flatMap(f => f.appIds));
-        const loose = apps.filter(a => !dock.includes(a.id) && !seeded.has(a.id)).map(a => a.id);
+        const loose = apps.filter(a => !dockIds.includes(a.id) && !seeded.has(a.id)).map(a => a.id);
         const FIRST_PAGE = 12;
         const arr: (string | null)[] = Array(ITEMS_PER_PAGE * 2).fill(null);
         loose.slice(0, FIRST_PAGE).forEach((id, i) => { arr[i] = id; });
@@ -173,16 +190,18 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
     useEffect(() => {
         const known = new Set(apps.map(a => a.id));
         const folderKeys = new Set(Object.keys(folders));
+        const docked = new Set(dockIds);
         setSlots(prev => {
             const cleaned = prev.map(id => {
                 if (!id) return id;
                 if (isFolderId(id)) return folderKeys.has(folderKeyOf(id)) ? id : null;
                 if (folderedIds.has(id)) return null;
+                if (docked.has(id)) return null;
                 return known.has(id) ? id : null;
             });
             const placed = new Set(cleaned.filter((x): x is string => !!x && !isFolderId(x)));
             const missing = apps
-                .filter(a => !dock.includes(a.id) && !folderedIds.has(a.id) && !placed.has(a.id))
+                .filter(a => !docked.has(a.id) && !folderedIds.has(a.id) && !placed.has(a.id))
                 .map(a => a.id);
             if (!missing.length && cleaned.every((v, i) => v === prev[i])) return prev;
             const next = [...cleaned];
@@ -192,7 +211,7 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
             }
             return normalize(next);
         });
-    }, [apps, dock, folders, folderedIds]);
+    }, [apps, dockIds, folders, folderedIds]);
 
     const [widgets, setWidgets] = useState<WidgetPlacement[]>(() => savedLayout?.widgets ?? []);
     // Read by the drag listeners, which are bound once per drag and would otherwise close over
@@ -200,11 +219,12 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
     const widgetsRef = useRef(widgets);
     widgetsRef.current = widgets;
 
-    const latestRef = useRef<SavedLayout>({ slots, folders: [], widgets: [] });
+    const latestRef = useRef<SavedLayout>({ slots, folders: [], widgets: [], dock: dockIds });
     latestRef.current = {
         slots,
         folders: Object.entries(folders).map(([key, f]) => ({ key, name: f.name, appIds: f.appIds })),
         widgets,
+        dock: dockIds,
     };
     const onLayoutChangeRef = useRef(onLayoutChange);
     onLayoutChangeRef.current = onLayoutChange;
@@ -217,7 +237,7 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
             layoutSaveTimer.current = null;
             onLayoutChangeRef.current?.(latestRef.current);
         }, 500);
-    }, [slots, folders, widgets]);
+    }, [slots, folders, widgets, dockIds]);
     useEffect(() => () => {
         if (layoutSaveTimer.current) {
             window.clearTimeout(layoutSaveTimer.current);
@@ -420,9 +440,15 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
     }, []);
 
     const stripRef = useRef<HTMLDivElement>(null);
+    const rootRef  = useRef<HTMLDivElement>(null);
+    const dockRef  = useRef<HTMLDivElement>(null);
     const [dragId, setDragId] = useState<string | null>(null);
     const [dragPos, setDragPos] = useState({ x: 0, y: 0 });
     const [overCell, setOverCell] = useState<number | null>(null);
+    const [dockOver, setDockOver] = useState<number | null>(null);
+    const dockOverRef = useRef<number | null>(null);
+    const [dragFromDock, setDragFromDock] = useState(false);
+    const fromDockRef = useRef(false);
     const startClient = useRef({ x: 0, y: 0 });
     const grabSlot = useRef({ x: 0, y: 0 });
     const grabZoom = useRef(1);
@@ -538,15 +564,54 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
         fromCell.current = localCell;
         fromPageRef.current = pageRef.current;
         overCellRef.current = localCell;
+        fromDockRef.current = false;
+        dockOverRef.current = null;
+        setDragFromDock(false); setDockOver(null);
         setDragId(id); setDragPos(s); setOverCell(localCell);
         stripRef.current?.setPointerCapture(e.pointerId);
     }
+
+    function onDockIconDown(e: ReactPointerEvent, id: string, index: number) {
+        if (!editingRef.current) return;
+        e.stopPropagation();
+        const zone = e.currentTarget as HTMLElement;
+        const p = offsetWithin(zone, rootRef.current);
+        const s = { x: p.x + Math.max(0, (zone.offsetWidth - ICON) / 2), y: p.y - stripTop };
+        grabSlot.current = s;
+        startClient.current = { x: e.clientX, y: e.clientY };
+        grabZoom.current = ancestorZoom(stripRef.current);
+        fromCell.current = -1;
+        fromPageRef.current = pageRef.current;
+        overCellRef.current = 0;
+        fromDockRef.current = true;
+        dockOverRef.current = index;
+        setDragFromDock(true); setDockOver(index);
+        setDragId(id); setDragPos(s); setOverCell(null);
+        stripRef.current?.setPointerCapture(e.pointerId);
+    }
+
+    function dockHitAt(clientX: number, clientY: number): number | null {
+        const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
+        if (!el || !dockRef.current?.contains(el)) return null;
+        const idx = el.closest('[data-dock-idx]')?.getAttribute('data-dock-idx');
+        if (idx != null) return Number(idx);
+        return dockOverRef.current ?? dockShownRef.current.length;
+    }
+
     function onIconMove(e: ReactPointerEvent) {
         if (!dragId) return;
         const z = grabZoom.current;
         const x = grabSlot.current.x + (e.clientX - startClient.current.x) / z;
         const y = grabSlot.current.y + (e.clientY - startClient.current.y) / z;
         setDragPos({ x, y });
+        const onDock = isFolderId(dragId) ? null : dockHitAt(e.clientX, e.clientY);
+        if (onDock !== dockOverRef.current) { dockOverRef.current = onDock; setDockOver(onDock); }
+        if (onDock !== null) {
+            clearDwell();
+            clearEdge();
+            setOverCell(null);
+            return;
+        }
         const over = cellFromCenter(x + ICON / 2, y + ICON / 2);
         overCellRef.current = over;
         setOverCell(over);
@@ -580,14 +645,37 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
             clearEdge();
         }
     }
+    function plop(ids: (string | null)[]) {
+        setPlopIds(new Set(ids.filter((x): x is string => !!x)));
+        if (plopTimer.current) window.clearTimeout(plopTimer.current);
+        plopTimer.current = window.setTimeout(() => setPlopIds(new Set()), 460);
+    }
+    function endIconDrag() {
+        dockOverRef.current = null;
+        fromDockRef.current = false;
+        setDragId(null); setOverCell(null); setDockOver(null); setDragFromDock(false);
+    }
     function onIconUp() {
         if (!dragId) return;
         clearEdge();
         const armed = mergeCellRef.current;
         clearDwell();
         const dragged = dragId;
+        const fromDock = fromDockRef.current;
+        const onDock = dockOverRef.current;
         const from = fromPageRef.current * ITEMS_PER_PAGE + fromCell.current;
         const to   = pageRef.current * ITEMS_PER_PAGE + overCellRef.current;
+
+        if (onDock !== null && !isFolderId(dragged)) {
+            const { dock: nextDock, displaced } = insertIntoDock(dockShownRef.current, dragged, onDock, DOCK_MAX);
+            setDockIds(prev => (prev.length === nextDock.length && prev.every((x, i) => x === nextDock[i]) ? prev : nextDock));
+            if (!fromDock) {
+                setSlots(prev => normalize(prev.map((x, i) => (i === from ? displaced : x))));
+                plop([dragged, displaced]);
+            }
+            endIconDrag();
+            return;
+        }
 
         if (armed !== null && !isFolderId(dragged) && to !== from) {
             const targetId = slots[to];
@@ -595,21 +683,46 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                 if (isFolderId(targetId)) {
                     const key = folderKeyOf(targetId);
                     setFolders(prev => ({ ...prev, [key]: { ...prev[key], appIds: [...prev[key].appIds, dragged] } }));
-                    setSlots(prev => normalize(prev.map((x, i) => (i === from ? null : x))));
+                    if (!fromDock) setSlots(prev => normalize(prev.map((x, i) => (i === from ? null : x))));
                 } else {
                     const key = newFolderKey();
                     setFolders(prev => ({ ...prev, [key]: { name: 'Folder', appIds: [targetId, dragged] } }));
-                    setSlots(prev => normalize(prev.map((x, i) => (i === to ? FOLDER_PREFIX + key : i === from ? null : x))));
+                    setSlots(prev => normalize(prev.map((x, i) => (i === to ? FOLDER_PREFIX + key : (!fromDock && i === from) ? null : x))));
                     setOpenFolder(key); setRenameFolder(key);
                 }
-                setDragId(null); setOverCell(null);
+                if (fromDock) setDockIds(prev => prev.filter(x => x !== dragged));
+                endIconDrag();
                 return;
             }
         }
 
+        if (fromDock) {
+            const base = pageRef.current * ITEMS_PER_PAGE;
+            const covered = coveredByPage.get(pageRef.current) ?? new Set<number>();
+            const cells = Array.from({ length: ITEMS_PER_PAGE }, (_, i) => slots[base + i] ?? null);
+            let cell = overCellRef.current;
+            const sitting = cells[cell];
+            if (covered.has(cell) || (sitting !== null && isFolderId(sitting))) {
+                const free = freeCellNear(cells, covered, cell);
+                if (free === null) { endIconDrag(); return; }
+                cell = free;
+            }
+            const swapped = cells[cell];
+            setSlots(prev => {
+                const n = [...prev];
+                while (n.length <= base + cell) n.push(null);
+                n[base + cell] = dragged;
+                return normalize(n);
+            });
+            setDockIds(prev => (swapped ? prev.map(x => (x === dragged ? swapped : x)) : prev.filter(x => x !== dragged)));
+            plop([dragged, swapped]);
+            endIconDrag();
+            return;
+        }
+
         if (isFolderId(dragged) && to === from) {
             setOpenFolder(folderKeyOf(dragged));
-            setDragId(null); setOverCell(null);
+            endIconDrag();
             return;
         }
 
@@ -622,11 +735,9 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                 else { const t = n[to]; n[to] = n[from]; n[from] = t; }
                 return normalize(n);
             });
-            setPlopIds(new Set(displaced ? [dragged, displaced] : [dragged]));
-            if (plopTimer.current) window.clearTimeout(plopTimer.current);
-            plopTimer.current = window.setTimeout(() => setPlopIds(new Set()), 460);
+            plop([dragged, displaced]);
         }
-        setDragId(null); setOverCell(null);
+        endIconDrag();
     }
 
     function removeApp(id: string) {
@@ -663,7 +774,7 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
 
 
     return (
-        <div className="absolute inset-0 select-none">
+        <div ref={rootRef} className="absolute inset-0 select-none">
             <div
                 className="wallpaper absolute inset-0"
                 style={{
@@ -812,7 +923,7 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                                             <div style={bloom ? { animation: 'home-icon-in 0.38s cubic-bezier(0.34,1.3,0.64,1) both', animationDelay: `${li * 20}ms` } : undefined}>
                                                 {folder
                                                     ? <FolderTile label={def!.name} apps={folderApps(fkey)} badge={folderBadge(fkey)} onOpen={() => setOpenFolder(fkey)} />
-                                                    : <AppIcon app={app!} onOpen={launch} badge={badges?.[app!.id]} />}
+                                                    : <AppIcon app={app!} label={showAppNames} onOpen={launch} badge={badges?.[app!.id]} />}
                                             </div>
                                         </div>
                                     );
@@ -876,14 +987,15 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                     </div>
                 )}
 
-                {editing && dragId && (
-                    <div className="pointer-events-none absolute left-0 top-0 z-[60]" style={{ width: ICON, transform: `translate(${dragPos.x}px, ${dragPos.y}px)` }}>
-                        {isFolderId(dragId)
-                            ? <div style={{ transform: 'scale(1.1)' }}><FolderTile label={folders[folderKeyOf(dragId)]?.name ?? ''} apps={folderApps(folderKeyOf(dragId))} badge={folderBadge(folderKeyOf(dragId))} onOpen={() => { /* lifted */ }} /></div>
-                            : appMap.get(dragId) && <EditTile app={appMap.get(dragId)!} dragging swapTarget={false} plopping={false} removable={false} merging={false} onRemove={() => { /* lifted */ }} />}
-                    </div>
-                )}
             </div>
+
+            {editing && dragId && (
+                <div className="pointer-events-none absolute left-0 top-0 z-[60]" style={{ width: ICON, transform: `translate(${dragPos.x}px, ${stripTop + dragPos.y}px)` }}>
+                    {isFolderId(dragId)
+                        ? <div style={{ transform: 'scale(1.1)' }}><FolderTile label={folders[folderKeyOf(dragId)]?.name ?? ''} apps={folderApps(folderKeyOf(dragId))} badge={folderBadge(folderKeyOf(dragId))} onOpen={() => { /* lifted */ }} /></div>
+                        : appMap.get(dragId) && <EditTile app={appMap.get(dragId)!} dragging swapTarget={false} plopping={false} removable={false} merging={false} onRemove={() => { /* lifted */ }} />}
+                </div>
+            )}
 
             {dragW && dragWidget && dragWidgetDef && dragWidgetBox && dragWidgetPos && (
                 <div
@@ -929,19 +1041,44 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                 )}
             </div>
 
-            <div className="absolute bottom-5 left-4 right-4 z-10">
-                <div className="flex items-center justify-around rounded-[28px] border border-white/20 bg-white/15 px-4 py-3.5 backdrop-blur-2xl">
+            <div ref={dockRef} className="absolute bottom-5 left-4 right-4 z-10">
+                <div className="flex items-center rounded-[28px] border border-white/20 bg-white/15 px-4 py-3.5 backdrop-blur-2xl">
                     {dockApps.map((app, di) => (
                         <div
                             key={app.id}
-                            className={editing ? 'animate-app-jiggle' : ''}
-                            style={editing
-                                ? { animationDelay: `${jiggleDelay(app.id)}ms` }
-                                : (bloom ? { animation: 'home-icon-in 0.38s cubic-bezier(0.34,1.3,0.64,1) both', animationDelay: `${140 + di * 25}ms` } : undefined)}
+                            data-dock-idx={di}
+                            onPointerDown={e => onDockIconDown(e, app.id, di)}
+                            className="relative flex flex-1 justify-center"
+                            style={{ touchAction: 'none' }}
                         >
-                            <AppIcon app={app} label={false} onOpen={launch} badge={badges?.[app.id]} />
+                            {dockOver === di && !!dragId && (
+                                <div
+                                    className="pointer-events-none absolute left-1/2 top-0 h-[78px] w-[78px] -translate-x-1/2"
+                                    style={{ borderRadius: '27.6%', boxShadow: '0 0 0 3.5px rgba(255,255,255,0.92), 0 2px 12px rgba(0,0,0,0.42)' }}
+                                />
+                            )}
+                            {app.id === dragId
+                                ? <div className="h-[78px] w-[78px]" />
+                                : (
+                                    <div
+                                        className={editing ? 'animate-app-jiggle' : ''}
+                                        style={editing
+                                            ? { animationDelay: `${jiggleDelay(app.id)}ms` }
+                                            : (bloom ? { animation: 'home-icon-in 0.38s cubic-bezier(0.34,1.3,0.64,1) both', animationDelay: `${140 + di * 25}ms` } : undefined)}
+                                    >
+                                        <AppIcon app={app} label={false} onOpen={launch} badge={badges?.[app.id]} />
+                                    </div>
+                                )}
                         </div>
                     ))}
+                    {dockOver !== null && !dragFromDock && dockApps.length < DOCK_MAX && (
+                        <div data-dock-idx={dockApps.length} className="relative flex flex-1 justify-center" style={{ touchAction: 'none' }}>
+                            <div
+                                className="h-[78px] w-[78px] border border-white/40 bg-white/10"
+                                style={{ borderRadius: '27.6%', boxShadow: dockOver === dockApps.length ? '0 0 0 3.5px rgba(255,255,255,0.92)' : undefined }}
+                            />
+                        </div>
+                    )}
                 </div>
             </div>
 
@@ -980,14 +1117,22 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
 }
 
 function EditTile({ app, dragging, swapTarget, plopping, removable, merging, badge, onRemove }: { app: AppDef; dragging: boolean; swapTarget: boolean; plopping: boolean; removable: boolean; merging: boolean; badge?: number; onRemove: () => void }): ReactNode {
+    const showNames = useShowAppNames();
+    const { background, glyph, art } = useIconAppearance(app.id, app.accent);
     return (
         <div className={dragging ? '' : 'animate-app-jiggle'} style={{ animationDelay: `${jiggleDelay(app.id)}ms` }}>
             <div className="relative">
                 {merging && <div className="pointer-events-none absolute -inset-[8px] rounded-[30%] bg-white/25 backdrop-blur-sm" />}
                 <div className={`relative h-[78px] w-[78px] overflow-hidden transition-[box-shadow,transform] duration-150 ${plopping ? 'animate-plop' : ''}`} style={{ borderRadius: '27.6%', boxShadow: swapTarget ? '0 2px 12px rgba(0,0,0,0.42), 0 0 0 3.5px rgba(255,255,255,0.92)' : '0 2px 10px rgba(0,0,0,0.38), 0 0 0 0.5px rgba(0,0,0,0.12)', transform: dragging || merging ? 'scale(1.12)' : undefined }}>
-                    <div style={{ width: 60, height: 60, transform: 'scale(1.3)', transformOrigin: '0 0' }}>
-                        <AppIconSVG icon={app.icon} />
-                    </div>
+                    {art === 'native' ? (
+                        <div style={{ width: 60, height: 60, transform: 'scale(1.3)', transformOrigin: '0 0' }}>
+                            <AppIconSVG icon={app.icon} />
+                        </div>
+                    ) : (
+                        <div className="flex h-full w-full items-center justify-center" style={{ background }}>
+                            <AppGlyph icon={app.icon} label={app.label} color={glyph} size={40} />
+                        </div>
+                    )}
                 </div>
                 {!dragging && <AppBadge count={badge} />}
                 {removable && (
@@ -996,22 +1141,30 @@ function EditTile({ app, dragging, swapTarget, plopping, removable, merging, bad
                     </button>
                 )}
             </div>
-            <span className="mt-[7px] block w-full truncate text-center font-sf text-[13px] font-semibold tracking-[0.01em] text-white" style={{ textShadow: '0 0 2px rgba(0,0,0,0.9), 0 1px 3px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.5)' }}>{app.label}</span>
+            {showNames && <span className="mt-[7px] block w-full truncate text-center font-sf text-[13px] font-semibold tracking-[0.01em] text-white" style={{ textShadow: '0 0 2px rgba(0,0,0,0.9), 0 1px 3px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.5)' }}>{app.label}</span>}
         </div>
     );
 }
 
-function FolderMini({ icon }: { icon: string }): ReactNode {
+function FolderMini({ app }: { app: AppDef }): ReactNode {
+    const { background, glyph, art } = useIconAppearance(app.id, app.accent);
     return (
         <div className="overflow-hidden" style={{ borderRadius: '30%' }}>
-            <div style={{ width: 60, height: 60, transform: 'scale(0.3)', transformOrigin: '0 0' }}>
-                <AppIconSVG icon={icon} />
-            </div>
+            {art === 'native' ? (
+                <div style={{ width: 60, height: 60, transform: 'scale(0.3)', transformOrigin: '0 0' }}>
+                    <AppIconSVG icon={app.icon} />
+                </div>
+            ) : (
+                <div className="flex h-full w-full items-center justify-center" style={{ background }}>
+                    <AppGlyph icon={app.icon} label={app.label} color={glyph} size={10} />
+                </div>
+            )}
         </div>
     );
 }
 
 function FolderTile({ label, apps, onOpen, merging = false, badge }: { label: string; apps: AppDef[]; onOpen: () => void; merging?: boolean; badge?: number }): ReactNode {
+    const showNames = useShowAppNames();
     return (
         <button type="button" onClick={onOpen} className="group block w-[78px]">
             <div className="relative">
@@ -1026,11 +1179,11 @@ function FolderTile({ label, apps, onOpen, merging = false, badge }: { label: st
                         transform: merging ? 'scale(1.14)' : undefined,
                     }}
                 >
-                    {apps.slice(0, 9).map(a => <FolderMini key={a.id} icon={a.icon} />)}
+                    {apps.slice(0, 9).map(a => <FolderMini key={a.id} app={a} />)}
                 </div>
                 <AppBadge count={badge} />
             </div>
-            <span className="mt-[7px] block w-full truncate text-center font-sf text-[13px] font-semibold tracking-[0.01em] text-white" style={{ textShadow: '0 0 2px rgba(0,0,0,0.9), 0 1px 3px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.5)' }}>{label}</span>
+            {showNames && <span className="mt-[7px] block w-full truncate text-center font-sf text-[13px] font-semibold tracking-[0.01em] text-white" style={{ textShadow: '0 0 2px rgba(0,0,0,0.9), 0 1px 3px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.5)' }}>{label}</span>}
         </button>
     );
 }
@@ -1049,6 +1202,7 @@ function FolderOverlay({ name, apps, badges, editing: homeEditing, autoEdit, wal
     onClose: () => void;
 }): ReactNode {
     const panelRef = useRef<HTMLDivElement>(null);
+    const showNames = useShowAppNames();
     const [localEdit, setLocalEdit] = useState(false);
     const editing = homeEditing || localEdit;
     const editingRef = useRef(editing);
@@ -1218,7 +1372,7 @@ function FolderOverlay({ name, apps, badges, editing: homeEditing, autoEdit, wal
                                     className={plopIds.has(a.id) ? 'animate-plop' : (jiggle ? 'animate-app-jiggle' : '')}
                                     style={jiggle ? { animationDelay: `${jiggleDelay(a.id)}ms` } : undefined}
                                 >
-                                    <AppIcon app={a} badge={badges?.[a.id]} onOpen={() => { /* launch handled by the cell gesture */ }} />
+                                    <AppIcon app={a} label={showNames} badge={badges?.[a.id]} onOpen={() => { /* launch handled by the cell gesture */ }} />
                                 </div>
                                 {editing && (
                                     <button

--- a/web/src/shell/dockMoves.ts
+++ b/web/src/shell/dockMoves.ts
@@ -1,0 +1,26 @@
+export const DOCK_MAX = 4;
+
+export function insertIntoDock(dock: string[], id: string, index: number, max: number = DOCK_MAX): { dock: string[]; displaced: string | null } {
+    const rest = dock.filter(x => x !== id);
+    if (rest.length < max) {
+        const at = Math.max(0, Math.min(rest.length, index));
+        const next = [...rest];
+        next.splice(at, 0, id);
+        return { dock: next, displaced: null };
+    }
+    const at = Math.max(0, Math.min(rest.length - 1, index));
+    const next = [...rest];
+    const displaced = next[at] ?? null;
+    next[at] = id;
+    return { dock: next, displaced };
+}
+
+export function freeCellNear(cells: (string | null)[], covered: Set<number>, from: number): number | null {
+    const usable = (c: number) => c >= 0 && c < cells.length && !covered.has(c) && cells[c] === null;
+    if (usable(from)) return from;
+    for (let d = 1; d < cells.length; d++) {
+        if (usable(from - d)) return from - d;
+        if (usable(from + d)) return from + d;
+    }
+    return null;
+}

--- a/web/src/shell/widgets/CustomWidgetFrame.tsx
+++ b/web/src/shell/widgets/CustomWidgetFrame.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import type { WidgetSize } from '@/apps/appstore/appsApi';
+import type { CustomAppDef, CustomWidgetDef } from '@/core/types';
+import { t } from '@/i18n';
+import { useCustomApps } from '@/stores/customAppsStore';
+import { useTheme } from '@/stores/themeStore';
+import { resolveCustomUi, withQuery } from './customUrl';
+import { WidgetTile, palette } from './WidgetTile';
+
+const PREFIX = 'custom:';
+
+const SANDBOX = 'allow-scripts allow-same-origin';
+
+export function customWidgetKind(appId: string, widgetId: string): string {
+    return `${PREFIX}${appId}:${widgetId}`;
+}
+
+export function parseCustomWidgetKind(kind: string): { appId: string; widgetId: string } | null {
+    if (!kind.startsWith(PREFIX)) return null;
+    const rest = kind.slice(PREFIX.length);
+    const cut = rest.lastIndexOf(':');
+    if (cut <= 0 || cut === rest.length - 1) return null;
+    return { appId: rest.slice(0, cut), widgetId: rest.slice(cut + 1) };
+}
+
+function findWidget(apps: CustomAppDef[], kind: string): { app: CustomAppDef; widget: CustomWidgetDef } | null {
+    const parsed = parseCustomWidgetKind(kind);
+    if (!parsed) return null;
+    const app = apps.find(a => a.id === parsed.appId);
+    const widget = app?.widgets?.find(w => w.id === parsed.widgetId);
+    return app && widget ? { app, widget } : null;
+}
+
+function prettyId(kind: string): string {
+    const id = parseCustomWidgetKind(kind)?.widgetId ?? '';
+    const words = id.replace(/[_-]+/g, ' ').trim();
+    return words ? words.charAt(0).toUpperCase() + words.slice(1) : '';
+}
+
+export function CustomWidgetFrame({ kind, size, width, height }: {
+    kind:   string;
+    size:   WidgetSize;
+    width:  number;
+    height: number;
+}) {
+    const apps = useCustomApps();
+    const { theme } = useTheme('theme');
+    const found = useMemo(() => findWidget(apps, kind), [apps, kind]);
+
+    const frameRef = useRef<HTMLIFrameElement>(null);
+    const [ready, setReady] = useState(false);
+
+    const src = useMemo(() => {
+        if (!found) return '';
+        return withQuery(resolveCustomUi(found.widget.ui), {
+            app:    found.app.id,
+            widget: found.widget.id,
+            size,
+            width,
+            height,
+        });
+    }, [found, size, width, height]);
+
+    useEffect(() => { setReady(false); }, [src]);
+
+    useEffect(() => {
+        if (!ready || !found) return;
+        frameRef.current?.contentWindow?.postMessage({
+            type:   'sd-phone:widget',
+            app:    found.app.id,
+            widget: found.widget.id,
+            size, width, height, theme,
+        }, '*');
+    }, [ready, found, size, width, height, theme]);
+
+    const radius = size === 'sm' ? 22 : 26;
+    const p = palette('dark');
+
+    if (!found || !src) {
+        const label = prettyId(kind);
+        return (
+            <WidgetTile width={width} height={height} radius={radius} tint={p.bg} hairline={false}>
+                <div className="flex h-full w-full flex-col items-center justify-center gap-1 px-3 text-center">
+                    <span className="text-[13px] font-semibold leading-tight" style={{ color: p.body }}>
+                        {label || t('widgets.thirdParty', 'Widget')}
+                    </span>
+                    <span className="text-[11px] leading-tight" style={{ color: p.faint }}>
+                        {t('widgets.unavailable', 'Not available')}
+                    </span>
+                </div>
+            </WidgetTile>
+        );
+    }
+
+    return (
+        <WidgetTile width={width} height={height} radius={radius} tint={p.bg} hairline={false}>
+            <iframe
+                ref={frameRef}
+                src={src}
+                title={found.widget.name}
+                sandbox={SANDBOX}
+                referrerPolicy="no-referrer"
+                onLoad={() => setReady(true)}
+                className="pointer-events-none absolute inset-0 border-0 transition-opacity duration-200"
+                style={{
+                    width,
+                    height,
+                    colorScheme: theme === 'dark' ? 'dark' : 'light',
+                    opacity: ready ? 1 : 0,
+                }}
+            />
+        </WidgetTile>
+    );
+}

--- a/web/src/shell/widgets/WidgetGallery.tsx
+++ b/web/src/shell/widgets/WidgetGallery.tsx
@@ -7,7 +7,7 @@ import { SegmentedControl } from '@/ui/SegmentedControl';
 import { Sheet } from '@/ui/Sheet';
 import { resolveWallpaper } from '../wallpapers';
 import { SPAN, widgetPx } from './geometry';
-import { WIDGETS } from './registry';
+import { useWidgetCatalog } from './registry';
 
 const SIZE_LABEL: Record<WidgetSize, string> = { sm: 'Small', md: 'Medium', lg: 'Large' };
 const ALIGN_LABEL: Record<WidgetAlign, string> = { left: 'Left', center: 'Centre', right: 'Right' };
@@ -26,6 +26,7 @@ export function WidgetGallery({
     onClose: () => void;
     wallpaper: string;
 }) {
+    const catalog = useWidgetCatalog();
     const [pick, setPick] = useState<Record<string, WidgetSize>>({});
     const [alignPick, setAlignPick] = useState<Record<string, WidgetAlign>>({});
     const [themePick, setThemePick] = useState<Record<string, WidgetTheme>>({});
@@ -50,8 +51,9 @@ export function WidgetGallery({
                     {t('widgets.blurb', 'Widgets show information from your apps at a glance. Pick a size, then add it to your Home Screen.')}
                 </p>
 
-                {WIDGETS.map(def => {
-                    const size = pick[def.kind] ?? def.sizes[0];
+                {catalog.map(def => {
+                    const picked = pick[def.kind];
+                    const size = picked && def.sizes.includes(picked) ? picked : def.sizes[0];
                     const { width: fullW,    height: fullH }    = widgetPx(size);
                     const { width: previewW, height: previewH } = widgetPx(size, PREVIEW_SCALE);
                     const align = alignPick[def.kind] ?? 'left';

--- a/web/src/shell/widgets/customUrl.ts
+++ b/web/src/shell/widgets/customUrl.ts
@@ -1,0 +1,18 @@
+export function resolveCustomUi(ui: string | null | undefined): string {
+    if (!ui) return '';
+    if (ui.startsWith('nui://')) return `https://cfx-nui-${ui.slice(6)}`;
+    if (ui.includes('http')) return ui;
+    return `https://cfx-nui-${ui.replace(/^\//, '')}`;
+}
+
+export function withQuery(url: string, params: Record<string, string | number>): string {
+    if (!url) return '';
+    const query = Object.entries(params)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+        .join('&');
+    if (!query) return url;
+    const hash = url.indexOf('#');
+    const base = hash === -1 ? url : url.slice(0, hash);
+    const frag = hash === -1 ? '' : url.slice(hash);
+    return `${base}${base.includes('?') ? '&' : '?'}${query}${frag}`;
+}

--- a/web/src/shell/widgets/registry.tsx
+++ b/web/src/shell/widgets/registry.tsx
@@ -1,7 +1,11 @@
+import { useMemo } from 'react';
 import type { ReactNode } from 'react';
 
 import type { WidgetAlign, WidgetSize, WidgetTheme } from '@/apps/appstore/appsApi';
+import type { CustomAppDef, CustomWidgetDef } from '@/core/types';
 import { t } from '@/i18n';
+import { useCustomApps } from '@/stores/customAppsStore';
+import { CustomWidgetFrame, customWidgetKind, parseCustomWidgetKind } from './CustomWidgetFrame';
 import { ActivityWidget } from './ActivityWidget';
 import { ClockWidget } from './ClockWidget';
 import { ContactsWidget } from './ContactsWidget';
@@ -34,7 +38,7 @@ export interface WidgetDef {
     render: (o: WidgetRender) => ReactNode;
 }
 
-export const WIDGETS: WidgetDef[] = [
+const WIDGETS: WidgetDef[] = [
     {
         kind: 'weather',
         label: () => t('widgets.weather', 'Weather'),
@@ -127,4 +131,47 @@ export const WIDGETS: WidgetDef[] = [
     },
 ];
 
-export const widgetByKind = (kind: string): WidgetDef | undefined => WIDGETS.find(w => w.kind === kind);
+function thirdPartyDef(app: CustomAppDef, widget: CustomWidgetDef): WidgetDef {
+    const kind = customWidgetKind(app.id, widget.id);
+    return {
+        kind,
+        label:  () => widget.name,
+        sizes:  widget.sizes,
+        appId:  app.id,
+        render: o => <CustomWidgetFrame kind={kind} size={o.size} width={o.width} height={o.height} />,
+    };
+}
+
+export function useWidgetCatalog(): WidgetDef[] {
+    const apps = useCustomApps();
+    return useMemo(() => {
+        const extra: WidgetDef[] = [];
+        for (const app of apps) {
+            for (const widget of app.widgets ?? []) extra.push(thirdPartyDef(app, widget));
+        }
+        return extra.length ? [...WIDGETS, ...extra] : WIDGETS;
+    }, [apps]);
+}
+
+const framed = new Map<string, WidgetDef>();
+
+function framedDef(kind: string, appId: string): WidgetDef {
+    const cached = framed.get(kind);
+    if (cached) return cached;
+    const def: WidgetDef = {
+        kind,
+        label:  () => t('widgets.thirdParty', 'Widget'),
+        sizes:  ['sm', 'md', 'lg'],
+        appId,
+        render: o => <CustomWidgetFrame kind={kind} size={o.size} width={o.width} height={o.height} />,
+    };
+    framed.set(kind, def);
+    return def;
+}
+
+export function widgetByKind(kind: string): WidgetDef | undefined {
+    const builtIn = WIDGETS.find(w => w.kind === kind);
+    if (builtIn) return builtIn;
+    const parsed = parseCustomWidgetKind(kind);
+    return parsed ? framedDef(kind, parsed.appId) : undefined;
+}

--- a/web/src/stores/iconThemeStore.ts
+++ b/web/src/stores/iconThemeStore.ts
@@ -4,13 +4,17 @@ import { fetchNui, isFiveM } from '@/core/nui';
 import { t } from '@/i18n';
 import { customAccent } from '@/stores/customAppsStore';
 
-export type IconThemeId =
+export type BuiltinIconThemeId =
     | 'default' | 'glass' | 'flat' | 'light' | 'pastel' | 'sand'
     | 'slate' | 'tinted' | 'noir' | 'mono' | 'contrast';
 
+export type CustomIconThemeId = `custom:${string}`;
+
+export type IconThemeId = BuiltinIconThemeId | CustomIconThemeId;
+
 type IconArt = 'native' | 'glyph';
 
-interface ColorRecipe {
+export interface ColorRecipe {
     from:    'accent' | 'fixed';
     color?:  string;
     toward?: string;
@@ -28,7 +32,16 @@ export interface IconThemeDef {
     hint:         () => string;
 }
 
+export interface CustomIconTheme {
+    id:         CustomIconThemeId;
+    name:       string;
+    background: ColorRecipe;
+    glyph:      ColorRecipe;
+    depth?:     boolean;
+}
+
 const WHITE_ON_COLOUR = 1.55;
+const CUSTOM_CONTRAST = WHITE_ON_COLOUR;
 
 export const ICON_THEMES: IconThemeDef[] = [
     {
@@ -124,7 +137,97 @@ export const ICON_THEMES: IconThemeDef[] = [
     },
 ];
 
-const BY_ID = Object.fromEntries(ICON_THEMES.map(d => [d.id, d])) as Record<IconThemeId, IconThemeDef>;
+const BY_ID = new Map<string, IconThemeDef>(ICON_THEMES.map(d => [d.id, d]));
+const DEFAULT_DEF = BY_ID.get('default') as IconThemeDef;
+
+export const MAX_CUSTOM_ICON_THEMES = 12;
+
+const CUSTOM_ID = /^custom:[a-z0-9]{4,8}$/;
+const HEX = /^#[0-9a-f]{6}$/i;
+const ID_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+const CUSTOM_BY_ID = new Map<string, IconThemeDef>();
+
+export function newCustomIconThemeId(): CustomIconThemeId {
+    let slug = '';
+    for (let i = 0; i < 6; i++) slug += ID_CHARS[Math.floor(Math.random() * ID_CHARS.length)];
+    return `custom:${slug}`;
+}
+
+function sanitizeRecipe(value: unknown): ColorRecipe | null {
+    if (!value || typeof value !== 'object') return null;
+    const raw = value as Record<string, unknown>;
+    if (raw.from !== 'accent' && raw.from !== 'fixed') return null;
+    const clean: ColorRecipe = { from: raw.from };
+    if (raw.color !== undefined) {
+        if (typeof raw.color !== 'string' || !HEX.test(raw.color)) return null;
+        clean.color = raw.color.toLowerCase();
+    } else if (raw.from === 'fixed') {
+        return null;
+    }
+    const hasToward = raw.toward !== undefined;
+    const hasAmount = raw.amount !== undefined;
+    if (hasToward !== hasAmount) return null;
+    if (hasToward) {
+        if (typeof raw.toward !== 'string' || !HEX.test(raw.toward)) return null;
+        if (typeof raw.amount !== 'number' || !Number.isFinite(raw.amount)) return null;
+        if (raw.amount < 0 || raw.amount > 1) return null;
+        clean.toward = raw.toward.toLowerCase();
+        clean.amount = raw.amount;
+    }
+    return clean;
+}
+
+export function sanitizeCustomIconTheme(value: unknown): CustomIconTheme | null {
+    if (!value || typeof value !== 'object') return null;
+    const raw = value as Record<string, unknown>;
+    if (typeof raw.id !== 'string' || !CUSTOM_ID.test(raw.id)) return null;
+    if (typeof raw.name !== 'string') return null;
+    const name = raw.name.trim();
+    if (name.length < 1 || name.length > 24) return null;
+    if (raw.depth !== undefined && typeof raw.depth !== 'boolean') return null;
+    const background = sanitizeRecipe(raw.background);
+    const glyph      = sanitizeRecipe(raw.glyph);
+    if (!background || !glyph) return null;
+    const clean: CustomIconTheme = { id: raw.id as CustomIconThemeId, name, background, glyph };
+    if (raw.depth === true) clean.depth = true;
+    return clean;
+}
+
+function sanitizeCustomList(value: unknown): CustomIconTheme[] {
+    if (!Array.isArray(value)) return [];
+    const out: CustomIconTheme[] = [];
+    for (const entry of value) {
+        if (out.length >= MAX_CUSTOM_ICON_THEMES) break;
+        const clean = sanitizeCustomIconTheme(entry);
+        if (clean && !out.some(x => x.id === clean.id)) out.push(clean);
+    }
+    return out;
+}
+
+function customDef(theme: CustomIconTheme): IconThemeDef {
+    return {
+        id:          theme.id,
+        art:         'glyph',
+        background:  theme.background,
+        glyph:       theme.glyph,
+        depth:       theme.depth === true,
+        minContrast: CUSTOM_CONTRAST,
+        label:       () => theme.name,
+        hint:        () => t('settings.iconThemeCustomHint', 'Your own tile and symbol colours'),
+    };
+}
+
+function syncCustomRegistry(list: CustomIconTheme[]) {
+    CUSTOM_BY_ID.clear();
+    for (const theme of list) CUSTOM_BY_ID.set(theme.id, customDef(theme));
+}
+
+function knownThemeId(value: unknown): IconThemeId | null {
+    if (typeof value !== 'string') return null;
+    if (BY_ID.has(value)) return value as BuiltinIconThemeId;
+    return CUSTOM_ID.test(value) ? value as CustomIconThemeId : null;
+}
 
 function clampByte(n: number): number {
     return Math.max(0, Math.min(255, Math.round(n)));
@@ -229,8 +332,7 @@ function litTile(solid: string): { css: string; shade: string } {
     return { css, shade };
 }
 
-export function resolveIconAppearance(theme: IconThemeId, appId: string, accent: string): IconAppearance {
-    const def = BY_ID[theme] ?? BY_ID.default;
+function appearanceOf(def: IconThemeDef, appId: string, accent: string): IconAppearance {
     const base = toRgb(accent) ? accent : customAccent(appId);
     const solid = resolveColor(def.background, base);
     const glyph = resolveColor(def.glyph, base);
@@ -244,13 +346,25 @@ export function resolveIconAppearance(theme: IconThemeId, appId: string, accent:
     };
 }
 
+export function resolveIconAppearance(theme: IconThemeId, appId: string, accent: string): IconAppearance {
+    return appearanceOf(BY_ID.get(theme) ?? CUSTOM_BY_ID.get(theme) ?? DEFAULT_DEF, appId, accent);
+}
+
+export function resolveDraftAppearance(
+    draft: { background: ColorRecipe; glyph: ColorRecipe; depth?: boolean },
+    appId: string,
+    accent: string,
+): IconAppearance {
+    return appearanceOf(customDef({ id: 'custom:draft', name: '', ...draft }), appId, accent);
+}
+
 const ICON_THEME_KEY = 'sd-phone:iconTheme';
 const APP_NAMES_KEY  = 'sd-phone:showAppNames';
+const CUSTOM_KEY     = 'sd-phone:iconCustom';
 
 function loadIconThemeLocal(): IconThemeId {
     try {
-        const v = window.localStorage.getItem(ICON_THEME_KEY);
-        return v && v in BY_ID ? v as IconThemeId : 'default';
+        return knownThemeId(window.localStorage.getItem(ICON_THEME_KEY)) ?? 'default';
     } catch { return 'default'; }
 }
 function saveIconThemeLocal(v: IconThemeId) {
@@ -264,17 +378,33 @@ function saveShowAppNamesLocal(v: boolean) {
     try { window.localStorage.setItem(APP_NAMES_KEY, v ? '1' : '0'); } catch {}
 }
 
+function loadCustomLocal(): CustomIconTheme[] {
+    try {
+        return sanitizeCustomList(JSON.parse(window.localStorage.getItem(CUSTOM_KEY) ?? '[]'));
+    } catch { return []; }
+}
+function saveCustomLocal(v: CustomIconTheme[]) {
+    try { window.localStorage.setItem(CUSTOM_KEY, JSON.stringify(v)); } catch {}
+}
+
 interface IconThemeState {
     iconTheme:       IconThemeId;
     setIconTheme:    (id: IconThemeId) => void;
     showAppNames:    boolean;
     setShowAppNames: (v: boolean) => void;
-    hydrate:         (data: { iconTheme?: unknown; showAppNames?: unknown }) => void;
+    customIconThemes:      CustomIconTheme[];
+    saveCustomIconTheme:   (theme: CustomIconTheme) => Promise<string | null>;
+    deleteCustomIconTheme: (id: CustomIconThemeId) => void;
+    hydrate:         (data: { iconTheme?: unknown; showAppNames?: unknown; customIconThemes?: unknown }) => void;
 }
 
-export const useIconThemeStore = create<IconThemeState>(set => ({
-    iconTheme:    isFiveM ? 'default' : loadIconThemeLocal(),
-    showAppNames: isFiveM ? true : loadShowAppNamesLocal(),
+const initialCustom = isFiveM ? [] : loadCustomLocal();
+syncCustomRegistry(initialCustom);
+
+export const useIconThemeStore = create<IconThemeState>((set, get) => ({
+    iconTheme:        isFiveM ? 'default' : loadIconThemeLocal(),
+    showAppNames:     isFiveM ? true : loadShowAppNamesLocal(),
+    customIconThemes: initialCustom,
 
     setIconTheme: (id) => {
         set({ iconTheme: id });
@@ -288,11 +418,41 @@ export const useIconThemeStore = create<IconThemeState>(set => ({
         else saveShowAppNamesLocal(v);
     },
 
+    saveCustomIconTheme: async (theme) => {
+        const clean = sanitizeCustomIconTheme(theme);
+        if (!clean) return t('settings.iconThemeSaveFailed', 'Could not save that icon theme.');
+        const list = get().customIconThemes;
+        const known = list.some(x => x.id === clean.id);
+        if (!known && list.length >= MAX_CUSTOM_ICON_THEMES) {
+            return t('settings.iconThemeFull', 'You can keep up to {n} of your own themes.', { n: MAX_CUSTOM_ICON_THEMES });
+        }
+        if (isFiveM) {
+            const res = await fetchNui<{ success?: boolean; message?: string }>('sd-phone:settings:saveCustomIconTheme', { theme: clean });
+            if (!res?.success) return res?.message ?? t('settings.iconThemeSaveFailed', 'Could not save that icon theme.');
+        }
+        const next = known ? list.map(x => x.id === clean.id ? clean : x) : [...list, clean];
+        set({ customIconThemes: next });
+        syncCustomRegistry(next);
+        if (!isFiveM) saveCustomLocal(next);
+        return null;
+    },
+
+    deleteCustomIconTheme: (id) => {
+        const next = get().customIconThemes.filter(x => x.id !== id);
+        set({ customIconThemes: next });
+        syncCustomRegistry(next);
+        if (isFiveM) void fetchNui('sd-phone:settings:deleteCustomIconTheme', { id }).catch(() => {});
+        else saveCustomLocal(next);
+        if (get().iconTheme === id) get().setIconTheme('default');
+    },
+
     hydrate: (data) => {
-        const stored = data.iconTheme;
+        const custom = sanitizeCustomList(data.customIconThemes);
+        syncCustomRegistry(custom);
         set({
-            iconTheme:    typeof stored === 'string' && stored in BY_ID ? stored as IconThemeId : 'default',
-            showAppNames: typeof data.showAppNames === 'boolean' ? data.showAppNames : true,
+            iconTheme:        knownThemeId(data.iconTheme) ?? 'default',
+            showAppNames:     typeof data.showAppNames === 'boolean' ? data.showAppNames : true,
+            customIconThemes: custom,
         });
     },
 }));
@@ -303,6 +463,10 @@ export function useIconTheme(): IconThemeId {
 
 export function useShowAppNames(): boolean {
     return useIconThemeStore(s => s.showAppNames);
+}
+
+export function useCustomIconThemes(): CustomIconTheme[] {
+    return useIconThemeStore(s => s.customIconThemes);
 }
 
 export function useIconAppearance(appId: string, accent: string): IconAppearance {

--- a/web/src/stores/iconThemeStore.ts
+++ b/web/src/stores/iconThemeStore.ts
@@ -4,7 +4,9 @@ import { fetchNui, isFiveM } from '@/core/nui';
 import { t } from '@/i18n';
 import { customAccent } from '@/stores/customAppsStore';
 
-export type IconThemeId = 'default' | 'mono' | 'pastel' | 'tinted';
+export type IconThemeId =
+    | 'default' | 'glass' | 'flat' | 'light' | 'pastel' | 'sand'
+    | 'slate' | 'tinted' | 'noir' | 'mono' | 'contrast';
 
 type IconArt = 'native' | 'glyph';
 
@@ -20,9 +22,13 @@ export interface IconThemeDef {
     art:        IconArt;
     background: ColorRecipe;
     glyph:      ColorRecipe;
-    label:      () => string;
-    hint:       () => string;
+    depth?:       boolean;
+    minContrast?: number;
+    label:        () => string;
+    hint:         () => string;
 }
+
+const WHITE_ON_COLOUR = 1.55;
 
 export const ICON_THEMES: IconThemeDef[] = [
     {
@@ -34,12 +40,31 @@ export const ICON_THEMES: IconThemeDef[] = [
         hint:       () => t('settings.iconThemeDefaultHint', 'Original app artwork'),
     },
     {
-        id:         'mono',
+        id:          'glass',
+        art:         'glyph',
+        background:  { from: 'accent' },
+        glyph:       { from: 'fixed', color: '#ffffff' },
+        depth:       true,
+        minContrast: WHITE_ON_COLOUR,
+        label:      () => t('settings.iconThemeGlass', 'Glass'),
+        hint:       () => t('settings.iconThemeGlassHint', 'Lit, glossy tiles in each app colour'),
+    },
+    {
+        id:          'flat',
+        art:         'glyph',
+        background:  { from: 'accent' },
+        glyph:       { from: 'fixed', color: '#ffffff' },
+        minContrast: WHITE_ON_COLOUR,
+        label:      () => t('settings.iconThemeFlat', 'Flat'),
+        hint:       () => t('settings.iconThemeFlatHint', 'Matching glyphs on full app colour'),
+    },
+    {
+        id:         'light',
         art:        'glyph',
-        background: { from: 'fixed', color: '#26262a' },
-        glyph:      { from: 'fixed', color: '#f5f5f7' },
-        label:      () => t('settings.iconThemeMono', 'Monochrome'),
-        hint:       () => t('settings.iconThemeMonoHint', 'One graphite tile for every app'),
+        background: { from: 'fixed', color: '#f4f4f6' },
+        glyph:      { from: 'accent', toward: '#1b1b1f', amount: 0.32 },
+        label:      () => t('settings.iconThemeLight', 'Light'),
+        hint:       () => t('settings.iconThemeLightHint', 'Off-white tiles, app-coloured glyphs'),
     },
     {
         id:         'pastel',
@@ -50,12 +75,52 @@ export const ICON_THEMES: IconThemeDef[] = [
         hint:       () => t('settings.iconThemePastelHint', 'Softened, pale app colours'),
     },
     {
+        id:         'sand',
+        art:        'glyph',
+        background: { from: 'accent', toward: '#e8dcc4', amount: 0.80 },
+        glyph:      { from: 'accent', toward: '#4a3a24', amount: 0.62 },
+        label:      () => t('settings.iconThemeSand', 'Sand'),
+        hint:       () => t('settings.iconThemeSandHint', 'Warm cream tiles with earthy glyphs'),
+    },
+    {
+        id:         'slate',
+        art:        'glyph',
+        background: { from: 'accent', toward: '#39414f', amount: 0.86 },
+        glyph:      { from: 'accent', toward: '#ffffff', amount: 0.72 },
+        label:      () => t('settings.iconThemeSlate', 'Slate'),
+        hint:       () => t('settings.iconThemeSlateHint', 'Cool grey tiles, barely tinted'),
+    },
+    {
         id:         'tinted',
         art:        'glyph',
         background: { from: 'accent', toward: '#0c0c0f', amount: 0.78 },
         glyph:      { from: 'accent', toward: '#ffffff', amount: 0.45 },
         label:      () => t('settings.iconThemeTinted', 'Tinted'),
         hint:       () => t('settings.iconThemeTintedHint', 'Dark tiles with a colour wash'),
+    },
+    {
+        id:         'noir',
+        art:        'glyph',
+        background: { from: 'fixed', color: '#0a0a0c' },
+        glyph:      { from: 'accent', toward: '#ffffff', amount: 0.22 },
+        label:      () => t('settings.iconThemeNoir', 'Noir'),
+        hint:       () => t('settings.iconThemeNoirHint', 'Black tiles that let the colour glow'),
+    },
+    {
+        id:         'mono',
+        art:        'glyph',
+        background: { from: 'fixed', color: '#26262a' },
+        glyph:      { from: 'fixed', color: '#f5f5f7' },
+        label:      () => t('settings.iconThemeMono', 'Monochrome'),
+        hint:       () => t('settings.iconThemeMonoHint', 'One graphite tile for every app'),
+    },
+    {
+        id:         'contrast',
+        art:        'glyph',
+        background: { from: 'fixed', color: '#000000' },
+        glyph:      { from: 'fixed', color: '#ffffff' },
+        label:      () => t('settings.iconThemeContrast', 'High Contrast'),
+        hint:       () => t('settings.iconThemeContrastHint', 'Pure black and white for legibility'),
     },
 ];
 
@@ -116,19 +181,66 @@ function resolveColor(recipe: ColorRecipe, accent: string): string {
     return mixColor(base, recipe.toward, recipe.amount);
 }
 
+const MIN_CONTRAST = 3;
+
+function luminance(rgb: [number, number, number]): number {
+    const [r, g, b] = rgb.map(v => {
+        const s = v / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    });
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a: string, b: string): number {
+    const x = toRgb(a);
+    const y = toRgb(b);
+    if (!x || !y) return MIN_CONTRAST;
+    const [hi, lo] = [luminance(x), luminance(y)].sort((p, q) => q - p);
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+function legible(glyph: string, tile: string[], floor: number): string {
+    const clears = (c: string) => tile.every(shade => contrast(c, shade) >= floor);
+    if (clears(glyph)) return glyph;
+    const bg = toRgb(tile[0]);
+    const target = bg && luminance(bg) > 0.4 ? '#000000' : '#ffffff';
+    for (let step = 1; step <= 10; step++) {
+        const lifted = mixColor(glyph, target, step / 10);
+        if (clears(lifted)) return lifted;
+    }
+    return target;
+}
+
 interface IconAppearance {
     background: string;
     glyph:      string;
     art:        IconArt;
 }
 
+function litTile(solid: string): { css: string; shade: string } {
+    const top   = mixColor(solid, '#ffffff', 0.34);
+    const mid   = mixColor(solid, '#ffffff', 0);
+    const shade = mixColor(solid, '#000000', 0.34);
+    const css = [
+        'radial-gradient(115% 78% at 30% -14%, rgba(255,255,255,0.46) 0%, rgba(255,255,255,0.06) 54%, rgba(255,255,255,0) 72%)',
+        'radial-gradient(130% 62% at 50% 116%, rgba(255,255,255,0.14) 0%, rgba(255,255,255,0) 62%)',
+        `linear-gradient(166deg, ${top} 0%, ${mid} 46%, ${shade} 100%)`,
+    ].join(', ');
+    return { css, shade };
+}
+
 export function resolveIconAppearance(theme: IconThemeId, appId: string, accent: string): IconAppearance {
     const def = BY_ID[theme] ?? BY_ID.default;
     const base = toRgb(accent) ? accent : customAccent(appId);
+    const solid = resolveColor(def.background, base);
+    const glyph = resolveColor(def.glyph, base);
+    const lit = def.depth ? litTile(solid) : null;
     return {
         art:        def.art,
-        background: resolveColor(def.background, base),
-        glyph:      resolveColor(def.glyph, base),
+        background: lit ? lit.css : solid,
+        glyph:      def.art === 'native'
+            ? glyph
+            : legible(glyph, lit ? [solid, lit.shade] : [solid], def.minContrast ?? MIN_CONTRAST),
     };
 }
 

--- a/web/src/stores/iconThemeStore.ts
+++ b/web/src/stores/iconThemeStore.ts
@@ -5,7 +5,7 @@ import { t } from '@/i18n';
 import { customAccent } from '@/stores/customAppsStore';
 import { useThemeStore } from '@/stores/themeStore';
 
-export type BuiltinIconThemeId =
+type BuiltinIconThemeId =
     | 'default' | 'glass' | 'flat' | 'light' | 'pastel' | 'sand'
     | 'slate' | 'tinted' | 'noir' | 'mono' | 'contrast';
 
@@ -24,7 +24,7 @@ export interface ColorRecipe {
 
 export type IconTexture = 'none' | 'noise' | 'dots' | 'stripes';
 
-export interface IconThemeBorder {
+interface IconThemeBorder {
     color: ColorRecipe;
     width: number;
 }
@@ -41,7 +41,7 @@ export interface IconThemeOverride {
     icon?:       string;
 }
 
-export interface IconThemeTraits {
+interface IconThemeTraits {
     radius?:      number;
     background2?: ColorRecipe;
     angle?:       number;

--- a/web/src/stores/iconThemeStore.ts
+++ b/web/src/stores/iconThemeStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import { fetchNui, isFiveM } from '@/core/nui';
 import { t } from '@/i18n';
 import { customAccent } from '@/stores/customAppsStore';
+import { useThemeStore } from '@/stores/themeStore';
 
 export type BuiltinIconThemeId =
     | 'default' | 'glass' | 'flat' | 'light' | 'pastel' | 'sand'
@@ -21,24 +22,70 @@ export interface ColorRecipe {
     amount?: number;
 }
 
-export interface IconThemeDef {
+export type IconTexture = 'none' | 'noise' | 'dots' | 'stripes';
+
+export interface IconThemeBorder {
+    color: ColorRecipe;
+    width: number;
+}
+
+export interface IconThemeLabel {
+    color?:  ColorRecipe;
+    weight?: number;
+    show?:   boolean;
+}
+
+export interface IconThemeOverride {
+    background?: ColorRecipe;
+    glyph?:      ColorRecipe;
+    icon?:       string;
+}
+
+export interface IconThemeTraits {
+    radius?:      number;
+    background2?: ColorRecipe;
+    angle?:       number;
+    gloss?:       number;
+    texture?:     IconTexture;
+    glyphScale?:  number;
+    glyphWeight?: number;
+    hue?:         number;
+    saturation?:  number;
+    border?:      IconThemeBorder;
+    bevel?:       boolean;
+    glow?:        number;
+    label?:       IconThemeLabel;
+    overrides?:   Record<string, IconThemeOverride>;
+    wallpaper?:   string;
+}
+
+export interface IconThemeVariant extends IconThemeTraits {
+    background?: ColorRecipe;
+    glyph?:      ColorRecipe;
+    depth?:      boolean;
+}
+
+export interface IconThemeDef extends Omit<IconThemeTraits, 'label'> {
     id:         IconThemeId;
     art:        IconArt;
     background: ColorRecipe;
     glyph:      ColorRecipe;
     depth?:       boolean;
     minContrast?: number;
+    dark?:        IconThemeVariant;
     label:        () => string;
     hint:         () => string;
 }
 
-export interface CustomIconTheme {
+export interface CustomIconTheme extends IconThemeVariant {
     id:         CustomIconThemeId;
     name:       string;
     background: ColorRecipe;
     glyph:      ColorRecipe;
-    depth?:     boolean;
+    dark?:      IconThemeVariant;
 }
+
+export type IconThemeDraft = Omit<CustomIconTheme, 'id' | 'name'>;
 
 const WHITE_ON_COLOUR = 1.55;
 const CUSTOM_CONTRAST = WHITE_ON_COLOUR;
@@ -137,16 +184,21 @@ export const ICON_THEMES: IconThemeDef[] = [
     },
 ];
 
-const BY_ID = new Map<string, IconThemeDef>(ICON_THEMES.map(d => [d.id, d]));
-const DEFAULT_DEF = BY_ID.get('default') as IconThemeDef;
-
 export const MAX_CUSTOM_ICON_THEMES = 12;
+export const MAX_ICON_OVERRIDES = 40;
 
 const CUSTOM_ID = /^custom:[a-z0-9]{4,8}$/;
 const HEX = /^#[0-9a-f]{6}$/i;
+const APP_ID = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+const WALLPAPER_KEY = /^[A-Za-z0-9._:/-]{1,255}$/;
 const ID_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
-const CUSTOM_BY_ID = new Map<string, IconThemeDef>();
+const TEXTURES: readonly IconTexture[] = ['none', 'noise', 'dots', 'stripes'];
+
+const DEFAULT_RADIUS       = 0.276;
+const DEFAULT_ANGLE        = 166;
+const DEFAULT_GLYPH_SIZE   = 40;
+const DEFAULT_GLYPH_WEIGHT = 1.9;
 
 export function newCustomIconThemeId(): CustomIconThemeId {
     let slug = '';
@@ -178,6 +230,184 @@ function sanitizeRecipe(value: unknown): ColorRecipe | null {
     return clean;
 }
 
+function bounded(value: unknown, lo: number, hi: number): number | null {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+    if (value < lo || value > hi) return null;
+    return value;
+}
+
+function sanitizeThemeWallpaper(value: unknown): string | null {
+    if (typeof value !== 'string' || value === '') return null;
+    if (/^https?:\/\//.test(value)) {
+        if (value.length > 512) return null;
+        if (/[\s\u0000-\u001f]/.test(value)) return null;
+        return /^https?:\/\/./.test(value) ? value : null;
+    }
+    return WALLPAPER_KEY.test(value) ? value : null;
+}
+
+function sanitizeOverrides(value: unknown): Record<string, IconThemeOverride> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const raw = value as Record<string, unknown>;
+    const keys = Object.keys(raw);
+    if (keys.length > MAX_ICON_OVERRIDES) return null;
+    const out: Record<string, IconThemeOverride> = {};
+    for (const key of keys) {
+        if (!APP_ID.test(key)) return null;
+        const entry = raw[key];
+        if (!entry || typeof entry !== 'object') return null;
+        const fields = entry as Record<string, unknown>;
+        const clean: IconThemeOverride = {};
+        if (fields.background !== undefined) {
+            const recipe = sanitizeRecipe(fields.background);
+            if (!recipe) return null;
+            clean.background = recipe;
+        }
+        if (fields.glyph !== undefined) {
+            const recipe = sanitizeRecipe(fields.glyph);
+            if (!recipe) return null;
+            clean.glyph = recipe;
+        }
+        if (fields.icon !== undefined) {
+            if (typeof fields.icon !== 'string' || !APP_ID.test(fields.icon)) return null;
+            clean.icon = fields.icon;
+        }
+        if (Object.keys(clean).length === 0) return null;
+        out[key] = clean;
+    }
+    return out;
+}
+
+function sanitizeLabel(value: unknown): IconThemeLabel | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const raw = value as Record<string, unknown>;
+    const clean: IconThemeLabel = {};
+    if (raw.color !== undefined) {
+        const recipe = sanitizeRecipe(raw.color);
+        if (!recipe) return null;
+        clean.color = recipe;
+    }
+    if (raw.weight !== undefined) {
+        const weight = bounded(raw.weight, 100, 900);
+        if (weight === null) return null;
+        clean.weight = weight;
+    }
+    if (raw.show !== undefined) {
+        if (typeof raw.show !== 'boolean') return null;
+        clean.show = raw.show;
+    }
+    return clean;
+}
+
+function sanitizeBorder(value: unknown): IconThemeBorder | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const raw = value as Record<string, unknown>;
+    const color = sanitizeRecipe(raw.color);
+    const width = bounded(raw.width, 0, 4);
+    if (!color || width === null) return null;
+    return { color, width };
+}
+
+function applyTraits(raw: Record<string, unknown>, clean: IconThemeVariant): boolean {
+    if (raw.radius !== undefined) {
+        const value = bounded(raw.radius, 0, 0.5);
+        if (value === null) return false;
+        clean.radius = value;
+    }
+    if (raw.background2 !== undefined) {
+        const recipe = sanitizeRecipe(raw.background2);
+        if (!recipe) return false;
+        clean.background2 = recipe;
+    }
+    if (raw.angle !== undefined) {
+        const value = bounded(raw.angle, 0, 360);
+        if (value === null) return false;
+        clean.angle = value;
+    }
+    if (raw.gloss !== undefined) {
+        const value = bounded(raw.gloss, 0, 1);
+        if (value === null) return false;
+        clean.gloss = value;
+    }
+    if (raw.texture !== undefined) {
+        if (typeof raw.texture !== 'string' || !TEXTURES.includes(raw.texture as IconTexture)) return false;
+        clean.texture = raw.texture as IconTexture;
+    }
+    if (raw.glyphScale !== undefined) {
+        const value = bounded(raw.glyphScale, 0.6, 1.4);
+        if (value === null) return false;
+        clean.glyphScale = value;
+    }
+    if (raw.glyphWeight !== undefined) {
+        const value = bounded(raw.glyphWeight, 1, 3);
+        if (value === null) return false;
+        clean.glyphWeight = value;
+    }
+    if (raw.hue !== undefined) {
+        const value = bounded(raw.hue, -180, 180);
+        if (value === null) return false;
+        clean.hue = value;
+    }
+    if (raw.saturation !== undefined) {
+        const value = bounded(raw.saturation, 0, 2);
+        if (value === null) return false;
+        clean.saturation = value;
+    }
+    if (raw.border !== undefined) {
+        const border = sanitizeBorder(raw.border);
+        if (!border) return false;
+        clean.border = border;
+    }
+    if (raw.bevel !== undefined) {
+        if (typeof raw.bevel !== 'boolean') return false;
+        if (raw.bevel) clean.bevel = true;
+    }
+    if (raw.glow !== undefined) {
+        const value = bounded(raw.glow, 0, 1);
+        if (value === null) return false;
+        clean.glow = value;
+    }
+    if (raw.label !== undefined) {
+        const label = sanitizeLabel(raw.label);
+        if (!label) return false;
+        if (Object.keys(label).length > 0) clean.label = label;
+    }
+    if (raw.overrides !== undefined) {
+        const overrides = sanitizeOverrides(raw.overrides);
+        if (!overrides) return false;
+        if (Object.keys(overrides).length > 0) clean.overrides = overrides;
+    }
+    if (raw.wallpaper !== undefined) {
+        const wallpaper = sanitizeThemeWallpaper(raw.wallpaper);
+        if (!wallpaper) return false;
+        clean.wallpaper = wallpaper;
+    }
+    return true;
+}
+
+function sanitizeVariant(value: unknown): IconThemeVariant | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const raw = value as Record<string, unknown>;
+    if (raw.dark !== undefined) return null;
+    const clean: IconThemeVariant = {};
+    if (raw.background !== undefined) {
+        const recipe = sanitizeRecipe(raw.background);
+        if (!recipe) return null;
+        clean.background = recipe;
+    }
+    if (raw.glyph !== undefined) {
+        const recipe = sanitizeRecipe(raw.glyph);
+        if (!recipe) return null;
+        clean.glyph = recipe;
+    }
+    if (raw.depth !== undefined) {
+        if (typeof raw.depth !== 'boolean') return null;
+        if (raw.depth) clean.depth = true;
+    }
+    if (!applyTraits(raw, clean)) return null;
+    return clean;
+}
+
 export function sanitizeCustomIconTheme(value: unknown): CustomIconTheme | null {
     if (!value || typeof value !== 'object') return null;
     const raw = value as Record<string, unknown>;
@@ -191,6 +421,12 @@ export function sanitizeCustomIconTheme(value: unknown): CustomIconTheme | null 
     if (!background || !glyph) return null;
     const clean: CustomIconTheme = { id: raw.id as CustomIconThemeId, name, background, glyph };
     if (raw.depth === true) clean.depth = true;
+    if (!applyTraits(raw, clean)) return null;
+    if (raw.dark !== undefined) {
+        const dark = sanitizeVariant(raw.dark);
+        if (!dark) return null;
+        if (Object.keys(dark).length > 0) clean.dark = dark;
+    }
     return clean;
 }
 
@@ -205,27 +441,35 @@ function sanitizeCustomList(value: unknown): CustomIconTheme[] {
     return out;
 }
 
-function customDef(theme: CustomIconTheme): IconThemeDef {
-    return {
-        id:          theme.id,
-        art:         'glyph',
-        background:  theme.background,
-        glyph:       theme.glyph,
-        depth:       theme.depth === true,
-        minContrast: CUSTOM_CONTRAST,
-        label:       () => theme.name,
-        hint:        () => t('settings.iconThemeCustomHint', 'Your own tile and symbol colours'),
-    };
+interface ThemeSource {
+    art:          IconArt;
+    minContrast?: number;
+    base:         IconThemeVariant;
+    dark?:        IconThemeVariant;
 }
+
+function sourceOfDef(def: IconThemeDef): ThemeSource {
+    const { id, label, hint, art, minContrast, dark, ...base } = def;
+    return { art, minContrast, base, dark };
+}
+
+function sourceOfTheme(theme: IconThemeDraft): ThemeSource {
+    const { dark, ...base } = theme;
+    return { art: 'glyph', minContrast: CUSTOM_CONTRAST, base, dark };
+}
+
+const SOURCE_BY_ID = new Map<string, ThemeSource>(ICON_THEMES.map(def => [def.id, sourceOfDef(def)]));
+const DEFAULT_SOURCE = SOURCE_BY_ID.get('default') as ThemeSource;
+const CUSTOM_BY_ID = new Map<string, ThemeSource>();
 
 function syncCustomRegistry(list: CustomIconTheme[]) {
     CUSTOM_BY_ID.clear();
-    for (const theme of list) CUSTOM_BY_ID.set(theme.id, customDef(theme));
+    for (const theme of list) CUSTOM_BY_ID.set(theme.id, sourceOfTheme(theme));
 }
 
 function knownThemeId(value: unknown): IconThemeId | null {
     if (typeof value !== 'string') return null;
-    if (BY_ID.has(value)) return value as BuiltinIconThemeId;
+    if (SOURCE_BY_ID.has(value)) return value as BuiltinIconThemeId;
     return CUSTOM_ID.test(value) ? value as CustomIconThemeId : null;
 }
 
@@ -246,6 +490,20 @@ function hslToRgb(h: number, s: number, l: number): [number, number, number] {
         : [c, 0, x];
     const m = l - c / 2;
     return [(seg[0] + m) * 255, (seg[1] + m) * 255, (seg[2] + m) * 255];
+}
+
+function rgbToHsl(rgb: [number, number, number]): [number, number, number] {
+    const [r, g, b] = rgb.map(v => v / 255);
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    const d = max - min;
+    if (d === 0) return [0, 0, l];
+    const s = d / (1 - Math.abs(2 * l - 1));
+    const h = max === r ? 60 * (((g - b) / d) % 6)
+        : max === g ? 60 * ((b - r) / d + 2)
+        : 60 * ((r - g) / d + 4);
+    return [((h % 360) + 360) % 360, s, l];
 }
 
 function toRgb(value: string): [number, number, number] | null {
@@ -278,6 +536,15 @@ function mixColor(from: string, toward: string, amount: number): string {
     return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
 }
 
+function shiftAccent(color: string, hue: number | undefined, saturation: number | undefined): string {
+    if (hue === undefined && saturation === undefined) return color;
+    const rgb = toRgb(color);
+    if (!rgb) return color;
+    const [h, s, l] = rgbToHsl(rgb);
+    const out = hslToRgb(h + (hue ?? 0), Math.max(0, Math.min(1, s * (saturation ?? 1))), l);
+    return `rgb(${clampByte(out[0])}, ${clampByte(out[1])}, ${clampByte(out[2])})`;
+}
+
 function resolveColor(recipe: ColorRecipe, accent: string): string {
     const base = recipe.from === 'accent' ? accent : (recipe.color ?? accent);
     if (!recipe.toward || recipe.amount === undefined) return base;
@@ -307,55 +574,140 @@ function legible(glyph: string, tile: string[], floor: number): string {
     if (clears(glyph)) return glyph;
     const bg = toRgb(tile[0]);
     const target = bg && luminance(bg) > 0.4 ? '#000000' : '#ffffff';
+    const away = target === '#000000' ? '#ffffff' : '#000000';
     for (let step = 1; step <= 10; step++) {
         const lifted = mixColor(glyph, target, step / 10);
         if (clears(lifted)) return lifted;
     }
-    return target;
+    for (let step = 1; step <= 10; step++) {
+        const lifted = mixColor(glyph, away, step / 10);
+        if (clears(lifted)) return lifted;
+    }
+    const worst = (c: string) => Math.min(...tile.map(shade => contrast(c, shade)));
+    return worst(target) >= worst(away) ? target : away;
 }
 
-interface IconAppearance {
-    background: string;
-    glyph:      string;
-    art:        IconArt;
+export interface IconAppearance {
+    art:          IconArt;
+    background:   string;
+    glyph:        string;
+    radius:       number;
+    glyphSize:    number;
+    glyphWeight:  number;
+    boxShadow:    string;
+    labelColor:   string | undefined;
+    labelWeight:  number | undefined;
+    labelShow:    boolean | undefined;
+    icon:         string | undefined;
 }
 
-function litTile(solid: string): { css: string; shade: string } {
-    const top   = mixColor(solid, '#ffffff', 0.34);
-    const mid   = mixColor(solid, '#ffffff', 0);
-    const shade = mixColor(solid, '#000000', 0.34);
-    const css = [
-        'radial-gradient(115% 78% at 30% -14%, rgba(255,255,255,0.46) 0%, rgba(255,255,255,0.06) 54%, rgba(255,255,255,0) 72%)',
-        'radial-gradient(130% 62% at 50% 116%, rgba(255,255,255,0.14) 0%, rgba(255,255,255,0) 62%)',
-        `linear-gradient(166deg, ${top} 0%, ${mid} 46%, ${shade} 100%)`,
-    ].join(', ');
-    return { css, shade };
+const ACCENT_RECIPE: ColorRecipe = { from: 'accent' };
+
+const TEXTURE_LAYERS: Record<IconTexture, string> = {
+    none:    '',
+    noise:   'radial-gradient(rgba(255,255,255,0.10) 0.5px, rgba(255,255,255,0) 0.7px) 0 0 / 3px 3px, '
+        + 'radial-gradient(rgba(0,0,0,0.08) 0.5px, rgba(0,0,0,0) 0.7px) 1.5px 1.5px / 3px 3px',
+    dots:    'radial-gradient(rgba(255,255,255,0.16) 1.2px, rgba(255,255,255,0) 1.5px) 0 0 / 9px 9px',
+    stripes: 'repeating-linear-gradient(135deg, rgba(255,255,255,0.10) 0 2px, rgba(255,255,255,0) 2px 6px)',
+};
+
+function alpha(n: number): string {
+    return String(Math.round(n * 1000) / 1000);
 }
 
-function appearanceOf(def: IconThemeDef, appId: string, accent: string): IconAppearance {
-    const base = toRgb(accent) ? accent : customAccent(appId);
-    const solid = resolveColor(def.background, base);
-    const glyph = resolveColor(def.glyph, base);
-    const lit = def.depth ? litTile(solid) : null;
+function variantFor(source: ThemeSource, dark: boolean): IconThemeVariant {
+    return dark && source.dark ? { ...source.base, ...source.dark } : source.base;
+}
+
+function appearanceOf(source: ThemeSource, appId: string, accent: string, dark: boolean): IconAppearance {
+    const look = variantFor(source, dark);
+    const rooted = toRgb(accent) ? accent : customAccent(appId);
+    const tint = shiftAccent(rooted, look.hue, look.saturation);
+
+    const override = look.overrides?.[appId];
+    const solid  = resolveColor(override?.background ?? look.background ?? ACCENT_RECIPE, tint);
+    const symbol = resolveColor(override?.glyph ?? look.glyph ?? ACCENT_RECIPE, tint);
+
+    const depth  = look.depth === true;
+    const angle  = look.angle ?? DEFAULT_ANGLE;
+    const second = look.background2 ? resolveColor(look.background2, tint) : null;
+    const shades = [solid];
+
+    let base: string;
+    if (second) {
+        base = `linear-gradient(${angle}deg, ${solid} 0%, ${second} 100%)`;
+        shades.push(second);
+    } else if (depth) {
+        const top   = mixColor(solid, '#ffffff', 0.34);
+        const mid   = mixColor(solid, '#ffffff', 0);
+        const shade = mixColor(solid, '#000000', 0.34);
+        base = `linear-gradient(${angle}deg, ${top} 0%, ${mid} 46%, ${shade} 100%)`;
+        shades.push(shade);
+    } else {
+        base = solid;
+    }
+
+    const layers: string[] = [];
+    const gloss = look.gloss ?? (depth ? 1 : 0);
+    if (gloss > 0) {
+        layers.push(
+            `radial-gradient(115% 78% at 30% -14%, rgba(255,255,255,${alpha(0.46 * gloss)}) 0%, `
+                + `rgba(255,255,255,${alpha(0.06 * gloss)}) 54%, rgba(255,255,255,0) 72%)`,
+            `radial-gradient(130% 62% at 50% 116%, rgba(255,255,255,${alpha(0.14 * gloss)}) 0%, rgba(255,255,255,0) 62%)`,
+        );
+        if (look.gloss !== undefined) shades.push(mixColor(solid, '#ffffff', 0.46 * gloss));
+    }
+    const texture = TEXTURE_LAYERS[look.texture ?? 'none'];
+    if (texture) layers.push(texture);
+    layers.push(base);
+
+    const shadow: string[] = [];
+    if (look.glow !== undefined && look.glow > 0) {
+        const lit = toRgb(mixColor(solid, '#ffffff', 0.25)) ?? [255, 255, 255];
+        shadow.push(`0 0 ${Math.round(6 + 18 * look.glow)}px rgba(${lit[0]}, ${lit[1]}, ${lit[2]}, ${alpha(0.12 + 0.48 * look.glow)})`);
+    }
+    if (look.border && look.border.width > 0) {
+        shadow.push(`inset 0 0 0 ${look.border.width}px ${resolveColor(look.border.color, tint)}`);
+    }
+    if (look.bevel === true) {
+        shadow.push('inset 0 1px 0 rgba(255,255,255,0.28)', 'inset 0 -1px 0 rgba(0,0,0,0.3)');
+    }
+
     return {
-        art:        def.art,
-        background: lit ? lit.css : solid,
-        glyph:      def.art === 'native'
-            ? glyph
-            : legible(glyph, lit ? [solid, lit.shade] : [solid], def.minContrast ?? MIN_CONTRAST),
+        art:         source.art,
+        background:  layers.join(', '),
+        glyph:       source.art === 'native'
+            ? symbol
+            : legible(symbol, shades, source.minContrast ?? MIN_CONTRAST),
+        radius:      look.radius ?? DEFAULT_RADIUS,
+        glyphSize:   Math.round(DEFAULT_GLYPH_SIZE * (look.glyphScale ?? 1)),
+        glyphWeight: look.glyphWeight ?? DEFAULT_GLYPH_WEIGHT,
+        boxShadow:   shadow.join(', '),
+        labelColor:  look.label?.color ? resolveColor(look.label.color, tint) : undefined,
+        labelWeight: look.label?.weight,
+        labelShow:   look.label?.show,
+        icon:        override?.icon,
     };
 }
 
-export function resolveIconAppearance(theme: IconThemeId, appId: string, accent: string): IconAppearance {
-    return appearanceOf(BY_ID.get(theme) ?? CUSTOM_BY_ID.get(theme) ?? DEFAULT_DEF, appId, accent);
+function sourceFor(theme: IconThemeId): ThemeSource {
+    return SOURCE_BY_ID.get(theme) ?? CUSTOM_BY_ID.get(theme) ?? DEFAULT_SOURCE;
 }
 
-export function resolveDraftAppearance(
-    draft: { background: ColorRecipe; glyph: ColorRecipe; depth?: boolean },
-    appId: string,
-    accent: string,
-): IconAppearance {
-    return appearanceOf(customDef({ id: 'custom:draft', name: '', ...draft }), appId, accent);
+function darkNow(): boolean {
+    return useThemeStore.getState().theme === 'dark';
+}
+
+export function resolveIconAppearance(theme: IconThemeId, appId: string, accent: string): IconAppearance {
+    return appearanceOf(sourceFor(theme), appId, accent, darkNow());
+}
+
+export function resolveDraftAppearance(draft: IconThemeDraft, appId: string, accent: string): IconAppearance {
+    return appearanceOf(sourceOfTheme(draft), appId, accent, darkNow());
+}
+
+export function iconThemeWallpaper(theme: IconThemeId): string | undefined {
+    return variantFor(sourceFor(theme), darkNow()).wallpaper;
 }
 
 const ICON_THEME_KEY = 'sd-phone:iconTheme';
@@ -470,5 +822,7 @@ export function useCustomIconThemes(): CustomIconTheme[] {
 }
 
 export function useIconAppearance(appId: string, accent: string): IconAppearance {
-    return resolveIconAppearance(useIconTheme(), appId, accent);
+    const theme = useIconTheme();
+    const dark  = useThemeStore(s => s.theme === 'dark');
+    return appearanceOf(sourceFor(theme), appId, accent, dark);
 }

--- a/web/src/stores/iconThemeStore.ts
+++ b/web/src/stores/iconThemeStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 
+import { fetchNui, isFiveM } from '@/core/nui';
 import { t } from '@/i18n';
 import { customAccent } from '@/stores/customAppsStore';
 
@@ -156,20 +157,31 @@ interface IconThemeState {
     setIconTheme:    (id: IconThemeId) => void;
     showAppNames:    boolean;
     setShowAppNames: (v: boolean) => void;
+    hydrate:         (data: { iconTheme?: unknown; showAppNames?: unknown }) => void;
 }
 
 export const useIconThemeStore = create<IconThemeState>(set => ({
-    iconTheme:    loadIconThemeLocal(),
-    showAppNames: loadShowAppNamesLocal(),
+    iconTheme:    isFiveM ? 'default' : loadIconThemeLocal(),
+    showAppNames: isFiveM ? true : loadShowAppNamesLocal(),
 
     setIconTheme: (id) => {
         set({ iconTheme: id });
-        saveIconThemeLocal(id);
+        if (isFiveM) void fetchNui('sd-phone:settings:setIconTheme', { iconTheme: id }).catch(() => {});
+        else saveIconThemeLocal(id);
     },
 
     setShowAppNames: (v) => {
         set({ showAppNames: v });
-        saveShowAppNamesLocal(v);
+        if (isFiveM) void fetchNui('sd-phone:settings:setShowAppNames', { on: v }).catch(() => {});
+        else saveShowAppNamesLocal(v);
+    },
+
+    hydrate: (data) => {
+        const stored = data.iconTheme;
+        set({
+            iconTheme:    typeof stored === 'string' && stored in BY_ID ? stored as IconThemeId : 'default',
+            showAppNames: typeof data.showAppNames === 'boolean' ? data.showAppNames : true,
+        });
     },
 }));
 

--- a/web/src/stores/iconThemeStore.ts
+++ b/web/src/stores/iconThemeStore.ts
@@ -1,0 +1,186 @@
+import { create } from 'zustand';
+
+import { t } from '@/i18n';
+import { customAccent } from '@/stores/customAppsStore';
+
+export type IconThemeId = 'default' | 'mono' | 'pastel' | 'tinted';
+
+type IconArt = 'native' | 'glyph';
+
+interface ColorRecipe {
+    from:    'accent' | 'fixed';
+    color?:  string;
+    toward?: string;
+    amount?: number;
+}
+
+export interface IconThemeDef {
+    id:         IconThemeId;
+    art:        IconArt;
+    background: ColorRecipe;
+    glyph:      ColorRecipe;
+    label:      () => string;
+    hint:       () => string;
+}
+
+export const ICON_THEMES: IconThemeDef[] = [
+    {
+        id:         'default',
+        art:        'native',
+        background: { from: 'accent' },
+        glyph:      { from: 'fixed', color: '#ffffff' },
+        label:      () => t('settings.iconThemeDefault', 'Default'),
+        hint:       () => t('settings.iconThemeDefaultHint', 'Original app artwork'),
+    },
+    {
+        id:         'mono',
+        art:        'glyph',
+        background: { from: 'fixed', color: '#26262a' },
+        glyph:      { from: 'fixed', color: '#f5f5f7' },
+        label:      () => t('settings.iconThemeMono', 'Monochrome'),
+        hint:       () => t('settings.iconThemeMonoHint', 'One graphite tile for every app'),
+    },
+    {
+        id:         'pastel',
+        art:        'glyph',
+        background: { from: 'accent', toward: '#ffffff', amount: 0.66 },
+        glyph:      { from: 'accent', toward: '#1b1b1f', amount: 0.55 },
+        label:      () => t('settings.iconThemePastel', 'Pastel'),
+        hint:       () => t('settings.iconThemePastelHint', 'Softened, pale app colours'),
+    },
+    {
+        id:         'tinted',
+        art:        'glyph',
+        background: { from: 'accent', toward: '#0c0c0f', amount: 0.78 },
+        glyph:      { from: 'accent', toward: '#ffffff', amount: 0.45 },
+        label:      () => t('settings.iconThemeTinted', 'Tinted'),
+        hint:       () => t('settings.iconThemeTintedHint', 'Dark tiles with a colour wash'),
+    },
+];
+
+const BY_ID = Object.fromEntries(ICON_THEMES.map(d => [d.id, d])) as Record<IconThemeId, IconThemeDef>;
+
+function clampByte(n: number): number {
+    return Math.max(0, Math.min(255, Math.round(n)));
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+    const c = (1 - Math.abs(2 * l - 1)) * s;
+    const hp = ((((h % 360) + 360) % 360) / 60);
+    const x = c * (1 - Math.abs((hp % 2) - 1));
+    const seg: [number, number, number] =
+        hp < 1 ? [c, x, 0]
+        : hp < 2 ? [x, c, 0]
+        : hp < 3 ? [0, c, x]
+        : hp < 4 ? [0, x, c]
+        : hp < 5 ? [x, 0, c]
+        : [c, 0, x];
+    const m = l - c / 2;
+    return [(seg[0] + m) * 255, (seg[1] + m) * 255, (seg[2] + m) * 255];
+}
+
+function toRgb(value: string): [number, number, number] | null {
+    const v = value.trim().toLowerCase();
+    if (v.startsWith('#')) {
+        const hex = v.slice(1);
+        if (hex.length === 3 || hex.length === 4) {
+            const p = [0, 1, 2].map(i => parseInt(hex[i] + hex[i], 16));
+            return p.some(Number.isNaN) ? null : [p[0], p[1], p[2]];
+        }
+        if (hex.length === 6 || hex.length === 8) {
+            const p = [0, 2, 4].map(i => parseInt(hex.slice(i, i + 2), 16));
+            return p.some(Number.isNaN) ? null : [p[0], p[1], p[2]];
+        }
+        return null;
+    }
+    const nums = v.match(/-?\d*\.?\d+/g);
+    if (!nums || nums.length < 3) return null;
+    if (v.startsWith('rgb')) return [Number(nums[0]), Number(nums[1]), Number(nums[2])];
+    if (v.startsWith('hsl')) return hslToRgb(Number(nums[0]), Number(nums[1]) / 100, Number(nums[2]) / 100);
+    return null;
+}
+
+function mixColor(from: string, toward: string, amount: number): string {
+    const a = toRgb(from);
+    const b = toRgb(toward);
+    if (!a || !b) return from;
+    const k = Math.max(0, Math.min(1, amount));
+    const c = [0, 1, 2].map(i => clampByte(a[i] + (b[i] - a[i]) * k));
+    return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+}
+
+function resolveColor(recipe: ColorRecipe, accent: string): string {
+    const base = recipe.from === 'accent' ? accent : (recipe.color ?? accent);
+    if (!recipe.toward || recipe.amount === undefined) return base;
+    return mixColor(base, recipe.toward, recipe.amount);
+}
+
+interface IconAppearance {
+    background: string;
+    glyph:      string;
+    art:        IconArt;
+}
+
+export function resolveIconAppearance(theme: IconThemeId, appId: string, accent: string): IconAppearance {
+    const def = BY_ID[theme] ?? BY_ID.default;
+    const base = toRgb(accent) ? accent : customAccent(appId);
+    return {
+        art:        def.art,
+        background: resolveColor(def.background, base),
+        glyph:      resolveColor(def.glyph, base),
+    };
+}
+
+const ICON_THEME_KEY = 'sd-phone:iconTheme';
+const APP_NAMES_KEY  = 'sd-phone:showAppNames';
+
+function loadIconThemeLocal(): IconThemeId {
+    try {
+        const v = window.localStorage.getItem(ICON_THEME_KEY);
+        return v && v in BY_ID ? v as IconThemeId : 'default';
+    } catch { return 'default'; }
+}
+function saveIconThemeLocal(v: IconThemeId) {
+    try { window.localStorage.setItem(ICON_THEME_KEY, v); } catch {}
+}
+
+function loadShowAppNamesLocal(): boolean {
+    try { return window.localStorage.getItem(APP_NAMES_KEY) !== '0'; } catch { return true; }
+}
+function saveShowAppNamesLocal(v: boolean) {
+    try { window.localStorage.setItem(APP_NAMES_KEY, v ? '1' : '0'); } catch {}
+}
+
+interface IconThemeState {
+    iconTheme:       IconThemeId;
+    setIconTheme:    (id: IconThemeId) => void;
+    showAppNames:    boolean;
+    setShowAppNames: (v: boolean) => void;
+}
+
+export const useIconThemeStore = create<IconThemeState>(set => ({
+    iconTheme:    loadIconThemeLocal(),
+    showAppNames: loadShowAppNamesLocal(),
+
+    setIconTheme: (id) => {
+        set({ iconTheme: id });
+        saveIconThemeLocal(id);
+    },
+
+    setShowAppNames: (v) => {
+        set({ showAppNames: v });
+        saveShowAppNamesLocal(v);
+    },
+}));
+
+export function useIconTheme(): IconThemeId {
+    return useIconThemeStore(s => s.iconTheme);
+}
+
+export function useShowAppNames(): boolean {
+    return useIconThemeStore(s => s.showAppNames);
+}
+
+export function useIconAppearance(appId: string, accent: string): IconAppearance {
+    return resolveIconAppearance(useIconTheme(), appId, accent);
+}

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -505,7 +505,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
             }
         };
         const keyAtRequest = wallpaperProfileKey;
-        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; wallpaperHome?: string; blurLock?: boolean; blurHome?: boolean; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; brightness?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string; iconTheme?: string; showAppNames?: boolean } }>('sd-phone:settings:get')
+        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; wallpaperHome?: string; blurLock?: boolean; blurHome?: boolean; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; brightness?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string; iconTheme?: string; showAppNames?: boolean; customIconThemes?: unknown } }>('sd-phone:settings:get')
             .then(res => {
                 if (!res?.data) { retry(); return; }
                 const d = res.data;

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -8,6 +8,7 @@ import devDefaultAsset from '@/assets/photos/background5.webp';
 import { fetchNui, isFiveM } from '@/core/nui';
 import { isDemo } from '@/core/demo';
 import { wallpaperKey } from '@/shell/wallpapers';
+import { useIconThemeStore } from '@/stores/iconThemeStore';
 import { DEFAULT_LOCK_CLOCK, loadLockClockLocal, saveLockClockLocal, type LockClock } from '@/shell/lockClock';
 import { DEFAULT_NOTIFICATION, DEFAULT_RINGTONE } from '@/apps/settings/tones';
 import type { CustomTone, ToneKind } from '@/apps/settings/tones';
@@ -504,7 +505,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
             }
         };
         const keyAtRequest = wallpaperProfileKey;
-        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; wallpaperHome?: string; blurLock?: boolean; blurHome?: boolean; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; brightness?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string } }>('sd-phone:settings:get')
+        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; wallpaperHome?: string; blurLock?: boolean; blurHome?: boolean; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; brightness?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string; iconTheme?: string; showAppNames?: boolean } }>('sd-phone:settings:get')
             .then(res => {
                 if (!res?.data) { retry(); return; }
                 const d = res.data;
@@ -549,6 +550,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 patch.customRingtones         = ring;
                 patch.customNotificationTones = notif;
                 set(patch);
+                useIconThemeStore.getState().hydrate(d);
                 // Freshest server answer becomes the profile's cached wallpapers - unless the
                 // acting profile changed while this request was in flight.
                 if (isFiveM && keyAtRequest === wallpaperProfileKey) {

--- a/web/src/ui/Slider.tsx
+++ b/web/src/ui/Slider.tsx
@@ -1,0 +1,67 @@
+import { useRef, useState } from 'react';
+
+import { trackFraction } from '@/lib/zoom';
+
+export function Slider({ value, min = 0, max = 100, step = 1, onChange, ariaLabel, className = '' }: {
+    value:      number;
+    min?:       number;
+    max?:       number;
+    step?:      number;
+    onChange:   (v: number) => void;
+    ariaLabel?: string;
+    className?: string;
+}) {
+    const ref = useRef<HTMLDivElement>(null);
+    const dragging = useRef(false);
+    const [drag, setDrag] = useState<number | null>(null);
+    const span = max - min;
+    const shown = drag ?? value;
+    const pct = span > 0 ? Math.max(0, Math.min(100, ((shown - min) / span) * 100)) : 0;
+
+    function posFrom(e: React.PointerEvent): number | null {
+        const el = ref.current;
+        if (!el || span <= 0) return null;
+        const f = trackFraction(el, e.clientX);
+        if (f === null) return null;
+        const snapped = Math.round((min + f * span) / step) * step;
+        return Math.max(min, Math.min(max, snapped));
+    }
+
+    return (
+        <div
+            ref={ref}
+            role="slider"
+            aria-label={ariaLabel}
+            aria-valuemin={min}
+            aria-valuemax={max}
+            aria-valuenow={Math.round(shown)}
+            className={`relative h-7 cursor-pointer touch-none ${className}`}
+            onPointerDown={e => {
+                const p = posFrom(e);
+                if (p === null) return;
+                dragging.current = true;
+                ref.current?.setPointerCapture?.(e.pointerId);
+                setDrag(p);
+                onChange(p);
+            }}
+            onPointerMove={e => {
+                if (!dragging.current) return;
+                const p = posFrom(e);
+                if (p !== null) { setDrag(p); onChange(p); }
+            }}
+            onPointerUp={() => { dragging.current = false; setDrag(null); }}
+            onPointerCancel={() => { dragging.current = false; setDrag(null); }}
+        >
+            <div className="pointer-events-none absolute inset-x-0 top-1/2 h-1 -translate-y-1/2 overflow-hidden rounded-full bg-black/[0.14] dark:bg-white/[0.18]">
+                <div className="h-full rounded-full bg-ios-blue" style={{ width: `${pct}%` }} />
+            </div>
+            <div
+                className="pointer-events-none absolute top-1/2 h-[22px] w-[22px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"
+                style={{
+                    left:      `${pct}%`,
+                    boxShadow: '0 2px 7px rgba(0,0,0,0.24), 0 0.5px 1.5px rgba(0,0,0,0.16)',
+                }}
+            />
+        </div>
+    );
+}

--- a/web/src/ui/SliderRow.tsx
+++ b/web/src/ui/SliderRow.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+
+import { Slider } from './Slider';
+
+export function SliderRow({
+    label, value, display, min = 0, max = 100, step = 1, divider = false, muted = false, accessory, onChange,
+}: {
+    label:      string;
+    value:      number;
+    display?:   string;
+    min?:       number;
+    max?:       number;
+    step?:      number;
+    divider?:   boolean;
+    muted?:     boolean;
+    accessory?: ReactNode;
+    onChange:   (v: number) => void;
+}) {
+    return (
+        <div className="relative px-4 pb-1.5 pt-2.5">
+            <div className="flex items-baseline gap-2">
+                <span className={`flex-1 text-[17px] font-normal ${muted ? 'text-ios-gray' : 'text-black dark:text-white'}`}>
+                    {label}
+                </span>
+                {accessory}
+                {display !== undefined && (
+                    <span className="shrink-0 text-[15px] tabular-nums text-ios-gray">{display}</span>
+                )}
+            </div>
+            <Slider
+                value={value}
+                min={min}
+                max={max}
+                step={step}
+                onChange={onChange}
+                ariaLabel={label}
+            />
+            {divider && (
+                <div
+                    className="pointer-events-none absolute inset-x-0 bottom-0 bg-ios-gray4 dark:bg-control"
+                    style={{ height: '0.5px' }}
+                />
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
Five requested home screen features.

## Drag icons between the dock and the pages
An icon can be dragged out of the dock onto any page and back again. Dropping onto a full dock displaces the tile under the pointer into the cell the dragged icon just left, the way iOS does, instead of refusing the drag. Dropping onto a page reuses the grid's own placement and reflow, so folders, widget-covered cells and a full page behave exactly as before. Dragging inside the dock reorders it.

The dock now rides the saved layout. A layout saved before this has no dock key and falls back to the configured one, while a deliberately emptied dock stays empty instead of the config resurrecting it.

## App names on the home screen
Settings > Appearance > App Icons toggles names under the grid icons. It drives AppIcon's existing label rather than a second implementation. Dock icons stay unlabelled. Every tile is absolutely positioned, so turning it on moves nothing: the full set of tile transforms was compared with names on and off and is byte-identical.

## Icon themes and a palette
Four themes on the same page: default keeps every app's own artwork, plus mono, pastel and tinted. Themes are a table of declarative recipes that derive a background and glyph colour from each app's accent, so adding one is a single row rather than another branch.

The default theme renders the exact markup it did before. Verified by pixel-diffing old against new tiles: max channel delta 1 of 255, which is the same noise floor as diffing the old markup against itself. Nobody's home screen changes on update.

## Configurable background and glyph colours
The background and glyph are both resolved through one appearance resolver instead of the background being pinned to the app's accent. The jiggle-mode tile and the folder previews were drawing artwork directly and bypassing it, so they now go through the same resolver and a non-default theme reaches them.

## External app widgets
A third party declares widgets alongside its app:

```lua
exports['sd-phone']:addCustomApp({
    identifier = 'acme_app',
    name       = 'Acme',
    ui         = 'acme_app/web/index.html',
    widgets    = {
        { name = 'Deliveries Today', ui = 'acme_app/web/widget.html', sizes = { 'sm', 'md' } },
        { id = 'fleet', name = 'Fleet', ui = 'nui://acme_app/web/fleet.html' },
    },
})
```

They appear in the gallery beside the built-ins and honour their declared sizes, checked both in the size switcher and again at add time, so an sm-only widget cannot be placed as lg. A malformed entry is refused on its own and the app still registers.

Rendering is a sandboxed iframe sized by the grid span; no foreign code runs in the phone's context. A widget whose ui resolves back into sd-phone is refused in every URL form, including the absolute cfx-nui one, because that page would share the shell's origin and could reach the parent through allow-same-origin. Once the owning resource stops the tile degrades to a Not available placeholder and keeps its slot, so reinstalling restores the live widget.

## Persistence
Icon theme and app names live in phone_settings beside the rest of the phone's settings, so they follow the character rather than the machine and survive a SIM swap or cloud restore. Hydration fans out from the settings:get that themeStore already runs on mount, characterLoaded and profile reset, so there is no extra round trip and no hydration site can forget them. The assignment is unconditional and type-checked, since showAppNames is a boolean whose stored false must not read as absent. localStorage remains the dev-only seed. server/migrations.lua back-fills the two columns on boot.

## Gates
| gate | result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors, 31 warnings (baseline) |
| `npm run test` | 223 passed, 21 files (199 baseline plus 24 new) |
| `npm run knip` | clean apart from the pre-existing .css hint |
| `lua tests/lua/run.lua` | 345 passed, 2 failed (the two pre-existing battery suites) |
| `loadfile` on every touched Lua file | exit 0 |

New coverage includes the dock move helpers and a case pinning that a stored `showAppNames: false` survives hydration rather than being skipped as falsy.

Verified visually through the Vite dev module graph under a fractional CSS zoom, since the Playwright lockscreen unlock is broken: names on and off, geometry unchanged, page to full dock swap, dock to empty cell, dock reorder, remount from a saved layout, and all four themes across the edit tiles and folder previews.

## Not verified
Nothing here has run on a live server yet. Dock hit-testing uses elementFromPoint rather than rect maths precisely because the in-game fractional zoom breaks the latter, but that path deserves an in-game check.
