### PR TITLE
feat: device profiles, so a companion resource can reuse the phone UI

### DIFF
--- a/client/companion.lua
+++ b/client/companion.lua
@@ -1,0 +1,173 @@
+-- Companion-device bus: lets a sibling resource (sd-tablet) reuse this client's NUI callbacks
+-- and receive its NUI pushes, without duplicating a single app module.
+--
+-- Two shadows do all the work:
+--   RegisterNUICallback  records every handler this resource registers, so a companion can
+--                        invoke one by name instead of re-implementing it.
+--   SendNUIMessage       re-emits every push as a client event, so a companion's own NUI frame
+--                        sees the same server data this one does.
+--
+-- Both are installed before any app module loads (client/main.lua requires this first) and
+-- nothing in the resource caches either global, so all 459 registrations and every push are
+-- covered - including the ones app modules build at runtime.
+--
+-- Inert with no companion running: the registry is a table write per registration, and the
+-- mirror is a nil check per push.
+
+---@class CompanionHook
+---@field companionOpen boolean a companion device currently owns the screen
+---@field phoneOpen boolean our own NUI is up (mirrored from client/main.lua)
+local hook = {
+    companionOpen = false,
+    phoneOpen     = false,
+    mirroring     = false,
+}
+
+---@type table<string, fun(payload: any, cb: fun(result: any))> Every NUI callback this resource registers.
+local handlers = {}
+
+-- Voice calling is the phone's alone. A companion may neither invoke these nor be told about
+-- them, so a tablet can never dial, answer, ring, or run the video (FaceTime) leg - and neither
+-- can a hand-edited companion build, because the refusal lives on this side of the seam.
+local DENY_PREFIX = { 'sd-phone:call:', 'sd-phone:video:', 'sd-phone:payphone:' }
+local DENY = {
+    ['sd-phone:calls:seen']           = true,
+    ['sd-phone:services:callCompany'] = true,
+}
+
+---Whether an action is closed to companion devices.
+---@param action string
+---@return boolean
+local function denied(action)
+    if DENY[action] then return true end
+    for _, prefix in ipairs(DENY_PREFIX) do
+        if action:sub(1, #prefix) == prefix then return true end
+    end
+    return false
+end
+
+hook.denied = denied
+
+-------------------------------------------------------------------- registration shadow
+
+local realRegister = RegisterNUICallback
+
+---Records the handler, then registers it normally.
+---@param action string
+---@param handler fun(payload: any, cb: fun(result: any))
+function RegisterNUICallback(action, handler)
+    handlers[action] = handler
+    realRegister(action, handler)
+end
+
+-------------------------------------------------------------------- push mirror
+
+local realSend = SendNUIMessage
+
+---Sends to our own frame, then mirrors to an armed companion. Call pushes are dropped here so
+---an incoming call can never ring on a device that isn't allowed to answer it.
+---@param data table NUI message { action = string, data = any }
+function SendNUIMessage(data)
+    realSend(data)
+    if not hook.mirroring then return end
+    if type(data) ~= 'table' or type(data.action) ~= 'string' then return end
+    if denied(data.action) then return end
+    TriggerEvent('sd-phone:client:companion:push', data)
+end
+
+-------------------------------------------------------------------- focus arbitration
+
+local realFocus     = SetNuiFocus
+local realKeepInput = SetNuiFocusKeepInput
+
+---While a companion owns the screen and our own phone is closed, our (hidden) frame must never
+---take focus back: a forwarded handler - the Camera app above all - is asking on behalf of the
+---device that is actually visible, so the request is handed to it instead.
+---@param hasFocus boolean
+---@param hasCursor boolean
+function SetNuiFocus(hasFocus, hasCursor)
+    if hook.companionOpen and not hook.phoneOpen then
+        TriggerEvent('sd-phone:client:companion:focus', hasFocus, hasCursor)
+        return
+    end
+    realFocus(hasFocus, hasCursor)
+end
+
+---@param keepInput boolean
+function SetNuiFocusKeepInput(keepInput)
+    if hook.companionOpen and not hook.phoneOpen then
+        TriggerEvent('sd-phone:client:companion:keepInput', keepInput)
+        return
+    end
+    realKeepInput(keepInput)
+end
+
+-------------------------------------------------------------------- invoke
+
+---Replies to one companion invocation. Tokens are the companion's; we only echo them back.
+---@param token any
+---@param result any
+local function reply(token, result)
+    TriggerEvent('sd-phone:client:companion:reply', token, result)
+end
+
+---Runs one of our recorded NUI handlers on a companion's behalf and echoes its response back.
+---The handler runs in this event's coroutine, so the `lib.callback.await` inside a proxied
+---callback yields exactly as it does for our own frame.
+---@param token any opaque request id, echoed to the reply
+---@param action string NUI action name
+---@param payload any handler payload
+AddEventHandler('sd-phone:client:companion:invoke', function(token, action, payload)
+    if type(action) ~= 'string' or action == '' then
+        return reply(token, { success = false, message = 'Bad request' })
+    end
+    if denied(action) then
+        return reply(token, { success = false, message = 'Not available on this device', unsupported = true })
+    end
+
+    local handler = handlers[action]
+    if not handler then
+        return reply(token, { success = false, message = ('Unknown action: %s'):format(action), unsupported = true })
+    end
+
+    -- A handler that answers twice (or throws after answering) must not desync the companion's
+    -- pending map, so only the first response is forwarded.
+    local answered = false
+    local ok, err = pcall(handler, payload, function(result)
+        if answered then return end
+        answered = true
+        reply(token, result)
+    end)
+    if not ok and not answered then
+        answered = true
+        print(('^1[sd-phone:companion]^0 %s failed: %s'):format(action, err))
+        reply(token, { success = false, message = 'Handler error' })
+    end
+end)
+
+-------------------------------------------------------------------- exports
+
+---exports['sd-phone']:setCompanionMirror(enabled) - start or stop re-emitting NUI pushes.
+exports('setCompanionMirror', function(enabled)
+    hook.mirroring = enabled == true
+end)
+
+---exports['sd-phone']:setCompanionOpen(open) - a companion device took or released the screen.
+exports('setCompanionOpen', function(open)
+    hook.companionOpen = open == true
+    TriggerEvent('sd-phone:client:companionState', hook.companionOpen)
+end)
+
+---exports['sd-phone']:isCompanionOpen()
+exports('isCompanionOpen', function() return hook.companionOpen end)
+
+-- A companion that stops mid-session must not leave the mirror or the focus guard armed.
+AddEventHandler('onResourceStop', function(resource)
+    if resource == GetCurrentResourceName() then return end
+    if hook.mirroring or hook.companionOpen then
+        hook.mirroring     = false
+        hook.companionOpen = false
+    end
+end)
+
+return hook

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,3 +1,7 @@
+---@type table Companion-device bus (client.companion): NUI callback registry + push mirror for a
+---sibling device resource (sd-tablet). Required FIRST - it shadows RegisterNUICallback and
+---SendNUIMessage, so it has to be installed before any module that uses them loads.
+local companion = require 'client.companion'
 ---@type table sd-phone config root (configs/config.lua).
 local config = require 'configs.config'
 ---@type table Notify bridge (bridge.client.notify): backend-agnostic on-screen toasts.
@@ -327,8 +331,13 @@ local function OpenPhone()
         return
     end
 
+    -- One device at a time: a companion holding the screen gives it up here, so focus, the
+    -- cell-cam and pma-voice only ever have one owner.
+    if companion.companionOpen then TriggerEvent('sd-phone:client:companion:close') end
+
     phoneState.open   = true
     phoneState.locked = true
+    companion.phoneOpen = true
 
     CreateThread(function()
         while phoneState.open do
@@ -423,6 +432,7 @@ function ClosePhone()
     if not phoneState.open then return end
 
     phoneState.open = false
+    companion.phoneOpen = false
     TriggerEvent('sd-phone:client:openState', false)
     TriggerServerEvent('sd-phone:server:phone:setOpen', false)
     SetNuiFocus(false, false)
@@ -653,17 +663,18 @@ pushWeather = function()
     })
 end
 
--- 5s weather poll while the phone is open.
+-- 5s weather poll while a device is on screen (ours or a companion's - the push mirror carries
+-- it across, so the tablet's Weather app stays live while the phone is stowed).
 CreateThread(function()
     while true do
-        if phoneState.open then pushWeather() end
+        if phoneState.open or companion.companionOpen then pushWeather() end
         Wait(5000)
     end
 end)
 
 -- Immediate push on every weather change.
 weatherBridge.onChange(function()
-    if phoneState.open then pushWeather() end
+    if phoneState.open or companion.companionOpen then pushWeather() end
 end)
 
 ---Returns a weather + world-time snapshot for the Weather app on mount.

--- a/client/payphone.lua
+++ b/client/payphone.lua
@@ -2,6 +2,8 @@
 local config = require 'configs.config'
 ---@type table Target bridge (bridge.client.target): ox_target/qb-target/qtarget wrapper.
 local target = require 'bridge.client.target'
+---@type table Companion-device bus (client.companion): whether a sibling device holds the screen.
+local companion = require 'client.companion'
 
 ---@type table Payphone config (configs/payphone.lua).
 local cfg = config.Payphone
@@ -316,6 +318,10 @@ end
 ---@param connected table|nil live-call payload when answering an inbound ring
 local function openPayphone(entity, coords, connected)
     if not cfg.Enabled or activeLocation then return end
+    -- One device at a time, the same exclusion OpenPhone starts: the booth's UI lives in THIS
+    -- frame and its pushes are denied to a companion, so a tablet holding the screen would keep
+    -- the cursor while the keypad drew behind it.
+    if companion.companionOpen then TriggerEvent('sd-phone:client:companion:close') end
     local location = locationKey(coords)
 
     local state

--- a/server/apps/actions.lua
+++ b/server/apps/actions.lua
@@ -128,10 +128,42 @@ function actions.uninstall(source, payload)
     return ok({ installed = remaining })
 end
 
----Persists the caller's home-screen layout, an opaque JSON string from the UI. Validation is
----type + a 16k size cap; scoped to the citizenid resolved from src.
+-- One player has one layout column but may own several devices, and a layout only means anything
+-- against the grid it was arranged on: the slot array's page boundaries are that device's
+-- cols * rows, 24 on the phone against 36 on the tablet. So the column holds an envelope,
+-- { devices = { <id> = '<layout json>' } }, one opaque string per device.
+---@type table<string, boolean> Device ids allowed to own a layout slice.
+local LAYOUT_DEVICES = { phone = true, tablet = true }
+
+---@type integer Cap on the merged envelope, sitting under the TEXT column's 65535 bytes with room
+---for the escaping the nesting adds - two full-size layouts still fit.
+local MAX_LAYOUT_COLUMN = 60000
+
+---Reads the layout column as a device -> layout-string map. The layout strings stay opaque: they
+---are never decoded here, because a slot array is full of nulls and a Lua table cannot hold those
+---without turning the array into holes and re-encoding it as something else entirely.
+---@param stored string|nil raw column value
+---@return table<string, string> devices device id -> layout JSON
+local function decodeLayouts(stored)
+    if type(stored) ~= 'string' or stored == '' then return {} end
+    local parsed, decoded = pcall(json.decode, stored)
+    if parsed and type(decoded) == 'table' and type(decoded.devices) == 'table' then
+        local out = {}
+        for id, layout in pairs(decoded.devices) do
+            if LAYOUT_DEVICES[id] and type(layout) == 'string' then out[id] = layout end
+        end
+        return out
+    end
+    -- No envelope: written when the phone was the only device, so it is the phone's layout and is
+    -- carried over under that id rather than dropped.
+    return { phone = stored }
+end
+
+---Persists the caller's home-screen layout for one device, an opaque JSON string from the UI,
+---merged into the envelope so the other device's layout survives. Validation is type + a 16k size
+---cap; scoped to the citizenid resolved from src.
 ---@param source number player server id
----@param payload { layout?: string } client payload
+---@param payload { layout?: string, device?: string } client payload
 ---@return table result { success }
 function actions.saveLayout(source, payload)
     if type(payload) ~= 'table' then payload = {} end
@@ -144,7 +176,16 @@ function actions.saveLayout(source, payload)
 
     local layout = payload.layout
     if type(layout) ~= 'string' or #layout > 16000 then return fail('Invalid layout') end
-    settings.setHomeLayout(cid, layout)
+
+    -- An absent or unrecognised device is the phone: that is what every caller predating the
+    -- tablet sent, so an older NUI bundle keeps writing exactly the slice it always wrote.
+    local deviceId = LAYOUT_DEVICES[payload.device] and payload.device or 'phone'
+    local devices = decodeLayouts(settings.getHomeLayout(cid))
+    devices[deviceId] = layout
+
+    local encoded = json.encode({ devices = devices })
+    if #encoded > MAX_LAYOUT_COLUMN then return fail('Invalid layout') end
+    settings.setHomeLayout(cid, encoded)
     return ok()
 end
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { device } from '@device';
 import { AdminPanel } from '@/admin/AdminPanel';
 import { PayphoneUI } from '@/payphone/PayphoneUI';
 import { CallLayer } from '@/apps/phone/CallLayer';
@@ -82,7 +83,11 @@ interface SetupSaved {
     wallpaper?: string;
 }
 
+// A device without the wizard is set up by definition: theme, wallpaper, locale and passcode
+// all live in phone_settings and hydrate normally, so there is nothing left to ask for. Both
+// halves short-circuit, which is what keeps the key unwritten on such a device.
 function loadSetup(): SetupSaved {
+    if (!device.setup) return { completed: true };
     try {
         const raw = window.localStorage.getItem(SETUP_KEY());
         if (raw) {
@@ -94,6 +99,7 @@ function loadSetup(): SetupSaved {
 }
 
 function saveSetup(s: SetupSaved): void {
+    if (!device.setup) return;
     try { window.localStorage.setItem(SETUP_KEY(), JSON.stringify(s)); } catch { /* ignore */ }
 }
 
@@ -153,8 +159,8 @@ export function App() {
         <ThemeProvider>
             <MusicProvider>
                 <AppContent />
-                <AdminPanel />
-                <PayphoneUI />
+                {device.admin && <AdminPanel />}
+                {device.payphone && <PayphoneUI />}
             </MusicProvider>
         </ThemeProvider>
     );
@@ -703,7 +709,9 @@ function AppContent() {
     // it only changes when the app list / install set / stable callbacks change.
     const deckCtx = useMemo<DeckAppCtx>(() => ({
         onClose:           handleCloseApp,
-        allApps:           [...(view?.apps ?? []), ...customDefs],
+        // The App Store is this list's only consumer, so the exclusion has to land here: an app
+        // the device has no route to launch must not be advertised for install either.
+        allApps:           [...(view?.apps ?? []), ...customDefs].filter(a => !device.excludedApps.includes(a.id)),
         installedApps,
         onInstall:         startDownload,
         onOpenApp:         openAppCentered,
@@ -827,7 +835,7 @@ function AppContent() {
         useBadgeStore.getState().patchServer(data ?? {});
     }, []));
     useEffect(() => {
-        if (currentApp === 'phone') void fetchNui('sd-phone:calls:seen');
+        if (device.calls && currentApp === 'phone') void fetchNui('sd-phone:calls:seen');
     }, [currentApp]);
     const currentAppRef = useRef(currentApp);
     currentAppRef.current = currentApp;
@@ -1220,7 +1228,8 @@ function AppContent() {
         setFinishingSetup(false);
         setSetupHello(true);
         setLocked(false);
-        setSetup({ completed: false });
+        // A factory reset re-arms the wizard; a device that has none stays complete.
+        setSetup({ completed: !device.setup });
     }, [resetNonce]);
 
     // The keep-alive deck is rendered ABOVE the shell (in both the closed and open
@@ -1290,16 +1299,19 @@ function AppContent() {
     const lockWallpaper = wallpaperLock || view.wallpaperLock;
 
     const allApps       = [...view.apps, ...customDefs.filter(c => !view.apps.some(a => a.id === c.id))];
-    const effectiveApps = allApps.filter(a => a.base || installedApps.has(a.id) || downloadingIds.includes(a.id));
+    // Excluded apps are dropped here, not just refused at launch: this list is the home grid,
+    // the switcher's card set and the App Store's catalogue.
+    const effectiveApps = allApps.filter(a => !device.excludedApps.includes(a.id) && (a.base || installedApps.has(a.id) || downloadingIds.includes(a.id)));
     const effectiveIds  = new Set(effectiveApps.map(a => a.id));
 
     const canShowSwitcher = recentApps.length > 0 || !!currentApp;
 
-    // Hello only renders once the answer is trustworthy: the localStorage flag OR the server
-    // flag says completed -> never; unique phones -> wait for the resolved profile; in-game ->
-    // wait for the profile's settings hydrate (serverSetupDone non-null) so a cleared cache
-    // can't flash setup at a phone whose server flag says done.
-    const showSetup = !setupCompleted
+    // Hello only renders once the answer is trustworthy: the device has no wizard, or the
+    // localStorage flag OR the server flag says completed -> never; unique phones -> wait for
+    // the resolved profile; in-game -> wait for the profile's settings hydrate (serverSetupDone
+    // non-null) so a cleared cache can't flash setup at a phone whose server flag says done.
+    const showSetup = device.setup
+        && !setupCompleted
         && (!simEnabled || simProfileReady)
         && (!isFiveM || serverSetupDone !== null);
 
@@ -1311,7 +1323,7 @@ function AppContent() {
         <>
         {deckLayer}
         <div key={showSetup ? 'setup' : locale} className={theme === 'dark' ? 'dark' : undefined} data-dark-theme={darkTheme}>
-            {import.meta.env.DEV && (
+            {import.meta.env.DEV && device.setup && (
                 <button
                     type="button"
                     onClick={() => setSetup(prev => { const next = { ...prev, completed: !prev.completed }; saveSetup(next); return next; })}
@@ -1455,7 +1467,9 @@ function AppContent() {
                     />
                 )}
 
-                <CallLayer wallpaper={homeWallpaper} />
+                {/* Must not MOUNT on a device without calls: CallLayer self-hydrates through
+                    getCurrentCall(), so an ongoing call would surface here even with no pushes. */}
+                {device.calls && <CallLayer wallpaper={homeWallpaper} />}
 
                 {ringingAlarm && (
                     <div className="absolute inset-0 z-30">

--- a/web/src/apps/_classifieds/ContactActions.tsx
+++ b/web/src/apps/_classifieds/ContactActions.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Trash2 } from 'lucide-react';
 
+import { device } from '@device';
 import { t } from '@/i18n';
 import { MailGlyph, MessageGlyph, PhoneGlyph } from '@/shell/AppGlyphs';
 
@@ -33,7 +34,7 @@ export function ContactActions({ onMessage, onCall, onEmail, onDelete, subject =
                     <MessageGlyph className="h-[25px] w-[25px]" />
                 </Tile>
             )}
-            {onCall && (
+            {onCall && device.calls && (
                 <Tile color="#0A84FF" label={t('common.callSubject', 'Call {subject}', { subject })} onClick={onCall}>
                     <PhoneGlyph className="h-[21px] w-[21px]" />
                 </Tile>

--- a/web/src/apps/_classifieds/ListingDetail.tsx
+++ b/web/src/apps/_classifieds/ListingDetail.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { ChevronLeft, ChevronRight, Image as ImageIcon, Pencil, Trash2 } from 'lucide-react';
 
+import { device } from '@device';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { Scroller } from '@/ui/Scroller';
 import { MailGlyph, MessageGlyph, PhoneGlyph } from '@/shell/AppGlyphs';
@@ -157,9 +158,11 @@ export function ListingDetail({ item, backLabel, itemNoun = t('classifieds.post'
                                         <Tile color="#34C759" label={t('classifieds.message', 'Message')} onClick={onMessage}>
                                             <MessageGlyph className="h-[32px] w-[32px]" />
                                         </Tile>
-                                        <Tile color="#0A84FF" label={t('classifieds.call', 'Call')} onClick={onCall}>
-                                            <PhoneGlyph className="h-[30px] w-[30px]" />
-                                        </Tile>
+                                        {device.calls && (
+                                            <Tile color="#0A84FF" label={t('classifieds.call', 'Call')} onClick={onCall}>
+                                                <PhoneGlyph className="h-[30px] w-[30px]" />
+                                            </Tile>
+                                        )}
                                     </>
                                 )}
                                 {item.email && onEmail && (

--- a/web/src/apps/_classifieds/useContactActions.tsx
+++ b/web/src/apps/_classifieds/useContactActions.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 
+import { device } from '@device';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { requestOpenMail, requestOpenMessages } from '@/shell/deeplink';
 import { fetchNui, isFiveM } from '@/core/nui';
@@ -49,7 +50,7 @@ export function useContactActions(): {
                 onConfirm={() => {
                     const num = dlg.number;
                     setDlg(null);
-                    if (isFiveM) void fetchNui('sd-phone:call:dial', { number: num });
+                    if (isFiveM && device.calls) void fetchNui('sd-phone:call:dial', { number: num });
                 }}
             />
         );

--- a/web/src/apps/appstore/appsApi.ts
+++ b/web/src/apps/appstore/appsApi.ts
@@ -1,3 +1,4 @@
+import { device } from '@device';
 import { fitsGrid } from '@/shell/widgets/geometry';
 import { fetchNui, isFiveM } from '@/core/nui';
 import { apiData } from '@/core/api';
@@ -29,7 +30,9 @@ export async function uninstallApp(id: string): Promise<string[]> {
     return r ? r.installed : listInstalledApps();
 }
 
-const LAYOUT_KEY = 'sd-phone:home-layout';
+// Namespaced per device, because a layout is only meaningful against the grid it was arranged on.
+// The phone keeps the bare key it has always used, so a harness layout saved before this survives.
+const LAYOUT_KEY = device.id === 'phone' ? 'sd-phone:home-layout' : `sd-phone:home-layout:${device.id}`;
 
 interface FolderDef { key: string; name: string; appIds: string[] }
 
@@ -115,40 +118,76 @@ function sanitiseWidgets(v: unknown): WidgetPlacement[] {
 }
 
 /**
- * A stored layout, or null when it cannot be trusted.
+ * One parsed layout, or null when it cannot be trusted.
  *
  * Validates rather than casts. A layout reaching render with a non-string slot throws inside
  * `icon.startsWith(...)`, which unmounts the phone mid-render and leaves NUI focus held, stranding
  * the player's mouse. lb-phone's layout is an array of PAGES, so it satisfies `Array.isArray` while
  * being the wrong shape entirely.
  */
+function parseValue(v: unknown): SavedLayout | null {
+    if (isSlotArray(v)) return { slots: v, folders: [] };
+    if (v && typeof v === 'object' && isSlotArray((v as SavedLayout).slots)) {
+        const o = v as SavedLayout;
+        const widgets = sanitiseWidgets(o.widgets);
+        // Only attached when there is something to attach, so a widget-less layout keeps the
+        // exact shape it had before widgets existed.
+        return {
+            slots: o.slots,
+            folders: Array.isArray(o.folders) ? o.folders : [],
+            ...(widgets.length ? { widgets } : {}),
+            ...(Array.isArray(o.dock) ? { dock: o.dock.filter((x): x is string => typeof x === 'string') } : {}),
+        };
+    }
+    return null;
+}
+
+/**
+ * How one stored layout column holds every device. `slots` is a flat array whose page boundaries
+ * are the device's own cols * rows - 24 on the phone, 36 on the tablet - so reading a tablet
+ * layout as a phone one puts every icon past the first page in a different cell, and a widget
+ * saved at column 4 does not exist on a 4-column grid at all. Each device therefore owns its own
+ * layout string under its device id, and the server merges by key without ever decoding the
+ * layout itself (`slots` is full of nulls, which Lua cannot hold without shredding the array).
+ */
+interface LayoutEnvelope { devices: Record<string, string> }
+
+function isEnvelope(v: unknown): v is LayoutEnvelope {
+    return !!v && typeof v === 'object'
+        && !!(v as LayoutEnvelope).devices && typeof (v as LayoutEnvelope).devices === 'object';
+}
+
+/** This device's slice of a stored value, or undefined when it holds nothing for us. */
+function ownSlice(v: unknown): unknown {
+    // No envelope means it was written when the phone was the only device, so it IS the phone's.
+    // A tablet starts from its own default rather than inheriting a layout built for 4 columns.
+    if (!isEnvelope(v)) return device.id === 'phone' ? v : undefined;
+    const raw = v.devices[device.id];
+    if (typeof raw !== 'string') return undefined;
+    try { return JSON.parse(raw) as unknown; } catch { return undefined; }
+}
+
+/** The layout the server stored for THIS device, or null when there is none to trust. */
 export function parseLayout(raw: string | null | undefined): SavedLayout | null {
     if (!raw) return null;
     try {
-        const v = JSON.parse(raw) as unknown;
-        if (isSlotArray(v)) return { slots: v, folders: [] };
-        if (v && typeof v === 'object' && isSlotArray((v as SavedLayout).slots)) {
-            const o = v as SavedLayout;
-            const widgets = sanitiseWidgets(o.widgets);
-            // Only attached when there is something to attach, so a widget-less layout keeps the
-            // exact shape it had before widgets existed.
-            return {
-                slots: o.slots,
-                folders: Array.isArray(o.folders) ? o.folders : [],
-                ...(widgets.length ? { widgets } : {}),
-                ...(Array.isArray(o.dock) ? { dock: o.dock.filter((x): x is string => typeof x === 'string') } : {}),
-            };
-        }
+        const own = ownSlice(JSON.parse(raw) as unknown);
+        return own === undefined ? null : parseValue(own);
     } catch { /* ignore */ }
     return null;
 }
 
 export function loadHomeLayout(): SavedLayout | null {
     if (isFiveM) return null;
-    try { return parseLayout(window.localStorage.getItem(LAYOUT_KEY)); } catch { return null; }
+    // The harness key is already per-device, so it holds this device's layout directly - there is
+    // no envelope to unwrap, and routing it through parseLayout would reject every tablet layout.
+    try {
+        const raw = window.localStorage.getItem(LAYOUT_KEY);
+        return raw ? parseValue(JSON.parse(raw) as unknown) : null;
+    } catch { return null; }
 }
 
 export function saveHomeLayout(layout: SavedLayout): void {
     if (!isFiveM) { writeJson(LAYOUT_KEY, layout); return; }
-    void fetchNui('sd-phone:apps:saveLayout', { layout: JSON.stringify(layout) });
+    void fetchNui('sd-phone:apps:saveLayout', { layout: JSON.stringify(layout), device: device.id });
 }

--- a/web/src/apps/phone/contacts/ContactDetail.tsx
+++ b/web/src/apps/phone/contacts/ContactDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { Check, ChevronLeft, Copy, MessageSquare, Phone, Share, Video } from 'lucide-react';
 
+import { device } from '@device';
 import { ContactAvatar } from '@/shared/ContactAvatar';
 import { ShareAction, ShareSheet } from '@/shared/ShareSheet';
 import { AlertDialog } from '@/ui/AlertDialog';
@@ -108,8 +109,8 @@ export function ContactDetail({ contact, onBack, backLabel = t('phone.contacts',
 
                 <div className="mb-7 flex gap-3">
                     <ActionButton label={t('phone.actionMessage','message')} disabled={minimal} onClick={() => requestOpenMessages({ number: current.phone, name: current.name })} icon={<MessageSquare className="h-[28px] w-[28px]" strokeWidth={2} fill="currentColor" />} />
-                    <ActionButton label={t('phone.actionCall','call')}    disabled={minimal} onClick={() => onCall?.({ number: current.phone, name: current.name })} icon={<Phone className="h-[28px] w-[28px]" strokeWidth={2} fill="currentColor" />} />
-                    <ActionButton label={t('phone.actionVideo','video')}   disabled={minimal} onClick={() => { requestVideoOnConnect(); onCall?.({ number: current.phone, name: current.name }); }} icon={<Video className="h-[28px] w-[28px]" strokeWidth={2} fill="currentColor" />} />
+                    {device.calls && <ActionButton label={t('phone.actionCall','call')}    disabled={minimal} onClick={() => onCall?.({ number: current.phone, name: current.name })} icon={<Phone className="h-[28px] w-[28px]" strokeWidth={2} fill="currentColor" />} />}
+                    {device.calls && <ActionButton label={t('phone.actionVideo','video')}   disabled={minimal} onClick={() => { requestVideoOnConnect(); onCall?.({ number: current.phone, name: current.name }); }} icon={<Video className="h-[28px] w-[28px]" strokeWidth={2} fill="currentColor" />} />}
                     <ActionButton label={t('phone.actionShare','share')}   onClick={() => setSharing(true)} icon={<Share className="h-[28px] w-[28px]" strokeWidth={2} />} />
                 </div>
 

--- a/web/src/apps/review/BusinessDetail.tsx
+++ b/web/src/apps/review/BusinessDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { device } from '@device';
 import { t } from '@/i18n';
 import { useContactActions } from '@/apps/_classifieds/useContactActions';
 import { BusinessLogo } from './BusinessCard';
@@ -99,7 +100,7 @@ export function BusinessDetail({ businessId, initial, onBack, onMutated }: {
                         <div className="flex items-center justify-between border-t border-black/[0.06] py-2.5 dark:border-white/[0.08]">
                             <span className="text-[14px] text-black/55 dark:text-white/55">{t('review.contact', 'Contact')}</span>
                             <div className="flex gap-4">
-                                <button type="button" onClick={() => contact.call(b.phone!)} className="text-[15px] font-medium text-ios-blue">{t('review.call', 'Call')}</button>
+                                {device.calls && <button type="button" onClick={() => contact.call(b.phone!)} className="text-[15px] font-medium text-ios-blue">{t('review.call', 'Call')}</button>}
                                 <button type="button" onClick={() => contact.message(b.phone!)} className="text-[15px] font-medium text-ios-blue">{t('review.message', 'Message')}</button>
                             </div>
                         </div>

--- a/web/src/apps/ryde/driver/TripDriver.tsx
+++ b/web/src/apps/ryde/driver/TripDriver.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { MapPin, MessageSquare, Navigation, Phone, X } from 'lucide-react';
 
+import { device } from '@device';
 import { fetchNui, isFiveM } from '@/core/nui';
 import { t } from '@/i18n';
 import { AlertDialog } from '@/ui/AlertDialog';
@@ -149,10 +150,12 @@ export function TripDriver() {
                         </div>
 
                         {r.riderNumber && (
-                            <div className="mb-3.5 grid grid-cols-2 gap-3">
-                                <button onClick={() => setConfirmCall(true)} className="flex items-center justify-center gap-2 rounded-[14px] bg-black/[0.06] py-3 text-[15px] font-semibold text-black active:opacity-70 dark:bg-white/10 dark:text-white">
-                                    <Phone className="h-[20px] w-[20px]" strokeWidth={2.2} /> {t('ryde.call', 'Call')}
-                                </button>
+                            <div className={`mb-3.5 grid ${device.calls ? 'grid-cols-2' : 'grid-cols-1'} gap-3`}>
+                                {device.calls && (
+                                    <button onClick={() => setConfirmCall(true)} className="flex items-center justify-center gap-2 rounded-[14px] bg-black/[0.06] py-3 text-[15px] font-semibold text-black active:opacity-70 dark:bg-white/10 dark:text-white">
+                                        <Phone className="h-[20px] w-[20px]" strokeWidth={2.2} /> {t('ryde.call', 'Call')}
+                                    </button>
+                                )}
                                 <button onClick={messageRider} className="flex items-center justify-center gap-2 rounded-[14px] bg-black/[0.06] py-3 text-[15px] font-semibold text-black active:opacity-70 dark:bg-white/10 dark:text-white">
                                     <MessageSquare className="h-[20px] w-[20px]" strokeWidth={2.2} /> {t('ryde.message', 'Message')}
                                 </button>

--- a/web/src/apps/ryde/rider/TripRider.tsx
+++ b/web/src/apps/ryde/rider/TripRider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ArrowLeftRight, Phone, MessageSquare, X } from 'lucide-react';
 
+import { device } from '@device';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { dialCall } from '@/apps/phone/callsApi';
 import { requestOpenMessages } from '@/shell/deeplink';
@@ -121,8 +122,8 @@ function TripRiderView({ r }: { r: Ride }) {
                 )}
 
                 {r.driver && !inTrip && !offered && (
-                    <div className="mb-3.5 grid grid-cols-2 gap-3">
-                        <Action icon={<Phone className="h-[24px] w-[24px]" />} label={t('ryde.call', 'Call')} onClick={() => setConfirmCall(true)} />
+                    <div className={`mb-3.5 grid ${device.calls ? 'grid-cols-2' : 'grid-cols-1'} gap-3`}>
+                        {device.calls && <Action icon={<Phone className="h-[24px] w-[24px]" />} label={t('ryde.call', 'Call')} onClick={() => setConfirmCall(true)} />}
                         <Action icon={<MessageSquare className="h-[24px] w-[24px]" />} label={t('ryde.message', 'Message')} onClick={messageDriver} />
                     </div>
                 )}

--- a/web/src/apps/services/CompaniesTab.tsx
+++ b/web/src/apps/services/CompaniesTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { Building2, MessageSquare, Navigation, Phone } from 'lucide-react';
 
+import { device } from '@device';
 import { ActionSheet } from '@/ui/ActionSheet';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { EmptyState } from '@/ui/EmptyState';
@@ -139,7 +140,7 @@ function CompanyCard({ company, onLocate, onCall, onMessage }: {
                 <ActionTile color="#FF9F0A" label={t('services.locateName', 'Locate {name}', { name: company.name })} onClick={onLocate}>
                     <Navigation className="h-[20px] w-[20px]" strokeWidth={2.2} fill="currentColor" />
                 </ActionTile>
-                {company.canCall && (
+                {company.canCall && device.calls && (
                     <ActionTile color="#34C759" label={t('services.callName', 'Call {name}', { name: company.name })} onClick={onCall}>
                         <Phone className="h-[20px] w-[20px]" strokeWidth={2.2} fill="currentColor" />
                     </ActionTile>

--- a/web/src/apps/settings/Settings.tsx
+++ b/web/src/apps/settings/Settings.tsx
@@ -1,3 +1,4 @@
+import { device } from '@device';
 import { t } from '@/i18n';
 import { useSessionState } from '@/hooks/useSessionState';
 import { AppIconsPage } from './appearance/AppIconsPage';
@@ -36,6 +37,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
     // The SIM & Backup row only exists while the server runs unique phones.
     const settingsGroups = getSettingsGroups()
         .map(g => simEnabled ? g : { ...g, rows: g.rows.filter(r => r.id !== 'sim') })
+        .map(g => device.calls ? g : { ...g, rows: g.rows.filter(r => r.id !== 'phone') })
         .map(g => wifiConfigured ? g : { ...g, rows: g.rows.filter(r => r.id !== 'wifi') })
         .map(g => bluetoothConfigured ? g : { ...g, rows: g.rows.filter(r => r.id !== 'bluetooth') })
         .map(g => ({

--- a/web/src/apps/settings/appearance/WallpaperPage.tsx
+++ b/web/src/apps/settings/appearance/WallpaperPage.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { Camera, ChevronRight, Flashlight } from 'lucide-react';
 
+import { device } from '@device';
 import { t } from '@/i18n';
 import { formatClockTime, formatLongDate, useClock } from '@/hooks/useClock';
 import { useIosPush } from '@/hooks/useIosPush';
@@ -15,13 +16,14 @@ import { Toggle } from '@/ui/Toggle';
 import { WallpaperPickerPage } from './WallpaperPickerPage';
 import { NavBar } from '@/ui/NavBar';
 
-// The previews are full-size 440x956 replicas of the real Lockscreen/Homescreen render,
-// scale-transformed to thumbnail size - geometry constants below mirror shell/Homescreen.tsx
-// and shell/Lockscreen.tsx so the previews can't drift from the real screens.
-const SW = 440;
-const SH = 956;
+// The previews are full-size replicas of the real Lockscreen/Homescreen render, scale-transformed
+// to thumbnail size - the geometry below is read from the device profile, the same source
+// shell/Homescreen.tsx reads, so the previews can't drift from the real screens.
+const { w: SW, h: SH } = device.screen;
+const { cols: COLS, padX: PAD_X, icon: ICON, colStride: COL_STRIDE, rowY0: ROW_Y0, rowStride: ROW_STRIDE, stripTop } = device.screen.grid;
 
-// Default first homescreen page: the first 12 non-dock apps in catalog order.
+// Default first homescreen page: the first 12 non-dock apps in catalog order. Both lists are
+// filtered the way the real home grid is - a preview must never show an app the device lacks.
 const PAGE_APPS = [
     { icon: 'mail',       label: 'Mail' },
     { icon: 'maps',       label: 'Maps' },
@@ -35,8 +37,8 @@ const PAGE_APPS = [
     { icon: 'bank',       label: 'Bank' },
     { icon: 'health',     label: 'Health' },
     { icon: 'documents',  label: 'Files' },
-];
-const DOCK_APPS = ['phone', 'messages', 'camera', 'photos'];
+].filter(a => !device.excludedApps.includes(a.icon));
+const DOCK_APPS = ['phone', 'messages', 'camera', 'photos'].filter(id => !device.excludedApps.includes(id));
 
 export function WallpaperPage({ onBack }: { onBack: () => void }) {
     const { goBack, pageStyle, animating } = useIosPush(onBack);
@@ -115,7 +117,7 @@ function BlurRow({ label, on, onToggle }: { label: string; on: boolean; onToggle
 }
 
 
-// Renders children on a full-size 440x956 stage, scale-transformed to the thumb's measured
+// Renders children on a full-size screen stage, scale-transformed to the thumb's measured
 // width - so every child uses the real screens' CSS values verbatim.
 function PreviewThumb({ caption, onPress, children }: { caption: string; onPress: () => void; children: ReactNode }) {
     const ref = useRef<HTMLButtonElement>(null);
@@ -152,6 +154,9 @@ function PreviewThumb({ caption, onPress, children }: { caption: string; onPress
 
 
 function DynamicIsland() {
+    // A device with no cutout has none on its real screens either, so painting one here would
+    // be exactly the drift these previews exist to avoid.
+    if (!device.screen.island) return null;
     return <div className="absolute left-1/2 top-[11px] -translate-x-1/2 rounded-full bg-black" style={{ width: 126, height: 37 }} />;
 }
 
@@ -235,7 +240,7 @@ function HomePreview({ wallpaper, blurred, animating }: { wallpaper: string; blu
                 <div
                     key={app.icon}
                     className="absolute"
-                    style={{ left: 28 + (i % 4) * 102, top: 78 + Math.floor(i / 4) * 122, width: 78 }}
+                    style={{ left: PAD_X + (i % COLS) * COL_STRIDE, top: stripTop + ROW_Y0 + Math.floor(i / COLS) * ROW_STRIDE, width: ICON }}
                 >
                     <PreviewIcon icon={app.icon} label={app.label} />
                 </div>

--- a/web/src/apps/settings/notifications/NotificationsPage.tsx
+++ b/web/src/apps/settings/notifications/NotificationsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 
+import { device } from '@device';
 import { t } from '@/i18n';
 import { useIosPush } from '@/hooks/useIosPush';
 import { AppIconSVG } from '@/shell/AppIconSVG';
@@ -29,7 +30,8 @@ const APPS: AppEntry[] = [
     { id: 'settings', label: 'Settings'  },
     { id: 'wallet',   label: 'Wallet'    },
     { id: 'weather',  label: 'Weather'   },
-].sort((a, b) => a.label.localeCompare(b.label));
+].filter(a => device.calls || a.id !== 'phone')
+    .sort((a, b) => a.label.localeCompare(b.label));
 
 export function NotificationsPage({ onBack }: { onBack: () => void }) {
     const { goBack, pageStyle } = useIosPush(onBack);

--- a/web/src/apps/settings/sound/SoundHapticsPage.tsx
+++ b/web/src/apps/settings/sound/SoundHapticsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Check, Play, Plus, Square, Trash2, Volume, Volume2 } from 'lucide-react';
 
+import { device } from '@device';
 import { t } from '@/i18n';
 import { useIosPush } from '@/hooks/useIosPush';
 import { useTheme } from '@/stores/themeStore';
@@ -76,26 +77,30 @@ export function SoundHapticsPage({ onBack }: { onBack: () => void }) {
                 </div>
             </ListGroup>
 
-            <ListGroup header={t('settings.callVolume', 'Call Volume')}>
-                <div className="flex items-center gap-3 px-4 py-3">
-                    <Volume
-                        className="h-[18px] w-[18px] shrink-0 text-ios-gray"
-                        strokeWidth={2}
-                    />
-                    <input
-                        type="range"
-                        min={0} max={100}
-                        value={callVol}
-                        onChange={e => setCallVol(+e.target.value)}
-                        className="ios-slider flex-1"
-                        style={{ '--sp': `${callVol}%`, '--se': trackEmpty } as React.CSSProperties}
-                    />
-                    <Volume2
-                        className="h-[20px] w-[20px] shrink-0 text-ios-gray"
-                        strokeWidth={2}
-                    />
-                </div>
-            </ListGroup>
+            {/* This slider sets the in-call voice level, so it has nothing to control on a
+                device that cannot call - dropped entirely rather than shown disabled. */}
+            {device.calls && (
+                <ListGroup header={t('settings.callVolume', 'Call Volume')}>
+                    <div className="flex items-center gap-3 px-4 py-3">
+                        <Volume
+                            className="h-[18px] w-[18px] shrink-0 text-ios-gray"
+                            strokeWidth={2}
+                        />
+                        <input
+                            type="range"
+                            min={0} max={100}
+                            value={callVol}
+                            onChange={e => setCallVol(+e.target.value)}
+                            className="ios-slider flex-1"
+                            style={{ '--sp': `${callVol}%`, '--se': trackEmpty } as React.CSSProperties}
+                        />
+                        <Volume2
+                            className="h-[20px] w-[20px] shrink-0 text-ios-gray"
+                            strokeWidth={2}
+                        />
+                    </div>
+                </ListGroup>
+            )}
 
             <ListGroup header={t('settings.soundHapticsPatterns', 'Sound and Haptics Patterns')}>
                 <ListRow

--- a/web/src/core/nui.ts
+++ b/web/src/core/nui.ts
@@ -1,3 +1,4 @@
+import { device } from '@device';
 
 interface FiveMWindowish {
     GetParentResourceName?: () => string;
@@ -27,16 +28,28 @@ export const isFiveM = detectFiveM(currentWindow);
 
 const resourceName: string = parseResourceName(currentWindow);
 
+/** The resource serving this NUI page. Custom-app iframes load their SDK from it. */
+export const hostResource = resourceName;
+
 export async function fetchNui<TResp = unknown>(event: string, payload?: unknown): Promise<TResp> {
     if (!isFiveM) {
         console.debug('[sd-phone:dev] fetchNui ->', event, payload);
         return { ok: true } as unknown as TResp;
     }
 
-    const res = await fetch(`https://${resourceName}/${event}`, {
+    // Phone: post straight to the action's own callback, as it always has.
+    // Companion device (sd-tablet): wrap every action in one envelope posted to a single
+    // callback, which forwards it into sd-phone's client. A companion cannot register the
+    // ~460 action names this UI uses - many are built at runtime - and a missing callback
+    // would 404 into a JSON parse error rather than a usable response.
+    const rpc  = device.rpcAction;
+    const url  = rpc ? `https://${resourceName}/${rpc}` : `https://${resourceName}/${event}`;
+    const body = rpc ? { action: event, payload: payload ?? {} } : (payload ?? {});
+
+    const res = await fetch(url, {
         method:  'POST',
         headers: { 'Content-Type': 'application/json; charset=UTF-8' },
-        body:    JSON.stringify(payload ?? {}),
+        body:    JSON.stringify(body),
     });
     const text = await res.text();
     return (text ? JSON.parse(text) : {}) as TResp;

--- a/web/src/device/phone.ts
+++ b/web/src/device/phone.ts
@@ -1,0 +1,38 @@
+import type { DeviceProfile } from './types';
+
+// The phone. Every value here is the constant the code carried inline before the device profile
+// existed, so this build is byte-for-byte the layout sd-phone has always shipped.
+export const device: DeviceProfile = {
+    id:           'phone',
+    rpcAction:    null,
+    calls:        true,
+    payphone:     true,
+    admin:        true,
+    setup:        true,
+    excludedApps: [],
+    defaultAlign: 'bottom-right',
+    screen: {
+        w:      440,
+        h:      956,
+        bezel:  9,
+        radius: 55,
+        island: true,
+        buttons: [
+            { side: 'left',  y: 174, h: 38, role: 'screenshot' },
+            { side: 'left',  y: 252, h: 64, role: 'volumeUp' },
+            { side: 'left',  y: 346, h: 64, role: 'volumeDown' },
+            { side: 'right', y: 217, h: 80, role: 'power' },
+            { side: 'right', y: 566, h: 60 },
+        ],
+        grid: {
+            cols:      4,
+            rows:      6,
+            padX:      28,
+            icon:      78,
+            colStride: 102,
+            rowY0:     8,
+            rowStride: 122,
+            stripTop:  70,
+        },
+    },
+};

--- a/web/src/device/types.ts
+++ b/web/src/device/types.ts
@@ -1,0 +1,81 @@
+// The device this bundle is built for.
+//
+// sd-phone builds `device/phone.ts`; the sibling sd-tablet resource builds the SAME source tree
+// against its own profile through the `@device` alias. Everything that differs between a phone
+// and a tablet - frame geometry, home-grid shape, whether the device can place a call - is a
+// field here, so no app file ever branches on the device it happens to be running on.
+
+export type DeviceId = 'phone' | 'tablet';
+
+/** Where the device sits on screen. Mirrors the nine positions Settings offers. */
+export type DeviceAlign =
+    | 'top-left'    | 'top-center'    | 'top-right'
+    | 'middle-left' | 'middle-center' | 'middle-right'
+    | 'bottom-left' | 'bottom-center' | 'bottom-right';
+
+/** One physical side button on the frame rail. */
+export interface DeviceButton {
+    /** Which rail it sits on; `x` is derived from the frame width. */
+    side: 'left' | 'right';
+    /** Distance from the top of the frame, in frame px. */
+    y: number;
+    /** Button height in frame px. */
+    h: number;
+    /** What tapping it does. Buttons without a role are decorative. */
+    role?: 'volumeUp' | 'volumeDown' | 'power' | 'screenshot';
+}
+
+/** Home-screen icon grid. All values are screen px. */
+export interface DeviceGrid {
+    cols: number;
+    rows: number;
+    /** Left/right padding before the first icon column. */
+    padX: number;
+    /** Icon tile edge length. */
+    icon: number;
+    /** Column pitch (icon + horizontal gap). */
+    colStride: number;
+    /** Y of the first icon row, measured from the top of the grid strip. */
+    rowY0: number;
+    /** Row pitch (icon + label + vertical gap). */
+    rowStride: number;
+    /** Height of the status-bar strip the grid starts below. */
+    stripTop: number;
+}
+
+export interface DeviceScreen {
+    /** Screen width/height in CSS px - the coordinate space every app is laid out in. */
+    w: number;
+    h: number;
+    /** Frame thickness around the screen. */
+    bezel: number;
+    /** Outer frame corner radius; the screen radius is this minus the bezel. */
+    radius: number;
+    /** Dynamic Island cutout, pills and the lens dot. Tablets have none. */
+    island: boolean;
+    buttons: readonly DeviceButton[];
+    grid: DeviceGrid;
+}
+
+export interface DeviceProfile {
+    id: DeviceId;
+    /**
+     * NUI transport. `null` posts each action to its own callback name (the phone, unchanged).
+     * A string wraps every call in a single `{ action, payload }` envelope posted to that one
+     * callback - which is how a companion device forwards them into sd-phone's client.
+     */
+    rpcAction: string | null;
+    /** Voice calls: the dialler, the call overlay, and every in-app "call" affordance. */
+    calls: boolean;
+    /** The street payphone UI (a call surface of its own). */
+    payphone: boolean;
+    /** The admin panel overlay. */
+    admin: boolean;
+    /** Run the first-run setup wizard. Off inherits the phone's settings instead. */
+    setup: boolean;
+    /** App ids this device does not have. Excluded ids can't be launched by any route. */
+    excludedApps: readonly string[];
+    /** Where it sits before the player moves it in Settings. */
+    defaultAlign: DeviceAlign;
+    screen: DeviceScreen;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -317,12 +317,14 @@ input[type='number'] {
     to   { transform: scale(0.01); }
 }
 
-/* Opening from the app switcher: the card is already a ~0.82-scale near-fullscreen
-   preview of the live app, so grow from THAT size (about the tapped card's centre)
-   instead of popping up from a point like a home-screen launch. 0.82 = CARD_W / SW. */
+/* Opening from the app switcher: the card is already a near-fullscreen preview of the live
+   app, so grow from THAT size (about the tapped card's centre) instead of popping up from a
+   point like a home-screen launch. The start scale IS AppSwitcher's SCALE (CARD_W / SW), so it
+   moves with the screen width - AppSwitcher publishes it as --switcher-scale; the fallback is
+   the phone's 362/440. */
 @keyframes ios-app-expand {
-    from { transform: scale(0.82); }
-    to   { transform: scale(1);    }
+    from { transform: scale(var(--switcher-scale, 0.82)); }
+    to   { transform: scale(1);                           }
 }
 
 /* Applied to the app wrapper only while its open/close scale is running (AppDeck's

--- a/web/src/shared/chat/ChatView.tsx
+++ b/web/src/shared/chat/ChatView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowUp, ChevronLeft, MapPin, Mic, Phone, UserPlus, Video, X } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
+import { device } from '@device';
 import { t } from '@/i18n';
 import { useTheme } from '@/stores/themeStore';
 import { useSessionState } from '@/hooks/useSessionState';
@@ -335,7 +336,7 @@ export function ChatView({ conv, totalUnread, contacts, myNumber, onBack, onSend
                     )}
 
                     <div className="flex flex-1 items-center justify-end gap-[18px] pr-1.5">
-                        {!conv.groupName && (
+                        {!conv.groupName && device.calls && (
                             <>
                                 <button type="button" onClick={() => setCallConfirm('voice')} className="text-[#007AFF] active:opacity-60">
                                     <Phone className="h-[28px] w-[28px]" strokeWidth={2} />

--- a/web/src/shell/AppIcon.tsx
+++ b/web/src/shell/AppIcon.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 
+import { device } from '@device';
 import type { AppDef } from '@/core/types';
 import { useDownloadProgress } from '@/stores/downloadStore';
 import { useIconAppearance, useShowAppNames } from '@/stores/iconThemeStore';
@@ -8,6 +9,12 @@ import { AppGlyph } from './AppGlyphs';
 import { AppBadge } from './AppBadge';
 import { launchOriginFrom } from './launchOrigin';
 import { CircularProgress } from '@/ui/CircularProgress';
+
+// The icon artwork IS the grid cell: `grid.icon` is documented as the tile edge length, and the
+// homescreen measures cells, hit-tests and landing pads with it, so the tile must be exactly it.
+export const TILE = device.screen.grid.icon;
+// AppIconSVG always draws on a fixed 60px design box; every caller scales that box to fit.
+export const ART = 60;
 
 export const TILE_SHADOW = '0 2px 10px rgba(0,0,0,0.38), 0 0 0 0.5px rgba(0,0,0,0.12)';
 
@@ -48,8 +55,10 @@ export function AppIcon({ app, label = true, onOpen, badge }: AppIconProps) {
         >
             <div className="relative">
                 <div
-                    className={`relative h-[78px] w-[78px] overflow-hidden transition-transform duration-150 ease-out ${downloading ? '' : 'group-active:scale-[0.96]'}`}
+                    className={`relative overflow-hidden transition-transform duration-150 ease-out ${downloading ? '' : 'group-active:scale-[0.96]'}`}
                     style={{
+                        width:        TILE,
+                        height:       TILE,
                         borderRadius: radiusPct(radius),
                         boxShadow:    [TILE_SHADOW, boxShadow].filter(Boolean).join(', '),
                     }}
@@ -57,9 +66,9 @@ export function AppIcon({ app, label = true, onOpen, badge }: AppIconProps) {
                     {art === 'native' ? (
                         <div
                             style={{
-                                width:           60,
-                                height:          60,
-                                transform:       'scale(1.3)',
+                                width:           ART,
+                                height:          ART,
+                                transform:       `scale(${TILE / ART})`,
                                 transformOrigin: '0 0',
                             }}
                         >

--- a/web/src/shell/AppSwitcher.tsx
+++ b/web/src/shell/AppSwitcher.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 
+import { device } from '@device';
 import { AppIconSVG } from './AppIconSVG';
 import { AppBadge } from './AppBadge';
 import { registerCardStage } from './appDeckBridge';
@@ -8,10 +9,10 @@ import { useBadges } from '@/stores/badgeStore';
 import type { AppDef } from '@/core/types';
 import { t } from '@/i18n';
 
-const SW         = 440;
-const SH         = 956;
-const SR         = 49;
-const CARD_W     = 362;
+const SW         = device.screen.w;
+const SH         = device.screen.h;
+const SR         = 49;   // card corner, drawn scaled - deliberately rounder than the screen's own radius
+const CARD_W     = Math.round(SW * 362 / 440);   // the card is a fraction of the screen, not a fixed width: hold the phone's 362/440
 const CARD_H     = Math.round(SH * CARD_W / SW);
 const SCALE      = CARD_W / SW;
 const CARD_STEP  = Math.round(CARD_W * 0.74);   // overlap so the focused card sits forward
@@ -21,6 +22,12 @@ const FLICK_VX   = 0.35;               // px/ms - a quick flick pages even on a 
 const HEADER_H   = 42;
 const HEADER_TOP = 46;
 const CARD_TOP   = HEADER_TOP + HEADER_H + 8;
+
+// index.css's ios-app-expand grows an opened app from exactly the card scale it was tapped at,
+// but that keyframe runs on AppDeck's host - not a descendant of this component, which unmounts
+// as the animation starts. PhoneShell publishes this on the screen instead: an ancestor of the
+// host that outlives the switcher.
+export const SWITCHER_SCALE = SCALE;
 
 const ICON_NATIVE = 60;
 const ICON_DISP   = 36;

--- a/web/src/shell/CustomAppFrame.tsx
+++ b/web/src/shell/CustomAppFrame.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { fetchNui } from '@/core/nui';
+import { device } from '@device';
+import { fetchNui, hostResource } from '@/core/nui';
 import { apiData } from '@/core/api';
 import { apiSavePhotoFromUrl } from '@/core/photosApi';
 import { t, getLocale, getLocaleTag } from '@/i18n';
@@ -20,7 +21,9 @@ import { useDeckActive } from './deckActive';
 import { resolveCustomUi } from './widgets/customUrl';
 import type { Contact } from '@/apps/phone/data';
 
-const COMPONENTS_URL = 'https://cfx-nui-sd-phone/web/build/components.js';
+// The SDK ships with whichever resource serves this page - a companion device may not reach
+// sd-phone's own files.
+const COMPONENTS_URL = `https://cfx-nui-${hostResource}/web/build/components.js`;
 
 const warned = new Set<string>();
 function warnOnce(name: string): void {
@@ -162,6 +165,7 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
     }, []);
 
     const createCall = useCallback((data: Record<string, unknown>) => {
+        if (!device.calls) { warnOnce('CreateCall'); return; }
         window.postMessage({ action: 'sd-phone:launchApp', data: { id: 'phone', link: data } }, '*');
         warnOnce('CreateCall(auto-dial)');
     }, []);

--- a/web/src/shell/Homescreen.tsx
+++ b/web/src/shell/Homescreen.tsx
@@ -2,10 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { LayoutGrid, Minus, Plus } from 'lucide-react';
 
+import { device } from '@device';
 import type { AppDef } from '@/core/types';
 import { useTheme } from '@/stores/themeStore';
 import { resolveWallpaper } from './wallpapers';
-import { AppIcon, TILE_SHADOW, radiusPct } from './AppIcon';
+import { ART, AppIcon, TILE, TILE_SHADOW, radiusPct } from './AppIcon';
 import { AppIconSVG } from './AppIconSVG';
 import { AppGlyph } from './AppGlyphs';
 import { AppBadge } from './AppBadge';
@@ -23,20 +24,13 @@ import { WidgetGallery } from './widgets/WidgetGallery';
 import { t } from '@/i18n';
 
 
-const COLS = 4;
-const ROWS = 6;
+// ICON is the grid's cell measure. AppIcon's TILE is the same number by construction - the cell IS
+// the artwork - so a centred tile and a left-aligned one land on the same pixel in either mode.
+const { cols: COLS, rows: ROWS, padX: PAD_X, icon: ICON, colStride: COL_STRIDE, rowY0: ROW_Y0, rowStride: ROW_STRIDE, stripTop } = device.screen.grid;
+const { w: SCREEN_W, h: SCREEN_H } = device.screen;
 const ITEMS_PER_PAGE = COLS * ROWS;
-const SCREEN_W = 440;
-const SCREEN_H = 956;
 const COMMIT_THRESHOLD = SCREEN_W * 0.2;
 const FLICK_VELOCITY = 0.4;
-
-const PAD_X = 28;
-const ICON = 78;
-const COL_STRIDE = ICON + 24;
-const ROW_Y0 = 8;
-const ROW_STRIDE = 122;
-const stripTop = 70;
 
 function chunk<T>(arr: T[], size: number): T[][] {
     const out: T[][] = [];
@@ -168,6 +162,7 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
         if (savedLayout && savedLayout.slots.length) return normalize(savedLayout.slots);
         const seeded = new Set(Object.values(folders).flatMap(f => f.appIds));
         const loose = apps.filter(a => !dockIds.includes(a.id) && !seeded.has(a.id)).map(a => a.id);
+        // A seeding count, not a grid measure: how many apps land on page one before it spills.
         const FIRST_PAGE = 12;
         const arr: (string | null)[] = Array(ITEMS_PER_PAGE * 2).fill(null);
         loose.slice(0, FIRST_PAGE).forEach((id, i) => { arr[i] = id; });
@@ -1104,12 +1099,12 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                         >
                             {!!dragId && (dockOver === di || app.id === dockPlan?.intoDock) && (
                                 <div
-                                    className="pointer-events-none absolute left-1/2 top-0 h-[78px] w-[78px] -translate-x-1/2"
-                                    style={{ borderRadius: '27.6%', boxShadow: '0 0 0 3.5px rgba(255,255,255,0.92), 0 2px 12px rgba(0,0,0,0.42)' }}
+                                    className="pointer-events-none absolute left-1/2 top-0 -translate-x-1/2"
+                                    style={{ width: TILE, height: TILE, borderRadius: '27.6%', boxShadow: '0 0 0 3.5px rgba(255,255,255,0.92), 0 2px 12px rgba(0,0,0,0.42)' }}
                                 />
                             )}
                             {app.id === dragId
-                                ? <div className="h-[78px] w-[78px]" />
+                                ? <div style={{ width: TILE, height: TILE }} />
                                 : (
                                     <div
                                         className={editing ? 'animate-app-jiggle' : ''}
@@ -1125,7 +1120,7 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                                                 onPointerDown={e => e.stopPropagation()}
                                                 onClick={() => setConfirmRemove(app)}
                                                 className="absolute z-10 flex h-[24px] w-[24px] items-center justify-center rounded-full bg-[#e4e4e6] shadow-[0_1px_3px_rgba(0,0,0,0.4)] active:scale-90"
-                                                style={{ left: 'calc(50% - 46px)', top: -7 }}
+                                                style={{ left: `calc(50% - ${TILE / 2 + 7}px)`, top: -7 }}
                                             >
                                                 <Minus className="h-[16px] w-[16px] text-black/75" strokeWidth={3} />
                                             </button>
@@ -1137,8 +1132,8 @@ export function Homescreen({ apps, dock, wallpaper, onLaunchApp, onUninstall, sa
                     {dockOver !== null && !dragFromDock && dockView.length < DOCK_MAX && (
                         <div data-dock-idx={dockView.length} className="relative flex flex-1 justify-center" style={{ touchAction: 'none' }}>
                             <div
-                                className="h-[78px] w-[78px] border border-white/40 bg-white/10"
-                                style={{ borderRadius: '27.6%', boxShadow: dockOver === dockView.length ? '0 0 0 3.5px rgba(255,255,255,0.92)' : undefined }}
+                                className="border border-white/40 bg-white/10"
+                                style={{ width: TILE, height: TILE, borderRadius: '27.6%', boxShadow: dockOver === dockView.length ? '0 0 0 3.5px rgba(255,255,255,0.92)' : undefined }}
                             />
                         </div>
                     )}
@@ -1190,9 +1185,9 @@ function EditTile({ app, dragging, swapTarget, plopping, removable, merging, bad
         <div className={dragging ? '' : 'animate-app-jiggle'} style={{ animationDelay: `${jiggleDelay(app.id)}ms` }}>
             <div className="relative">
                 {merging && <div className="pointer-events-none absolute -inset-[8px] rounded-[30%] bg-white/25 backdrop-blur-sm" />}
-                <div className={`relative h-[78px] w-[78px] overflow-hidden transition-[box-shadow,transform] duration-150 ${plopping ? 'animate-plop' : ''}`} style={{ borderRadius: radiusPct(radius), boxShadow: [swapTarget ? '0 2px 12px rgba(0,0,0,0.42), 0 0 0 3.5px rgba(255,255,255,0.92)' : TILE_SHADOW, boxShadow].filter(Boolean).join(', '), transform: dragging || merging ? 'scale(1.12)' : undefined }}>
+                <div className={`relative overflow-hidden transition-[box-shadow,transform] duration-150 ${plopping ? 'animate-plop' : ''}`} style={{ width: TILE, height: TILE, borderRadius: radiusPct(radius), boxShadow: [swapTarget ? '0 2px 12px rgba(0,0,0,0.42), 0 0 0 3.5px rgba(255,255,255,0.92)' : TILE_SHADOW, boxShadow].filter(Boolean).join(', '), transform: dragging || merging ? 'scale(1.12)' : undefined }}>
                     {art === 'native' ? (
-                        <div style={{ width: 60, height: 60, transform: 'scale(1.3)', transformOrigin: '0 0' }}>
+                        <div style={{ width: ART, height: ART, transform: `scale(${TILE / ART})`, transformOrigin: '0 0' }}>
                             <AppIconSVG icon={app.icon} />
                         </div>
                     ) : (
@@ -1220,13 +1215,16 @@ const TILE_RADIUS = 0.276;
 const MINI_RADIUS = 0.30;
 const TILE_GLYPH  = 40;
 const MINI_GLYPH  = 10;
+// One cell of the folder's 3x3 preview: the tile less its 9px padding and two 3px gutters. Derived
+// rather than fixed so a native mini keeps filling its cell when the tile follows a bigger profile.
+const MINI = (TILE - 9 * 2 - 3 * 2) / 3;
 
 function FolderMini({ app }: { app: AppDef }): ReactNode {
     const { background, glyph, art, radius, glyphSize, glyphWeight, icon: glyphOverride } = useIconAppearance(app.id, app.accent);
     return (
         <div className="overflow-hidden" style={{ borderRadius: radiusPct(radius * (MINI_RADIUS / TILE_RADIUS)) }}>
             {art === 'native' ? (
-                <div style={{ width: 60, height: 60, transform: 'scale(0.3)', transformOrigin: '0 0' }}>
+                <div style={{ width: ART, height: ART, transform: `scale(${MINI / ART})`, transformOrigin: '0 0' }}>
                     <AppIconSVG icon={app.icon} />
                 </div>
             ) : (
@@ -1248,11 +1246,13 @@ function FolderMini({ app }: { app: AppDef }): ReactNode {
 function FolderTile({ label, apps, onOpen, merging = false, badge }: { label: string; apps: AppDef[]; onOpen: () => void; merging?: boolean; badge?: number }): ReactNode {
     const showNames = useShowAppNames();
     return (
-        <button type="button" onClick={onOpen} className="group block w-[78px]">
+        <button type="button" onClick={onOpen} className="group block" style={{ width: TILE }}>
             <div className="relative">
                 <div
-                    className="grid h-[78px] w-[78px] grid-cols-3 grid-rows-3 gap-[3px] overflow-hidden p-[9px] backdrop-blur-xl transition-[transform,box-shadow] duration-150 group-active:scale-[0.94]"
+                    className="grid grid-cols-3 grid-rows-3 gap-[3px] overflow-hidden p-[9px] backdrop-blur-xl transition-[transform,box-shadow] duration-150 group-active:scale-[0.94]"
                     style={{
+                        width:        TILE,
+                        height:       TILE,
                         borderRadius: '27.6%',
                         background: merging ? 'rgba(118,122,132,0.6)' : 'rgba(70,70,78,0.42)',
                         boxShadow: merging
@@ -1420,6 +1420,7 @@ function FolderOverlay({ name, apps, badges, editing: homeEditing, autoEdit, wal
                     style={{ touchAction: 'none' }}
                     className="w-[calc(100%-48px)] rounded-[34px] border border-white/15 bg-white/10 p-5 backdrop-blur-2xl"
                 >
+                    {/* A folder page is its own 4-up grid, not the home grid, so it does not follow device cols. */}
                     <div ref={gridRef} className="relative grid grid-cols-4 gap-x-3 gap-y-5">
                         {apps.map((a, i) => {
                             const isDragging = dragIdx === i;
@@ -1447,7 +1448,7 @@ function FolderOverlay({ name, apps, badges, editing: homeEditing, autoEdit, wal
                                 }}
                             >
                                 {isOver && (
-                                    <div className="pointer-events-none absolute left-0 top-0 h-[78px] w-[78px]" style={{ borderRadius: '27.6%', boxShadow: '0 0 0 3.5px rgba(255,255,255,0.92), 0 2px 12px rgba(0,0,0,0.42)' }} />
+                                    <div className="pointer-events-none absolute left-0 top-0" style={{ width: TILE, height: TILE, borderRadius: '27.6%', boxShadow: '0 0 0 3.5px rgba(255,255,255,0.92), 0 2px 12px rgba(0,0,0,0.42)' }} />
                                 )}
                                 <div
                                     className={plopIds.has(a.id) ? 'animate-plop' : (jiggle ? 'animate-app-jiggle' : '')}

--- a/web/src/shell/PhoneShell.tsx
+++ b/web/src/shell/PhoneShell.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { AlarmClock, Music2, Pause, Phone, Play, Radio, SkipBack, SkipForward } from 'lucide-react';
 
+import { device } from '@device';
 import { useTheme } from '@/stores/themeStore';
 import type { PhoneAlign } from '@/stores/themeStore';
 import { useCallStore } from '@/stores/callStore';
@@ -11,19 +12,20 @@ import { coverGradient, youtubeId } from '@/apps/music/data';
 import type { Track } from '@/apps/music/data';
 import { RingDuration } from '@/apps/clock/AlarmRinging';
 import { playShutter } from '@/media/shutter';
+import { SWITCHER_SCALE } from './AppSwitcher';
 import { DEFAULT_FRAME_COLOR, frameStops } from './frameColors';
 import { t } from '@/i18n';
 
 
-const B  = 9;
+const B  = device.screen.bezel;
 
-const SW = 440;
-const SH = 956;
+const SW = device.screen.w;
+const SH = device.screen.h;
 const W  = SW + B * 2;
 const H  = SH + B * 2;
 const SX = B;
 const SY = B;
-const BR = 55;
+const BR = device.screen.radius;
 const SR = BR - B;
 
 const SCREEN_MASK =
@@ -76,13 +78,13 @@ const BEZEL = rrect(0, 0, W, H, BR) + ' ' + rrect(
 const BTN_W  = 3.5;
 const BTN_RX = 1.75;
 
-const BUTTONS = [
-    { x: -BTN_W, y: 174, h: 38 },
-    { x: -BTN_W, y: 252, h: 64 },
-    { x: -BTN_W, y: 346, h: 64 },
-    { x: W,      y: 217, h: 80 },
-    { x: W,      y: 566, h: 60 },
-] as const;
+// The profile stores a rail side; the rail's x is whatever the frame width makes it.
+const BUTTONS = device.screen.buttons.map(b => ({ ...b, x: b.side === 'left' ? -BTN_W : W }));
+
+const VOL_UP_BTN     = BUTTONS.find(b => b.role === 'volumeUp');
+const VOL_DOWN_BTN   = BUTTONS.find(b => b.role === 'volumeDown');
+const POWER_BTN      = BUTTONS.find(b => b.role === 'power');
+const SCREENSHOT_BTN = BUTTONS.find(b => b.role === 'screenshot');
 
 
 const ALIGN_MAP: Record<string, string> = {
@@ -379,7 +381,12 @@ export function PhoneShell({ children, cameraActive = false, entering = false, l
     const reanchor = (H - W) / 2;
     const shiftX = align.includes('right') ? -reanchor : align.includes('left') ? reanchor : 0;
     const shiftY = align.includes('bottom') ? reanchor : align.includes('top') ? -reanchor : 0;
-    const landscapeTransform = `translate(${shiftX}px, ${shiftY}px) rotate(-90deg)`;
+    // A device that is already wider than it is tall has nothing to rotate into: turning it would
+    // stand a landscape tablet on its end. The reanchor shifts would be backwards there too.
+    const nativeLandscape = SW > SH;
+    const landscapeTransform = nativeLandscape
+        ? undefined
+        : `translate(${shiftX}px, ${shiftY}px) rotate(-90deg)`;
 
     return (
         <div
@@ -412,6 +419,10 @@ export function PhoneShell({ children, cameraActive = false, entering = false, l
                         maskSize: '100% 100%',
                         WebkitMaskRepeat: 'no-repeat',
                         maskRepeat: 'no-repeat',
+                        // The switcher's card scale, for index.css's ios-app-expand. The deck
+                        // re-parents the opening app's host into this screen, so the value
+                        // inherits down to it - and unlike the switcher, this element stays.
+                        ...({ '--switcher-scale': String(SWITCHER_SCALE) } as React.CSSProperties),
                     }}
                 >
                     {!cameraActive && (
@@ -475,26 +486,30 @@ export function PhoneShell({ children, cameraActive = false, entering = false, l
                         strokeWidth="1.5"
                     />
 
-                    <rect
-                        x={DI_X} y={DI_Y}
-                        width={DI_W} height={DI_H}
-                        rx={DI_R}
-                        fill="#000"
-                    />
-                    <circle cx={DI_X + DI_W - DI_R * 1.12} cy={DI_Y + DI_H / 2} r={7}   fill="#0c0c14" />
-                    <circle cx={DI_X + DI_W - DI_R * 1.12} cy={DI_Y + DI_H / 2} r={4}   fill="#07070f" />
-                    <circle cx={DI_X + DI_W - DI_R * 1.12 - 1.5} cy={DI_Y + DI_H / 2 - 2} r={1.5} fill="rgba(255,255,255,0.18)" />
+                    {device.screen.island && (
+                        <>
+                            <rect
+                                x={DI_X} y={DI_Y}
+                                width={DI_W} height={DI_H}
+                                rx={DI_R}
+                                fill="#000"
+                            />
+                            <circle cx={DI_X + DI_W - DI_R * 1.12} cy={DI_Y + DI_H / 2} r={7}   fill="#0c0c14" />
+                            <circle cx={DI_X + DI_W - DI_R * 1.12} cy={DI_Y + DI_H / 2} r={4}   fill="#07070f" />
+                            <circle cx={DI_X + DI_W - DI_R * 1.12 - 1.5} cy={DI_Y + DI_H / 2 - 2} r={1.5} fill="rgba(255,255,255,0.18)" />
 
-                    {cameraActive && (() => {
-                        const dotCx = DI_X + DI_W - DI_R * 2.5;
-                        const dotCy = DI_Y + DI_H / 2;
-                        return (
-                            <>
-                                <circle cx={dotCx} cy={dotCy} r={7}   fill="rgba(48,209,88,0.18)" />
-                                <circle cx={dotCx} cy={dotCy} r={3.6} fill="#30D158" />
-                            </>
-                        );
-                    })()}
+                            {cameraActive && (() => {
+                                const dotCx = DI_X + DI_W - DI_R * 2.5;
+                                const dotCy = DI_Y + DI_H / 2;
+                                return (
+                                    <>
+                                        <circle cx={dotCx} cy={dotCy} r={7}   fill="rgba(48,209,88,0.18)" />
+                                        <circle cx={dotCx} cy={dotCy} r={3.6} fill="#30D158" />
+                                    </>
+                                );
+                            })()}
+                        </>
+                    )}
 
                     {BUTTONS.map((btn, i) => (
                         <g key={i}>
@@ -520,40 +535,46 @@ export function PhoneShell({ children, cameraActive = false, entering = false, l
                     ))}
                 </svg>
 
-                <button
-                    type="button"
-                    aria-label={t('shell.volumeUp','Volume up')}
-                    onClick={() => bumpVolume(1)}
-                    className="absolute z-[300] cursor-pointer bg-transparent"
-                    style={{ left: BUTTONS[1].x - 6, top: BUTTONS[1].y, width: 16, height: BUTTONS[1].h }}
-                />
-                <button
-                    type="button"
-                    aria-label={t('shell.volumeDown','Volume down')}
-                    onClick={() => bumpVolume(-1)}
-                    className="absolute z-[300] cursor-pointer bg-transparent"
-                    style={{ left: BUTTONS[2].x - 6, top: BUTTONS[2].y, width: 16, height: BUTTONS[2].h }}
-                />
+                {VOL_UP_BTN && (
+                    <button
+                        type="button"
+                        aria-label={t('shell.volumeUp','Volume up')}
+                        onClick={() => bumpVolume(1)}
+                        className="absolute z-[300] cursor-pointer bg-transparent"
+                        style={{ left: VOL_UP_BTN.x - 6, top: VOL_UP_BTN.y, width: 16, height: VOL_UP_BTN.h }}
+                    />
+                )}
+                {VOL_DOWN_BTN && (
+                    <button
+                        type="button"
+                        aria-label={t('shell.volumeDown','Volume down')}
+                        onClick={() => bumpVolume(-1)}
+                        className="absolute z-[300] cursor-pointer bg-transparent"
+                        style={{ left: VOL_DOWN_BTN.x - 6, top: VOL_DOWN_BTN.y, width: 16, height: VOL_DOWN_BTN.h }}
+                    />
+                )}
 
-                {onClose && (
+                {POWER_BTN && onClose && (
                     <button
                         type="button"
                         aria-label={t('shell.power','Power')}
                         onClick={onClose}
                         className="absolute z-[300] cursor-pointer bg-transparent"
-                        style={{ left: BUTTONS[3].x - 8, top: BUTTONS[3].y, width: 16, height: BUTTONS[3].h }}
+                        style={{ left: POWER_BTN.x - 8, top: POWER_BTN.y, width: 16, height: POWER_BTN.h }}
                     />
                 )}
 
-                <button
-                    type="button"
-                    aria-label={t('shell.screenshot','Screenshot (double-click the Action button)')}
-                    onDoubleClick={() => void takeScreenshot()}
-                    className="absolute z-[300] cursor-pointer bg-transparent"
-                    style={{ left: BUTTONS[0].x - 6, top: BUTTONS[0].y, width: 16, height: BUTTONS[0].h }}
-                />
+                {SCREENSHOT_BTN && (
+                    <button
+                        type="button"
+                        aria-label={t('shell.screenshot','Screenshot (double-click the Action button)')}
+                        onDoubleClick={() => void takeScreenshot()}
+                        className="absolute z-[300] cursor-pointer bg-transparent"
+                        style={{ left: SCREENSHOT_BTN.x - 6, top: SCREENSHOT_BTN.y, width: 16, height: SCREENSHOT_BTN.h }}
+                    />
+                )}
 
-                {islandTrack && !callActive && !radioOn && !radioStandby && !alarmRinging && (
+                {device.screen.island && islandTrack && !callActive && !radioOn && !radioStandby && !alarmRinging && (
                     <MusicIsland
                         track={islandTrack}
                         playing={musicPlaying}
@@ -567,47 +588,55 @@ export function PhoneShell({ children, cameraActive = false, entering = false, l
                     />
                 )}
 
-                <IslandPill
-                    active={callActive}
-                    onClick={() => void fetchNui('sd-phone:requestOpen')}
-                    compactX={DI_X} compactW={DI_W} expandedX={CALL_X} expandedW={CALL_W}
-                >
-                    <span className="absolute left-3 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
-                        <Phone className="h-[14px] w-[14px]" style={{ color: '#30D158' }} fill="currentColor" strokeWidth={0} />
-                        <span className="text-[13px] font-semibold tabular-nums" style={{ color: '#30D158' }}>
-                            {callStartedAt ? <RingDuration since={callStartedAt} /> : t('shell.mobile','Mobile')}
+                {device.screen.island && device.calls && (
+                    <IslandPill
+                        active={callActive}
+                        onClick={() => void fetchNui('sd-phone:requestOpen')}
+                        compactX={DI_X} compactW={DI_W} expandedX={CALL_X} expandedW={CALL_W}
+                    >
+                        <span className="absolute left-3 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
+                            <Phone className="h-[14px] w-[14px]" style={{ color: '#30D158' }} fill="currentColor" strokeWidth={0} />
+                            <span className="text-[13px] font-semibold tabular-nums" style={{ color: '#30D158' }}>
+                                {callStartedAt ? <RingDuration since={callStartedAt} /> : t('shell.mobile','Mobile')}
+                            </span>
                         </span>
-                    </span>
-                </IslandPill>
+                    </IslandPill>
+                )}
 
-                <IslandPill
-                    active={(radioOn || radioStandby) && !callActive && !alarmRinging}
-                    onClick={() => { if (radioOn) void fetchNui('sd-phone:radio:leave'); else void fetchNui('sd-phone:radio:set', { on: true }); }}
-                    compactX={DI_X} compactW={DI_W} expandedX={CALL_X} expandedW={CALL_W}
-                >
-                    <span className="absolute left-3 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
-                        <Radio className={`h-[16px] w-[16px] ${radioOnAir ? 'animate-pulse' : ''}`} style={{ color: radioOn ? '#30D158' : '#FF453A', transition: 'color 0.2s ease' }} strokeWidth={2.4} />
-                        <span className="text-[13px] font-semibold tabular-nums" style={{ color: radioOn ? '#30D158' : '#FF453A', transition: 'color 0.2s ease' }}>{radioFreq.toFixed(1)}</span>
-                    </span>
-                </IslandPill>
+                {device.screen.island && (
+                    <IslandPill
+                        active={(radioOn || radioStandby) && !callActive && !alarmRinging}
+                        onClick={() => { if (radioOn) void fetchNui('sd-phone:radio:leave'); else void fetchNui('sd-phone:radio:set', { on: true }); }}
+                        compactX={DI_X} compactW={DI_W} expandedX={CALL_X} expandedW={CALL_W}
+                    >
+                        <span className="absolute left-3 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
+                            <Radio className={`h-[16px] w-[16px] ${radioOnAir ? 'animate-pulse' : ''}`} style={{ color: radioOn ? '#30D158' : '#FF453A', transition: 'color 0.2s ease' }} strokeWidth={2.4} />
+                            <span className="text-[13px] font-semibold tabular-nums" style={{ color: radioOn ? '#30D158' : '#FF453A', transition: 'color 0.2s ease' }}>{radioFreq.toFixed(1)}</span>
+                        </span>
+                    </IslandPill>
+                )}
 
-                <IslandPill
-                    active={alarmRinging && !callActive}
-                    compactX={DI_X} compactW={DI_W} expandedX={CALL_X} expandedW={CALL_W}
-                >
-                    <span className="absolute left-3 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
-                        <AlarmClock className="h-[15px] w-[15px]" style={{ color: '#FF9F0A' }} strokeWidth={2.5} />
-                        <span className="text-[13px] font-semibold tabular-nums" style={{ color: '#FF9F0A' }}><RingDuration since={alarmSince} /></span>
-                    </span>
-                </IslandPill>
+                {device.screen.island && (
+                    <IslandPill
+                        active={alarmRinging && !callActive}
+                        compactX={DI_X} compactW={DI_W} expandedX={CALL_X} expandedW={CALL_W}
+                    >
+                        <span className="absolute left-3 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
+                            <AlarmClock className="h-[15px] w-[15px]" style={{ color: '#FF9F0A' }} strokeWidth={2.5} />
+                            <span className="text-[13px] font-semibold tabular-nums" style={{ color: '#FF9F0A' }}><RingDuration since={alarmSince} /></span>
+                        </span>
+                    </IslandPill>
+                )}
 
-                <span
-                    className="pointer-events-none absolute z-[320] rounded-full"
-                    style={{ left: DI_X + DI_W - DI_R * 1.12 - 7, top: DI_Y + DI_H / 2 - 7, width: 14, height: 14, background: '#0c0c14' }}
-                >
-                    <span className="absolute rounded-full" style={{ left: 3, top: 3, width: 8, height: 8, background: '#07070f' }} />
-                    <span className="absolute rounded-full" style={{ left: 2.5, top: 1.5, width: 3, height: 3, background: 'rgba(255,255,255,0.18)' }} />
-                </span>
+                {device.screen.island && (
+                    <span
+                        className="pointer-events-none absolute z-[320] rounded-full"
+                        style={{ left: DI_X + DI_W - DI_R * 1.12 - 7, top: DI_Y + DI_H / 2 - 7, width: 14, height: 14, background: '#0c0c14' }}
+                    >
+                        <span className="absolute rounded-full" style={{ left: 3, top: 3, width: 8, height: 8, background: '#07070f' }} />
+                        <span className="absolute rounded-full" style={{ left: 2.5, top: 1.5, width: 3, height: 3, background: 'rgba(255,255,255,0.18)' }} />
+                    </span>
+                )}
             </div>
         </div>
     );

--- a/web/src/shell/appRegistry.tsx
+++ b/web/src/shell/appRegistry.tsx
@@ -1,6 +1,7 @@
 import { lazy } from 'react';
 import type { ComponentType, LazyExoticComponent, ReactNode } from 'react';
 
+import { device } from '@device';
 import type { AppDef } from '@/core/types';
 import { isCustomApp } from '@/stores/customAppsStore';
 
@@ -121,11 +122,18 @@ export function isPreviewApp(id: AppId): boolean {
     return !PREVIEW_EXCLUDE.has(id);
 }
 
+// Apps this device does not have. The registry stays complete (AppId must keep naming every
+// app or the tree stops type-checking); the ids are refused at asAppId instead.
+const EXCLUDED_APPS = new Set<string>(device.excludedApps);
+
 // A raw id becomes an openable AppId when it is either a statically-registered app
 // or a runtime-registered custom app. Every downstream AppId-typed site keys off the
-// id string, so widening the union at this single boundary is enough to open it.
+// id string, so widening the union at this single boundary is enough to open it -
+// and refusing it here is what stops a notification tap, a deeplink, Control Center,
+// sd-phone:launchApp or the custom-app SDK from opening an app this device lacks.
 export function asAppId(id: string | null | undefined): AppId | null {
     if (id == null) return null;
+    if (EXCLUDED_APPS.has(id)) return null;
     if (id in APP_REGISTRY) return id as AppId;
     if (isCustomApp(id)) return id as AppId;
     return null;

--- a/web/src/shell/widgets/geometry.ts
+++ b/web/src/shell/widgets/geometry.ts
@@ -1,18 +1,16 @@
+import { device } from '@device';
 import { freeCellNear } from '../dockMoves';
 import type { WidgetSize, WidgetPlacement } from '@/apps/appstore/appsApi';
 
-const COLS = 4;
-const ROWS = 6;
+// The same destructure the homescreen does. A widget's cells have to index the SAME number space
+// the icons are drawn in, so both sides must read the grid from the profile rather than inline it.
+const { cols: COLS, rows: ROWS, icon: ICON, colStride: COL_STRIDE, rowStride: ROW_STRIDE } = device.screen.grid;
 
 export const SPAN: Record<WidgetSize, { w: number; h: number }> = {
     sm: { w: 2, h: 2 },
     md: { w: 4, h: 2 },
     lg: { w: 4, h: 4 },
 };
-
-const ICON = 78;
-const COL_STRIDE = 102;
-const ROW_STRIDE = 122;
 
 export function widgetPx(size: WidgetSize, scale = 1): { width: number; height: number } {
     const { w, h } = SPAN[size];

--- a/web/src/shell/widgets/registry.tsx
+++ b/web/src/shell/widgets/registry.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { ReactNode } from 'react';
 
+import { device } from '@device';
 import type { WidgetAlign, WidgetSize, WidgetTheme } from '@/apps/appstore/appsApi';
 import type { CustomAppDef, CustomWidgetDef } from '@/core/types';
 import { t } from '@/i18n';
@@ -38,7 +39,7 @@ export interface WidgetDef {
     render: (o: WidgetRender) => ReactNode;
 }
 
-const WIDGETS: WidgetDef[] = [
+const ALL_WIDGETS: WidgetDef[] = [
     {
         kind: 'weather',
         label: () => t('widgets.weather', 'Weather'),
@@ -130,6 +131,9 @@ const WIDGETS: WidgetDef[] = [
         render: o => <TimersWidget size={o.size} width={o.width} height={o.height} theme={o.theme} />,
     },
 ];
+
+// Contacts is a speed-dial: every tile places a call, so it is gone on a device that cannot.
+const WIDGETS: WidgetDef[] = device.calls ? ALL_WIDGETS : ALL_WIDGETS.filter(w => w.kind !== 'contacts');
 
 function thirdPartyDef(app: CustomAppDef, widget: CustomWidgetDef): WidgetDef {
     const kind = customWidgetKind(app.id, widget.id);

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 
+import { device } from '@device';
+import type { DeviceAlign } from '@/device/types';
 import lockscreenAsset from '@/assets/wallpapers/lockscreen.webp';
 import devDefaultAsset from '@/assets/photos/background5.webp';
 import { fetchNui, isFiveM } from '@/core/nui';
@@ -131,10 +133,7 @@ function savePhoneScaleLocal(v: number) {
     try { window.localStorage.setItem(PHONE_SCALE_KEY, String(v)); } catch { /* ignore */ }
 }
 
-export type PhoneAlign =
-    | 'top-left'    | 'top-center'    | 'top-right'
-    | 'middle-left' | 'middle-center' | 'middle-right'
-    | 'bottom-left' | 'bottom-center' | 'bottom-right';
+export type PhoneAlign = DeviceAlign;
 
 const PHONE_ALIGN_KEY = 'sd-phone:phoneAlign';
 const PHONE_ALIGNS: PhoneAlign[] = [
@@ -145,8 +144,8 @@ const PHONE_ALIGNS: PhoneAlign[] = [
 function loadPhoneAlignLocal(): PhoneAlign {
     try {
         const v = window.localStorage.getItem(PHONE_ALIGN_KEY) as PhoneAlign | null;
-        return v && PHONE_ALIGNS.includes(v) ? v : 'bottom-right';
-    } catch { return 'bottom-right'; }
+        return v && PHONE_ALIGNS.includes(v) ? v : device.defaultAlign;
+    } catch { return device.defaultAlign; }
 }
 function savePhoneAlignLocal(v: PhoneAlign) {
     try { window.localStorage.setItem(PHONE_ALIGN_KEY, v); } catch { /* ignore */ }
@@ -265,7 +264,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     brightness: 100,
     phoneScale: isFiveM ? 50 : loadPhoneScaleLocal(),
     chatTextScale: isFiveM ? 1 : loadChatScaleLocal(),
-    phoneAlign: isFiveM ? 'bottom-right' : loadPhoneAlignLocal(),
+    phoneAlign: isFiveM && device.id === 'phone' ? device.defaultAlign : loadPhoneAlignLocal(),
     ringtoneVol: 40,
     callVol: 60,
     airplaneMode: false,
@@ -362,9 +361,12 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
         else saveBlurLocal(BLUR_HOME_KEY, v);
     },
 
+    // Where the device sits is the one setting that is NOT shared with the phone: the two have
+    // different shapes and want different spots, and phone_settings holds a single value. A
+    // companion device keeps its own position in its own NUI origin's storage instead.
     setPhoneAlign: (v) => {
         set({ phoneAlign: v });
-        if (isFiveM) void fetchNui('sd-phone:settings:setPhoneAlign', { align: v }).catch(() => {});
+        if (isFiveM && device.id === 'phone') void fetchNui('sd-phone:settings:setPhoneAlign', { align: v }).catch(() => {});
         else savePhoneAlignLocal(v);
     },
 
@@ -383,8 +385,9 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
         set({ callVol: v });
         if (isFiveM) {
             persistDebounced('volumes', () => { void fetchNui('sd-phone:settings:setVolumes', { ringtone: get().ringtoneVol, call: get().callVol }).catch(() => {}); });
-            // Live in-call volume must track the drag in real time - never debounced.
-            void fetchNui('sd-phone:call:setVolume', { volume: v }).catch(() => {});
+            // Live in-call volume must track the drag in real time - never debounced. Only the
+            // device that owns the call may set it; a companion would stomp the phone's call.
+            if (device.calls) void fetchNui('sd-phone:call:setVolume', { volume: v }).catch(() => {});
         }
     },
 
@@ -536,7 +539,9 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 if (typeof d.chatTextScale === 'number') patch.chatTextScale = clampChatScale(d.chatTextScale);
                 if (typeof d.phoneScale === 'number') patch.phoneScale = clampPhoneScale(d.phoneScale);
                 if (typeof d.brightness === 'number') patch.brightness = clampPhoneScale(d.brightness);
-                if (typeof d.phoneAlign === 'string' && (PHONE_ALIGNS as string[]).includes(d.phoneAlign)) patch.phoneAlign = d.phoneAlign as PhoneAlign;
+                // Position is device-local (see setPhoneAlign): a companion must not adopt the
+                // phone's corner out of the shared settings row.
+                if (device.id === 'phone' && typeof d.phoneAlign === 'string' && (PHONE_ALIGNS as string[]).includes(d.phoneAlign)) patch.phoneAlign = d.phoneAlign as PhoneAlign;
                 if (typeof d.ringtoneVol === 'number') patch.ringtoneVol = clampVol(d.ringtoneVol);
                 if (typeof d.callVol === 'number') patch.callVol = clampVol(d.callVol);
                 patch.lockClock = (d.lockClock && typeof d.lockClock === 'object')
@@ -556,7 +561,8 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 if (isFiveM && keyAtRequest === wallpaperProfileKey) {
                     cacheWallpapers(lockWall, homeWall);
                 }
-                if (isFiveM) void fetchNui('sd-phone:call:setVolume', { volume: get().callVol }).catch(() => {});
+                // Same rule on hydrate: a companion opening would push its volume onto the call.
+                if (isFiveM && device.calls) void fetchNui('sd-phone:call:setVolume', { volume: get().callVol }).catch(() => {});
                 const ringIsYt  = !!d.ringtone         && ring.some(c => c.id === d.ringtone);
                 const notifIsYt = !!d.notificationTone && notif.some(c => c.id === d.notificationTone);
                 if (ringIsYt || notifIsYt) warmYouTube();

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -7,7 +7,7 @@
         "skipLibCheck": true,
         "moduleResolution": "bundler",
         "baseUrl": ".",
-        "paths": { "@/*": ["./src/*"] },
+        "paths": { "@/*": ["./src/*"], "@device": ["./src/device/phone.ts"] },
         "allowImportingTsExtensions": true,
         "resolveJsonModule": true,
         "isolatedModules": true,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,7 +6,12 @@ export default defineConfig(({ mode }) => ({
     plugins: [react()],
     base: './',
     resolve: {
-        alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
+            // The device profile this build targets. sd-tablet points the same alias at its own
+            // profile and compiles this exact source tree against it.
+            '@device': fileURLToPath(new URL('./src/device/phone.ts', import.meta.url)),
+        },
     },
     // The UI locale catalog lives in the resource-root locales/ folder (shared
     // with the Lua side), which is above the Vite root — allow the dev server to


### PR DESCRIPTION
Everything specific to "this device is a phone" now lives in a profile (web/src/device/) that the UI reads, instead of being inlined across the shell. sd-phone builds device/phone.ts, which carries the exact constants that were hard-coded before, so this build is unchanged: same geometry, same grid, same call surfaces.

A sibling resource can now build this same source against its own profile. That is how sd-tablet works - it ships no copied UI files, it aliases web/src and swaps the profile.

What the profile controls:
  - frame geometry (screen size, bezel, corner radius, side buttons)
  - the Dynamic Island, which a tablet does not have
  - the home-screen grid (columns, rows, pitch, icon size)
  - whether the device can place a call, show the payphone, run the admin panel, or run first-run setup
  - which apps the device does not have at all
  - where it sits on screen before the player moves it

Calls are the one capability a companion is refused outright. The Phone app is rejected by asAppId, so no notification, deep link, Control Center entry or custom-app SDK call can open it; CallLayer and PayphoneUI never mount (CallLayer self-hydrates on mount, so not receiving pushes is not enough); and every in-app "call" affordance is gated.

Lua side: client/companion.lua records the NUI callbacks this resource registers, re-emits its NUI pushes, and arbitrates NUI focus, so a companion device can ride the existing client and server layers rather than duplicating 459 action names - many of which are built at runtime. It is inert with no companion running. The phone gives up the screen to nothing; a companion gives it up whenever the phone, the payphone or the admin panel needs it.

Two things that had to change to stay correct:

  - Home layouts are now stored per device. The slot array's page boundaries are cols*rows, so one shared layout read at two grid shapes corrupts both. server/apps/actions.lua merges per-device slices into the existing column; a stored layout with no device key is carried over as the phone's, so existing players are unaffected.

  - On-screen position is no longer written to the shared settings row by a companion, and is not adopted from it. Two devices with different shapes want different spots and the row holds one value. Phone behaviour is unchanged.

Also fixes a latent bug in the shell: the camera's rotate-to-landscape transform now no-ops on a device that is already landscape, where it would otherwise stand the device on its end and mis-anchor it.

## Summary

Describe what this PR changes.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

Closes #

or

Related to #

## Testing

Describe how this was tested.

- [ ] Tested locally
- [ ] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

Does this introduce any breaking changes?

If yes, explain.

---

## Checklist

- [ ] My code follows the existing style of the project.
- [ ] I have tested my changes.
- [ ] I have updated any necessary documentation.
- [ ] I have removed any debug code.
- [ ] This PR does not include unrelated changes.
- [ ] I have verified this works on the latest version of sd-phone.