### PR TITLE
perf(stocks): persist the market in one statement instead of thirty

### DIFF
--- a/server/stocks/store.lua
+++ b/server/stocks/store.lua
@@ -139,19 +139,27 @@ function store.loadPrices()
     return out
 end
 
----Batch-persist the in-memory market (upsert per symbol, one prepared statement). `rows` is an
----array of { symbol, price, history (number[]) } straight from engine.persistRows.
+---Batch-persist the in-memory market as one multi-row upsert. `rows` is an array of
+---{ symbol, price, history (number[]) } straight from engine.persistRows.
 ---@param rows table[] rows to persist
 function store.savePrices(rows)
     if #rows == 0 then return end
+
     local ts = os.time()
-    local params = {}
-    for i, r in ipairs(rows) do
-        params[i] = { r.symbol, r.price, json.encode(r.history or {}), ts }
+    local values, params = {}, {}
+    for i = 1, #rows do
+        local row = rows[i]
+        values[i] = '(?, ?, ?, ?)'
+        params[#params + 1] = row.symbol
+        params[#params + 1] = row.price
+        params[#params + 1] = json.encode(row.history or {})
+        params[#params + 1] = ts
     end
+
     MySQL.prepare.await(
-        'INSERT INTO `phone_stock_prices` (symbol, price, history, updated_at) VALUES (?, ?, ?, ?) ' ..
-        'ON DUPLICATE KEY UPDATE price = VALUES(price), history = VALUES(history), updated_at = VALUES(updated_at)',
+        'INSERT INTO `phone_stock_prices` (symbol, price, history, updated_at) VALUES ' ..
+        table.concat(values, ', ') ..
+        ' ON DUPLICATE KEY UPDATE price = VALUES(price), history = VALUES(history), updated_at = VALUES(updated_at)',
         params)
 end
 


### PR DESCRIPTION
## The warning

```
sd-phone took 595.8000ms to execute a query!
INSERT INTO `phone_stock_prices` (symbol, price, history, updated_at) VALUES (?, ?, ?, ?)
ON DUPLICATE KEY UPDATE ... ["MZB", 226.07, "[...48 points...]", 1785429982]
```

## What was actually happening

`store.savePrices` looked batched. It built 30 parameter sets and handed them to one prepared statement, which reads like a bulk insert. oxmysql does not treat it that way. From `dist/build.js`, `rawExecute` does:

```js
for (let index = 0; index < parametersLength; index++) {
  const values = parameters[index];
  const startTime = !hasProfiler && performance.now();
  const result = await connection.execute(query, values);
  ...
  logQuery(invokingResource, query, performance.now() - startTime, values);
}
```

Two consequences:

1. **The save was 30 sequential round trips**, each its own transaction under autocommit, so 30 InnoDB commits and 30 fsyncs every `SaveSeconds` (30s by default, 30 configured assets).
2. **`logQuery` runs per iteration**, so the warning naming `MZB` was reporting *one row's* commit time, not the batch. A single ~1KB upsert taking 595ms is a stalled commit, and the old shape handed the disk 30 chances per cycle to stall.

## The change

One multi-row `INSERT ... ON DUPLICATE KEY UPDATE` with a flat parameter array. `parseExecute` wraps a flat array of scalars as a single parameter set:

```js
if (!parameters.every(Array.isArray)) {
  if (parameters.every((item) => typeof item === "object")) { /* N sets */ }
  else parameters = [[...parameters]];   // one set
}
```

So this is one execute, one commit, one fsync. 30 fsyncs per cycle become 1.

The statement stays fully parameterized: only the `(?, ?, ?, ?)` groups are generated from the row count, every value is still bound. Nothing is interpolated.

## Verification

Stubbed the oxmysql surface, loaded the real `store.lua`, and inspected what it builds for 30 assets:

```
statements:        1    (want 1)
value groups:      30   (want 30)
ON DUPLICATE:      1    (want 1)
placeholders:      120  (want 120)
params:            120  (want 120)
nested params:     0    (want 0, else oxmysql runs N statements)
PASS: one statement, one commit
```

The `nested params` check matters: a single table anywhere in that array would flip `parseExecute` back to N executions and silently undo the fix.

`lua tests/lua/run.lua`: 398 passed. The 2 suite errors are pre-existing and unrelated (battery suites reference files not present on `main`).

## Notes

- 30 assets is 120 placeholders and roughly 30KB of history JSON, both far inside MariaDB's limits, so no chunking.
- Nothing else in the resource writes on a timer, so this was the only recurring burst. Wallet writes are event-driven, on trade.
- This also shortens the `onResourceStop` flush, which previously blocked shutdown for the same 30 commits.
- If a single-row upsert still stalls after this, the remaining cause is disk or host contention rather than sd-phone.

Not yet run against a live server.