### PR TITLE
feat(compatibility): add support for qs-advancedgarages, wasabi, dusa, and renewed keys

### DIFF
--- a/bridge/client/vehiclekeys.lua
+++ b/bridge/client/vehiclekeys.lua
@@ -1,5 +1,8 @@
 ---@type string[] Supported vehicle-key resources, in detection-priority order.
-local RESOURCES = { 'qbx_vehiclekeys', 'qb-vehiclekeys', 'qs-vehiclekeys', 'vehicles_keys', 'mk_vehiclekeys' }
+local RESOURCES = {
+    'qbx_vehiclekeys', 'qb-vehiclekeys', 'qs-vehiclekeys', 'Renewed-Vehiclekeys',
+    'dusa_vehiclekeys', 'wasabi_carlock', 'vehicles_keys', 'mk_vehiclekeys',
+}
 
 ---@type table Vehicle-lock module; the table returned at end of file. Reads and toggles lock
 ---state on the live entity found by plate; returns nil for vehicles not streamed nearby.
@@ -80,8 +83,9 @@ local function fobLights(veh)
 end
 
 ---Lock or unlock the nearby spawned vehicle for a plate, requesting network control first. Fires
----qbx_vehiclekeys' own lock path when active, else the native door lock + hazard flash; nil when
----not streamed nearby.
+---qbx_vehiclekeys' own lock path when active, or Renewed-Vehiclekeys' `vehicleLock` statebag; the
+---rest (wasabi_carlock, dusa_vehiclekeys, qs-vehiclekeys, qb) read the door lock straight off the
+---entity, so they get the native door lock + hazard flash. nil when not streamed nearby.
 ---@param plate string
 ---@param locked boolean true = lock, false = unlock
 ---@return boolean|nil locked the applied state, or nil if no nearby entity
@@ -92,10 +96,14 @@ function M.setLocked(plate, locked)
         NetworkRequestControlOfEntity(veh)
     end
 
+    local sys       = M.active()
     local lockstate = locked and 2 or 1
-    if M.active() == 'qbx_vehiclekeys' then
+    if sys == 'qbx_vehiclekeys' then
         TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(veh), lockstate)
         PlaySoundFromEntity(-1, 'Remote_Control_Fob', veh, 'PI_Menu_Sounds', false, 0)
+        fobLights(veh)
+    elseif sys == 'Renewed-Vehiclekeys' then
+        Entity(veh).state:set('vehicleLock', { lock = lockstate, sound = true }, true)
         fobLights(veh)
     else
         SetVehicleDoorsLocked(veh, lockstate)

--- a/bridge/server/garages.lua
+++ b/bridge/server/garages.lua
@@ -33,6 +33,10 @@ local BASE = framework.name == 'esx'
 --   esx_garage (+ ESX variants)                    : owned_vehicles
 --       owner=`owner`, props=`vehicle` JSON (model hash, fuelLevel, engineHealth,
 --       bodyHealth), stored=`stored`/`state`, garage=`parking`/`garage`
+--   qs-advancedgarages                             : owned_vehicles (esx) / player_vehicles (qb)
+--       garage=`garage` ('OUT' while the car is out), state=`stored` (esx) or
+--       `state` (qb), impound=`impound_data` (JSON blob, '' when free),
+--       type=`type` ('vehicle'|'boat'|'plane')
 ---@type table Permissive fallback column profile for systems without an exact entry.
 local DEFAULT_PROFILE = {
     garage     = { 'garage', 'parking', 'garage_id', 'garagename' },
@@ -43,6 +47,7 @@ local DEFAULT_PROFILE = {
 }
 ---@type table<string, table> Exact column profiles, keyed by garage resource name.
 local PROFILES = {
+    ['qs-advancedgarages'] = { garage = { 'garage' },             state = { 'stored', 'state' }, impoundCol = 'impound_data' },
     ['qb-garages']         = { garage = { 'garage' },             state = { 'state' } },
     ['qbx_garages']        = { garage = { 'garage' },             state = { 'state' } },
     ['jg-advancedgarages'] = { garage = { 'garage_id', 'garage' },state = { 'in_garage' }, impoundCol = 'impound' },
@@ -251,6 +256,7 @@ local function loadGarageCollection()
         if ACTIVE == 'qb-garages'         then return exports['qb-garages']:getAllGarages() end
         if ACTIVE == 'jg-advancedgarages' then return exports['jg-advancedgarages']:getAllGarages() end
         if ACTIVE == 'cd_garage'          then return exports['cd_garage']:GetConfig() end
+        if ACTIVE == 'qs-advancedgarages' then return exports['qs-advancedgarages']:GetAllGarages(true) end
         return nil
     end)
     gcolCache, gcolAt = ok and data or nil, now
@@ -283,7 +289,11 @@ local function systemCoords(gcol, row, garageId)
             return g and (g.CenterOfZone or g.AccessPoint)
         end
         if not gcol then return nil end
-        if ACTIVE == 'qbx_garages' then
+        if ACTIVE == 'qs-advancedgarages' then
+            local g = garageId and gcol[garageId]
+            local c = g and g.coords
+            return c and (c.menuCoords or c.spawnCoords)
+        elseif ACTIVE == 'qbx_garages' then
             local g  = gcol[garageId]
             local ap = g and g.accessPoints and g.accessPoints[1]
             return ap and ap.coords
@@ -340,7 +350,20 @@ local function impoundCoords(gcol, row, garageId)
             return g and g.Coords
         end
         if not gcol then return nil end
-        if ACTIVE == 'qbx_garages' then
+        if ACTIVE == 'qs-advancedgarages' then
+            local own = garageId and gcol[garageId]
+            local oc  = own and own.isImpound and own.coords
+            if oc then return oc.menuCoords or oc.spawnCoords end
+            local fallback
+            for _, g in pairs(gcol) do
+                local c = g.isImpound and g.coords and (g.coords.menuCoords or g.coords.spawnCoords)
+                if c then
+                    if g.type == nil or g.type == 'vehicle' then return c end
+                    fallback = fallback or c
+                end
+            end
+            return fallback
+        elseif ACTIVE == 'qbx_garages' then
             local own = garageId and gcol[garageId]
             local ap  = own and own.type == 'depot' and own.accessPoints and own.accessPoints[1]
             if ap then return ap.coords end
@@ -423,7 +446,9 @@ function garages.list(source)
         end
 
         local garageName = pick(row, PROFILE.garage)
-        if type(garageName) ~= 'string' or garageName == '' then garageName = nil end
+        if type(garageName) ~= 'string' or garageName == '' or garageName:upper() == 'OUT' then
+            garageName = nil
+        end
 
         local rawModel = row.vehicle
         if type(rawModel) ~= 'string' or rawModel:sub(1, 1) == '{' then

--- a/configs/garages.lua
+++ b/configs/garages.lua
@@ -15,8 +15,8 @@ return {
     -- Resources checked, in priority order, when System = 'auto'. The first
     -- one that's `started` wins. Add custom/renamed resources here.
     Resources = {
-        'jg-advancedgarages', 'qbx_garages', 'qb-garages', 'cd_garage',
-        'okokGarage', 'codem-garage', 'lunar_garage', 'nc_garage',
+        'qs-advancedgarages', 'jg-advancedgarages', 'qbx_garages', 'qb-garages',
+        'cd_garage', 'okokGarage', 'codem-garage', 'lunar_garage', 'nc_garage',
         'op_garages', 'esx_garage',
     },
 
@@ -40,10 +40,12 @@ return {
 
     -- Garage waypoint coordinates - used as a FALLBACK. The app first auto-reads
     -- a garage's coords from the running system's own export, so these systems
-    -- need NO setup: qbx_garages, qb-garages, jg-advancedgarages, cd_garage,
-    -- op-garages. Only systems without a usable export (esx, codem, okok, nc,
-    -- lunar) need entries here: key by the exact Location TEXT a stored OR
-    -- impounded vehicle shows (open one and copy it - e.g. a garage name, or
+    -- need NO setup: qs-advancedgarages, qbx_garages, qb-garages,
+    -- jg-advancedgarages, cd_garage, op-garages. Only systems without a usable
+    -- export (esx, codem, okok, nc, lunar) need entries here, plus any garage a
+    -- player built themselves in qs-advancedgarages (those live in
+    -- `player_garages`, not the config): key by the exact Location TEXT a
+    -- stored OR impounded vehicle shows (open one and copy it - e.g. a garage name, or
     -- 'Impound' to mark the impound lot) and map it to a vec2(x, y). Locations
     -- left out (and vehicles out on the street) simply don't get a button.
     Locations = {


### PR DESCRIPTION
## Summary

Adds compatibility support for `qs-advancedgarages`, `wasabi_carlock`, `dusa_vehiclekeys`, and `Renewed-Vehiclekeys` using existing bridge logic:

* Added `qs-advancedgarages` profile support, waypoint lookups, and handled vehicles in `'OUT'` state.
* Added `wasabi_carlock`, `dusa_vehiclekeys` (ESX/QB), and `Renewed-Vehiclekeys` into key bridge detection tables.

## Type of Change

- [x] Compatibility

## Related Issues

N/A

## Testing

- [x] Tested locally
- [x] Tested with latest sd-phone
- [x] Tested with latest ox_lib

## Breaking Changes

None.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.