### PR TITLE
Custom apps: device and job gating

### DIFF
--- a/bridge/client/job.lua
+++ b/bridge/client/job.lua
@@ -1,0 +1,117 @@
+---@type FrameworkInfo Framework detection (bridge.shared.framework): name ('qbx'|'qb'|'esx') + live core handle.
+local framework = require 'bridge.shared.framework'
+
+---@type table Job module; the table returned at end of file. Client-side job identity, kept live off
+---the framework's own job-change events so callers never poll.
+local job = {}
+
+---@type string|nil Active job name, nil until the player loads.
+local currentName = nil
+
+---@type integer Active grade level; 0 when unknown.
+local currentGrade = 0
+
+---@type fun(name: string|nil, grade: integer)[] Fired after the job actually changes.
+local listeners = {}
+
+---The framework's player-data table, or nil before the player has loaded.
+---@return table|nil
+local function playerData()
+    if framework.name == 'qbx' then
+        local ok, data = pcall(function() return exports.qbx_core:GetPlayerData() end)
+        return ok and data or nil
+    end
+    if framework.qb then
+        if not framework.core then return nil end
+        local ok, data = pcall(function() return framework.core.Functions.GetPlayerData() end)
+        return ok and data or nil
+    end
+    if framework.name == 'esx' then
+        if not framework.core then return nil end
+        local ok, data = pcall(function() return framework.core.GetPlayerData() end)
+        return ok and data or nil
+    end
+    return nil
+end
+
+---Name and grade pulled out of a framework job table. ESX flattens the grade onto the job; the qb
+---family nests it under `grade.level`.
+---@param raw table|nil
+---@return string|nil name, integer grade
+local function readJob(raw)
+    if type(raw) ~= 'table' then return nil, 0 end
+    local name = type(raw.name) == 'string' and raw.name or nil
+    if framework.qb then
+        local grade = type(raw.grade) == 'table' and tonumber(raw.grade.level) or nil
+        return name, grade or 0
+    end
+    return name, tonumber(raw.grade) or 0
+end
+
+---Stores the job and notifies listeners, but only when it actually moved.
+---@param name string|nil
+---@param grade integer
+local function apply(name, grade)
+    if name == currentName and grade == currentGrade then return end
+    currentName  = name
+    currentGrade = grade
+    for i = 1, #listeners do
+        pcall(listeners[i], currentName, currentGrade)
+    end
+end
+
+---Re-reads the job straight off the framework. Used at load, and whenever an event arrives without
+---a usable payload.
+local function refresh()
+    local data = playerData()
+    apply(readJob(data and data.job))
+end
+
+---The player's active job name, or nil before they have loaded.
+---@return string|nil
+function job.name()
+    return currentName
+end
+
+---The player's active grade level. 0 when unknown.
+---@return integer
+function job.grade()
+    return currentGrade
+end
+
+---Predicate: does the player hold `jobName` at grade >= `minGrade`? Fails closed on an unloaded
+---player, matching the server bridge.
+---@param jobName any
+---@param minGrade? integer Default 0.
+---@return boolean
+function job.has(jobName, minGrade)
+    if type(jobName) ~= 'string' or currentName == nil then return false end
+    if currentName ~= jobName then return false end
+    return currentGrade >= (tonumber(minGrade) or 0)
+end
+
+---Registers a listener fired on every job change. Returns nothing: listeners live for the session.
+---@param callback fun(name: string|nil, grade: integer)
+function job.onChange(callback)
+    if type(callback) ~= 'function' then return end
+    listeners[#listeners + 1] = callback
+end
+
+if framework.qb then
+    RegisterNetEvent('QBCore:Client:OnJobUpdate', function(raw)
+        if type(raw) == 'table' then apply(readJob(raw)) else refresh() end
+    end)
+    RegisterNetEvent('QBCore:Client:OnPlayerLoaded', refresh)
+    RegisterNetEvent('QBCore:Client:OnPlayerUnload', function() apply(nil, 0) end)
+elseif framework.name == 'esx' then
+    RegisterNetEvent('esx:setJob', function(raw)
+        if type(raw) == 'table' then apply(readJob(raw)) else refresh() end
+    end)
+    RegisterNetEvent('esx:playerLoaded', refresh)
+    RegisterNetEvent('esx:onPlayerLogout', function() apply(nil, 0) end)
+end
+
+-- A resource restart lands mid-session, where no load event is coming.
+CreateThread(refresh)
+
+return job

--- a/client/customapps.lua
+++ b/client/customapps.lua
@@ -4,6 +4,9 @@ local config = require 'configs.config'
 ---@type {list: string[], set: table<string, true>} Canonical built-in app ids, reserved from custom apps.
 local appIds = require 'client.appids'
 
+---@type table Client job bridge (bridge.client.job): live job name/grade plus a change hook.
+local job = require 'bridge.client.job'
+
 ---@type table<string, {def: table, resource: string, onOpen: function?, onClose: function?, onDelete: function?}>
 ---Registered third-party apps keyed by identifier. onOpen also covers lb-phone's onUse alias.
 local registry = {}
@@ -173,13 +176,64 @@ local function removeOrder(id)
     end
 end
 
----Builds the sanitized def array in registration order.
+---A device allow-list: non-empty lowercased strings, or nil when the caller named none. Nil means
+---every device shows the app; the frontend does the matching, since one client serves both devices.
+---@param value any
+---@return string[]|nil
+local function readDevices(value)
+    if type(value) == 'string' then value = { value } end
+    if type(value) ~= 'table' then return nil end
+    local out = {}
+    for _, entry in ipairs(value) do
+        if type(entry) == 'string' and entry ~= '' then out[#out + 1] = entry:lower() end
+    end
+    if #out == 0 then return nil end
+    return out
+end
+
+---A job gate as `{ [jobName] = minGrade }`, from a name, an array of names, or a name->grade map.
+---Nil when the caller named none, which leaves the app ungated.
+---@param value any
+---@return table<string, integer>|nil
+local function readJobs(value)
+    if type(value) == 'string' then value = { value } end
+    if type(value) ~= 'table' then return nil end
+    local out = {}
+    local count = 0
+    for key, entry in pairs(value) do
+        if type(key) == 'string' and key ~= '' then
+            out[key] = math.max(0, math.floor(tonumber(entry) or 0))
+            count = count + 1
+        elseif type(entry) == 'string' and entry ~= '' then
+            out[entry] = 0
+            count = count + 1
+        end
+    end
+    if count == 0 then return nil end
+    return out
+end
+
+---Whether the player's current job clears an entry's gate. Ungated entries always pass; gated ones
+---fail closed until the framework has a job for us.
+---@param entry table
+---@return boolean
+local function jobAllows(entry)
+    local gate = entry.jobs
+    if not gate then return true end
+    for name, minGrade in pairs(gate) do
+        if job.has(name, minGrade) then return true end
+    end
+    return false
+end
+
+---The sanitized def array in registration order, job gate applied. The device gate is not applied
+---here: one client serves both the phone and the tablet, so only the UI knows which is asking.
 ---@return table[] list
 local function currentList()
     local list = {}
     for i = 1, #order do
         local entry = registry[order[i]]
-        if entry then list[#list + 1] = entry.def end
+        if entry and jobAllows(entry) then list[#list + 1] = entry.def end
     end
     return list
 end
@@ -240,11 +294,17 @@ function M.add(data, resource)
     local widgets = readWidgets(data.widgets, identifier)
     if #widgets > 0 then def.widgets = widgets end
 
+    -- Devices ride on the def because the UI does that matching; the job gate does not, so a job
+    -- the player cannot hold never reaches the page at all.
+    local devices = readDevices(data.devices)
+    if devices then def.devices = devices end
+
     local onOpen = data.onOpen
     if type(onOpen) ~= 'function' then onOpen = data.onUse end
     registry[identifier] = {
         def      = def,
         resource = resource,
+        jobs     = readJobs(data.job),
         onOpen   = type(onOpen) == 'function' and onOpen or nil,
         onClose  = type(data.onClose) == 'function' and data.onClose or nil,
         onDelete = type(data.onDelete) == 'function' and data.onDelete or nil,
@@ -352,5 +412,8 @@ AddEventHandler('onResourceStop', function(stopped)
     end
     if changed then pushSet() end
 end)
+
+---Job-gated apps appear and disappear with the player's job, so every change re-pushes the list.
+job.onChange(function() pushSet() end)
 
 return M

--- a/client/main.lua
+++ b/client/main.lua
@@ -876,6 +876,12 @@ exports('getConnectedDevices', function() return bluetoothClient.devices() end)
 
 ---Registers a third-party app - exports['sd-phone']:addCustomApp(data). Attribution is the calling
 ---resource; re-registering an identifier is only allowed from that same resource.
+---
+---`devices` limits which devices list the app ('phone', 'tablet'); absent means all of them.
+---`job` limits who sees it, as a name, an array of names, or a name->minimum-grade map.
+---
+---Both only decide whether an icon is DRAWN. Neither authorises anything: a player can still fire
+---your resource's events and callbacks directly, so keep checking the job server-side.
 ---@param data table lb-phone-shaped app definition
 ---@return boolean ok, string? err
 exports('addCustomApp', function(data)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -647,6 +647,15 @@ function AppContent() {
         });
     }, []);
 
+    const knownCustomIds = useRef<Set<string>>(new Set());
+    useEffect(() => {
+        const live = new Set(customApps.map(a => a.id));
+        for (const id of knownCustomIds.current) {
+            if (!live.has(id)) handleRemoveFromRecents(id);
+        }
+        knownCustomIds.current = live;
+    }, [customApps, handleRemoveFromRecents]);
+
     const handleRemoveAll = useCallback(() => {
         setRecentApps([]);
         setCurrentApp(null);

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -105,6 +105,8 @@ export interface CustomAppDef {
     landscape?:  boolean;
     /** Wi-Fi network id (configs/wifi.lua) the phone must be joined to before this app downloads. */
     wifi?:       string;
+    /** Device ids this app appears on. Absent means every device. */
+    devices?:    string[];
     widgets?:    CustomWidgetDef[];
     resource:    string;
 }

--- a/web/src/stores/customAppsStore.ts
+++ b/web/src/stores/customAppsStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 import { fetchNui } from '@/core/nui';
 import { readJson, writeJson } from '@/lib/storage';
+import { device } from '@device';
 import type { AppDef, CustomAppDef } from '@/core/types';
 
 const INSTALLED_KEY = 'customApps:installed';
@@ -25,6 +26,11 @@ export function clearCustomInstalled(): void {
     writeJson(INSTALLED_KEY, []);
 }
 
+function forThisDevice(apps: CustomAppDef[] | null | undefined): CustomAppDef[] {
+    if (!Array.isArray(apps)) return [];
+    return apps.filter(a => !a.devices?.length || a.devices.includes(device.id));
+}
+
 interface CustomAppsState {
     apps:    CustomAppDef[];
     setAll:  (apps: CustomAppDef[] | null | undefined) => void;
@@ -33,10 +39,10 @@ interface CustomAppsState {
 
 export const useCustomAppsStore = create<CustomAppsState>((set) => ({
     apps: [],
-    setAll: (apps) => set({ apps: Array.isArray(apps) ? apps : [] }),
+    setAll: (apps) => set({ apps: forThisDevice(apps) }),
     hydrate: () => {
         void fetchNui<CustomAppDef[]>('customApps/get').then(list => {
-            if (Array.isArray(list)) set({ apps: list });
+            if (Array.isArray(list)) set({ apps: forThisDevice(list) });
         }).catch(() => { /* offline / dev: keep current */ });
     },
 }));


### PR DESCRIPTION
Closes the gap that `addCustomApp` had no gating of any kind, so a third-party app appeared on every device for every player.

## `devices`

Allow-list of device ids, accepting a bare string or an array, lowercased on the way in. Absent or empty means every device.

```lua
devices = 'tablet'
devices = { 'phone', 'tablet' }
```

An allow-list rather than a `tablet` boolean: a boolean cannot express phone-only without a second flag, and `DeviceId` is already a union.

## `job`

Name, array of names, or a name to minimum-grade map, all normalised into one map. Re-evaluated on every job change, so the icon appears and disappears with duty status.

```lua
job = 'police'
job = { 'police', 'ambulance' }
job = { police = 3, ambulance = 0 }
```

## Why the two gates live in different layers

One sd-phone client serves both devices (sd-tablet forwards NUI through the `rpcAction` envelope into the same callbacks), so Lua cannot tell which device is asking. `devices` therefore rides on the def and is matched in the frontend, in the same `customAppsStore` funnel that both `customApps:set` and `hydrate()` pass through, against the build-time `device.id` the built-in `excludedApps` list already uses.

Only Lua knows the job, so that gate runs in `currentList()`. A gated app never reaches the page at all, which also keeps it out of the App Store listing.

## Neither field is security

Both decide whether an **icon is drawn**. A player can still trigger the owning resource's events and callbacks directly. The export doc block and the docs site both say so explicitly, with a worked server-side example, because shipping a `job` param that merely looks like access control would be worse than not shipping one.

## Supporting changes

- **`bridge/client/job.lua`** (new). Only the server had a job bridge. Mirrors `bridge/server/job.lua`'s shape for qb/qbx and ESX, exposing `name()`, `grade()`, `has()` and `onChange()`. Fails closed while the player is unloaded, so a resource restart cannot flash restricted icons at everyone, and refreshes at load time to cover restarting mid-session where no player-loaded event is coming.
- **Deck eviction.** A custom app that disappears is now closed and removed from recents/retained. A demoted officer would otherwise sit on a blank frame. This also fixes the same pre-existing bug when a custom app's resource stops while its app is open.

## Verification

All four CI steps pass locally (`build`, `lint`, `test`, `knip` all exit 0).

- **20 Lua tests** driving the real module with FiveM globals stubbed: device normalisation (bare string, array, junk entries, empty list, wrong type), unloaded/wrong/right job, arrays, exact-minimum and below-minimum grades, mixed maps, and the automatic re-push on job change.
- **7 frontend tests** on the device filter, including that an empty list means unscoped rather than no devices, matching the Lua side.
- Docs updated and deployed: https://docs.samueldev.shop/resources/phone/custom-apps#limiting-who-sees-an-app