### PR TITLE
fix: keep installed custom apps through an app store install (#158)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ import { ThemeProvider, useTheme, useThemeStore } from '@/stores/themeStore';
 import { useCallStore } from '@/stores/callStore';
 import type { AppDef } from '@/core/types';
 import { listInstalledApps, installApp, uninstallApp, loadHomeLayout, saveHomeLayout, parseLayout, type SavedLayout } from '@/apps/appstore/appsApi';
-import { customToAppDef, installedCustomIds, isCustomApp, setCustomInstalled, useCustomApps, useCustomAppsStore } from '@/stores/customAppsStore';
+import { clearCustomInstalled, customToAppDef, isCustomApp, setCustomInstalled, useCustomApps, useCustomAppsStore, withCustomInstalled } from '@/stores/customAppsStore';
 import { resolveWallpaper } from '@/shell/wallpapers';
 import { NoSimScreen } from '@/shell/NoSimScreen';
 import { useNoService, useNoSim, useSimStore } from '@/stores/simStore';
@@ -405,10 +405,10 @@ function AppContent() {
         // payload still counts as ready - the Homescreen must never wait on a follow-up that
         // isn't coming. The dev harness fetches from its local mock instead.
         if (data.installedApps) {
-            setInstalledApps(new Set([...data.installedApps, ...installedCustomIds()]));
+            setInstalledApps(withCustomInstalled(data.installedApps));
             setAppsReady(true);
         } else {
-            if (!isFiveM) void listInstalledApps().then(ids => setInstalledApps(new Set([...ids, ...installedCustomIds()])));
+            if (!isFiveM) void listInstalledApps().then(ids => setInstalledApps(withCustomInstalled(ids)));
             setAppsReady(!isFiveM);
         }
         // Under unique phones the localStorage layout fallback is another profile's - server only.
@@ -428,7 +428,7 @@ function AppContent() {
     // fetched after the reveal so the server round-trip never delayed the phone appearing.
     useNuiEvent('sd-phone:apps', useCallback((data) => {
         if (!data) return;
-        setInstalledApps(new Set([...(data.installedApps ?? []), ...installedCustomIds()]));
+        setInstalledApps(withCustomInstalled(data.installedApps ?? []));
         setSavedLayout(data.homeLayout ? parseLayout(data.homeLayout) : null);
         setAppsReady(true);
     }, []));
@@ -652,7 +652,7 @@ function AppContent() {
     const finishInstall = useCallback((id: string) => {
         setInstalledApps(prev => new Set(prev).add(id));
         if (isCustomApp(id)) { setCustomInstalled(id, true); void fetchNui('customApps/lifecycle', { id, action: 'install' }); }
-        else void installApp(id).then(ids => setInstalledApps(new Set(ids)));
+        else void installApp(id).then(ids => setInstalledApps(withCustomInstalled(ids)));
     }, []);
     const pumpDownloads = useCallback(function pump() {
         const id = downloadQueue.current[0];
@@ -689,7 +689,7 @@ function AppContent() {
         setRecentApps(prev => prev.filter(x => x !== id));
         setForegroundKeys(m => { const n = { ...m }; delete n[id]; return n; });
         if (isCustomApp(id)) { setCustomInstalled(id, false); void fetchNui('customApps/lifecycle', { id, action: 'uninstall' }); }
-        else void uninstallApp(id).then(ids => setInstalledApps(new Set(ids)));
+        else void uninstallApp(id).then(ids => setInstalledApps(withCustomInstalled(ids)));
     }, []);
     const handleSaveLayout = useCallback((layout: SavedLayout) => {
         saveHomeLayout(layout);
@@ -1195,6 +1195,7 @@ function AppContent() {
         for (const k of doomed) window.localStorage.removeItem(k);
         if (scope === 'erase') {
             resetAuth();
+            clearCustomInstalled();
             useMusicLibrary.getState().reset();
             useLocaleStore.getState().hydrate();
             void fetchNui('sd-phone:settings:factoryReset');

--- a/web/src/stores/customAppsStore.ts
+++ b/web/src/stores/customAppsStore.ts
@@ -21,6 +21,14 @@ export function setCustomInstalled(id: string, installed: boolean): void {
     writeJson(INSTALLED_KEY, [...set]);
 }
 
+export function withCustomInstalled(ids: Iterable<string>): Set<string> {
+    return new Set([...ids, ...readInstalled()]);
+}
+
+export function clearCustomInstalled(): void {
+    writeJson(INSTALLED_KEY, []);
+}
+
 interface CustomAppsState {
     apps:    CustomAppDef[];
     setAll:  (apps: CustomAppDef[] | null | undefined) => void;

--- a/web/src/stores/customAppsStore.ts
+++ b/web/src/stores/customAppsStore.ts
@@ -11,10 +11,6 @@ function readInstalled(): string[] {
     return arr ? arr.filter((x): x is string => typeof x === 'string') : [];
 }
 
-export function installedCustomIds(): string[] {
-    return readInstalled();
-}
-
 export function setCustomInstalled(id: string, installed: boolean): void {
     const set = new Set(readInstalled());
     if (installed) set.add(id); else set.delete(id);


### PR DESCRIPTION
Closes #158.

## What was reported

A custom app registered with `defaultApp = false` appeared on a freshly wiped phone, then vanished as soon as any other app was downloaded. Reported by @boppescripting with a video repro.

## Root cause

Custom apps record their installed state in `localStorage` under `customApps:installed`, because the server's `installed_apps` only tracks first-party ids. Two separate places forgot that, and they line up with the two halves of the report.

**1. Installing any ordinary app dropped every custom app.**

```js
// App.tsx, before
else void installApp(id).then(ids => setInstalledApps(new Set(ids)));
else void uninstallApp(id).then(ids => setInstalledApps(new Set(ids)));
```

Both replaced the *whole* set with the server's reply. Custom ids aren't in that reply, so they fell out; `effectiveApps` stopped listing them, the home-screen reconcile nulled their slots, and the debounced save persisted the loss. That's the disappearing half.

Three other sites already merged the custom ids correctly (`sd-phone:apps`, the open payload, and the dev fallback), so this was two call sites drifting from an established pattern rather than a design gap. All five now go through one helper:

```js
export function withCustomInstalled(ids: Iterable<string>): Set<string> {
    return new Set([...ids, ...readInstalled()]);
}
```

**2. A factory reset never forgot them.**

The reset removes `localStorage` keys prefixed `sd-phone:`. This key isn't prefixed, so a wiped phone still counted the app as installed and put it straight back on the home screen — the "shows on a fresh phone" half, and why the reporter saw it after step 3.

`clearCustomInstalled()` is now called on erase **by name**, rather than by widening the prefix list, so renaming the key later can't quietly reintroduce this.

## Verification

Eight regression tests written first and confirmed failing before the fix, covering both defects:

- a server list that omits an installed custom app carries it through
- an uninstalled custom app stays gone
- no duplicate when the server already lists the id
- empty server list, corrupt stored value
- `clearCustomInstalled` forgets everything, and is safe when nothing is installed

| Gate | Result |
|---|---|
| `vitest` | **354 passed** (27 files) |
| `tsc --noEmit` | clean |
| `eslint src` | 0 errors |
| `knip` | clean |
| `npm run build` | clean |

Per this repo's convention the test file itself is not committed.

## Noted, not addressed here

`banking:newInvoice`, `services:newInvoice` and `garages:showImages` also sit outside the `sd-phone:` prefix and therefore survive a factory reset. They're drafts and a display toggle rather than install state, so they don't affect this issue, but they're the same class of oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)