### PR TITLE
feat(bluetooth): lifecycle events, client exports, five more server exports

### DIFF
--- a/client/bluetooth.lua
+++ b/client/bluetooth.lua
@@ -1,3 +1,79 @@
+---@type table Bluetooth module; the table returned at end of file.
+local bluetoothClient = {}
+
+---@type boolean The radio switch, mirrored from the server so an export never has to ask for it.
+local radioOn = true
+---@type table[] Devices connected right now, as { id, name, kind }.
+local devices = {}
+---@type table<string, boolean> The same devices as a set, for a lookup that does not walk the list.
+local index = {}
+
+---Whether this character's Bluetooth radio is switched on.
+---@return boolean
+function bluetoothClient.enabled()
+    return radioOn
+end
+
+---Every device this phone is connected to, as fresh tables so a caller mutating the result cannot
+---reach into the mirror.
+---@return table[] devices { id, name, kind }
+function bluetoothClient.devices()
+    local out = {}
+    for i = 1, #devices do
+        out[i] = { id = devices[i].id, name = devices[i].name, kind = devices[i].kind }
+    end
+    return out
+end
+
+---Whether this phone is connected to a device right now.
+---@param id string|nil
+---@return boolean
+function bluetoothClient.isConnected(id)
+    return type(id) == 'string' and index[id] == true
+end
+
+---Replaces the mirror wholesale. The server sends the whole picture on every change, so there is no
+---patch to merge and no way for the two sides to drift apart.
+---@param data table { enabled: boolean, devices: table[] }
+local function apply(data)
+    if type(data) ~= 'table' then return end
+
+    radioOn = data.enabled ~= false
+    devices, index = {}, {}
+
+    local list = type(data.devices) == 'table' and data.devices or {}
+    for i = 1, #list do
+        local device = list[i]
+        if type(device) == 'table' and type(device.id) == 'string' then
+            devices[#devices + 1] = {
+                id   = device.id,
+                name = type(device.name) == 'string' and device.name or device.id,
+                kind = type(device.kind) == 'string' and device.kind or 'device',
+            }
+            index[device.id] = true
+        end
+    end
+end
+
+---Asks the server for a fresh picture, for the points where this side cannot know it has gone stale.
+local function sync()
+    TriggerServerEvent('sd-phone:server:bluetooth:sync')
+end
+
+RegisterNetEvent('sd-phone:client:bluetooth', apply)
+
+-- The same signals client/main.lua rebuilds its character state on: a live character switch has to
+-- drop the outgoing character's connections before the incoming one's land on top of them.
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', sync)
+RegisterNetEvent('esx:playerLoaded', sync)
+RegisterNetEvent('sd-phone:client:rehydrate', sync)
+
+-- A restart puts this script beside a player who is already loaded, so nothing above would fire.
+CreateThread(function()
+    Wait(2000)
+    sync()
+end)
+
 ---Nearby and paired devices for the Bluetooth settings page. Thin forward into server/bluetooth,
 ---which reads player distances server-side.
 RegisterNUICallback('sd-phone:bluetooth:scan', function(_, cb)
@@ -23,3 +99,5 @@ end)
 RegisterNUICallback('sd-phone:bluetooth:setEnabled', function(payload, cb)
     cb(lib.callback.await('sd-phone:server:bluetooth:setEnabled', false, payload) or { success = false })
 end)
+
+return bluetoothClient

--- a/client/main.lua
+++ b/client/main.lua
@@ -47,10 +47,11 @@ local phonecam = require 'client.phonecam'
 local service = require 'client.service'
 ---@type table Wi-Fi (client.wifi): joined network, nearby scan + capability gating.
 local wifiClient = require 'client.wifi'
+---@type table Bluetooth (client.bluetooth): the radio switch + connected devices, mirrored server-side.
+local bluetoothClient = require 'client.bluetooth'
 
 -- Loaded for side effects: each app module registers its own NUI callbacks, net events and
 -- server proxies.
-require 'client.bluetooth'
 require 'client.apps.groups'
 require 'client.apps.health'
 require 'client.apps.mail'
@@ -821,6 +822,18 @@ exports('getWifiNetworks', function() return wifiClient.networks() end)
 ---The networks in reach as of the last scan, strongest first, as { id, ssid, secured, strength,
 ---bars, known }. Empty while the radio is off or nothing is in range.
 exports('getNearbyWifi', function() return wifiClient.nearby() end)
+
+---Whether this character's Bluetooth radio is switched on. Says nothing about what is connected:
+---a switched-on radio with nothing in range is still on.
+exports('isBluetoothOn', function() return bluetoothClient.enabled() end)
+
+---Whether this phone is connected to a device right now, by the id its owning script registered.
+---@param deviceId string
+exports('isBluetoothConnected', function(deviceId) return bluetoothClient.isConnected(deviceId) end)
+
+---Every device this phone is connected to as { id, name, kind }. Empty while the radio is off or
+---nothing paired is in range.
+exports('getConnectedDevices', function() return bluetoothClient.devices() end)
 
 ---Registers a third-party app - exports['sd-phone']:addCustomApp(data). Attribution is the calling
 ---resource; re-registering an identifier is only allowed from that same resource.

--- a/server/bluetooth/init.lua
+++ b/server/bluetooth/init.lua
@@ -9,8 +9,8 @@ local actions = require 'server.bluetooth.actions'
 ---feature carries when nobody is looking at the Bluetooth page.
 local TICK_MS = 4000
 
----@type table<number, table|false> Per-player state the tick needs, loaded once per session. `false`
----records a player with nothing paired, so they are never queried again.
+---@type table<number, table> Per-player state the tick and the exports need, loaded once per session
+---and dropped again by anything that changes it.
 local watch = {}
 
 CreateThread(function()
@@ -21,22 +21,18 @@ CreateThread(function()
 end)
 
 ---A player's cached state, read from the database the first time and kept until they leave or change
----something. Returns nil when they have nothing paired and so need no sweeping.
+---something. Returns nil when they have no loaded character to read for.
 ---@param src number player server id
----@return table|nil state { enabled: boolean, paired: table<string, string> }
+---@return { enabled: boolean, paired: table<string, string> }|nil state
 local function stateOf(src)
     local cached = watch[src]
-    if cached ~= nil then return cached or nil end
+    if cached then return cached end
 
     local player = require 'bridge.server.player'
     local cid = player.getIdentifier(src)
     if not cid then return nil end
 
     local state = store.get(cid)
-    if not next(state.paired) then
-        watch[src] = false
-        return nil
-    end
     watch[src] = state
     return state
 end
@@ -46,6 +42,41 @@ end
 local function invalidate(src)
     watch[src] = nil
 end
+
+---The picture the client-side cache mirrors: the radio switch plus the devices connected right now.
+---Threaded because the lifecycle events driving it are synchronous and a cold cache reads the
+---database, which would otherwise hold up the reconnect sweep.
+---@param src number player server id
+local function pushState(src)
+    CreateThread(function()
+        if not src or not GetPlayerName(src) then return end
+
+        local state = stateOf(src)
+        local connected = {}
+        for _, id in ipairs(registry.connectedTo(src)) do
+            local device = registry.get(id)
+            connected[#connected + 1] = device
+                and { id = id, name = device.name, kind = device.kind }
+                or { id = id, name = id, kind = 'device' }
+        end
+
+        TriggerClientEvent('sd-phone:client:bluetooth', src, {
+            enabled = state == nil or state.enabled == true,
+            devices = connected,
+        })
+    end)
+end
+
+-- Mirroring off the lifecycle events rather than the call sites means every path that opens or
+-- closes a connection keeps the client cache honest, including the reconnect sweep.
+AddEventHandler('sd-phone:server:bluetooth:connected', function(src) pushState(src) end)
+AddEventHandler('sd-phone:server:bluetooth:disconnected', function(src) pushState(src) end)
+
+---Seeds the cache on the client's first ask, which is the earliest point a citizenid is sure to
+---exist. Only ever answers the caller with their own state.
+RegisterNetEvent('sd-phone:server:bluetooth:sync', function()
+    pushState(source)
+end)
 
 lib.callback.register('sd-phone:server:bluetooth:scan', function(source)
     invalidate(source)
@@ -71,6 +102,7 @@ end)
 lib.callback.register('sd-phone:server:bluetooth:setEnabled', function(source, payload)
     local res = actions.setEnabled(source, payload)
     invalidate(source)
+    pushState(source)
     return res
 end)
 
@@ -118,26 +150,98 @@ AddEventHandler('onResourceStop', function(name)
     registry.removeByOwner(name)
 end)
 
+---Registers a device phones can pair with. Attribution is the calling resource, and its devices go
+---with it when it stops.
+---@param def table { id, name, kind?, coords?, entity?, range?, maxConnections?, onConnect?, onDisconnect? }
+---@return boolean ok, string? err
 exports('registerBluetoothDevice', function(def)
     return registry.add(def, GetInvokingResource() or GetCurrentResourceName())
 end)
 
+---Patches a registered device in place, so a rename or a move keeps everyone connected. Only the
+---resource that registered a device may patch it; omitted keys keep their current value.
+---@param id string
+---@param patch table fields to change
+---@return boolean ok, string? err
+exports('updateBluetoothDevice', function(id, patch)
+    local ok, err = registry.update(id, patch, GetInvokingResource() or GetCurrentResourceName())
+    if ok then
+        for _, src in ipairs(registry.connections(id)) do pushState(src) end
+    end
+    return ok, err
+end)
+
+---Removes a device, disconnecting everyone on it first with reason `unregistered`.
+---@param id string
+---@return boolean removed
 exports('unregisterBluetoothDevice', function(id)
     return registry.remove(id)
 end)
 
+---Every registered device, as identity only.
+---@return table[] devices { id, name, kind, owner }
+exports('getBluetoothDevices', function()
+    local out = {}
+    for _, id in ipairs(registry.ids()) do
+        local device = registry.get(id)
+        if device then out[#out + 1] = registry.view(device) end
+    end
+    return out
+end)
+
+---One registered device, as identity only.
+---@param id string
+---@return table? device { id, name, kind, owner }
+exports('getBluetoothDevice', function(id)
+    local device = type(id) == 'string' and registry.get(id) or nil
+    return device and registry.view(device) or nil
+end)
+
+---@param source number player server id
+---@param deviceId string
+---@return boolean connected
 exports('isBluetoothConnected', function(source, deviceId)
     return registry.isConnected(source, deviceId)
 end)
 
+---@param deviceId string
+---@return number[] sources players connected to the device
 exports('getBluetoothConnections', function(deviceId)
     return registry.connections(deviceId)
 end)
 
+---@param source number player server id
+---@return string[] ids devices the player is connected to
 exports('getConnectedDevices', function(source)
     return registry.connectedTo(source)
 end)
 
+---Whether a player's Bluetooth radio is switched on. False for a source with no loaded character,
+---which is what tells "the radio is off" apart from "the device is out of range".
+---@param source number player server id
+---@return boolean enabled
+exports('isBluetoothEnabled', function(source)
+    local state = stateOf(source)
+    return state ~= nil and state.enabled == true
+end)
+
+---Connects a player to a device from script. Honours the radio switch and the device's connection
+---limit but not its range, which is the point of connecting by hand; it does not pair.
+---@param source number player server id
+---@param deviceId string
+---@return boolean ok, string? err
+exports('connectBluetooth', function(source, deviceId)
+    local state = stateOf(source)
+    if not state then return false, 'no character' end
+    if not state.enabled then return false, 'bluetooth is off' end
+    return registry.connect(source, deviceId)
+end)
+
+---Disconnects a player from a device with reason `kicked`. The pairing survives, so the reconnect
+---sweep picks it up again while they stay in range.
+---@param source number player server id
+---@param deviceId string
+---@return boolean disconnected
 exports('disconnectBluetooth', function(source, deviceId)
     return registry.disconnect(source, deviceId, 'kicked')
 end)

--- a/server/bluetooth/registry.lua
+++ b/server/bluetooth/registry.lua
@@ -24,6 +24,14 @@ function registry.get(id)
     return devices[id]
 end
 
+---A device as another resource may see it: identity only, so neither the owning script's callbacks
+---nor a table the registry still holds ever leaves this module.
+---@param device table
+---@return table view { id, name, kind, owner }
+function registry.view(device)
+    return { id = device.id, name = device.name, kind = device.kind, owner = device.owner }
+end
+
 ---Adds a device. Rejects a duplicate id rather than replacing, so two resources cannot silently
 ---fight over one device.
 ---@param def table registration passed to registerBluetoothDevice
@@ -37,6 +45,30 @@ function registry.add(def, owner)
     device.owner = owner
     devices[device.id] = device
     links[device.id] = {}
+    return true
+end
+
+---Patches a device in place, so renaming or moving one does not have to unregister it and drop
+---everyone connected. Only the resource that registered a device may patch it.
+---@param id string
+---@param patch table fields to change; omitted keys keep their current value
+---@param owner string resource asking
+---@return boolean ok, string|nil err
+function registry.update(id, patch, owner)
+    local current = devices[id]
+    if not current then return false, ('device %s is not registered'):format(tostring(id)) end
+    if current.owner ~= owner then
+        return false, ('device %s belongs to %s'):format(id, tostring(current.owner))
+    end
+
+    local merged = bt.merge(current, patch)
+    if not merged then return false, 'patch must be a table' end
+
+    local device, err = bt.validate(merged)
+    if not device then return false, err end
+
+    device.owner = current.owner
+    devices[id] = device
     return true
 end
 
@@ -119,6 +151,21 @@ local function safely(fn, ...)
     end
 end
 
+---Server-local lifecycle events, fired once per change. Every path that touches `links` goes through
+---connect and disconnect below, so none of them can open or close a connection silently.
+---@param src number player server id
+---@param device table the device connected to
+local function announceConnect(src, device)
+    TriggerEvent('sd-phone:server:bluetooth:connected', src, device.id, registry.view(device))
+end
+
+---@param src number player server id
+---@param id string device the player was on, read before the link was cleared
+---@param reason string why it ended
+local function announceDisconnect(src, id, reason)
+    TriggerEvent('sd-phone:server:bluetooth:disconnected', src, id, reason)
+end
+
 ---Links a player to a device, if it exists and has room. Range is the caller's to check, because
 ---pairing and the reconnect tick already hold the player's coords.
 ---@param src number
@@ -132,6 +179,7 @@ function registry.connect(src, id)
 
     links[id][src] = true
     safely(device.onConnect, src, id)
+    announceConnect(src, device)
     return true
 end
 
@@ -144,8 +192,10 @@ function registry.disconnect(src, id, reason)
     if not registry.isConnected(src, id) then return false end
     links[id][src] = nil
 
+    local why = reason or 'manual'
     local device = devices[id]
-    if device then safely(device.onDisconnect, src, id, reason or 'manual') end
+    if device then safely(device.onDisconnect, src, id, why) end
+    announceDisconnect(src, id, why)
     return true
 end
 

--- a/shared/bluetooth.lua
+++ b/shared/bluetooth.lua
@@ -51,6 +51,30 @@ function bluetooth.cleanId(v)
     return v:sub(1, bluetooth.MAX_ID)
 end
 
+---@type string[] Registration fields a patch may carry. `id` is absent on purpose: it keys the
+---registry, so a device that changed it would be a different device.
+local PATCHABLE = {
+    'name', 'kind', 'coords', 'entity', 'range', 'maxConnections', 'onConnect', 'onDisconnect',
+}
+
+---Folds a patch over a registration so a device can be renamed, moved or resized in place. Keys the
+---patch omits keep their current value, which is why a patch cannot accidentally drop a callback.
+---@param device table the registration already held
+---@param patch table fields to change
+---@return table|nil def a registration for validate, nil when either side is not a table
+function bluetooth.merge(device, patch)
+    if type(device) ~= 'table' or type(patch) ~= 'table' then return nil end
+
+    local def = { id = device.id }
+    for i = 1, #PATCHABLE do
+        local key = PATCHABLE[i]
+        local value = patch[key]
+        if value == nil then value = device[key] end
+        def[key] = value
+    end
+    return def
+end
+
 ---Validates a registration, returning the fields worth keeping. Rejects rather than repairs, so a
 ---script learns its device is wrong instead of finding it silently unreachable.
 ---@param def table registration passed to registerBluetoothDevice


### PR DESCRIPTION
## What

Rounds out the Bluetooth API. Before this the whole surface was six server exports and a pair of per-device callbacks that only the registering resource could see.

### Lifecycle events (new)

| Event | Payload |
|---|---|
| `sd-phone:server:bluetooth:connected` | `source, deviceId, device` |
| `sd-phone:server:bluetooth:disconnected` | `source, deviceId, reason` |

Fired from inside `registry.connect` / `registry.disconnect` rather than from their call sites, so all six paths that end a connection are covered by construction: `manual`, `range`, `disabled`, `dropped`, `unregistered`, `kicked`. This mirrors how `server/wifi.lua` guards its own `announceDisconnect`.

### Client exports (new)

`isBluetoothOn`, `isBluetoothConnected(deviceId)`, `getConnectedDevices()`.

The client held no Bluetooth state, so these read a mirror the server pushes off the events above. The push is threaded: the events are synchronous and a cold state cache reads the database, which would otherwise hold up the 4s reconnect sweep. Deferring also gives it a liveness check, so a dropping player cannot re-warm the cache entry their own teardown just cleared.

### Server exports (new)

- `connectBluetooth(source, deviceId)` connects from script. Honours the radio switch and the connection limit but not range, which is the point. Does not pair.
- `isBluetoothEnabled(source)` tells "the radio is off" apart from "out of range". Both are indistinguishable through `isBluetoothConnected` alone.
- `getBluetoothDevices()` / `getBluetoothDevice(id)` expose the registry, identity only. No coords, no callbacks, rebuilt per call.
- `updateBluetoothDevice(id, patch)` renames or moves a device in place. Previously the only route was unregister plus re-register, which drops every connected phone with reason `unregistered` first.

`updateBluetoothDevice` is owner-scoped and re-validates the merged result, so a patch can neither install a broken device nor reach into another resource's registration. Shrinking `maxConnections` below the live count refuses new connections rather than kicking anyone.

## Notes

- The per-player cache no longer stores `false` for "nothing paired". The exports need the radio switch for those players too, and an empty paired table already costs the sweep nothing.
- `unregisterBluetoothDevice` is still *not* owner-scoped, unlike the new `updateBluetoothDevice`. Left as-is rather than changed under you; worth deciding separately.

## Verification

- `lua tests/lua/run.lua`: 398 passed. The 2 suite errors are pre-existing and unrelated (the battery suites reference `server/battery/store.lua` and `client/battery_tick.lua`, neither of which exists on `main`).
- Bluetooth suite alone: 53 passed, 0 failed, including 14 new assertions covering `bluetooth.merge` (patch semantics, id immutability, re-validation, bad input).
- All five changed files load clean under `loadfile`.

Not yet exercised in-game; the reconnect sweep and the client mirror want a live server before merge.

## Docs

Documented on the site in a separate change: Bluetooth sections added to Server Exports, Client Exports and Server Events.