### PR TITLE
MDT: iOS pull-down select

### DIFF
--- a/web/src/apps/mdt/BookingDialog.tsx
+++ b/web/src/apps/mdt/BookingDialog.tsx
@@ -11,7 +11,8 @@ import { sentenceLabel } from './ChargePicker';
 import type { ArrestRow } from './data';
 import { mdtBook, mdtJailQuote, mdtReport } from './mdtApi';
 import { ReportLinker } from './ReportEditor';
-import { mdtFieldClass, mdtSectionHeader } from './mdtTheme';
+import { mdtSectionHeader } from './mdtTheme';
+import { MdtSelect } from './ui/MdtSelect';
 
 export function BookingDialog({ onClose, onBooked }: {
     onClose:  () => void;
@@ -139,16 +140,13 @@ export function BookingDialog({ onClose, onBooked }: {
         >
             <div className="mt-4 text-left">
                 {suspects.length > 1 && (
-                    <select
+                    <MdtSelect
                         value={citizenid}
-                        onChange={e => setCitizenid(e.target.value)}
-                        aria-label={t('mdt.suspect', 'Suspect')}
-                        className={`mb-3 ${mdtFieldClass}`}
-                    >
-                        {suspects.map(suspect => (
-                            <option key={suspect.citizenid} value={suspect.citizenid}>{suspect.name}</option>
-                        ))}
-                    </select>
+                        onChange={setCitizenid}
+                        options={suspects.map(suspect => ({ value: suspect.citizenid, label: suspect.name }))}
+                        ariaLabel={t('mdt.suspect', 'Suspect')}
+                        className="mb-3"
+                    />
                 )}
 
                 <div className="flex gap-2">

--- a/web/src/apps/mdt/CaseFile.tsx
+++ b/web/src/apps/mdt/CaseFile.tsx
@@ -18,10 +18,11 @@ import {
 import { PersonPicker } from './PersonPicker';
 import { ReportLinker, reportTypeLabel, reportTypeTone } from './ReportEditor';
 import { useMdtSession } from './useMdtSession';
-import { mdtFieldArea, mdtFieldSm, mdtFieldXs, mdtPanePad, mdtRef, mdtRowMeta, mdtRowTitle, mdtSectionHeader, STATUS_TONE } from './mdtTheme';
+import { mdtFieldArea, mdtPanePad, mdtRef, mdtRowMeta, mdtRowTitle, mdtSectionHeader, STATUS_TONE } from './mdtTheme';
 import { MdtButton } from './ui/MdtButton';
 import { MdtCard } from './ui/MdtCard';
 import { MdtField } from './ui/MdtField';
+import { MdtSelect } from './ui/MdtSelect';
 
 export const CASE_STATUSES: readonly CaseStatus[] = ['open', 'in_progress', 'closed'] as const;
 export const CASE_PRIORITIES: readonly CasePriority[] = ['low', 'medium', 'high'] as const;
@@ -243,22 +244,20 @@ export function CaseFile({ caseRef, onSaved, onDeleted, onClose, onChanged }: {
                 <div className="mt-4 flex flex-wrap items-center gap-3">
                     {editable ? (
                         <>
-                            <select
+                            <MdtSelect<CaseStatus>
                                 value={file.status}
-                                onChange={e => void patch({ status: e.target.value as CaseStatus })}
-                                aria-label={t('mdt.status', 'Status')}
-                                className={mdtFieldSm}
-                            >
-                                {CASE_STATUSES.map((s: CaseStatus) => <option key={s} value={s}>{caseStatusLabel(s)}</option>)}
-                            </select>
-                            <select
+                                onChange={status => void patch({ status })}
+                                options={CASE_STATUSES.map((s: CaseStatus) => ({ value: s, label: caseStatusLabel(s) }))}
+                                size="sm"
+                                ariaLabel={t('mdt.status', 'Status')}
+                            />
+                            <MdtSelect<CasePriority>
                                 value={file.priority}
-                                onChange={e => void patch({ priority: e.target.value as CasePriority })}
-                                aria-label={t('mdt.priority', 'Priority')}
-                                className={mdtFieldSm}
-                            >
-                                {CASE_PRIORITIES.map((p: CasePriority) => <option key={p} value={p}>{casePriorityLabel(p)}</option>)}
-                            </select>
+                                onChange={priority => void patch({ priority })}
+                                options={CASE_PRIORITIES.map((p: CasePriority) => ({ value: p, label: casePriorityLabel(p) }))}
+                                size="sm"
+                                ariaLabel={t('mdt.priority', 'Priority')}
+                            />
                         </>
                     ) : (
                         <>
@@ -337,17 +336,15 @@ export function CaseFile({ caseRef, onSaved, onDeleted, onClose, onChanged }: {
                                         )}
                                     </span>
                                     {editable ? (
-                                        <select
+                                        <MdtSelect<CaseRole>
                                             value={officer.role}
-                                            onChange={e => void apply(mdtCaseAssign(
-                                                file.ref, officer.citizenid, e.target.value as CaseRole, true))}
-                                            aria-label={t('mdt.role', 'Role')}
-                                            className={`shrink-0 ${mdtFieldXs}`}
-                                        >
-                                            {CASE_ROLES.map((role: CaseRole) => (
-                                                <option key={role} value={role}>{caseRoleLabel(role)}</option>
-                                            ))}
-                                        </select>
+                                            onChange={role => void apply(mdtCaseAssign(
+                                                file.ref, officer.citizenid, role, true))}
+                                            options={CASE_ROLES.map((role: CaseRole) => ({ value: role, label: caseRoleLabel(role) }))}
+                                            size="xs"
+                                            ariaLabel={t('mdt.role', 'Role')}
+                                            className="shrink-0"
+                                        />
                                     ) : (
                                         <Pill tone={STATUS_TONE[officer.role] ?? 'blue'}>{caseRoleLabel(officer.role)}</Pill>
                                     )}

--- a/web/src/apps/mdt/ChargePicker.tsx
+++ b/web/src/apps/mdt/ChargePicker.tsx
@@ -10,8 +10,9 @@ import { SearchBar } from '@/ui/SearchBar';
 
 import { CHARGE_CLASSES, type ChargeClass, type ChargeInput, type Offence } from './data';
 import { useMdtSession } from './useMdtSession';
-import { mdtFieldXs, mdtRowHover, mdtRowMeta, mdtRowTitle, mdtSectionHeader, STATUS_TONE } from './mdtTheme';
+import { mdtRowHover, mdtRowMeta, mdtRowTitle, mdtSectionHeader, STATUS_TONE } from './mdtTheme';
 import { MdtCard } from './ui/MdtCard';
+import { MdtSelect } from './ui/MdtSelect';
 
 const MAX_COUNT = 99;
 
@@ -138,18 +139,14 @@ export function ChargePicker({ lines, onChange, subjects = [], className = '' }:
                                     </span>
 
                                     {subjects.length > 1 && (
-                                        <select
+                                        <MdtSelect
                                             value={line.citizenid ?? ''}
-                                            onChange={e => setSubject(index, e.target.value)}
-                                            aria-label={t('mdt.attributeCharge', 'Attribute charge')}
-                                            className={`max-w-[150px] shrink-0 ${mdtFieldXs}`}
-                                        >
-                                            {subjects.map(subject => (
-                                                <option key={subject.citizenid} value={subject.citizenid}>
-                                                    {subject.name}
-                                                </option>
-                                            ))}
-                                        </select>
+                                            onChange={next => setSubject(index, next)}
+                                            options={subjects.map(subject => ({ value: subject.citizenid, label: subject.name }))}
+                                            size="xs"
+                                            ariaLabel={t('mdt.attributeCharge', 'Attribute charge')}
+                                            className="max-w-[150px] shrink-0"
+                                        />
                                     )}
 
                                     <span className="flex shrink-0 items-center gap-1 rounded-full bg-black/[0.06] px-1 py-0.5 dark:bg-white/[0.12]">

--- a/web/src/apps/mdt/Mdt.tsx
+++ b/web/src/apps/mdt/Mdt.tsx
@@ -71,6 +71,7 @@ function MdtTerminal() {
     return (
         <div
             ref={rootRef}
+            data-mdt-root=""
             className={`absolute inset-0 z-10 flex select-none flex-col font-sf text-black dark:text-white ${mdtBackdrop}`}
             style={{ '--mdt-accent': accent } as CSSProperties}
         >

--- a/web/src/apps/mdt/ReportEditor.tsx
+++ b/web/src/apps/mdt/ReportEditor.tsx
@@ -18,15 +18,16 @@ import { SearchBar } from '@/ui/SearchBar';
 import { catalogIndex, ChargePicker, inputTotals, sentenceLabel } from './ChargePicker';
 import { EMS_INVOLVED_ROLES, EMS_REPORT_TYPES } from './data';
 import type {
-    AnyReportType, Charge, ChargeInput, Involved, InvolvedRole, ReportDetail, ReportSummary, ReportType,
+    AnyInvolvedRole, AnyReportType, Charge, ChargeInput, Involved, InvolvedRole, ReportDetail, ReportSummary, ReportType,
 } from './data';
 import { mdtDeleteReport, mdtReport, mdtReports, mdtSaveReport } from './mdtApi';
 import { PersonPicker } from './PersonPicker';
 import { useMdtSession, useViewEnter } from './useMdtSession';
-import { mdtFieldXs, mdtPanePad, mdtRef, mdtRowHover, mdtRowMeta, mdtRowTitle, mdtSectionHeader, STATUS_TONE } from './mdtTheme';
+import { mdtPanePad, mdtRef, mdtRowHover, mdtRowMeta, mdtRowTitle, mdtSectionHeader, STATUS_TONE } from './mdtTheme';
 import { MdtButton } from './ui/MdtButton';
 import { MdtCard } from './ui/MdtCard';
 import { MdtField } from './ui/MdtField';
+import { MdtSelect } from './ui/MdtSelect';
 
 export const REPORT_TYPES: readonly ReportType[] = ['Incident', 'Traffic', 'Arrest', 'Investigation', 'Warrant'] as const;
 export const INVOLVED_ROLES: readonly InvolvedRole[] = ['suspect', 'victim', 'witness'] as const;
@@ -492,16 +493,17 @@ function DraftView({ draft, saving, error, enter, onChange, onAddPerson, onSave,
                                     className="w-full bg-transparent text-[12.5px] font-medium text-ios-gray outline-none placeholder:text-ios-gray/70"
                                 />
                             </div>
-                            <select
+                            <MdtSelect<AnyInvolvedRole>
                                 value={person.role}
-                                onChange={e => setPerson(index, { role: e.target.value as InvolvedRole })}
-                                aria-label={t('mdt.role', 'Role')}
-                                className={`shrink-0 ${mdtFieldXs}`}
-                            >
-                                {(medical ? EMS_INVOLVED_ROLES : INVOLVED_ROLES).map((role: string) => (
-                                    <option key={role} value={role}>{roleLabel(role)}</option>
-                                ))}
-                            </select>
+                                onChange={role => setPerson(index, { role })}
+                                options={(medical ? EMS_INVOLVED_ROLES : INVOLVED_ROLES).map(role => ({
+                                    value: role,
+                                    label: roleLabel(role),
+                                }))}
+                                size="xs"
+                                ariaLabel={t('mdt.role', 'Role')}
+                                className="shrink-0"
+                            />
                             <button
                                 type="button"
                                 onClick={() => removePerson(index)}

--- a/web/src/apps/mdt/ui/MdtField.tsx
+++ b/web/src/apps/mdt/ui/MdtField.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { mdtFieldClass, mdtSectionHeader } from '../mdtTheme';
+import { MdtSelect } from './MdtSelect';
 
 interface MdtFieldProps {
     label?:       string;
@@ -43,16 +44,15 @@ export function MdtField({
     return (
         <Labelled label={label} hint={hint} className={className}>
             {options ? (
-                <select
+                <MdtSelect
                     value={value}
-                    onChange={e => onChange(e.target.value)}
+                    onChange={onChange}
+                    options={options}
                     disabled={disabled}
-                    className={`${base} appearance-none pr-8`}
-                >
-                    {options.map(o => (
-                        <option key={o.value} value={o.value}>{o.label}</option>
-                    ))}
-                </select>
+                    ariaLabel={label}
+                    placeholder={placeholder}
+                    className={fieldClassName}
+                />
             ) : multiline ? (
                 <textarea
                     value={value}

--- a/web/src/apps/mdt/ui/MdtPopover.tsx
+++ b/web/src/apps/mdt/ui/MdtPopover.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-
-import { ancestorZoom } from '@/lib/zoom';
+import { useAnchoredMenu } from './useAnchoredMenu';
 
 export interface MdtPopoverAction {
     label:        string;
@@ -9,74 +7,23 @@ export interface MdtPopoverAction {
     disabled?:    boolean;
 }
 
-const GAP = 6;
-const EDGE = 8;
-
 export function MdtPopover({ anchor, actions, onClose }: {
     anchor:  HTMLElement | null;
     actions: MdtPopoverAction[];
     onClose: () => void;
 }) {
-    const hostRef = useRef<HTMLDivElement>(null);
-    const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
-
-    useLayoutEffect(() => {
-        const host = hostRef.current;
-        if (!host || !anchor) return;
-
-        const parent = host.offsetParent as HTMLElement | null;
-        const zoom = ancestorZoom(host) || 1;
-        const a = anchor.getBoundingClientRect();
-        const p = parent?.getBoundingClientRect();
-
-        const boxW = parent ? parent.clientWidth : window.innerWidth;
-        const boxH = parent ? parent.clientHeight : window.innerHeight;
-        const w = host.offsetWidth;
-        const h = host.offsetHeight;
-
-        const anchorLeft = ((a.left - (p?.left ?? 0)) / zoom);
-        const anchorRight = ((a.right - (p?.left ?? 0)) / zoom);
-        const anchorTop = ((a.top - (p?.top ?? 0)) / zoom);
-        const anchorBottom = ((a.bottom - (p?.top ?? 0)) / zoom);
-
-        let left = anchorRight - w;
-        if (left < EDGE) left = Math.min(anchorLeft, boxW - w - EDGE);
-        left = Math.max(EDGE, Math.min(left, boxW - w - EDGE));
-
-        let top = anchorBottom + GAP;
-        if (top + h > boxH - EDGE) top = anchorTop - GAP - h;
-        top = Math.max(EDGE, Math.min(top, boxH - h - EDGE));
-
-        setPos({ left, top });
-    }, [anchor, actions.length]);
-
-    useEffect(() => {
-        function onDown(e: PointerEvent) {
-            const host = hostRef.current;
-            if (host && e.target instanceof Node && host.contains(e.target)) return;
-            onClose();
-        }
-        function onKey(e: KeyboardEvent) {
-            if (e.key === 'Escape') { e.stopPropagation(); onClose(); }
-        }
-        window.addEventListener('pointerdown', onDown, true);
-        window.addEventListener('keydown', onKey, true);
-        return () => {
-            window.removeEventListener('pointerdown', onDown, true);
-            window.removeEventListener('keydown', onKey, true);
-        };
-    }, [onClose]);
+    const { hostRef, style } = useAnchoredMenu({ anchor, onClose, revision: actions.length });
 
     return (
         <div
             ref={hostRef}
             className="absolute z-20 min-w-[188px] overflow-hidden rounded-[13px] bg-[#f4f4f4] shadow-[0_8px_30px_rgba(0,0,0,0.18)] ring-1 ring-black/[0.08] dark:bg-elevated dark:ring-white/[0.10]"
             style={{
-                left:       pos?.left ?? 0,
-                top:        pos?.top ?? 0,
-                opacity:    pos ? 1 : 0,
-                transformOrigin: 'top right',
-                animation:  pos ? 'ios-alert-in 0.16s cubic-bezier(0.32,0.72,0,1)' : undefined,
+                left:            style?.left ?? 0,
+                top:             style?.top ?? 0,
+                opacity:         style ? 1 : 0,
+                transformOrigin: style?.origin ?? 'top right',
+                animation:       style ? 'ios-alert-in 0.16s cubic-bezier(0.32,0.72,0,1)' : undefined,
             }}
         >
             {actions.map((a, i) => (

--- a/web/src/apps/mdt/ui/MdtSelect.tsx
+++ b/web/src/apps/mdt/ui/MdtSelect.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, ChevronDown } from 'lucide-react';
+
+import { isFiveM } from '@/core/nui';
+import { mdtFieldClass, mdtFieldSm, mdtFieldXs } from '../mdtTheme';
+import { useAnchoredMenu } from './useAnchoredMenu';
+
+export interface MdtSelectOption<T extends string = string> {
+    value:     T;
+    label:     string;
+    disabled?: boolean;
+}
+
+type MdtSelectSize = 'md' | 'sm' | 'xs';
+
+const TRIGGER: Record<MdtSelectSize, string> = {
+    md: mdtFieldClass,
+    sm: mdtFieldSm,
+    xs: mdtFieldXs,
+};
+
+const ROW: Record<MdtSelectSize, string> = {
+    md: 'px-3 py-[9px] text-[15px]',
+    sm: 'px-3 py-2 text-[14px]',
+    xs: 'px-2.5 py-1.5 text-[13px]',
+};
+
+const CHEVRON: Record<MdtSelectSize, string> = {
+    md: 'h-[15px] w-[15px]',
+    sm: 'h-[14px] w-[14px]',
+    xs: 'h-[13px] w-[13px]',
+};
+
+export function MdtSelect<T extends string = string>({
+    value, onChange, options, size = 'md', disabled = false, className = '', ariaLabel, placeholder,
+}: {
+    value:       T;
+    onChange:    (value: T) => void;
+    options:     readonly MdtSelectOption<T>[];
+    size?:       MdtSelectSize;
+    disabled?:   boolean;
+    className?:  string;
+    ariaLabel?:  string;
+    placeholder?: string;
+}) {
+    const [open, setOpen] = useState(false);
+    const [active, setActive] = useState(0);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const rowsRef = useRef<HTMLDivElement>(null);
+    const typed = useRef({ buffer: '', at: 0 });
+
+    const close = useCallback(() => setOpen(false), []);
+    const { hostRef, style } = useAnchoredMenu({
+        anchor: open ? triggerRef.current : null,
+        onClose: close,
+        align: 'start',
+        matchWidth: true,
+        revision: options.length,
+    });
+
+    const selectedIndex = useMemo(() => options.findIndex(o => o.value === value), [options, value]);
+    const selected = selectedIndex >= 0 ? options[selectedIndex] : undefined;
+
+    const host = triggerRef.current?.closest('[data-mdt-root]') ?? null;
+
+    useEffect(() => {
+        if (open) setActive(selectedIndex >= 0 ? selectedIndex : 0);
+    }, [open, selectedIndex]);
+
+    useEffect(() => {
+        if (!open) return;
+        rowsRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({ block: 'nearest' });
+    }, [open, active]);
+
+    function commit(index: number) {
+        const option = options[index];
+        if (!option || option.disabled) return;
+        onChange(option.value);
+        setOpen(false);
+        triggerRef.current?.focus();
+    }
+
+    function step(delta: number) {
+        if (!options.length) return;
+        let next = active;
+        for (let i = 0; i < options.length; i++) {
+            next = (next + delta + options.length) % options.length;
+            if (!options[next]?.disabled) break;
+        }
+        setActive(next);
+    }
+
+    function typeAhead(key: string) {
+        const now = Date.now();
+        const buffer = now - typed.current.at > 800 ? key : typed.current.buffer + key;
+        typed.current = { buffer, at: now };
+        const found = options.findIndex(o => !o.disabled && o.label.toLowerCase().startsWith(buffer.toLowerCase()));
+        if (found >= 0) setActive(found);
+    }
+
+    function onKeyDown(e: React.KeyboardEvent) {
+        if (disabled) return;
+        // Jump stays bound in NUI, so Space activates whatever is focused; taking it here as well
+        // would fire twice. Outside FiveM it is the expected way to open a select.
+        if (e.key === ' ' && !isFiveM) {
+            e.preventDefault();
+            setOpen(o => !o);
+            return;
+        }
+        if (!open) {
+            if (e.key === 'Enter' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+                e.preventDefault();
+                setOpen(true);
+            }
+            return;
+        }
+        if (e.key === 'ArrowDown')      { e.preventDefault(); step(1); }
+        else if (e.key === 'ArrowUp')   { e.preventDefault(); step(-1); }
+        else if (e.key === 'Home')      { e.preventDefault(); setActive(0); }
+        else if (e.key === 'End')       { e.preventDefault(); setActive(options.length - 1); }
+        else if (e.key === 'Enter')     { e.preventDefault(); commit(active); }
+        else if (e.key === 'Tab')       { setOpen(false); }
+        else if (e.key.length === 1 && /\S/.test(e.key)) { typeAhead(e.key); }
+    }
+
+    const menu = open && host && createPortal(
+        <div
+            ref={hostRef}
+            role="listbox"
+            aria-label={ariaLabel}
+            className="absolute z-30 overflow-y-auto overscroll-contain rounded-[12px] bg-[#f4f4f4] py-1 shadow-[0_8px_30px_rgba(0,0,0,0.18)] ring-1 ring-black/[0.08] dark:bg-elevated dark:ring-white/[0.10]"
+            style={{
+                left:            style?.left ?? 0,
+                top:             style?.top ?? 0,
+                maxHeight:       style?.maxHeight,
+                minWidth:        style?.minWidth,
+                opacity:         style ? 1 : 0,
+                transformOrigin: style?.origin ?? 'top left',
+                animation:       style ? 'ios-alert-in 0.16s cubic-bezier(0.32,0.72,0,1)' : undefined,
+            }}
+        >
+            <div ref={rowsRef}>
+                {options.map((option, index) => {
+                    const isSelected = option.value === value;
+                    return (
+                        <button
+                            key={option.value}
+                            type="button"
+                            role="option"
+                            aria-selected={isSelected}
+                            data-active={index === active}
+                            disabled={option.disabled}
+                            onPointerEnter={() => !option.disabled && setActive(index)}
+                            onClick={() => commit(index)}
+                            className={[
+                                'flex w-full items-center gap-2 text-left transition-colors duration-100',
+                                ROW[size],
+                                option.disabled
+                                    ? 'text-black/30 dark:text-white/30'
+                                    : index === active
+                                        ? 'bg-black/[0.06] dark:bg-white/[0.08]'
+                                        : '',
+                                isSelected ? 'font-semibold text-ios-blue' : 'text-black dark:text-white',
+                            ].join(' ')}
+                        >
+                            <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                            {isSelected && <Check className="h-[15px] w-[15px] shrink-0 text-ios-blue" strokeWidth={2.6} />}
+                        </button>
+                    );
+                })}
+            </div>
+        </div>,
+        host,
+    );
+
+    return (
+        <>
+            <button
+                ref={triggerRef}
+                type="button"
+                role="combobox"
+                aria-expanded={open}
+                aria-label={ariaLabel}
+                disabled={disabled}
+                onClick={() => setOpen(o => !o)}
+                onKeyDown={onKeyDown}
+                className={[
+                    TRIGGER[size],
+                    'flex items-center gap-1.5 text-left',
+                    disabled ? 'opacity-50' : '',
+                    className,
+                ].join(' ')}
+            >
+                <span className={`min-w-0 flex-1 truncate ${selected ? '' : 'text-black/35 dark:text-white/35'}`}>
+                    {selected?.label ?? placeholder ?? ''}
+                </span>
+                <ChevronDown
+                    className={`${CHEVRON[size]} shrink-0 text-ios-gray transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
+                    strokeWidth={2.4}
+                />
+            </button>
+            {menu}
+        </>
+    );
+}

--- a/web/src/apps/mdt/ui/useAnchoredMenu.ts
+++ b/web/src/apps/mdt/ui/useAnchoredMenu.ts
@@ -1,0 +1,104 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import { ancestorZoom } from '@/lib/zoom';
+
+const GAP = 6;
+const EDGE = 8;
+
+export interface AnchoredMenuStyle {
+    left:      number;
+    top:       number;
+    maxHeight: number;
+    minWidth?: number;
+    origin:    string;
+}
+
+export interface AnchoredMenuOptions {
+    anchor:      HTMLElement | null;
+    onClose:     () => void;
+    /** Which edge of the menu lines up with the anchor. Menus read from the left, action lists hang off the right. */
+    align?:      'start' | 'end';
+    /** Floor the menu at the anchor's own width, so a select never looks narrower than its trigger. */
+    matchWidth?: boolean;
+    /** Any value that should force a re-measure, such as the option count. */
+    revision?:   unknown;
+}
+
+/**
+ * Positions a floating menu against an anchor and wires its dismissal. Coordinates are resolved
+ * inside the menu's own offsetParent and divided by the ancestor CSS zoom, so callers can portal
+ * the menu out of a clipping row as long as the destination sits in the same zoom space.
+ */
+export function useAnchoredMenu({ anchor, onClose, align = 'end', matchWidth = false, revision }: AnchoredMenuOptions) {
+    const hostRef = useRef<HTMLDivElement>(null);
+    const [style, setStyle] = useState<AnchoredMenuStyle | null>(null);
+
+    useLayoutEffect(() => {
+        const host = hostRef.current;
+        if (!host || !anchor) return;
+
+        const parent = host.offsetParent as HTMLElement | null;
+        const zoom = ancestorZoom(host) || 1;
+        const a = anchor.getBoundingClientRect();
+        const p = parent?.getBoundingClientRect();
+
+        const boxW = parent ? parent.clientWidth : window.innerWidth;
+        const boxH = parent ? parent.clientHeight : window.innerHeight;
+        const w = host.offsetWidth;
+        const h = host.offsetHeight;
+
+        const anchorLeft   = (a.left   - (p?.left ?? 0)) / zoom;
+        const anchorRight  = (a.right  - (p?.left ?? 0)) / zoom;
+        const anchorTop    = (a.top    - (p?.top  ?? 0)) / zoom;
+        const anchorBottom = (a.bottom - (p?.top  ?? 0)) / zoom;
+
+        let left = align === 'start' ? anchorLeft : anchorRight - w;
+        if (left < EDGE) left = Math.min(align === 'start' ? anchorLeft : anchorRight - w, boxW - w - EDGE);
+        left = Math.max(EDGE, Math.min(left, boxW - w - EDGE));
+
+        // Prefer below, but take whichever side actually has room for the list.
+        const roomBelow = boxH - EDGE - (anchorBottom + GAP);
+        const roomAbove = anchorTop - GAP - EDGE;
+        const below = h <= roomBelow || roomBelow >= roomAbove;
+
+        const maxHeight = Math.max(96, Math.floor(below ? roomBelow : roomAbove));
+        const top = below
+            ? anchorBottom + GAP
+            : Math.max(EDGE, anchorTop - GAP - Math.min(h, maxHeight));
+
+        setStyle({
+            left,
+            top,
+            maxHeight,
+            minWidth: matchWidth ? a.width / zoom : undefined,
+            origin: `${below ? 'top' : 'bottom'} ${align === 'start' ? 'left' : 'right'}`,
+        });
+    }, [anchor, align, matchWidth, revision]);
+
+    useEffect(() => {
+        function onDown(e: PointerEvent) {
+            const host = hostRef.current;
+            if (host && e.target instanceof Node && host.contains(e.target)) return;
+            onClose();
+        }
+        function onKey(e: KeyboardEvent) {
+            if (e.key === 'Escape') { e.stopPropagation(); onClose(); }
+        }
+        // Anchored to a rect measured once, so a scroll underneath would leave it stranded.
+        function onScroll(e: Event) {
+            const host = hostRef.current;
+            if (host && e.target instanceof Node && host.contains(e.target)) return;
+            onClose();
+        }
+        window.addEventListener('pointerdown', onDown, true);
+        window.addEventListener('keydown', onKey, true);
+        window.addEventListener('scroll', onScroll, true);
+        return () => {
+            window.removeEventListener('pointerdown', onDown, true);
+            window.removeEventListener('keydown', onKey, true);
+            window.removeEventListener('scroll', onScroll, true);
+        };
+    }, [onClose]);
+
+    return { hostRef, style };
+}


### PR DESCRIPTION
Replaces all seven native `<select>` elements in the MDT with an iOS pull-down.

Along the way it fixes a defect: `MdtField` rendered its select `appearance-none pr-8`, which strips the native arrow and reserves 32px for a replacement that nothing in the component or `index.css` ever drew. The shared MDT select primitive had **no dropdown affordance at all**.

## MdtSelect

Trigger carries the existing `mdtField*` token for its size plus a real chevron that rotates when open. The menu is rounded and elevated with a hairline ring, the selected row in `ios-blue` with a checkmark, hover/active highlight, dimmed disabled rows. Three sizes map to `mdtFieldClass` / `Sm` / `Xs` so it sits flush with neighbouring inputs.

| Call site | Size |
|---|---|
| `MdtField` (shared primitive) | md |
| `BookingDialog` suspect | md |
| `CaseFile` status, priority | sm |
| `CaseFile` officer role | xs |
| `ChargePicker` subject | xs |
| `ReportEditor` involved role | xs |

## useAnchoredMenu

Positioning extracted from `MdtPopover`, which now consumes it too — it had exactly one caller, so extracting beat duplicating forty lines of zoom math. Keeps the `ancestorZoom` handling, adds start/end alignment, a width floor, a computed `maxHeight` so long lists scroll rather than overflow, and close-on-scroll (the menu anchors to a rect measured once, so a scroll underneath would otherwise strand it).

The menu portals to `[data-mdt-root]`, not in place — several triggers sit inside scrolling rows and a dialog that would clip it. Not `document.body` either, since that leaves the CSS-zoom coordinate space the anchor math assumes.

## Keyboard

Enter/arrows to open, arrows/Home/End to move past disabled rows, Enter to commit, Escape and Tab to close, type-ahead on an 800ms buffer.

Space is gated on `!isFiveM`: jump stays bound in NUI so Space already activates the focused element, and handling it here too would fire twice.

## A wrong cast removed

`ReportEditor` read the role as `e.target.value as InvolvedRole`, but `Involved.role` is `AnyInvolvedRole` — the wider union including the EMS-only `'patient'`. The assertion claimed a type the value could not have, and only compiled because it was assigned into a wider field. The typed generic makes it checkable.

## Verification

All four CI steps pass locally (`build`, `lint`, `test`, `knip` all exit 0).

Component mounted through the Vite module graph and driven with real input:

- Dark and light, all three sizes
- Portals to the MDT root, left-aligns to the trigger, never narrower than it
- Flips above when short on room (`transform-origin: left bottom`) and stays inside the root
- ArrowDown opens; two arrows + Enter committed the expected option; type-ahead `pa` selected Patient; Escape closes

**Not verified in game.** Worth checking the row dropdowns inside scrolling lists specifically, since the portal exists for them.