### PR TITLE
feat(squawk): multiple accounts per character

### DIFF
--- a/configs/accounts.lua
+++ b/configs/accounts.lua
@@ -1,6 +1,6 @@
 -- App accounts engine. Governs how many accounts one character may create in each app that
--- signs in through it (Photogram, Cherry, Vibez, Ryde), and nothing else - Mail keeps its own
--- limits in configs/mail.lua, and Squawk is still one account per character.
+-- signs in through it (Photogram, Cherry, Vibez, Ryde, Squawk), and nothing else - Mail keeps
+-- its own limit in configs/mail.lua.
 return {
     -- Accounts one character may create per app. Their usernames must still differ, but the
     -- accounts may share a recovery email and phone number, so one person can run several
@@ -11,5 +11,6 @@ return {
     PerApp = {
         -- photogram = 5,
         -- ryde      = 1,
+        -- birdy     = 3,
     },
 }

--- a/server/accounts/actions.lua
+++ b/server/accounts/actions.lua
@@ -26,6 +26,10 @@ local ok, fail, digits, trim = util.ok, util.fail, util.digits, util.trim
 -- App whitelists; every handler resolves its payload `app` against one of these.
 ---@type table<string, boolean> Apps served by the generic register/login/logout/me callbacks.
 local DIRECT_APPS    = { photogram = true, cherry = true, vibez = true, ryde = true }
+---@type table<string, boolean> Apps offering the in-app account switcher. Squawk owns its own
+---register/login because it writes a profile row beside the account, so adding it to DIRECT_APPS
+---would let the generic register mint an account with no profile; switching only moves a session.
+local SWITCH_APPS    = { photogram = true, cherry = true, vibez = true, ryde = true, birdy = true }
 ---@type table<string, boolean> Every account app the engine knows (reset + vault callbacks).
 local ALL_APPS       = { photogram = true, cherry = true, vibez = true, birdy = true, mail = true, ryde = true }
 
@@ -246,7 +250,7 @@ end
 ---@return table envelope on success data = { accounts, active }
 function actions.switchable(source, payload)
     local app = payload and payload.app
-    if not DIRECT_APPS[app] then return fail('Unknown app') end
+    if not SWITCH_APPS[app] then return fail('Unknown app') end
     local cid = player.getIdentifier(source); if not cid then return fail('Player not found') end
 
     local current = store.getSessionAccount(app, cid)
@@ -271,7 +275,7 @@ end
 function actions.switchAccount(source, payload)
     payload = payload or {}
     local app = payload.app
-    if not DIRECT_APPS[app] then return fail('Unknown app') end
+    if not SWITCH_APPS[app] then return fail('Unknown app') end
     local cid = player.getIdentifier(source); if not cid then return fail('Player not found') end
     if not util.cooldown(cid, 'accounts:switch', 500) then return fail('Slow down') end
 

--- a/server/accounts/init.lua
+++ b/server/accounts/init.lua
@@ -47,6 +47,7 @@ local WIPE_TABLES = {
     'phone_birdy_profiles',
     'phone_birdy_posts',
     'phone_birdy_likes',
+    'phone_birdy_reposts',
     'phone_birdy_follows',
     'phone_birdy_dms',
     'phone_birdy_notifications',

--- a/server/accounts/store.lua
+++ b/server/accounts/store.lua
@@ -285,12 +285,22 @@ function store.migrateLegacy()
         FROM phone_birdy_profiles p
         WHERE p.handle <> '' AND p.password <> ''
     ]])
+    -- The NOT EXISTS is load-bearing, not belt-and-braces: the session key is
+    -- (app, citizenid, account_id), so a character who already signed into a second Squawk
+    -- account would collect a SECOND session row here rather than being ignored, and
+    -- getSessionAccount would then pick between them arbitrarily.
     MySQL.query.await([[
         INSERT IGNORE INTO phone_app_sessions (app, citizenid, account_id)
         SELECT 'birdy', p.citizenid, a.id
         FROM phone_birdy_profiles p
         JOIN phone_app_accounts a ON a.app = 'birdy' AND a.username = p.handle COLLATE utf8mb4_unicode_ci
         WHERE p.logged_in = 1
+          AND NOT EXISTS (
+              -- Wrapped in a derived table: a bare subquery over the INSERT's own target is
+              -- rejected outright by MySQL.
+              SELECT 1 FROM (SELECT citizenid FROM phone_app_sessions WHERE app = 'birdy') s
+              WHERE s.citizenid = p.citizenid
+          )
     ]])
     MySQL.query.await([[
         INSERT IGNORE INTO phone_app_accounts (app, username, display_name, password_hash, email)

--- a/server/admin/actions.lua
+++ b/server/admin/actions.lua
@@ -447,13 +447,14 @@ function actions.forceLogout(source, payload)
     if not cid then return fail('Missing player') end
     local app = payload and payload.app
 
+    -- The Squawk flag is resolved through the session, so it has to clear before the session does.
     if type(app) == 'string' and app ~= '' then
-        acctStore.clearSession(app, cid)
         if app == 'birdy' then store.clearBirdyLoggedIn(cid) end
+        acctStore.clearSession(app, cid)
     else
         app = 'all apps'
-        acctStore.clearAllSessions(cid)
         store.clearBirdyLoggedIn(cid)
+        acctStore.clearAllSessions(cid)
     end
 
     local aCid, aName = adminIdent(source)
@@ -497,17 +498,18 @@ function actions.birdyDeletePost(source, payload)
     return ok()
 end
 
----Toggles the verified badge on a player's Birdy profile.
+---Toggles the verified badge on one Birdy account, addressed by handle: a character can hold
+---several, so a citizenid no longer names one.
 ---@param source number admin player server id
----@param payload { cid?: string, verified?: boolean }|nil
+---@param payload { handle?: string, verified?: boolean }|nil
 ---@return table envelope
 function actions.birdySetVerified(source, payload)
-    local cid = cleanCid(payload and payload.cid)
-    if not cid then return fail('Missing player') end
+    local handle = util.trim(payload and payload.handle):lower()
+    if handle == '' or #handle > 32 then return fail('Missing account') end
     local verified = payload and payload.verified == true
-    if store.setBirdyVerified(cid, verified) == 0 then return fail('No Birdy profile') end
+    if store.setBirdyVerified(handle, verified) == 0 then return fail('No Birdy profile') end
     local aCid, aName = adminIdent(source)
-    store.audit(aCid, aName, verified and 'birdy-verify' or 'birdy-unverify', cid, '')
+    store.audit(aCid, aName, verified and 'birdy-verify' or 'birdy-unverify', nil, '@' .. handle)
     return ok()
 end
 

--- a/server/admin/store.lua
+++ b/server/admin/store.lua
@@ -6,6 +6,25 @@ local util = require 'server.util'
 ---@type table Store module; the table returned at end of file.
 local store = {}
 
+---@type string Resolves an app account username to the citizenid signed into it; formatted with
+---(app, username expression) wherever a content row carries an account rather than a character.
+local SESSION_CID = [[(
+    SELECT s.citizenid FROM phone_app_sessions s
+    JOIN phone_app_accounts a ON a.id = s.account_id
+    WHERE a.app = '%s' AND a.username = %s
+    LIMIT 1
+)]]
+
+---@type string Subquery for every Squawk handle one character is tied to: the accounts they
+---created plus the one they are signed into. Takes the citizenid twice.
+local BIRDY_HANDLES_FOR_CID = [[
+    SELECT handle FROM phone_birdy_profiles WHERE citizenid = ?
+    UNION
+    SELECT a.username FROM phone_app_sessions s
+    JOIN phone_app_accounts a ON a.id = s.account_id
+    WHERE a.app = 'birdy' AND s.citizenid = ?
+]]
+
 ---Creates the audit table and the phone-number search index idempotently.
 function store.ensureSchema()
     MySQL.query.await([[
@@ -273,19 +292,38 @@ function store.playerOverview(cid)
         ORDER BY a.app, a.username
     ]], { cid }) or {}
 
-    local birdy = MySQL.single.await([[
-        SELECT handle, display_name, bio, verified, logged_in, protected,
-               UNIX_TIMESTAMP(created_at) AS created_at
-        FROM phone_birdy_profiles WHERE citizenid = ?
-    ]], { cid })
+    -- Squawk is multi-account: a character can hold several profiles, and can also be signed into
+    -- one another character created, so both sides of the link are listed.
+    -- logged_in is derived from live sessions, not the profile column: that column is a legacy
+    -- per-account flag and cannot say which characters are in the account right now.
+    local birdy = MySQL.query.await(([[
+        SELECT p.handle, p.display_name, p.bio, p.verified, p.protected,
+               UNIX_TIMESTAMP(p.created_at) AS created_at,
+               EXISTS(SELECT 1 FROM phone_app_sessions s
+                      JOIN phone_app_accounts a ON a.id = s.account_id
+                      WHERE a.app = 'birdy' AND a.username = p.handle) AS logged_in
+        FROM phone_birdy_profiles p WHERE p.handle IN (%s) ORDER BY p.created_at
+    ]]):format(BIRDY_HANDLES_FOR_CID), { cid, cid }) or {}
 
-    if not settings and #accounts == 0 and not birdy then return nil end
+    if not settings and #accounts == 0 and #birdy == 0 then return nil end
 
     local function count(sql)
         return tonumber(MySQL.scalar.await(sql, { cid })) or 0
     end
+
+    local handles = {}
+    for i = 1, #birdy do handles[i] = birdy[i].handle end
+    local birdyPosts = 0
+    if #handles > 0 then
+        local marks = {}
+        for i = 1, #handles do marks[i] = '?' end
+        birdyPosts = tonumber(MySQL.scalar.await(
+            ('SELECT COUNT(*) FROM phone_birdy_posts WHERE author IN (%s)'):format(table.concat(marks, ',')),
+            handles)) or 0
+    end
+
     local counts = {
-        birdyPosts = count('SELECT COUNT(*) FROM phone_birdy_posts WHERE author_cid = ?'),
+        birdyPosts = birdyPosts,
         messages   = count('SELECT COUNT(*) FROM phone_messages WHERE citizenid = ?'),
         calls      = count('SELECT COUNT(*) FROM phone_calls WHERE citizenid = ?'),
         photos     = count('SELECT COUNT(*) FROM phone_photos WHERE citizenid = ?'),
@@ -305,6 +343,19 @@ function store.playerOverview(cid)
         }
     end
 
+    local birdyList = {}
+    for i, b in ipairs(birdy) do
+        birdyList[i] = {
+            handle      = b.handle,
+            displayName = b.display_name,
+            bio         = b.bio,
+            verified    = util.truthy(b.verified),
+            loggedIn    = util.truthy(b.logged_in),
+            protected   = util.truthy(b.protected),
+            createdAt   = tonumber(b.created_at),
+        }
+    end
+
     return {
         settings = settings and {
             phoneNumber  = settings.phone_number,
@@ -320,15 +371,7 @@ function store.playerOverview(cid)
             updatedAt    = tonumber(settings.updated_at),
         } or nil,
         accounts = accountList,
-        birdy = birdy and {
-            handle      = birdy.handle,
-            displayName = birdy.display_name,
-            bio         = birdy.bio,
-            verified    = util.truthy(birdy.verified),
-            loggedIn    = util.truthy(birdy.logged_in),
-            protected   = util.truthy(birdy.protected),
-            createdAt   = tonumber(birdy.created_at),
-        } or nil,
+        birdy = birdyList,
         counts = counts,
     }
 end
@@ -388,21 +431,23 @@ function store.listBirdyPosts(cursor, limit, query, authorCid)
     local ts, id = splitCursor(cursor)
     local like = (type(query) == 'string' and query ~= '') and ('%' .. escapeLike(query) .. '%') or nil
 
-    local rows = MySQL.query.await([[
-        SELECT p.id, p.author_cid, p.body, p.parent_id, p.images, p.views,
+    local rows = MySQL.query.await(([[
+        SELECT p.id, p.author, p.body, p.parent_id, p.images, p.views,
                UNIX_TIMESTAMP(p.created_at) AS ts,
                pr.handle, pr.display_name, pr.verified,
+               %s AS author_cid,
                (SELECT COUNT(*) FROM phone_birdy_likes l WHERE l.post_id = p.id) AS likes,
                (SELECT COUNT(*) FROM phone_birdy_posts c WHERE c.parent_id = p.id) AS replies
         FROM phone_birdy_posts p
-        LEFT JOIN phone_birdy_profiles pr ON pr.citizenid = p.author_cid
-        WHERE (? IS NULL OR p.author_cid = ?)
+        LEFT JOIN phone_birdy_profiles pr ON pr.handle = p.author
+        WHERE (? IS NULL OR p.author IN (%s))
           AND (? IS NULL OR p.body LIKE ? OR pr.handle LIKE ?)
           AND (? IS NULL OR p.created_at < FROM_UNIXTIME(?)
                OR (p.created_at = FROM_UNIXTIME(?) AND p.id < ?))
         ORDER BY p.created_at DESC, p.id DESC
         LIMIT ?
-    ]], { authorCid, authorCid, like, like, like, ts, ts, ts, id, limit + 1 }) or {}
+    ]]):format(SESSION_CID:format('birdy', 'p.author'), BIRDY_HANDLES_FOR_CID),
+        { authorCid, authorCid, authorCid, like, like, like, ts, ts, ts, id, limit + 1 }) or {}
 
     return shapePosts(rows, limit)
 end
@@ -425,20 +470,29 @@ function store.deleteBirdyPost(id)
     return removed
 end
 
----Sets the verified flag on a Birdy profile.
----@param cid string profile owner citizenid
+---Sets the verified flag on one Birdy profile.
+---@param handle string profile handle
 ---@param verified boolean
 ---@return integer affected
-function store.setBirdyVerified(cid, verified)
+function store.setBirdyVerified(handle, verified)
     return tonumber(MySQL.update.await(
-        'UPDATE phone_birdy_profiles SET verified = ? WHERE citizenid = ?',
-        { verified and 1 or 0, cid })) or 0
+        'UPDATE phone_birdy_profiles SET verified = ? WHERE handle = ?',
+        { verified and 1 or 0, handle })) or 0
 end
 
----Clears the legacy logged_in flag on a Birdy profile (used on admin force-logout).
----@param cid string profile owner citizenid
+---Clears the legacy logged_in flag on whichever Birdy profile this character is signed into, so
+---the one-time credential import cannot sign them back in on a later boot. Call before dropping
+---the engine session, or the lookup finds nothing.
+---@param cid string citizenid being signed out
 function store.clearBirdyLoggedIn(cid)
-    MySQL.update.await('UPDATE phone_birdy_profiles SET logged_in = 0 WHERE citizenid = ?', { cid })
+    MySQL.update.await([[
+        UPDATE phone_birdy_profiles SET logged_in = 0
+        WHERE handle IN (
+            SELECT a.username FROM phone_app_sessions s
+            JOIN phone_app_accounts a ON a.id = s.account_id
+            WHERE a.app = 'birdy' AND s.citizenid = ?
+        )
+    ]], { cid })
 end
 
 ---Clears a player's passcode and Face ID so they can get back into a locked phone.
@@ -529,15 +583,6 @@ end
 -- { id, ts, authorCid?, label?, title?, body, kind?, images? } keyset-paged
 -- newest-first on (ts, id) with an opaque "ts:id" cursor.
 -- ---------------------------------------------------------------------------
-
----Resolves a photogram/cherry account username to the citizenid signed into it (subquery
----fragment used inside the adapters below).
-local SESSION_CID = [[(
-    SELECT s.citizenid FROM phone_app_sessions s
-    JOIN phone_app_accounts a ON a.id = s.account_id
-    WHERE a.app = '%s' AND a.username = %s
-    LIMIT 1
-)]]
 
 -- Adapter shape: { deletable: boolean, list: fun(ts, id, like, limit): rows, delete?: fun(id): removed }.
 ---@type table<string, table>

--- a/server/admin/wipe.lua
+++ b/server/admin/wipe.lua
@@ -49,18 +49,12 @@ local CID_SINGLE = {
     { 'darkchat_nicknames',          'citizenid' },
     { 'darkchat_reactions',          'citizenid' },
     { 'darkchat_rooms',              'owner' },
-    { 'phone_birdy_profiles',        'citizenid' },
-    { 'phone_birdy_posts',           'author_cid' },
-    { 'phone_birdy_likes',           'citizenid' },
 }
 
 ---@type table<integer, string[]> Tables where the character can appear on either side of a
 ---relation, deleted with WHERE a = ? OR b = ?: { table, columnA, columnB }.
 local CID_PAIR = {
-    { 'phone_friends',                 'owner',         'friend' },
-    { 'phone_birdy_follows',           'follower_cid',  'target_cid' },
-    { 'phone_birdy_dms',               'from_cid',      'to_cid' },
-    { 'phone_birdy_notifications',     'recipient_cid', 'actor_cid' },
+    { 'phone_friends', 'owner', 'friend' },
 }
 
 ---Deletes one character's entire phone footprint: citizenid-keyed rows, social-app rows keyed by
@@ -130,6 +124,32 @@ local function wipeCid(cid)
         rows = rows + del('DELETE FROM phone_cherry_swipes WHERE swiper = ? OR target = ?', { ch, ch })
         rows = rows + del('DELETE FROM phone_cherry_blocks WHERE blocker = ? OR blocked = ?', { ch, ch })
         rows = rows + del('DELETE FROM phone_cherry_profiles WHERE username = ?', { ch })
+    end
+
+    -- Squawk keys its content by handle, and one character can hold several accounts, so the wipe
+    -- covers every account they created as well as whichever one they are signed into.
+    local birdyRows = MySQL.query.await([[
+        SELECT handle FROM phone_birdy_profiles WHERE citizenid = ?
+        UNION
+        SELECT a.username FROM phone_app_sessions s
+        JOIN phone_app_accounts a ON a.id = s.account_id
+        WHERE a.app = 'birdy' AND s.citizenid = ?
+    ]], { cid, cid }) or {}
+    for _, r in ipairs(birdyRows) do
+        local h = r.handle
+        del('DELETE FROM phone_birdy_likes         WHERE post_id IN (SELECT id FROM phone_birdy_posts WHERE author = ?)', { h })
+        del('DELETE FROM phone_birdy_reposts       WHERE post_id IN (SELECT id FROM phone_birdy_posts WHERE author = ?)', { h })
+        del('DELETE FROM phone_birdy_notifications WHERE post_id IN (SELECT id FROM phone_birdy_posts WHERE author = ?)', { h })
+        rows = rows + del('DELETE FROM phone_birdy_likes         WHERE handle = ?', { h })
+        rows = rows + del('DELETE FROM phone_birdy_reposts       WHERE handle = ?', { h })
+        rows = rows + del('DELETE FROM phone_birdy_posts         WHERE author = ?', { h })
+        rows = rows + del('DELETE FROM phone_birdy_follows       WHERE follower = ? OR target = ?', { h, h })
+        rows = rows + del('DELETE FROM phone_birdy_dms           WHERE from_handle = ? OR to_handle = ?', { h, h })
+        rows = rows + del('DELETE FROM phone_birdy_notifications WHERE recipient = ? OR actor = ?', { h, h })
+        rows = rows + del('DELETE FROM phone_birdy_profiles      WHERE handle = ?', { h })
+        -- By username, not by created_by: accounts made before the creator column existed carry
+        -- no owner, and leaving one behind is a login that resolves to a profile that is gone.
+        rows = rows + del("DELETE FROM phone_app_accounts WHERE app = 'birdy' AND username = ?", { h })
     end
 
     local ry = userFor['ryde']

--- a/server/badges/init.lua
+++ b/server/badges/init.lua
@@ -42,6 +42,16 @@ local function vibezCount(cid)
     return vibezStore.unseenNotificationCount(acc.username)
 end
 
+---Birdy unread = unseen notifications, keyed by the Squawk account signed in on this character;
+---0 if not signed in.
+---@param cid string framework per-character id
+---@return number unread
+local function birdyCount(cid)
+    local acc = acctStore.getSessionAccount('birdy', cid)
+    if not acc then return 0 end
+    return birdyStore.unseenNotificationCount(acc.username)
+end
+
 ---@type table<string, fun(cid: string): number> One count resolver per home-screen app id. The
 ---single source of truth for both the full snapshot and a single-app push, so the two can never
 ---disagree about which apps carry a badge.
@@ -52,7 +62,7 @@ local counters = {
     groups    = function(cid) return groupStore.pendingInviteCount(cid) end,
     photogram = photogramCount,
     vibez     = vibezCount,
-    birdy     = function(cid) return birdyStore.unseenNotificationCount(cid) end,
+    birdy     = birdyCount,
 }
 
 ---@type integer How long a computed snapshot stays reusable for the client-facing fetch (ms).

--- a/server/birdy/actions.lua
+++ b/server/birdy/actions.lua
@@ -53,7 +53,8 @@ local WRITE_BUDGET = {
 local BUDGET_WINDOW = 86400000
 
 ---Applies the caller's write budget for `key`. nil means the call may proceed; anything else is
----the envelope to hand straight back to the client.
+---the envelope to hand straight back to the client. Keyed by citizenid, never by account: a
+---budget spent per account would reset every time a player switched to an alt.
 ---@param cid string citizenid of the acting player
 ---@param key string WRITE_BUDGET key
 ---@return table|nil refusal
@@ -133,26 +134,49 @@ local function timeLabel(ms)
     return os.date('%H:%M', math.floor(ms / 1000))
 end
 
----Resolves the requesting player's signed-in Birdy profile through the shared accounts engine
----session. Returns nil when signed out.
+---The Birdy account the requesting player is signed into, plus their citizenid. The profile is
+---nil when signed out; the citizenid is nil only when the character cannot be resolved.
 ---@param source number player server id
----@return table|nil profile
+---@return table|nil profile, string|nil cid
 local function viewer(source)
     local cid = player.getIdentifier(source)
-    if not cid then return nil end
+    if not cid then return nil, nil end
     local acc = acctStore.getSessionAccount('birdy', cid)
-    if not acc then return nil end
-    return store.getProfileByHandle(acc.username)
+    if not acc then return nil, cid end
+    return store.getProfileByHandle(acc.username), cid
 end
 
----Resolves a viewer citizenid for the public read actions: the signed-in account's cid, or ''
+---Resolves a viewer handle for the public read actions: the signed-in account's handle, or ''
 ---for a guest.
 ---@param source number player server id
----@return string viewerCid '' = anonymous guest
-local function optionalViewerCid(source)
+---@return string viewerHandle '' = anonymous guest
+local function optionalViewerHandle(source)
     local prof = viewer(source)
-    return prof and prof.citizenid or ''
+    return prof and prof.handle or ''
 end
+
+---Online sources signed into `handle`'s Birdy account. One account can be open on several
+---characters at once, so a push has to reach all of them rather than a single citizenid.
+---@param handle string Birdy handle
+---@param activeSrcs table<string, number>|nil prebuilt citizenid -> source map for a fan-out
+---@return integer[] sources
+local function sourcesFor(handle, activeSrcs)
+    local acc = acctStore.getAccount('birdy', handle)
+    if not acc then return {} end
+    local out = {}
+    for _, cid in ipairs(acctStore.sessionCitizens('birdy', acc.id)) do
+        -- Indexing a prebuilt map is the same lookup getSourceByIdentifier does, minus the
+        -- rescan of every connected player that it costs once per recipient.
+        local src = activeSrcs and activeSrcs[cid] or nil
+        if not activeSrcs then src = player.getSourceByIdentifier(cid) end
+        if src then out[#out + 1] = src end
+    end
+    return out
+end
+
+---@type fun(handle: string, activeSrcs: table|nil): integer[] Shared with server.birdy.init for
+---its DM and reaction pushes.
+actions.sourcesFor = sourcesFor
 
 ---Public author shape embedded in posts, notifications and conversation heads.
 ---@param profile table
@@ -175,8 +199,8 @@ local function serializeProfile(profile)
         protected = profile.protected == true,
         avatar    = profile.avatar,
         banner    = profile.banner,
-        following = store.countFollowing(profile.citizenid),
-        followers = store.countFollowers(profile.citizenid),
+        following = store.countFollowing(profile.handle),
+        followers = store.countFollowers(profile.handle),
     }
 end
 
@@ -211,7 +235,8 @@ function actions.me(source)
 end
 
 ---Registers a new Birdy account and signs the character in. Handle uniqueness is checked
----against both stores; every field is trimmed and bounds-checked against config.Birdy.
+---against both stores; every field is trimmed and bounds-checked against config.Birdy. How many
+---accounts one character may hold is the accounts engine's per-app cap (configs/accounts.lua).
 ---@param source number player server id
 ---@param payload { name?: string, username?: string, password?: string, bio?: string, email?: string, phone?: string }
 ---@return table envelope
@@ -249,9 +274,6 @@ function actions.register(source, payload)
     if store.getProfileByHandle(handle) or acctStore.getAccount('birdy', handle) then
         return fail('That username is taken')
     end
-    if store.getProfile(cid) then
-        return fail('This character already created a Birdy account. Log into it instead')
-    end
 
     local acctRes = acctActions.createAccount('birdy', {
         username = handle, password = password, name = name,
@@ -259,14 +281,14 @@ function actions.register(source, payload)
     }, cid)
     if not acctRes.success then return acctRes end
 
-    if not store.insertAccount(cid, handle, name, store.hashPassword(password), bio, birdyCfg.DefaultVerified == true, os.date('%B %Y')) then
+    if not store.insertAccount(handle, cid, name, store.hashPassword(password), bio, birdyCfg.DefaultVerified == true, os.date('%B %Y')) then
         acctStore.deleteAccount(acctRes.data.account.id)
         return fail('Failed to create the account')
     end
     acctStore.setSession('birdy', cid, acctRes.data.account.id)
-    store.setLoggedIn(cid, true)
+    store.setLoggedIn(handle, true)
 
-    return ok({ me = serializeAuthor(store.getProfile(cid)) })
+    return ok({ me = serializeAuthor(store.getProfileByHandle(handle)) })
 end
 
 ---Signs in to any existing Birdy account by handle + password. Accepts the handle or the linked
@@ -301,18 +323,22 @@ function actions.login(source, payload)
     if not prof then return fail('That account has no Birdy profile') end
 
     acctStore.setSession('birdy', cid, acc.id)
-    store.setLoggedIn(prof.citizenid, true)
+    store.setLoggedIn(prof.handle, true)
     return ok({ me = serializeAuthor(prof) })
 end
 
----Signs out: keeps the account, drops this character's engine session. Idempotent.
+---Signs out: keeps the account, drops this character's engine session. Idempotent. The account's
+---signed-in flag only clears once no character is left in it.
 ---@param source number player server id
 ---@return table envelope
 function actions.logout(source)
     local cid = player.getIdentifier(source)
     if cid then
+        local acc = acctStore.getSessionAccount('birdy', cid)
         acctStore.clearSession('birdy', cid)
-        store.setLoggedIn(cid, false)
+        if acc and #acctStore.sessionCitizens('birdy', acc.id) == 0 then
+            store.setLoggedIn(acc.username, false)
+        end
     end
     return ok()
 end
@@ -324,55 +350,55 @@ end
 ---@return table envelope
 function actions.profile(source, payload)
     payload = tbl(payload)
-    local viewerCid = optionalViewerCid(source)
+    local me = optionalViewerHandle(source)
     local handle = payload and payload.handle and normalizeHandle(payload.handle)
     local prof
     if handle and handle ~= '' then
         prof = store.getProfileByHandle(handle)
-    elseif viewerCid ~= '' then
-        prof = store.getProfile(viewerCid)
+    elseif me ~= '' then
+        prof = store.getProfileByHandle(me)
     end
     if not prof then return fail('Profile not found') end
 
     local data = serializeProfile(prof)
-    local isMe = viewerCid ~= '' and prof.citizenid == viewerCid
+    local isMe = me ~= '' and prof.handle == me
     data.isMe = isMe
-    data.isFollowing = ((not isMe) and viewerCid ~= '' and store.isFollowing(viewerCid, prof.citizenid)) or false
+    data.isFollowing = ((not isMe) and me ~= '' and store.isFollowing(me, prof.handle)) or false
     return ok({ profile = data })
 end
 
----Posts for a profile tab: 'posts', 'replies', 'media', or 'likes'. targetCid = whose posts,
----viewerCid = whose like-state colours the hearts. Read-only.
+---Posts for a profile tab: 'posts', 'replies', 'media', or 'likes'. target = whose posts,
+---me = whose like-state colours the hearts. Read-only.
 ---@param source number player server id
 ---@param payload { kind?: string, handle?: string }|nil
 ---@return table envelope
 function actions.profilePosts(source, payload)
     payload = tbl(payload)
-    local viewerCid = optionalViewerCid(source)
+    local me = optionalViewerHandle(source)
     local handle = payload and payload.handle and normalizeHandle(payload.handle)
-    local targetCid
+    local target
     if handle and handle ~= '' then
         local tp = store.getProfileByHandle(handle)
-        targetCid = tp and tp.citizenid
-    elseif viewerCid ~= '' then
-        targetCid = viewerCid
+        target = tp and tp.handle
+    elseif me ~= '' then
+        target = me
     end
-    if not targetCid then return fail('Profile not found') end
+    if not target then return fail('Profile not found') end
     local kind = (payload and payload.kind) or 'posts'
 
     -- Protected profiles expose posts only to themselves and their followers.
-    if targetCid ~= viewerCid then
-        local tp = store.getProfile(targetCid)
-        if tp and tp.protected and not (viewerCid ~= '' and store.isFollowing(viewerCid, targetCid)) then
+    if target ~= me then
+        local tp = store.getProfileByHandle(target)
+        if tp and tp.protected and not (me ~= '' and store.isFollowing(me, target)) then
             return ok({ posts = {}, protected = true })
         end
     end
 
     local rows
     if kind == 'likes' then
-        rows = store.listLikedBy(targetCid, viewerCid, birdyCfg.FeedLimit)
+        rows = store.listLikedBy(target, me, birdyCfg.FeedLimit)
     else
-        rows = store.listPostsBy(targetCid, kind, viewerCid, birdyCfg.FeedLimit)
+        rows = store.listPostsBy(target, kind, me, birdyCfg.FeedLimit)
     end
 
     local posts = {}
@@ -387,10 +413,10 @@ end
 ---@return table envelope
 function actions.search(source, payload)
     payload = tbl(payload)
-    local viewerCid = optionalViewerCid(source)
+    local me = optionalViewerHandle(source)
     local q = trimmed(payload and payload.query)
     if not q or #q == 0 then return ok({ users = {} }) end
-    local rows = store.searchProfiles(q:sub(1, 64), viewerCid, 20)
+    local rows = store.searchProfiles(q:sub(1, 64), me, 20)
     local users = {}
     for i = 1, #rows do
         users[i] = { name = rows[i].displayName, handle = rows[i].handle, verified = rows[i].verified }
@@ -410,17 +436,17 @@ end
 ---@return table envelope
 function actions.hashtag(source, payload)
     payload = tbl(payload)
-    local viewerCid = optionalViewerCid(source)
+    local me = optionalViewerHandle(source)
     local raw = trimmed(payload.tag)
     local tag = raw and raw:sub(1, 64):match('^#?([%w_]+)')
     if not tag then return ok({ posts = {} }) end
-    local rows = store.postsByHashtag(tag:lower(), viewerCid, birdyCfg.FeedLimit)
+    local rows = store.postsByHashtag(tag:lower(), me, birdyCfg.FeedLimit)
     local posts = {}
     for i = 1, #rows do posts[i] = serializePost(rows[i]) end
     return ok({ posts = posts })
 end
 
----Updates the signed-in user's editable profile fields. Missing fields keep their current
+---Updates the signed-in account's editable profile fields. Missing fields keep their current
 ---value; everything is trimmed and bounds-checked.
 ---@param source number player server id
 ---@param payload { name?: string, bio?: string, protected?: boolean, avatar?: string|false, banner?: string|false }|nil
@@ -446,12 +472,12 @@ function actions.updateProfile(source, payload)
     local banner = imageUrl(payload.banner, prof.banner)
 
     -- joinLabel is ignored; the join date is derived from created_at.
-    store.updateProfileFields(prof.citizenid, name, bio, prof.joinLabel or '', payload.protected == true, avatar, banner)
-    return ok({ profile = serializeProfile(store.getProfile(prof.citizenid)) })
+    store.updateProfileFields(prof.handle, name, bio, prof.joinLabel or '', payload.protected == true, avatar, banner)
+    return ok({ profile = serializeProfile(store.getProfileByHandle(prof.handle)) })
 end
 
----Changes the signed-in user's password, syncing the engine hash, the Passwords-app vault copy,
----and Birdy's legacy profile-row hash.
+---Changes the signed-in account's password, syncing the engine hash, the Passwords-app vault
+---copy, and Birdy's legacy profile-row hash.
 ---@param source number player server id
 ---@param payload { password?: string }|nil
 ---@return table envelope
@@ -468,11 +494,11 @@ function actions.changePassword(source, payload)
     acctStore.setPassword(acc.id, acctStore.hashPassword(password))
     acctStore.syncVaultPassword('birdy', acc.username, password)
     local prof = store.getProfileByHandle(acc.username)
-    if prof then store.setPassword(prof.citizenid, store.hashPassword(password)) end
+    if prof then store.setPassword(prof.handle, store.hashPassword(password)) end
     return ok()
 end
 
----Permanently deletes the signed-in user's account and all of its content: content rows first,
+---Permanently deletes the signed-in account and all of its content: content rows first,
 ---then the engine account.
 ---@param source number player server id
 ---@return table envelope
@@ -481,7 +507,7 @@ function actions.deleteAccount(source)
     local acc = cid and acctStore.getSessionAccount('birdy', cid) or nil
     if not acc then return fail('Not signed in') end
     local prof = store.getProfileByHandle(acc.username)
-    if prof then store.deleteAccount(prof.citizenid) end
+    if prof then store.deleteAccount(prof.handle) end
     acctStore.deleteAccount(acc.id)
     return ok()
 end
@@ -493,9 +519,9 @@ end
 ---@return table envelope
 function actions.feed(source, payload)
     payload = tbl(payload)
-    local viewerCid = optionalViewerCid(source)
-    local following = viewerCid ~= '' and payload and payload.following == true
-    local rows = store.listFeed(viewerCid, birdyCfg.FeedLimit, following)
+    local me = optionalViewerHandle(source)
+    local following = me ~= '' and payload and payload.following == true
+    local rows = store.listFeed(me, birdyCfg.FeedLimit, following)
     local posts = {}
     for i = 1, #rows do posts[i] = serializePost(rows[i]) end
     return ok({ posts = posts })
@@ -507,16 +533,16 @@ end
 ---@return table envelope
 function actions.post(source, payload)
     payload = tbl(payload)
-    local viewerCid = optionalViewerCid(source)
+    local me = optionalViewerHandle(source)
     local id = payload and payload.id
     if type(id) ~= 'string' or id == '' then return fail('Post id required') end
 
-    store.bumpViews(id, viewerCid)
-    local row = store.getPost(id, viewerCid)
+    store.bumpViews(id, me)
+    local row = store.getPost(id, me)
     if not row then return fail('Post not found') end
 
     local post = serializePost(row)
-    local replyRows = store.listReplies(id, viewerCid)
+    local replyRows = store.listReplies(id, me)
     local thread = {}
     for i = 1, #replyRows do thread[i] = serializePost(replyRows[i]) end
     post.thread = thread
@@ -524,15 +550,15 @@ function actions.post(source, payload)
     return ok({ post = post })
 end
 
----Creates a top-level post as the session profile. A post needs text OR at least one image; the
+---Creates a top-level post as the session account. A post needs text OR at least one image; the
 ---body is trimmed and capped, images are whitelisted, and the row id is server-generated.
 ---@param source number player server id
 ---@param payload { body?: string, images?: string[] }|nil
 ---@return table envelope
 function actions.create(source, payload)
-    local prof = viewer(source); if not prof then return fail('Player not found') end
-    local muted = moderation.guard(prof.citizenid, 'birdy'); if muted then return muted end
-    local slow = throttle(prof.citizenid, 'create'); if slow then return slow end
+    local prof, cid = viewer(source); if not prof or not cid then return fail('Player not found') end
+    local muted = moderation.guard(cid, 'birdy'); if muted then return muted end
+    local slow = throttle(cid, 'create'); if slow then return slow end
     payload = tbl(payload)
     local body = trimmed(payload and payload.body) or ''
     local images = sanitizeImages(payload and payload.images)
@@ -540,11 +566,12 @@ function actions.create(source, payload)
     if #body > birdyCfg.MaxPostLength then return fail('Post is too long') end
 
     local id = store.newId()
-    if not store.insertPost(id, prof.citizenid, body, nil, images) then return fail('Failed to post') end
+    if not store.insertPost(id, prof.handle, body, nil, images) then return fail('Failed to post') end
 
-    -- First-party hook: one server-local event per created post; the payload carries a citizenid.
+    -- First-party hook: one server-local event per created post; the citizenid is the character
+    -- who posted, which is not necessarily the one that created the account.
     TriggerEvent('sd-phone:server:birdy:post', {
-        id = id, source = source, citizenid = prof.citizenid,
+        id = id, source = source, citizenid = cid,
         username = prof.handle, displayName = prof.displayName,
         body = body, images = images,
     })
@@ -554,22 +581,21 @@ function actions.create(source, payload)
     watchers.push('sd-phone:client:birdy:feedChanged', {})
 
     local preview   = body ~= '' and body:sub(1, 80) or 'shared a photo'
-    local followers = store.followerCids(prof.citizenid)
+    local followers = store.followerHandles(prof.handle)
 
-    if #followers == 0 then return ok({ post = serializePost(store.getPost(id, prof.citizenid)) }) end
+    if #followers == 0 then return ok({ post = serializePost(store.getPost(id, prof.handle)) }) end
 
     local notifs = {}
     for i = 1, #followers do
-        notifs[i] = { id = store.newId(), recipient = followers[i], kind = 'post', actor = prof.citizenid, postId = id }
+        notifs[i] = { id = store.newId(), recipient = followers[i], kind = 'post', actor = prof.handle, postId = id }
     end
     store.insertNotifications(notifs)
 
     -- One pass over the connected players for the whole fan-out; this resolved each follower
     -- separately, and every resolution re-scanned every player on the server.
     local activeSrcs = player.activeCidMap()
-    for _, cid in ipairs(followers) do
-        local src = activeSrcs[cid]
-        if src then
+    for _, handle in ipairs(followers) do
+        for _, src in ipairs(sourcesFor(handle, activeSrcs)) do
             TriggerClientEvent('sd-phone:client:birdy:notification', src, {})
             TriggerClientEvent('sd-phone:client:notify', src, {
                 app = 'birdy', appId = 'birdy', title = 'Squawk',
@@ -580,19 +606,19 @@ function actions.create(source, payload)
         end
     end
 
-    return ok({ post = serializePost(store.getPost(id, prof.citizenid)) })
+    return ok({ post = serializePost(store.getPost(id, prof.handle)) })
 end
 
 ---Replies to a post; the parent must exist. A reply needs text OR at least one image. Returns
----the new reply plus the recipient citizenid for the parent-author notification (never for
+---the new reply plus the recipient handle for the parent-author notification (never for
 ---self-replies).
 ---@param source number player server id
 ---@param payload { parentId?: string, body?: string, images?: string[] }|nil
 ---@return table envelope
 function actions.reply(source, payload)
-    local prof = viewer(source); if not prof then return fail('Player not found') end
-    local muted = moderation.guard(prof.citizenid, 'birdy'); if muted then return muted end
-    local slow = throttle(prof.citizenid, 'reply'); if slow then return slow end
+    local prof, cid = viewer(source); if not prof or not cid then return fail('Player not found') end
+    local muted = moderation.guard(cid, 'birdy'); if muted then return muted end
+    local slow = throttle(cid, 'reply'); if slow then return slow end
     payload = tbl(payload)
     local parentId = payload and payload.parentId
     local body = trimmed(payload and payload.body) or ''
@@ -605,87 +631,87 @@ function actions.reply(source, payload)
     if not parentAuthor then return fail('Post not found') end
 
     local id = store.newId()
-    if not store.insertPost(id, prof.citizenid, body, parentId, images) then return fail('Failed to reply') end
+    if not store.insertPost(id, prof.handle, body, parentId, images) then return fail('Failed to reply') end
 
-    local notifyCid = nil
-    if parentAuthor ~= prof.citizenid then
-        store.insertNotification(store.newId(), parentAuthor, 'reply', prof.citizenid, id)
-        notifyCid = parentAuthor
+    local notify = nil
+    if parentAuthor ~= prof.handle then
+        store.insertNotification(store.newId(), parentAuthor, 'reply', prof.handle, id)
+        notify = parentAuthor
     end
 
-    return ok({ post = serializePost(store.getPost(id, prof.citizenid)), notifyCid = notifyCid })
+    return ok({ post = serializePost(store.getPost(id, prof.handle)), notify = notify })
 end
 
----Toggles the viewer's like on a post. Returns the new liked state plus the author citizenid to
+---Toggles the viewer's like on a post. Returns the new liked state plus the author handle to
 ---notify when a like was just added (not on unlike, never for self-likes).
 ---@param source number player server id
 ---@param payload { id?: string }|nil
 ---@return table envelope
 function actions.toggleLike(source, payload)
-    local prof = viewer(source); if not prof then return fail('Player not found') end
+    local prof, cid = viewer(source); if not prof or not cid then return fail('Player not found') end
     payload = tbl(payload)
     local id = payload and payload.id
     if type(id) ~= 'string' or id == '' then return fail('Missing post') end
-    local slow = throttle(prof.citizenid, 'like'); if slow then return slow end
+    local slow = throttle(cid, 'like'); if slow then return slow end
 
     local author = store.getPostAuthor(id)
     if not author then return fail('Post not found') end
 
     local nowLiked
-    if store.isLiked(id, prof.citizenid) then
-        store.removeLike(id, prof.citizenid)
+    if store.isLiked(id, prof.handle) then
+        store.removeLike(id, prof.handle)
         nowLiked = false
     else
-        store.addLike(id, prof.citizenid)
+        store.addLike(id, prof.handle)
         nowLiked = true
     end
 
     -- Un-liking does not delete the notification, so re-liking would otherwise mint a permanent
     -- duplicate on every flip.
-    local notifyCid = nil
-    if nowLiked and author ~= prof.citizenid
-        and not store.recentNotification(author, 'like', prof.citizenid, id, NOTIF_DEDUPE) then
-        store.insertNotification(store.newId(), author, 'like', prof.citizenid, id)
-        notifyCid = author
+    local notify = nil
+    if nowLiked and author ~= prof.handle
+        and not store.recentNotification(author, 'like', prof.handle, id, NOTIF_DEDUPE) then
+        store.insertNotification(store.newId(), author, 'like', prof.handle, id)
+        notify = author
     end
 
-    return ok({ liked = nowLiked, notifyCid = notifyCid })
+    return ok({ liked = nowLiked, notify = notify })
 end
 
----Toggles a repost of a post. Mirrors toggleLike: idempotent per (post, citizen), and notifies
+---Toggles a repost of a post. Mirrors toggleLike: idempotent per (post, account), and notifies
 ---the post's author on a new repost (never on un-repost, never for self-reposts).
 ---@param source number player server id
 ---@param payload { id?: string }|nil
 ---@return table envelope
 function actions.toggleRepost(source, payload)
-    local prof = viewer(source); if not prof then return fail('Player not found') end
+    local prof, cid = viewer(source); if not prof or not cid then return fail('Player not found') end
     payload = tbl(payload)
     local id = payload and payload.id
     if type(id) ~= 'string' or id == '' then return fail('Missing post') end
-    local slow = throttle(prof.citizenid, 'repost'); if slow then return slow end
+    local slow = throttle(cid, 'repost'); if slow then return slow end
 
     local author = store.getPostAuthor(id)
     if not author then return fail('Post not found') end
 
     local nowReposted
-    if store.isReposted(id, prof.citizenid) then
-        store.removeRepost(id, prof.citizenid)
+    if store.isReposted(id, prof.handle) then
+        store.removeRepost(id, prof.handle)
         nowReposted = false
     else
-        store.addRepost(id, prof.citizenid)
+        store.addRepost(id, prof.handle)
         nowReposted = true
     end
 
     -- Un-reposting does not delete the notification, so re-reposting would otherwise mint a
     -- permanent duplicate on every flip.
-    local notifyCid = nil
-    if nowReposted and author ~= prof.citizenid
-        and not store.recentNotification(author, 'repost', prof.citizenid, id, NOTIF_DEDUPE) then
-        store.insertNotification(store.newId(), author, 'repost', prof.citizenid, id)
-        notifyCid = author
+    local notify = nil
+    if nowReposted and author ~= prof.handle
+        and not store.recentNotification(author, 'repost', prof.handle, id, NOTIF_DEDUPE) then
+        store.insertNotification(store.newId(), author, 'repost', prof.handle, id)
+        notify = author
     end
 
-    return ok({ reposted = nowReposted, notifyCid = notifyCid })
+    return ok({ reposted = nowReposted, notify = notify })
 end
 
 ---Followers or following for a handle (defaulting to the viewer's own profile), shaped for the
@@ -700,20 +726,20 @@ function actions.followList(source, payload)
     local kind = payload.kind == 'following' and 'following' or 'followers'
 
     -- No handle means own list; an unknown handle is empty, not an error.
-    local targetCid = prof.citizenid
+    local target = prof.handle
     local handle = payload.handle and normalizeHandle(payload.handle)
     if handle and handle ~= '' and handle ~= prof.handle then
         local tp = store.getProfileByHandle(handle)
         if not tp then return ok({ users = {} }) end
         -- Protected profiles hide their follow graph from non-followers.
-        if tp.protected and not store.isFollowing(prof.citizenid, tp.citizenid) then
+        if tp.protected and not store.isFollowing(prof.handle, tp.handle) then
             return ok({ users = {} })
         end
-        targetCid = tp.citizenid
+        target = tp.handle
     end
 
     local users = {}
-    for _, row in ipairs(store.followList(prof.citizenid, targetCid, kind)) do
+    for _, row in ipairs(store.followList(prof.handle, target, kind)) do
         users[#users + 1] = {
             name        = row.display_name,
             handle      = row.handle,
@@ -727,41 +753,38 @@ function actions.followList(source, payload)
     return ok({ users = users })
 end
 
----Toggles following another account, addressed by handle (preferred) or citizenid. Self-follows
----are rejected. Returns the target to notify on a new follow (not on unfollow).
+---Toggles following another account by handle. Self-follows are rejected. Returns the target to
+---notify on a new follow (not on unfollow).
 ---@param source number player server id
----@param payload { handle?: string, targetCid?: string }|nil
+---@param payload { handle?: string }|nil
 ---@return table envelope
 function actions.toggleFollow(source, payload)
-    local prof = viewer(source); if not prof then return fail('Player not found') end
+    local prof, cid = viewer(source); if not prof or not cid then return fail('Player not found') end
     payload = tbl(payload)
     local handle = payload and payload.handle and normalizeHandle(payload.handle)
-    local target = payload and payload.targetCid
-    if handle and handle ~= '' then
-        local tp = store.getProfileByHandle(handle)
-        target = tp and tp.citizenid
-    end
-    if type(target) ~= 'string' or target == '' or #target > 64 then return fail('Missing account') end
-    if target == prof.citizenid then return fail('You cannot follow yourself') end
-    local slow = throttle(prof.citizenid, 'follow'); if slow then return slow end
+    if not handle or handle == '' or #handle > 32 then return fail('Missing account') end
+    if handle == prof.handle then return fail('You cannot follow yourself') end
+    local target = store.getProfileByHandle(handle)
+    if not target then return fail('Missing account') end
+    local slow = throttle(cid, 'follow'); if slow then return slow end
 
-    local notifyCid = nil
+    local notify = nil
     local nowFollowing
-    if store.isFollowing(prof.citizenid, target) then
-        store.removeFollow(prof.citizenid, target)
+    if store.isFollowing(prof.handle, target.handle) then
+        store.removeFollow(prof.handle, target.handle)
         nowFollowing = false
     else
-        store.addFollow(prof.citizenid, target)
+        store.addFollow(prof.handle, target.handle)
         nowFollowing = true
         -- Unfollowing does not delete the notification, so re-following would otherwise mint a
         -- permanent duplicate on every flip.
-        if not store.recentNotification(target, 'follow', prof.citizenid, nil, NOTIF_DEDUPE) then
-            store.insertNotification(store.newId(), target, 'follow', prof.citizenid, nil)
-            notifyCid = target
+        if not store.recentNotification(target.handle, 'follow', prof.handle, nil, NOTIF_DEDUPE) then
+            store.insertNotification(store.newId(), target.handle, 'follow', prof.handle, nil)
+            notify = target.handle
         end
     end
 
-    return ok({ following = nowFollowing, notifyCid = notifyCid })
+    return ok({ following = nowFollowing, notify = notify })
 end
 
 ---Lists the viewer's notifications, serialized into the React union shape. Reply notifications
@@ -770,17 +793,17 @@ end
 ---@return table envelope
 function actions.notifications(source)
     local prof = viewer(source); if not prof then return fail('Player not found') end
-    local rows = store.listNotifications(prof.citizenid, birdyCfg.NotificationLimit)
+    local rows = store.listNotifications(prof.handle, birdyCfg.NotificationLimit)
 
-    local actorCids = {}
-    for i = 1, #rows do actorCids[#actorCids + 1] = rows[i].actor_cid end
-    local profiles = store.getProfilesByCids(actorCids)
+    local actors = {}
+    for i = 1, #rows do actors[#actors + 1] = rows[i].actor end
+    local profiles = store.getProfilesByHandles(actors)
 
     local replyPostIds = {}
     for i = 1, #rows do
         if rows[i].kind == 'reply' and rows[i].post_id then replyPostIds[#replyPostIds + 1] = rows[i].post_id end
     end
-    local replyPosts = store.postsByIds(replyPostIds, prof.citizenid)
+    local replyPosts = store.postsByIds(replyPostIds, prof.handle)
 
     local items = {}
     for i = 1, #rows do
@@ -791,7 +814,7 @@ function actions.notifications(source)
                 items[#items + 1] = { id = r.id, kind = 'reply', post = serializePost(postRow) }
             end
         else
-            local ap = profiles[r.actor_cid]
+            local ap = profiles[r.actor]
             local user = ap and serializeAuthor(ap) or { name = 'Someone', handle = 'someone', verified = false }
             if r.kind == 'like' then
                 items[#items + 1] = { id = r.id, kind = 'like', user = user, text = 'liked your post' }
@@ -805,7 +828,7 @@ function actions.notifications(source)
         end
     end
 
-    store.markNotificationsSeen(prof.citizenid)
+    store.markNotificationsSeen(prof.handle)
     badges.pushApp(source, 'birdy')
 
     return ok({ notifications = items })
@@ -817,7 +840,7 @@ end
 function actions.notificationCount(source)
     local prof = viewer(source)
     if not prof then return ok({ count = 0 }) end
-    return ok({ count = store.unseenNotificationCount(prof.citizenid) })
+    return ok({ count = store.unseenNotificationCount(prof.handle) })
 end
 
 -- Rich DM messages (text / image / gif / money / location / voice).
@@ -877,13 +900,13 @@ end
 ---DB row -> the client DM message shape: `fromMe` from the viewer's perspective plus whichever
 ---rich fields the bubble renders. Reactions are re-shaped per viewer.
 ---@param row table
----@param viewerCid string
+---@param viewerHandle string
 ---@return table
-local function serializeDm(row, viewerCid)
+local function serializeDm(row, viewerHandle)
     local meta = store.decodeJson(row.meta)
     local msg = {
         id     = row.id,
-        fromMe = row.from_cid == viewerCid,
+        fromMe = row.from_handle == viewerHandle,
         body   = row.body or '',
         kind   = row.kind or 'text',
         ts     = row.created_ms or 0,
@@ -903,7 +926,7 @@ local function serializeDm(row, viewerCid)
         local out = {}
         for emoji, users in pairs(reactions) do
             local mine = false
-            for _, u in ipairs(users) do if u == viewerCid then mine = true break end end
+            for _, u in ipairs(users) do if u == viewerHandle then mine = true break end end
             if #users > 0 then out[#out + 1] = { emoji = emoji, count = #users, mine = mine } end
         end
         if #out > 0 then msg.reactions = out end
@@ -917,16 +940,16 @@ end
 ---@return table envelope
 function actions.dmList(source)
     local prof = viewer(source); if not prof then return fail('Player not found') end
-    local msgs = store.listMessagesFor(prof.citizenid)
+    local msgs = store.listMessagesFor(prof.handle)
 
     local function isRead(v) return v == true or v == 1 or v == '1' end
 
     local lastByOther, unreadByOther = {}, {}
     for i = 1, #msgs do
         local m = msgs[i]
-        local other = (m.from_cid == prof.citizenid) and m.to_cid or m.from_cid
+        local other = (m.from_handle == prof.handle) and m.to_handle or m.from_handle
         lastByOther[other] = m
-        if m.to_cid == prof.citizenid and not isRead(m.read_flag) then
+        if m.to_handle == prof.handle and not isRead(m.read_flag) then
             unreadByOther[other] = (unreadByOther[other] or 0) + 1
         end
     end
@@ -935,7 +958,7 @@ function actions.dmList(source)
     for other in pairs(lastByOther) do others[#others + 1] = other end
     table.sort(others, function(a, b) return lastByOther[a].created_ms > lastByOther[b].created_ms end)
 
-    local profiles = store.getProfilesByCids(others)
+    local profiles = store.getProfilesByHandles(others)
     local convos = {}
     for i = 1, #others do
         local other = others[i]
@@ -946,14 +969,14 @@ function actions.dmList(source)
             user     = p and serializeAuthor(p) or { name = 'Unknown', handle = 'unknown', verified = false },
             updated  = relativeLabel(last.created_ms),
             unread   = unreadByOther[other] or 0,
-            messages = { serializeDm(last, prof.citizenid) },
+            messages = { serializeDm(last, prof.handle) },
         }
     end
 
     return ok({ conversations = convos })
 end
 
----Full message thread with one other party (conversation id = their cid). Opening the thread
+---Full message thread with one other party (conversation id = their handle). Opening the thread
 ---clears its unread flags.
 ---@param source number player server id
 ---@param payload { id?: string }|nil
@@ -964,13 +987,13 @@ function actions.dmThread(source, payload)
     local other = payload and payload.id
     if type(other) ~= 'string' or other == '' then return fail('Missing conversation') end
 
-    local rows = store.listThread(prof.citizenid, other)
+    local rows = store.listThread(prof.handle, other)
     local messages = {}
-    for i = 1, #rows do messages[i] = serializeDm(rows[i], prof.citizenid) end
+    for i = 1, #rows do messages[i] = serializeDm(rows[i], prof.handle) end
 
-    store.markThreadRead(prof.citizenid, other)
+    store.markThreadRead(prof.handle, other)
 
-    local op = store.getProfile(other)
+    local op = store.getProfileByHandle(other)
     return ok({
         id       = other,
         user     = op and serializeAuthor(op) or { name = 'Unknown', handle = 'unknown', verified = false },
@@ -987,12 +1010,12 @@ function actions.markRead(source, payload)
     payload = tbl(payload)
     local other = payload and payload.id
     if type(other) ~= 'string' or other == '' then return fail('Missing conversation') end
-    store.markThreadRead(prof.citizenid, other)
+    store.markThreadRead(prof.handle, other)
     return ok()
 end
 
----Resolves a handle to its DM conversation id (the other party's cid) plus their author card,
----so the UI can open a thread with someone it has never messaged. Read-only.
+---Resolves a handle to its DM conversation id plus the account's author card, so the UI can open
+---a thread with someone it has never messaged. Read-only.
 ---@param source number player server id
 ---@param payload { handle?: string }|nil
 ---@return table envelope
@@ -1001,31 +1024,26 @@ function actions.dmResolve(source, payload)
     payload = tbl(payload)
     local tp = store.getProfileByHandle(normalizeHandle(payload.handle or '') or '')
     if not tp then return fail('Account not found') end
-    if tp.citizenid == prof.citizenid then return fail('You cannot message yourself') end
-    return ok({ id = tp.citizenid, user = serializeAuthor(tp) })
+    if tp.handle == prof.handle then return fail('You cannot message yourself') end
+    return ok({ id = tp.handle, user = serializeAuthor(tp) })
 end
 
 ---Sends a DM of any kind. Returns the sender's own message + the recipient's copy + the routing
 ---data init needs. Money clears through banking.send before the row is stored.
 ---@param source number player server id
----@param payload table { toCid, kind, body, gifUrl, amount, requested, duration, audioUrl, waveform, wpCode, wpSub }
+---@param payload table { to, kind, body, gifUrl, amount, requested, duration, audioUrl, waveform, wpCode, wpSub }
 ---@return table envelope
 function actions.dmSend(source, payload)
-    local prof = viewer(source); if not prof then return fail('Player not found') end
-    local muted = moderation.guard(prof.citizenid, 'birdy'); if muted then return muted end
-    local slow = throttle(prof.citizenid, 'dm'); if slow then return slow end
+    local prof, cid = viewer(source); if not prof or not cid then return fail('Player not found') end
+    local muted = moderation.guard(cid, 'birdy'); if muted then return muted end
+    local slow = throttle(cid, 'dm'); if slow then return slow end
     payload = tbl(payload)
-    local toCid = payload.toCid
-    -- Discovery surfaces only expose handles, so accept one and resolve it here.
-    if (type(toCid) ~= 'string' or toCid == '') and payload.toHandle then
-        local tp = store.getProfileByHandle(normalizeHandle(payload.toHandle) or '')
-        toCid = tp and tp.citizenid
-    end
-    if type(toCid) ~= 'string' or toCid == '' or #toCid > 64 then return fail('Missing recipient') end
-    if toCid == prof.citizenid then return fail('You cannot message yourself') end
-    -- Without this a DM addressed to a made-up citizenid is stored forever: no owner can open it,
+    local to = normalizeHandle(payload.to or payload.toHandle or '')
+    if not to or to == '' or #to > 32 then return fail('Missing recipient') end
+    if to == prof.handle then return fail('You cannot message yourself') end
+    -- Without this a DM addressed to a made-up handle is stored forever: no owner can open it,
     -- and no account-delete or wipe path reaches it.
-    if not store.getProfile(toCid) then return fail('Account not found') end
+    if not store.getProfileByHandle(to) then return fail('Account not found') end
 
     local kind = VALID_DM_KINDS[payload.kind] and payload.kind or 'text'
     local body = (trimmed(payload.body) or ''):sub(1, birdyCfg.MaxDmLength)
@@ -1033,8 +1051,14 @@ function actions.dmSend(source, payload)
     if not dmHasContent(kind, body, meta) then return fail('Message cannot be empty') end
 
     if kind == 'money' and not meta.requested then
-        local tsrc = player.getSourceByIdentifier(toCid)
-        if not tsrc then return fail('They need to be online to receive money') end
+        -- The money lands in a character's account, not the Squawk account, so it needs whichever
+        -- character currently has the recipient's account open.
+        local acc = acctStore.getAccount('birdy', to)
+        local toCid
+        for _, c in ipairs(acc and acctStore.sessionCitizens('birdy', acc.id) or {}) do
+            if player.getSourceByIdentifier(c) then toCid = c break end
+        end
+        if not toCid then return fail('They need to be online to receive money') end
         local number = settings.getPhoneNumber(toCid)
         if not number then return fail('Payment failed') end
         local res = banking.send(source, { number = number, amount = meta.amount, note = 'Birdy payment' })
@@ -1042,30 +1066,30 @@ function actions.dmSend(source, payload)
     end
 
     local id = store.newId()
-    if not store.insertDm(id, prof.citizenid, toCid, kind, body, meta) then return fail('Failed to send') end
+    if not store.insertDm(id, prof.handle, to, kind, body, meta) then return fail('Failed to send') end
 
     local row = store.getDm(id)
     return ok({
-        message         = serializeDm(row, prof.citizenid),
-        messageForOther = serializeDm(row, toCid),
-        toCid           = toCid,
-        fromCid         = prof.citizenid,
+        message         = serializeDm(row, prof.handle),
+        messageForOther = serializeDm(row, to),
+        to              = to,
+        from            = prof.handle,
         fromProfile     = serializeAuthor(prof),
     })
 end
 
 ---Toggles the viewer's reaction on a DM; both parties get the new set. Only a participant may
----react; the emoji key is length-capped. conversationId = the caller's cid.
+---react; the emoji key is length-capped. conversationId = the caller's handle.
 ---@param source number player server id
 ---@param payload { id?: string, emoji?: string }|nil
 ---@return table envelope
 function actions.dmReact(source, payload)
-    local prof = viewer(source); if not prof then return fail('Player not found') end
+    local prof, cid = viewer(source); if not prof or not cid then return fail('Player not found') end
     payload = tbl(payload)
-    local slow = throttle(prof.citizenid, 'react'); if slow then return slow end
+    local slow = throttle(cid, 'react'); if slow then return slow end
     local row = type(payload.id) == 'string' and store.getDm(payload.id) or nil
     if not row then return fail('Message not found') end
-    if row.from_cid ~= prof.citizenid and row.to_cid ~= prof.citizenid then return fail('Message not found') end
+    if row.from_handle ~= prof.handle and row.to_handle ~= prof.handle then return fail('Message not found') end
 
     local emoji = tostring(payload.emoji or '')
     if not REACTION_SET[emoji] then return fail('Invalid reaction') end
@@ -1073,19 +1097,19 @@ function actions.dmReact(source, payload)
     local reactions = store.decodeJson(row.reactions)
     local users = reactions[emoji] or {}
     local found
-    for i, u in ipairs(users) do if u == prof.citizenid then found = i break end end
-    if found then table.remove(users, found) else users[#users + 1] = prof.citizenid end
+    for i, u in ipairs(users) do if u == prof.handle then found = i break end end
+    if found then table.remove(users, found) else users[#users + 1] = prof.handle end
     if #users > 0 then reactions[emoji] = users else reactions[emoji] = nil end
     store.updateDmReactions(row.id, reactions)
 
     local fresh = store.getDm(row.id)
-    local other = (row.from_cid == prof.citizenid) and row.to_cid or row.from_cid
+    local other = (row.from_handle == prof.handle) and row.to_handle or row.from_handle
     return ok({
         id             = row.id,
-        reactions      = serializeDm(fresh, prof.citizenid).reactions or {},
-        otherCid       = other,
+        reactions      = serializeDm(fresh, prof.handle).reactions or {},
+        other          = other,
         otherReactions = serializeDm(fresh, other).reactions or {},
-        conversationId = prof.citizenid,
+        conversationId = prof.handle,
     })
 end
 

--- a/server/birdy/init.lua
+++ b/server/birdy/init.lua
@@ -5,8 +5,6 @@ local boot = require 'server.boot'
 local store   = require 'server.birdy.store'
 ---@type table Authoritative Birdy handlers (server.birdy.actions): all validation + mutation.
 local actions = require 'server.birdy.actions'
----@type table Player bridge (bridge.server.player): citizenid -> online source for pushes.
-local player  = require 'bridge.server.player'
 ---@type table Watcher registry (server.watchers): shared with the feed broadcast in actions.
 local watchers = require('server.watchers').of('birdy')
 ---@type table Shared server helpers (server.util): disconnect sweep registration.
@@ -22,23 +20,26 @@ CreateThread(function()
     boot.schemaReady()
 end)
 
----Pushes an event to a single player. No-op when they're offline.
----@param src number|nil online server id, or nil
+---Pushes an event to every phone signed into a Birdy account. An account can be open on more
+---than one character, so a handle resolves to a list of sources rather than one.
+---@param handle string|nil Birdy handle
 ---@param event string client event name
 ---@param payload any
-local function pushTo(src, event, payload)
-    if not src then return end
-    TriggerClientEvent(event, src, payload)
+local function pushTo(handle, event, payload)
+    if not handle then return end
+    for _, src in ipairs(actions.sourcesFor(handle)) do
+        TriggerClientEvent(event, src, payload)
+    end
 end
 
----Forwards an action result, pinging the `notifyCid` player (if online) with a notification
----event, then stripping that internal field.
+---Forwards an action result, pinging the `notify` account (wherever it is open) with a
+---notification event, then stripping that internal field.
 ---@param result table
 ---@return table
 local function withNotifyPush(result)
-    if result.success and result.data and result.data.notifyCid then
-        pushTo(player.getSourceByIdentifier(result.data.notifyCid), 'sd-phone:client:birdy:notification', {})
-        result.data.notifyCid = nil
+    if result.success and result.data and result.data.notify then
+        pushTo(result.data.notify, 'sd-phone:client:birdy:notification', {})
+        result.data.notify = nil
     end
     return result
 end
@@ -92,8 +93,8 @@ lib.callback.register('sd-phone:server:birdy:dmSend', function(src, payload)
     local result = actions.dmSend(src, payload)
     if result.success and result.data then
         local d = result.data
-        pushTo(player.getSourceByIdentifier(d.toCid), 'sd-phone:client:birdy:dmReceived', {
-            conversationId = d.fromCid,
+        pushTo(d.to, 'sd-phone:client:birdy:dmReceived', {
+            conversationId = d.from,
             user           = d.fromProfile,
             message        = d.messageForOther,
         })
@@ -110,7 +111,7 @@ lib.callback.register('sd-phone:server:birdy:dmReact', function(src, payload)
     local result = actions.dmReact(src, payload)
     if result.success and result.data then
         local d = result.data
-        pushTo(player.getSourceByIdentifier(d.otherCid), 'sd-phone:client:birdy:dmReaction', {
+        pushTo(d.other, 'sd-phone:client:birdy:dmReaction', {
             conversationId = d.conversationId,
             id             = d.id,
             reactions      = d.otherReactions,

--- a/server/birdy/store.lua
+++ b/server/birdy/store.lua
@@ -27,13 +27,180 @@ function store.hashPassword(password)
     return ('%08x%08x%08x'):format(h1, h2, h3)
 end
 
+---True when a column is present on a table.
+---@param tbl string
+---@param column string
+---@return boolean
+local function hasColumn(tbl, column)
+    return (tonumber(MySQL.scalar.await([[
+        SELECT COUNT(*) FROM information_schema.columns
+        WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?
+    ]], { tbl, column })) or 0) > 0
+end
+
+---Drops an index when it exists; a missing one is a no-op rather than a failed ALTER.
+---@param tbl string
+---@param index string
+local function dropIndex(tbl, index)
+    local present = MySQL.scalar.await([[
+        SELECT COUNT(*) FROM information_schema.statistics
+        WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?
+    ]], { tbl, index })
+    if (tonumber(present) or 0) > 0 then
+        MySQL.query.await(('ALTER TABLE `%s` DROP INDEX `%s`'):format(tbl, index))
+    end
+end
+
+---Adds the handle column that replaces a citizenid column, then fills it by joining the profile
+---that citizenid owned. Returns how many rows resolved to a handle.
+---@param tbl string
+---@param newCol string handle column being introduced
+---@param oldCol string citizenid column being replaced
+---@return integer mapped
+local function addAndFill(tbl, newCol, oldCol)
+    if not hasColumn(tbl, newCol) then
+        MySQL.query.await(("ALTER TABLE `%s` ADD COLUMN `%s` VARCHAR(32) NOT NULL DEFAULT ''"):format(tbl, newCol))
+    end
+    return tonumber(MySQL.update.await((
+        'UPDATE `%s` c JOIN phone_birdy_profiles p ON p.citizenid = c.`%s` SET c.`%s` = p.handle'
+    ):format(tbl, oldCol, newCol))) or 0
+end
+
+---Rewrites the DM reaction blobs, whose JSON values are arrays of citizenids. DDL alone cannot
+---reach inside the column, so every reaction would keep pointing at a dead identity.
+---@param byCid table<string, string> citizenid -> handle
+---@return integer rewritten
+local function rekeyDmReactions(byCid)
+    local rows = MySQL.query.await(
+        "SELECT id, reactions FROM phone_birdy_dms WHERE reactions IS NOT NULL AND reactions <> ''") or {}
+    local rewritten = 0
+    for i = 1, #rows do
+        local okDecode, decoded = pcall(json.decode, rows[i].reactions)
+        if okDecode and type(decoded) == 'table' then
+            local out = {}
+            for emoji, users in pairs(decoded) do
+                if type(users) == 'table' then
+                    local kept = {}
+                    for j = 1, #users do
+                        local handle = byCid[users[j]]
+                        if handle then kept[#kept + 1] = handle end
+                    end
+                    if #kept > 0 then out[emoji] = kept end
+                end
+            end
+            MySQL.update.await('UPDATE phone_birdy_dms SET reactions = ? WHERE id = ?',
+                { next(out) ~= nil and json.encode(out) or nil, rows[i].id })
+            rewritten = rewritten + 1
+        end
+    end
+    return rewritten
+end
+
+---Moves every Birdy table from citizenid to handle, so one character can hold several accounts.
+---Rows whose citizenid owns no profile cannot be attributed to an account and are dropped.
+---@return table stats
+local function rekeyToHandle()
+    if not util.tableExists('phone_birdy_profiles') then return { fresh = true } end
+
+    local byCid = {}
+    for _, p in ipairs(MySQL.query.await('SELECT citizenid, handle FROM phone_birdy_profiles') or {}) do
+        byCid[p.citizenid] = p.handle
+    end
+
+    local stats = { profiles = 0 }
+    for _ in pairs(byCid) do stats.profiles = stats.profiles + 1 end
+
+    if hasColumn('phone_birdy_dms', 'reactions') then
+        stats.reactions = rekeyDmReactions(byCid)
+    end
+
+    if hasColumn('phone_birdy_posts', 'author_cid') then
+        stats.posts = addAndFill('phone_birdy_posts', 'author', 'author_cid')
+        MySQL.update.await("DELETE FROM phone_birdy_posts WHERE author = ''")
+        dropIndex('phone_birdy_posts', 'idx_birdy_posts_author')
+        MySQL.query.await('ALTER TABLE phone_birdy_posts DROP COLUMN author_cid')
+        util.ensureIndex('phone_birdy_posts', 'idx_birdy_posts_author', '(author)')
+    end
+
+    for _, tbl in ipairs({ 'phone_birdy_likes', 'phone_birdy_reposts' }) do
+        if hasColumn(tbl, 'citizenid') then
+            stats[tbl] = addAndFill(tbl, 'handle', 'citizenid')
+            MySQL.update.await(("DELETE FROM `%s` WHERE handle = ''"):format(tbl))
+            MySQL.query.await((
+                'ALTER TABLE `%s` DROP PRIMARY KEY, DROP COLUMN citizenid, ADD PRIMARY KEY (post_id, handle)'
+            ):format(tbl))
+        end
+    end
+
+    if hasColumn('phone_birdy_follows', 'follower_cid') then
+        stats.follows = addAndFill('phone_birdy_follows', 'follower', 'follower_cid')
+        addAndFill('phone_birdy_follows', 'target', 'target_cid')
+        MySQL.update.await("DELETE FROM phone_birdy_follows WHERE follower = '' OR target = ''")
+        dropIndex('phone_birdy_follows', 'idx_birdy_follows_target')
+        MySQL.query.await([[
+            ALTER TABLE phone_birdy_follows
+                DROP PRIMARY KEY,
+                DROP COLUMN follower_cid,
+                DROP COLUMN target_cid,
+                ADD PRIMARY KEY (follower, target)
+        ]])
+        util.ensureIndex('phone_birdy_follows', 'idx_birdy_follows_target', '(target)')
+    end
+
+    if hasColumn('phone_birdy_dms', 'from_cid') then
+        stats.dms = addAndFill('phone_birdy_dms', 'from_handle', 'from_cid')
+        addAndFill('phone_birdy_dms', 'to_handle', 'to_cid')
+        MySQL.update.await("DELETE FROM phone_birdy_dms WHERE from_handle = '' OR to_handle = ''")
+        dropIndex('phone_birdy_dms', 'idx_birdy_dms_from')
+        dropIndex('phone_birdy_dms', 'idx_birdy_dms_to')
+        MySQL.query.await('ALTER TABLE phone_birdy_dms DROP COLUMN from_cid, DROP COLUMN to_cid')
+        util.ensureIndex('phone_birdy_dms', 'idx_birdy_dms_from', '(from_handle)')
+        util.ensureIndex('phone_birdy_dms', 'idx_birdy_dms_to', '(to_handle)')
+    end
+
+    if hasColumn('phone_birdy_notifications', 'recipient_cid') then
+        stats.notifications = addAndFill('phone_birdy_notifications', 'recipient', 'recipient_cid')
+        addAndFill('phone_birdy_notifications', 'actor', 'actor_cid')
+        MySQL.update.await("DELETE FROM phone_birdy_notifications WHERE recipient = '' OR actor = ''")
+        dropIndex('phone_birdy_notifications', 'idx_birdy_notifs_recipient')
+        dropIndex('phone_birdy_notifications', 'idx_birdy_notifs_unseen')
+        dropIndex('phone_birdy_notifications', 'idx_birdy_notifs_dedupe')
+        MySQL.query.await('ALTER TABLE phone_birdy_notifications DROP COLUMN recipient_cid, DROP COLUMN actor_cid')
+        util.ensureIndex('phone_birdy_notifications', 'idx_birdy_notifs_recipient', '(recipient, created_at)')
+    end
+
+    -- Last, so a failure part-way through leaves the profile table still keyed the old way and the
+    -- whole migration retries from the top on the next boot.
+    local pk = MySQL.scalar.await([[
+        SELECT COLUMN_NAME FROM information_schema.statistics
+        WHERE table_schema = DATABASE() AND table_name = 'phone_birdy_profiles'
+          AND index_name = 'PRIMARY' AND SEQ_IN_INDEX = 1
+    ]])
+    if pk == 'citizenid' then
+        dropIndex('phone_birdy_profiles', 'uq_phone_birdy_handle')
+        MySQL.query.await([[
+            ALTER TABLE phone_birdy_profiles
+                DROP PRIMARY KEY,
+                MODIFY citizenid VARCHAR(64) NOT NULL DEFAULT '',
+                ADD PRIMARY KEY (handle)
+        ]])
+        util.ensureIndex('phone_birdy_profiles', 'idx_birdy_profiles_creator', '(citizenid)')
+    end
+
+    return stats
+end
+
 ---Creates every Birdy table idempotently and back-fills columns added after first release. Runs
 ---once at boot.
 function store.ensureSchema()
+    -- Before the CREATEs: they are IF NOT EXISTS, so an install still on the citizenid shape would
+    -- keep it and every query below would select columns that no longer match the code.
+    util.runOnce('birdy_handle_rekey', rekeyToHandle)
+
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_birdy_profiles (
-            citizenid    VARCHAR(64)  NOT NULL,
             handle       VARCHAR(32)  NOT NULL,
+            citizenid    VARCHAR(64)  NOT NULL DEFAULT '',
             display_name VARCHAR(64)  NOT NULL,
             password     VARCHAR(64)  NOT NULL DEFAULT '',
             bio          VARCHAR(200) NOT NULL DEFAULT '',
@@ -42,22 +209,22 @@ function store.ensureSchema()
             join_label   VARCHAR(32)  NOT NULL DEFAULT '',
             protected    TINYINT(1)   NOT NULL DEFAULT 0,
             created_at   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (citizenid),
-            UNIQUE KEY uq_phone_birdy_handle (handle)
+            PRIMARY KEY (handle),
+            INDEX idx_birdy_profiles_creator (citizenid)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_birdy_posts (
             id         VARCHAR(16) NOT NULL,
-            author_cid VARCHAR(64) NOT NULL,
+            author     VARCHAR(32) NOT NULL,
             body       TEXT        NOT NULL,
             parent_id  VARCHAR(16) NULL,
             images     TEXT        NULL,
             views      INT         NOT NULL DEFAULT 0,
             created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
-            INDEX idx_birdy_posts_author  (author_cid),
+            INDEX idx_birdy_posts_author  (author),
             INDEX idx_birdy_posts_parent  (parent_id),
             INDEX idx_birdy_posts_created (created_at)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -66,9 +233,9 @@ function store.ensureSchema()
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_birdy_likes (
             post_id    VARCHAR(16) NOT NULL,
-            citizenid  VARCHAR(64) NOT NULL,
+            handle     VARCHAR(32) NOT NULL,
             created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (post_id, citizenid),
+            PRIMARY KEY (post_id, handle),
             INDEX idx_birdy_likes_post (post_id)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
@@ -77,51 +244,51 @@ function store.ensureSchema()
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_birdy_reposts (
             post_id    VARCHAR(16) NOT NULL,
-            citizenid  VARCHAR(64) NOT NULL,
+            handle     VARCHAR(32) NOT NULL,
             created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (post_id, citizenid),
+            PRIMARY KEY (post_id, handle),
             INDEX idx_birdy_reposts_post (post_id)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_birdy_follows (
-            follower_cid VARCHAR(64) NOT NULL,
-            target_cid   VARCHAR(64) NOT NULL,
-            created_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (follower_cid, target_cid),
-            INDEX idx_birdy_follows_target (target_cid)
+            follower   VARCHAR(32) NOT NULL,
+            target     VARCHAR(32) NOT NULL,
+            created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (follower, target),
+            INDEX idx_birdy_follows_target (target)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_birdy_dms (
-            id         VARCHAR(16) NOT NULL,
-            from_cid   VARCHAR(64) NOT NULL,
-            to_cid     VARCHAR(64) NOT NULL,
-            body       TEXT        NOT NULL,
-            kind       VARCHAR(16) NOT NULL DEFAULT 'text',
-            meta       TEXT        NULL,
-            reactions  TEXT        NULL,
-            read_flag  TINYINT(1)  NOT NULL DEFAULT 0,
-            created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            id          VARCHAR(16) NOT NULL,
+            from_handle VARCHAR(32) NOT NULL,
+            to_handle   VARCHAR(32) NOT NULL,
+            body        TEXT        NOT NULL,
+            kind        VARCHAR(16) NOT NULL DEFAULT 'text',
+            meta        TEXT        NULL,
+            reactions   TEXT        NULL,
+            read_flag   TINYINT(1)  NOT NULL DEFAULT 0,
+            created_at  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
-            INDEX idx_birdy_dms_from (from_cid),
-            INDEX idx_birdy_dms_to   (to_cid)
+            INDEX idx_birdy_dms_from (from_handle),
+            INDEX idx_birdy_dms_to   (to_handle)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_birdy_notifications (
-            id            VARCHAR(16) NOT NULL,
-            recipient_cid VARCHAR(64) NOT NULL,
-            kind          VARCHAR(16) NOT NULL,
-            actor_cid     VARCHAR(64) NOT NULL,
-            post_id       VARCHAR(16) NULL,
-            seen          TINYINT(1)  NOT NULL DEFAULT 0,
-            created_at    TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            id         VARCHAR(16) NOT NULL,
+            recipient  VARCHAR(32) NOT NULL,
+            kind       VARCHAR(16) NOT NULL,
+            actor      VARCHAR(32) NOT NULL,
+            post_id    VARCHAR(16) NULL,
+            seen       TINYINT(1)  NOT NULL DEFAULT 0,
+            created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
-            INDEX idx_birdy_notifs_recipient (recipient_cid, created_at)
+            INDEX idx_birdy_notifs_recipient (recipient, created_at)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
@@ -153,8 +320,8 @@ function store.ensureSchema()
     if ensureColumn('phone_birdy_notifications', 'seen', 'seen TINYINT(1) NOT NULL DEFAULT 0') then
         MySQL.update.await('UPDATE phone_birdy_notifications SET seen = 1')
     end
-    util.ensureIndex('phone_birdy_notifications', 'idx_birdy_notifs_unseen', '(recipient_cid, seen)')
-    util.ensureIndex('phone_birdy_notifications', 'idx_birdy_notifs_dedupe', '(recipient_cid, kind, actor_cid, post_id)')
+    util.ensureIndex('phone_birdy_notifications', 'idx_birdy_notifs_unseen', '(recipient, seen)')
+    util.ensureIndex('phone_birdy_notifications', 'idx_birdy_notifs_dedupe', '(recipient, kind, actor, post_id)')
 
     -- Referential integrity, added on boot so existing installs migrate with no manual SQL.
     -- Each is a no-op once present; orphaned children are cleared first (they point at a
@@ -185,14 +352,15 @@ local function escapeLike(s)
     return (s:gsub('[%%_\\]', '\\%0'))
 end
 
----Reshapes a raw profile row, normalising every TINYINT flag to a boolean.
+---Reshapes a raw profile row, normalising every TINYINT flag to a boolean. `citizenid` is the
+---character that created the account, not whoever is signed into it now.
 ---@param row table|nil
----@return { citizenid: string, handle: string, displayName: string, verified: boolean }|nil
+---@return { handle: string, displayName: string, verified: boolean, citizenid: string }|nil
 local function hydrateProfile(row)
     if not row then return nil end
     return {
-        citizenid   = row.citizenid,
         handle      = row.handle,
+        citizenid   = row.citizenid,
         displayName = row.display_name,
         password    = row.password,
         bio         = row.bio,
@@ -207,24 +375,13 @@ local function hydrateProfile(row)
     }
 end
 
----A profile by its owning citizenid, or nil.
----@param citizenid string
----@return table|nil
-function store.getProfile(citizenid)
-    if not citizenid or citizenid == '' then return nil end
-    local row = MySQL.single.await(
-        'SELECT citizenid, handle, display_name, password, bio, verified, logged_in, join_label, protected, avatar, banner, UNIX_TIMESTAMP(created_at) AS created_ts FROM phone_birdy_profiles WHERE citizenid = ?',
-        { citizenid }
-    )
-    return hydrateProfile(row)
-end
-
----Looks up a profile by its unique handle.
+---Looks up a profile by its handle, the account's identity.
 ---@param handle string
 ---@return table|nil
 function store.getProfileByHandle(handle)
+    if not handle or handle == '' then return nil end
     return hydrateProfile(MySQL.single.await(
-        'SELECT citizenid, handle, display_name, password, bio, verified, logged_in, join_label, protected, avatar, banner, UNIX_TIMESTAMP(created_at) AS created_ts FROM phone_birdy_profiles WHERE handle = ?',
+        'SELECT handle, citizenid, display_name, password, bio, verified, logged_in, join_label, protected, avatar, banner, UNIX_TIMESTAMP(created_at) AS created_ts FROM phone_birdy_profiles WHERE handle = ?',
         { handle }
     ))
 end
@@ -233,72 +390,72 @@ end
 ---the client's text are escaped, so a bare '%' searches for a literal percent instead of
 ---scanning the whole table.
 ---@param query string
----@param viewerCid string
+---@param viewerHandle string
 ---@param limit number
----@return table[] {citizenid, handle, displayName, verified}
-function store.searchProfiles(query, viewerCid, limit)
+---@return table[] {handle, displayName, verified, avatar}
+function store.searchProfiles(query, viewerHandle, limit)
     local like = '%' .. escapeLike(query) .. '%'
     local rows = MySQL.query.await([[
-        SELECT citizenid, handle, display_name, verified, avatar FROM phone_birdy_profiles
-        WHERE (handle LIKE ? ESCAPE '\\' OR display_name LIKE ? ESCAPE '\\') AND citizenid <> ?
+        SELECT handle, display_name, verified, avatar FROM phone_birdy_profiles
+        WHERE (handle LIKE ? ESCAPE '\\' OR display_name LIKE ? ESCAPE '\\') AND handle <> ?
         ORDER BY created_at DESC LIMIT ?
-    ]], { like, like, viewerCid or '', limit }) or {}
+    ]], { like, like, viewerHandle or '', limit }) or {}
     local out = {}
     for i = 1, #rows do
         local r = rows[i]
-        out[i] = { citizenid = r.citizenid, handle = r.handle, displayName = r.display_name, verified = isTruthy(r.verified), avatar = r.avatar }
+        out[i] = { handle = r.handle, displayName = r.display_name, verified = isTruthy(r.verified), avatar = r.avatar }
     end
     return out
 end
 
----Creates a fresh, signed-in profile row for a citizenid; a duplicate handle fails the UNIQUE
----key and returns false.
----@param citizenid string
+---Creates a fresh, signed-in profile row; a duplicate handle fails the primary key and returns
+---false. `citizenid` records the character that created the account.
 ---@param handle string
+---@param citizenid string
 ---@param displayName string
 ---@param passwordHash string
 ---@param bio string
 ---@param verified boolean
 ---@param joinLabel string
 ---@return boolean
-function store.insertAccount(citizenid, handle, displayName, passwordHash, bio, verified, joinLabel)
+function store.insertAccount(handle, citizenid, displayName, passwordHash, bio, verified, joinLabel)
     return MySQL.insert.await([[
-        INSERT INTO phone_birdy_profiles (citizenid, handle, display_name, password, bio, verified, logged_in, join_label)
+        INSERT INTO phone_birdy_profiles (handle, citizenid, display_name, password, bio, verified, logged_in, join_label)
         VALUES (?, ?, ?, ?, ?, ?, 1, ?)
-    ]], { citizenid, handle, displayName, passwordHash, bio, verified and 1 or 0, joinLabel or '' }) ~= nil
+    ]], { handle, citizenid, displayName, passwordHash, bio, verified and 1 or 0, joinLabel or '' }) ~= nil
 end
 
 ---Updates the editable profile fields (name, bio, join label, protected).
----@param citizenid string
+---@param handle string
 ---@param displayName string
 ---@param bio string
 ---@param joinLabel string
 ---@param protected boolean
-function store.updateProfileFields(citizenid, displayName, bio, joinLabel, protected, avatar, banner)
+function store.updateProfileFields(handle, displayName, bio, joinLabel, protected, avatar, banner)
     MySQL.update.await([[
         UPDATE phone_birdy_profiles
         SET display_name = ?, bio = ?, join_label = ?, protected = ?, avatar = ?, banner = ?
-        WHERE citizenid = ?
-    ]], { displayName, bio, joinLabel, protected and 1 or 0, avatar, banner, citizenid })
+        WHERE handle = ?
+    ]], { displayName, bio, joinLabel, protected and 1 or 0, avatar, banner, handle })
 end
 
----Replace a citizenid's legacy profile-row password hash (kept in sync with the engine hash).
----@param citizenid string
+---Replace an account's legacy profile-row password hash (kept in sync with the engine hash).
+---@param handle string
 ---@param passwordHash string
-function store.setPassword(citizenid, passwordHash)
-    MySQL.update.await('UPDATE phone_birdy_profiles SET password = ? WHERE citizenid = ?', { passwordHash, citizenid })
+function store.setPassword(handle, passwordHash)
+    MySQL.update.await('UPDATE phone_birdy_profiles SET password = ? WHERE handle = ?', { passwordHash, handle })
 end
 
----@param citizenid string
+---@param handle string
 ---@return number following count
-function store.countFollowing(citizenid)
-    return tonumber(MySQL.scalar.await('SELECT COUNT(*) FROM phone_birdy_follows WHERE follower_cid = ?', { citizenid })) or 0
+function store.countFollowing(handle)
+    return tonumber(MySQL.scalar.await('SELECT COUNT(*) FROM phone_birdy_follows WHERE follower = ?', { handle })) or 0
 end
 
----@param citizenid string
+---@param handle string
 ---@return number follower count
-function store.countFollowers(citizenid)
-    return tonumber(MySQL.scalar.await('SELECT COUNT(*) FROM phone_birdy_follows WHERE target_cid = ?', { citizenid })) or 0
+function store.countFollowers(handle)
+    return tonumber(MySQL.scalar.await('SELECT COUNT(*) FROM phone_birdy_follows WHERE target = ?', { handle })) or 0
 end
 
 ---Reshapes a joined POST_SELECT row into the hydrated post table. `images` decodes from a JSON
@@ -314,7 +471,7 @@ local function hydratePost(row)
     end
     return {
         id          = row.id,
-        authorCid   = row.author_cid,
+        author      = row.author,
         handle      = row.handle,
         displayName = row.display_name,
         verified    = isTruthy(row.verified),
@@ -332,31 +489,31 @@ local function hydratePost(row)
     }
 end
 
----@type string SELECT prefix producing hydratePost-shaped rows. The viewer cid is params #1 AND
+---@type string SELECT prefix producing hydratePost-shaped rows. The viewer handle is params #1 AND
 ---#2 (the `liked` and `reposted` flags), so every caller must pass it twice, ahead of its own
 ---parameters.
 local POST_SELECT = [[
     SELECT
-        p.id, p.author_cid, p.body, p.parent_id, p.images, p.views,
+        p.id, p.author, p.body, p.parent_id, p.images, p.views,
         UNIX_TIMESTAMP(p.created_at) AS created_s,
         pr.handle, pr.display_name, pr.verified, pr.avatar,
         (SELECT COUNT(*) FROM phone_birdy_likes l  WHERE l.post_id   = p.id) AS like_count,
         (SELECT COUNT(*) FROM phone_birdy_posts r  WHERE r.parent_id = p.id) AS reply_count,
         (SELECT COUNT(*) FROM phone_birdy_reposts rp WHERE rp.post_id = p.id) AS repost_count,
-        (SELECT COUNT(*) FROM phone_birdy_likes lv WHERE lv.post_id  = p.id AND lv.citizenid = ?) AS liked,
-        (SELECT COUNT(*) FROM phone_birdy_reposts rv WHERE rv.post_id = p.id AND rv.citizenid = ?) AS reposted
+        (SELECT COUNT(*) FROM phone_birdy_likes lv WHERE lv.post_id  = p.id AND lv.handle = ?) AS liked,
+        (SELECT COUNT(*) FROM phone_birdy_reposts rv WHERE rv.post_id = p.id AND rv.handle = ?) AS reposted
     FROM phone_birdy_posts p
-    JOIN phone_birdy_profiles pr ON pr.citizenid = p.author_cid
+    JOIN phone_birdy_profiles pr ON pr.handle = p.author
 ]]
 
 ---Lists a single author's posts for a profile tab, newest first. 'replies' = posts with a
 ---parent; 'media' = any post carrying images; anything else = top-level only.
----@param authorCid string
+---@param author string
 ---@param kind string
----@param viewerCid string
+---@param viewerHandle string
 ---@param limit number
 ---@return table[]
-function store.listPostsBy(authorCid, kind, viewerCid, limit)
+function store.listPostsBy(author, kind, viewerHandle, limit)
     local clause
     if kind == 'replies' then
         clause = 'p.parent_id IS NOT NULL'
@@ -366,25 +523,25 @@ function store.listPostsBy(authorCid, kind, viewerCid, limit)
         clause = 'p.parent_id IS NULL'
     end
     local rows = MySQL.query.await(
-        POST_SELECT .. (' WHERE p.author_cid = ? AND %s ORDER BY p.created_at DESC LIMIT ?'):format(clause),
-        { viewerCid, viewerCid, authorCid, limit }
+        POST_SELECT .. (' WHERE p.author = ? AND %s ORDER BY p.created_at DESC LIMIT ?'):format(clause),
+        { viewerHandle, viewerHandle, author, limit }
     ) or {}
     for i = 1, #rows do rows[i] = hydratePost(rows[i]) end
     return rows
 end
 
----List posts a citizenid has liked, most-recently-liked first.
----@param likerCid string
----@param viewerCid string
+---List posts an account has liked, most-recently-liked first.
+---@param likerHandle string
+---@param viewerHandle string
 ---@param limit number
 ---@return table[]
-function store.listLikedBy(likerCid, viewerCid, limit)
+function store.listLikedBy(likerHandle, viewerHandle, limit)
     local rows = MySQL.query.await(
         POST_SELECT .. [[
-            JOIN phone_birdy_likes lk ON lk.post_id = p.id AND lk.citizenid = ?
+            JOIN phone_birdy_likes lk ON lk.post_id = p.id AND lk.handle = ?
             ORDER BY lk.created_at DESC LIMIT ?
         ]],
-        { viewerCid, viewerCid, likerCid, limit }
+        { viewerHandle, viewerHandle, likerHandle, limit }
     ) or {}
     for i = 1, #rows do rows[i] = hydratePost(rows[i]) end
     return rows
@@ -392,80 +549,66 @@ end
 
 ---Deletes an account and every row it owns or references: likes and reposts (its own, and
 ---others' on its posts), posts, follows, DMs, notifications, then the profile row.
----@param citizenid string
-function store.deleteAccount(citizenid)
-    MySQL.update.await('DELETE FROM phone_birdy_likes WHERE citizenid = ?', { citizenid })
-    MySQL.update.await('DELETE FROM phone_birdy_likes WHERE post_id IN (SELECT id FROM phone_birdy_posts WHERE author_cid = ?)', { citizenid })
-    MySQL.update.await('DELETE FROM phone_birdy_reposts WHERE citizenid = ?', { citizenid })
-    MySQL.update.await('DELETE FROM phone_birdy_reposts WHERE post_id IN (SELECT id FROM phone_birdy_posts WHERE author_cid = ?)', { citizenid })
-    MySQL.update.await('DELETE FROM phone_birdy_posts WHERE author_cid = ?', { citizenid })
-    MySQL.update.await('DELETE FROM phone_birdy_follows WHERE follower_cid = ? OR target_cid = ?', { citizenid, citizenid })
-    MySQL.update.await('DELETE FROM phone_birdy_dms WHERE from_cid = ? OR to_cid = ?', { citizenid, citizenid })
-    MySQL.update.await('DELETE FROM phone_birdy_notifications WHERE recipient_cid = ? OR actor_cid = ?', { citizenid, citizenid })
-    MySQL.update.await('DELETE FROM phone_birdy_profiles WHERE citizenid = ?', { citizenid })
+---@param handle string
+function store.deleteAccount(handle)
+    MySQL.update.await('DELETE FROM phone_birdy_likes WHERE handle = ?', { handle })
+    MySQL.update.await('DELETE FROM phone_birdy_likes WHERE post_id IN (SELECT id FROM phone_birdy_posts WHERE author = ?)', { handle })
+    MySQL.update.await('DELETE FROM phone_birdy_reposts WHERE handle = ?', { handle })
+    MySQL.update.await('DELETE FROM phone_birdy_reposts WHERE post_id IN (SELECT id FROM phone_birdy_posts WHERE author = ?)', { handle })
+    MySQL.update.await('DELETE FROM phone_birdy_posts WHERE author = ?', { handle })
+    MySQL.update.await('DELETE FROM phone_birdy_follows WHERE follower = ? OR target = ?', { handle, handle })
+    MySQL.update.await('DELETE FROM phone_birdy_dms WHERE from_handle = ? OR to_handle = ?', { handle, handle })
+    MySQL.update.await('DELETE FROM phone_birdy_notifications WHERE recipient = ? OR actor = ?', { handle, handle })
+    MySQL.update.await('DELETE FROM phone_birdy_profiles WHERE handle = ?', { handle })
     store.invalidateTrending()
 end
 
----Overwrites an existing profile's editable fields and signs it in.
----@param citizenid string
+---Flips an account's informational signed-in flag.
 ---@param handle string
----@param displayName string
----@param passwordHash string
----@param bio string
-function store.updateAccount(citizenid, handle, displayName, passwordHash, bio)
-    MySQL.update.await([[
-        UPDATE phone_birdy_profiles
-        SET handle = ?, display_name = ?, password = ?, bio = ?, logged_in = 1
-        WHERE citizenid = ?
-    ]], { handle, displayName, passwordHash, bio, citizenid })
-end
-
----Flips a citizenid's informational signed-in flag.
----@param citizenid string
 ---@param value boolean
-function store.setLoggedIn(citizenid, value)
+function store.setLoggedIn(handle, value)
     MySQL.update.await(
-        'UPDATE phone_birdy_profiles SET logged_in = ? WHERE citizenid = ?',
-        { value and 1 or 0, citizenid }
+        'UPDATE phone_birdy_profiles SET logged_in = ? WHERE handle = ?',
+        { value and 1 or 0, handle }
     )
 end
 
----Batch-loads profiles keyed by citizenid.
----@param cids string[]
+---Batch-loads profiles keyed by handle.
+---@param handles string[]
 ---@return table<string, table>
-function store.getProfilesByCids(cids)
+function store.getProfilesByHandles(handles)
     local out = {}
-    if not cids or #cids == 0 then return out end
+    if not handles or #handles == 0 then return out end
     local marks = {}
-    for i = 1, #cids do marks[i] = '?' end
+    for i = 1, #handles do marks[i] = '?' end
     local rows = MySQL.query.await(
-        ('SELECT citizenid, handle, display_name, verified, avatar FROM phone_birdy_profiles WHERE citizenid IN (%s)')
+        ('SELECT handle, citizenid, display_name, verified, avatar FROM phone_birdy_profiles WHERE handle IN (%s)')
             :format(table.concat(marks, ',')),
-        cids
+        handles
     ) or {}
     for i = 1, #rows do
         local p = hydrateProfile(rows[i])
-        if p then out[p.citizenid] = p end
+        if p then out[p.handle] = p end
     end
     return out
 end
 
----A single post by id, hydrated for `viewerCid`'s liked flag.
+---A single post by id, hydrated for `viewerHandle`'s liked flag.
 ---@param id string
----@param viewerCid string
+---@param viewerHandle string
 ---@return table|nil
-function store.getPost(id, viewerCid)
+function store.getPost(id, viewerHandle)
     return hydratePost(MySQL.single.await(
-        POST_SELECT .. ' WHERE p.id = ? LIMIT 1', { viewerCid, viewerCid, id }
+        POST_SELECT .. ' WHERE p.id = ? LIMIT 1', { viewerHandle, viewerHandle, id }
     ))
 end
 
 ---Hydrated posts for many ids in one query. Returns an id -> hydrated post map (missing ids
 ---absent). Read-only.
 ---@param ids string[] post ids
----@param viewerCid string viewer citizenid (for the liked flag)
+---@param viewerHandle string viewer handle (for the liked flag)
 ---@return table<string, table> id -> hydrated post
-function store.postsByIds(ids, viewerCid)
+function store.postsByIds(ids, viewerHandle)
     local out = {}
     if type(ids) ~= 'table' or #ids == 0 then return out end
     local seen, list = {}, {}
@@ -476,7 +619,7 @@ function store.postsByIds(ids, viewerCid)
     if #list == 0 then return out end
     local marks = {}
     for i = 1, #list do marks[i] = '?' end
-    local params = { viewerCid, viewerCid }
+    local params = { viewerHandle, viewerHandle }
     for i = 1, #list do params[#params + 1] = list[i] end
     local rows = MySQL.query.await(
         POST_SELECT .. (' WHERE p.id IN (%s)'):format(table.concat(marks, ',')), params) or {}
@@ -488,38 +631,38 @@ function store.postsByIds(ids, viewerCid)
 end
 
 ---Lists top-level posts newest-first, optionally limited to accounts the viewer follows.
----@param viewerCid string
+---@param viewerHandle string
 ---@param limit number
 ---@param onlyFollowing boolean
 ---@return table[]
-function store.listFeed(viewerCid, limit, onlyFollowing)
+function store.listFeed(viewerHandle, limit, onlyFollowing)
     local rows
     if onlyFollowing then
         rows = MySQL.query.await(POST_SELECT .. [[
             WHERE p.parent_id IS NULL
-              AND p.author_cid IN (SELECT target_cid FROM phone_birdy_follows WHERE follower_cid = ?)
+              AND p.author IN (SELECT target FROM phone_birdy_follows WHERE follower = ?)
             ORDER BY p.created_at DESC LIMIT ?
-        ]], { viewerCid, viewerCid, viewerCid, limit }) or {}
+        ]], { viewerHandle, viewerHandle, viewerHandle, limit }) or {}
     else
         -- Protected authors are visible only to themselves and their followers.
         rows = MySQL.query.await(POST_SELECT .. [[
             WHERE p.parent_id IS NULL
-              AND (pr.protected = 0 OR p.author_cid = ?
-                   OR p.author_cid IN (SELECT target_cid FROM phone_birdy_follows WHERE follower_cid = ?))
+              AND (pr.protected = 0 OR p.author = ?
+                   OR p.author IN (SELECT target FROM phone_birdy_follows WHERE follower = ?))
             ORDER BY p.created_at DESC LIMIT ?
-        ]], { viewerCid, viewerCid, viewerCid, viewerCid, limit }) or {}
+        ]], { viewerHandle, viewerHandle, viewerHandle, viewerHandle, limit }) or {}
     end
     for i = 1, #rows do rows[i] = hydratePost(rows[i]) end
     return rows
 end
 
 ---@param parentId string
----@param viewerCid string
+---@param viewerHandle string
 ---@return table[] replies oldest-first
-function store.listReplies(parentId, viewerCid)
+function store.listReplies(parentId, viewerHandle)
     local rows = MySQL.query.await(
         POST_SELECT .. ' WHERE p.parent_id = ? ORDER BY p.created_at ASC',
-        { viewerCid, viewerCid, parentId }
+        { viewerHandle, viewerHandle, parentId }
     ) or {}
     for i = 1, #rows do rows[i] = hydratePost(rows[i]) end
     return rows
@@ -570,7 +713,7 @@ function store.trendingHashtags(windowDays, limit)
     end
     local rows = MySQL.query.await([[
         SELECT p.body FROM phone_birdy_posts p
-        JOIN phone_birdy_profiles pr ON pr.citizenid = p.author_cid
+        JOIN phone_birdy_profiles pr ON pr.handle = p.author
         WHERE pr.protected = 0 AND p.body LIKE '%#%'
           AND p.created_at > NOW() - INTERVAL ? DAY
         ORDER BY p.created_at DESC LIMIT ?
@@ -606,17 +749,17 @@ end
 ---Posts and replies carrying an exact hashtag, newest first, honouring the feed's
 ---protected-author visibility. `tagLower` arrives lowercased without the '#'.
 ---@param tagLower string
----@param viewerCid string
+---@param viewerHandle string
 ---@param limit number
 ---@return table[]
-function store.postsByHashtag(tagLower, viewerCid, limit)
+function store.postsByHashtag(tagLower, viewerHandle, limit)
     local like = '%#' .. escapeLike(tagLower) .. '%'
     local rows = MySQL.query.await(POST_SELECT .. [[
         WHERE p.body LIKE ?
-          AND (pr.protected = 0 OR p.author_cid = ?
-               OR p.author_cid IN (SELECT target_cid FROM phone_birdy_follows WHERE follower_cid = ?))
+          AND (pr.protected = 0 OR p.author = ?
+               OR p.author IN (SELECT target FROM phone_birdy_follows WHERE follower = ?))
         ORDER BY p.created_at DESC LIMIT ?
-    ]], { viewerCid, viewerCid, like, viewerCid, viewerCid, limit }) or {}
+    ]], { viewerHandle, viewerHandle, like, viewerHandle, viewerHandle, limit }) or {}
 
     local out = {}
     for i = 1, #rows do
@@ -629,85 +772,85 @@ end
 
 ---Inserts a post row.
 ---@param id string
----@param authorCid string
+---@param author string
 ---@param body string
 ---@param parentId string|nil
 ---@param images string[]|nil up to 3 image URLs, stored as a JSON array
 ---@return boolean
-function store.insertPost(id, authorCid, body, parentId, images)
+function store.insertPost(id, author, body, parentId, images)
     local imagesJson = (type(images) == 'table' and #images > 0) and json.encode(images) or nil
     return MySQL.insert.await([[
-        INSERT INTO phone_birdy_posts (id, author_cid, body, parent_id, images) VALUES (?, ?, ?, ?, ?)
-    ]], { id, authorCid, body, parentId, imagesJson }) ~= nil
+        INSERT INTO phone_birdy_posts (id, author, body, parent_id, images) VALUES (?, ?, ?, ?, ?)
+    ]], { id, author, body, parentId, imagesJson }) ~= nil
 end
 
 ---Increments a post's view count, but never for the author's own views.
 ---@param id string
----@param viewerCid string
-function store.bumpViews(id, viewerCid)
+---@param viewerHandle string
+function store.bumpViews(id, viewerHandle)
     MySQL.update.await(
-        'UPDATE phone_birdy_posts SET views = views + 1 WHERE id = ? AND author_cid <> ?',
-        { id, viewerCid }
+        'UPDATE phone_birdy_posts SET views = views + 1 WHERE id = ? AND author <> ?',
+        { id, viewerHandle }
     )
 end
 
 ---@param id string
----@return string|nil author citizenid
+---@return string|nil author handle
 function store.getPostAuthor(id)
-    return MySQL.scalar.await('SELECT author_cid FROM phone_birdy_posts WHERE id = ?', { id })
+    return MySQL.scalar.await('SELECT author FROM phone_birdy_posts WHERE id = ?', { id })
 end
 
 ---Adds a like. INSERT IGNORE makes replays a no-op.
 ---@param postId string
----@param cid string
-function store.addLike(postId, cid)
-    MySQL.insert.await('INSERT IGNORE INTO phone_birdy_likes (post_id, citizenid) VALUES (?, ?)', { postId, cid })
+---@param handle string
+function store.addLike(postId, handle)
+    MySQL.insert.await('INSERT IGNORE INTO phone_birdy_likes (post_id, handle) VALUES (?, ?)', { postId, handle })
 end
 
 ---@param postId string
----@param cid string
-function store.removeLike(postId, cid)
-    MySQL.update.await('DELETE FROM phone_birdy_likes WHERE post_id = ? AND citizenid = ?', { postId, cid })
+---@param handle string
+function store.removeLike(postId, handle)
+    MySQL.update.await('DELETE FROM phone_birdy_likes WHERE post_id = ? AND handle = ?', { postId, handle })
 end
 
 ---Adds a repost. INSERT IGNORE makes replays a no-op.
 ---@param postId string
----@param cid string
-function store.addRepost(postId, cid)
-    MySQL.insert.await('INSERT IGNORE INTO phone_birdy_reposts (post_id, citizenid) VALUES (?, ?)', { postId, cid })
+---@param handle string
+function store.addRepost(postId, handle)
+    MySQL.insert.await('INSERT IGNORE INTO phone_birdy_reposts (post_id, handle) VALUES (?, ?)', { postId, handle })
 end
 
 ---@param postId string
----@param cid string
-function store.removeRepost(postId, cid)
-    MySQL.update.await('DELETE FROM phone_birdy_reposts WHERE post_id = ? AND citizenid = ?', { postId, cid })
+---@param handle string
+function store.removeRepost(postId, handle)
+    MySQL.update.await('DELETE FROM phone_birdy_reposts WHERE post_id = ? AND handle = ?', { postId, handle })
 end
 
 ---@param postId string
----@param cid string
----@return boolean true when `cid` has reposted the post
-function store.isReposted(postId, cid)
+---@param handle string
+---@return boolean true when `handle` has reposted the post
+function store.isReposted(postId, handle)
     return MySQL.scalar.await(
-        'SELECT 1 FROM phone_birdy_reposts WHERE post_id = ? AND citizenid = ? LIMIT 1', { postId, cid }
+        'SELECT 1 FROM phone_birdy_reposts WHERE post_id = ? AND handle = ? LIMIT 1', { postId, handle }
     ) ~= nil
 end
 
 ---@param postId string
----@param cid string
----@return boolean true when `cid` has liked the post
-function store.isLiked(postId, cid)
+---@param handle string
+---@return boolean true when `handle` has liked the post
+function store.isLiked(postId, handle)
     return MySQL.scalar.await(
-        'SELECT 1 FROM phone_birdy_likes WHERE post_id = ? AND citizenid = ? LIMIT 1', { postId, cid }
+        'SELECT 1 FROM phone_birdy_likes WHERE post_id = ? AND handle = ? LIMIT 1', { postId, handle }
     ) ~= nil
 end
 
----Citizenids of everyone following `targetCid`, for notification fan-out. Read-only.
----@param targetCid string
+---Handles of every account following `target`, for notification fan-out. Read-only.
+---@param target string
 ---@return string[]
-function store.followerCids(targetCid)
-    local rows = MySQL.query.await('SELECT follower_cid FROM phone_birdy_follows WHERE target_cid = ?', { targetCid }) or {}
+function store.followerHandles(target)
+    local rows = MySQL.query.await('SELECT follower FROM phone_birdy_follows WHERE target = ?', { target }) or {}
     local out = {}
-    for i = 1, #rows do out[#out + 1] = rows[i].follower_cid end
+    for i = 1, #rows do out[#out + 1] = rows[i].follower end
     return out
 end
 
@@ -715,37 +858,38 @@ end
 ---@param follower string
 ---@param target string
 function store.addFollow(follower, target)
-    MySQL.insert.await('INSERT IGNORE INTO phone_birdy_follows (follower_cid, target_cid) VALUES (?, ?)', { follower, target })
+    MySQL.insert.await('INSERT IGNORE INTO phone_birdy_follows (follower, target) VALUES (?, ?)', { follower, target })
 end
 
 ---@param follower string
 ---@param target string
 function store.removeFollow(follower, target)
-    MySQL.update.await('DELETE FROM phone_birdy_follows WHERE follower_cid = ? AND target_cid = ?', { follower, target })
+    MySQL.update.await('DELETE FROM phone_birdy_follows WHERE follower = ? AND target = ?', { follower, target })
 end
 
----One side of `targetCid`'s follow graph, newest first, with both reciprocal flags resolved against `viewerCid`.
----@param viewerCid string the signed-in player, for the reciprocal flags
----@param targetCid string whose list is being read
+---One side of `target`'s follow graph, newest first, with both reciprocal flags resolved against
+---`viewerHandle`.
+---@param viewerHandle string the signed-in account, for the reciprocal flags
+---@param target string whose list is being read
 ---@param kind 'followers'|'following'
 ---@return table[] rows
-function store.followList(viewerCid, targetCid, kind)
-    local joinOn, whereCol = 'pr.citizenid = f.follower_cid', 'f.target_cid'
+function store.followList(viewerHandle, target, kind)
+    local joinOn, whereCol = 'pr.handle = f.follower', 'f.target'
     if kind == 'following' then
-        joinOn, whereCol = 'pr.citizenid = f.target_cid', 'f.follower_cid'
+        joinOn, whereCol = 'pr.handle = f.target', 'f.follower'
     end
 
     return MySQL.query.await(([[
-        SELECT pr.citizenid, pr.handle, pr.display_name, pr.bio, pr.verified, pr.avatar,
+        SELECT pr.handle, pr.display_name, pr.bio, pr.verified, pr.avatar,
                EXISTS(SELECT 1 FROM phone_birdy_follows x
-                      WHERE x.follower_cid = pr.citizenid AND x.target_cid = ?)   AS follows_you,
+                      WHERE x.follower = pr.handle AND x.target = ?)   AS follows_you,
                EXISTS(SELECT 1 FROM phone_birdy_follows y
-                      WHERE y.follower_cid = ? AND y.target_cid = pr.citizenid)   AS is_following
+                      WHERE y.follower = ? AND y.target = pr.handle)   AS is_following
         FROM phone_birdy_follows f
         JOIN phone_birdy_profiles pr ON %s
         WHERE %s = ?
         ORDER BY f.created_at DESC
-    ]]):format(joinOn, whereCol), { viewerCid, viewerCid, targetCid }) or {}
+    ]]):format(joinOn, whereCol), { viewerHandle, viewerHandle, target }) or {}
 end
 
 ---@param follower string
@@ -753,67 +897,67 @@ end
 ---@return boolean true when `follower` follows `target`
 function store.isFollowing(follower, target)
     return MySQL.scalar.await(
-        'SELECT 1 FROM phone_birdy_follows WHERE follower_cid = ? AND target_cid = ? LIMIT 1', { follower, target }
+        'SELECT 1 FROM phone_birdy_follows WHERE follower = ? AND target = ? LIMIT 1', { follower, target }
     ) ~= nil
 end
 
 ---Inserts a DM row; the meta table is JSON-encoded here.
 ---@param id string
----@param fromCid string
----@param toCid string
+---@param from string
+---@param to string
 ---@param kind string
 ---@param body string
 ---@param meta table|nil decoded metadata (gifUrl / amount / waveform / wpCode ...)
 ---@return boolean
-function store.insertDm(id, fromCid, toCid, kind, body, meta)
+function store.insertDm(id, from, to, kind, body, meta)
     local metaJson = (type(meta) == 'table' and next(meta) ~= nil) and json.encode(meta) or nil
     return MySQL.insert.await([[
-        INSERT INTO phone_birdy_dms (id, from_cid, to_cid, kind, body, meta) VALUES (?, ?, ?, ?, ?, ?)
-    ]], { id, fromCid, toCid, kind or 'text', body or '', metaJson }) ~= nil
+        INSERT INTO phone_birdy_dms (id, from_handle, to_handle, kind, body, meta) VALUES (?, ?, ?, ?, ?, ?)
+    ]], { id, from, to, kind or 'text', body or '', metaJson }) ~= nil
 end
 
----A player's most recent messages, oldest-first, with `created_ms` added. The inbox derives one
+---An account's most recent messages, oldest-first, with `created_ms` added. The inbox derives one
 ---conversation head per peer from these, so it only needs the recent tail; without the cap a
 ---flooded mailbox pulls every row it has ever held into Lua on each app open.
----@param cid string
+---@param handle string
 ---@return table[]
-function store.listMessagesFor(cid)
+function store.listMessagesFor(handle)
     local rows = MySQL.query.await([[
         SELECT * FROM (
-            SELECT id, from_cid, to_cid, body, kind, meta, reactions, read_flag,
+            SELECT id, from_handle, to_handle, body, kind, meta, reactions, read_flag,
                    created_at, UNIX_TIMESTAMP(created_at) AS created_s
-            FROM phone_birdy_dms WHERE from_cid = ? OR to_cid = ? ORDER BY created_at DESC LIMIT 5000
+            FROM phone_birdy_dms WHERE from_handle = ? OR to_handle = ? ORDER BY created_at DESC LIMIT 5000
         ) recent ORDER BY created_at ASC
-    ]], { cid, cid }) or {}
+    ]], { handle, handle }) or {}
     for i = 1, #rows do rows[i].created_ms = (tonumber(rows[i].created_s) or 0) * 1000 end
     return rows
 end
 
----Marks every message from `otherCid` to `viewerCid` as read. Idempotent.
----@param viewerCid string
----@param otherCid string
-function store.markThreadRead(viewerCid, otherCid)
-    if not viewerCid or viewerCid == '' or not otherCid or otherCid == '' then return end
+---Marks every message from `other` to `viewerHandle` as read. Idempotent.
+---@param viewerHandle string
+---@param other string
+function store.markThreadRead(viewerHandle, other)
+    if not viewerHandle or viewerHandle == '' or not other or other == '' then return end
     MySQL.update.await(
-        'UPDATE phone_birdy_dms SET read_flag = 1 WHERE to_cid = ? AND from_cid = ? AND read_flag = 0',
-        { viewerCid, otherCid })
+        'UPDATE phone_birdy_dms SET read_flag = 1 WHERE to_handle = ? AND from_handle = ? AND read_flag = 0',
+        { viewerHandle, other })
 end
 
----The newest 500 messages between two players (both directions), oldest-first, with `created_ms`
+---The newest 500 messages between two accounts (both directions), oldest-first, with `created_ms`
 ---added.
----@param cidA string
----@param cidB string
+---@param a string
+---@param b string
 ---@return table[]
-function store.listThread(cidA, cidB)
+function store.listThread(a, b)
     local rows = MySQL.query.await([[
         SELECT * FROM (
-            SELECT id, from_cid, to_cid, body, kind, meta, reactions,
+            SELECT id, from_handle, to_handle, body, kind, meta, reactions,
                    created_at, UNIX_TIMESTAMP(created_at) AS created_s
             FROM phone_birdy_dms
-            WHERE (from_cid = ? AND to_cid = ?) OR (from_cid = ? AND to_cid = ?)
+            WHERE (from_handle = ? AND to_handle = ?) OR (from_handle = ? AND to_handle = ?)
             ORDER BY created_at DESC LIMIT 500
         ) recent ORDER BY created_at ASC
-    ]], { cidA, cidB, cidB, cidA }) or {}
+    ]], { a, b, b, a }) or {}
     for i = 1, #rows do rows[i].created_ms = (tonumber(rows[i].created_s) or 0) * 1000 end
     return rows
 end
@@ -823,14 +967,14 @@ end
 ---@return table|nil
 function store.getDm(id)
     local row = MySQL.single.await([[
-        SELECT id, from_cid, to_cid, body, kind, meta, reactions, UNIX_TIMESTAMP(created_at) AS created_s
+        SELECT id, from_handle, to_handle, body, kind, meta, reactions, UNIX_TIMESTAMP(created_at) AS created_s
         FROM phone_birdy_dms WHERE id = ?
     ]], { id })
     if row then row.created_ms = (tonumber(row.created_s) or 0) * 1000 end
     return row
 end
 
----Overwrites a DM's reactions (a JSON object of emoji -> array of citizenids); an empty table
+---Overwrites a DM's reactions (a JSON object of emoji -> array of handles); an empty table
 ---stores NULL.
 ---@param id string
 ---@param reactions table
@@ -844,33 +988,33 @@ end
 ---or follow toggle would otherwise mint on every flip. The postless kinds are matched through
 ---IFNULL because SQL treats two NULL post_ids as distinct, which is also why this is not a
 ---UNIQUE key.
----@param recipientCid string
+---@param recipient string
 ---@param kind string
----@param actorCid string
+---@param actor string
 ---@param postId string|nil
 ---@param withinSecs integer age limit in seconds
 ---@return boolean exists
-function store.recentNotification(recipientCid, kind, actorCid, postId, withinSecs)
+function store.recentNotification(recipient, kind, actor, postId, withinSecs)
     local n = MySQL.scalar.await([[
         SELECT 1 FROM phone_birdy_notifications
-        WHERE recipient_cid = ? AND kind = ? AND actor_cid = ?
+        WHERE recipient = ? AND kind = ? AND actor = ?
           AND IFNULL(post_id, '') = ?
           AND created_at > NOW() - INTERVAL ? SECOND
         LIMIT 1
-    ]], { recipientCid, kind, actorCid, postId or '', withinSecs })
+    ]], { recipient, kind, actor, postId or '', withinSecs })
     return n ~= nil
 end
 
 ---@param id string
----@param recipientCid string
+---@param recipient string
 ---@param kind string
----@param actorCid string
+---@param actor string
 ---@param postId string|nil
-function store.insertNotification(id, recipientCid, kind, actorCid, postId)
+function store.insertNotification(id, recipient, kind, actor, postId)
     MySQL.insert.await([[
-        INSERT INTO phone_birdy_notifications (id, recipient_cid, kind, actor_cid, post_id)
+        INSERT INTO phone_birdy_notifications (id, recipient, kind, actor, post_id)
         VALUES (?, ?, ?, ?, ?)
-    ]], { id, recipientCid, kind, actorCid, postId })
+    ]], { id, recipient, kind, actor, postId })
 end
 
 ---Inserts many notifications in one statement. The post fan-out wrote one row per follower, so
@@ -892,35 +1036,35 @@ function store.insertNotifications(rows)
     end
     if n == 0 then return end
     MySQL.insert.await((
-        'INSERT INTO phone_birdy_notifications (id, recipient_cid, kind, actor_cid, post_id) VALUES %s'
+        'INSERT INTO phone_birdy_notifications (id, recipient, kind, actor, post_id) VALUES %s'
     ):format(table.concat(ph, ',')), args)
 end
 
----@param recipientCid string
+---@param recipient string
 ---@param limit number
 ---@return table[] rows with `created_ms` added
-function store.listNotifications(recipientCid, limit)
+function store.listNotifications(recipient, limit)
     local rows = MySQL.query.await([[
-        SELECT id, kind, actor_cid, post_id, UNIX_TIMESTAMP(created_at) AS created_s
-        FROM phone_birdy_notifications WHERE recipient_cid = ?
+        SELECT id, kind, actor, post_id, UNIX_TIMESTAMP(created_at) AS created_s
+        FROM phone_birdy_notifications WHERE recipient = ?
         ORDER BY created_at DESC LIMIT ?
-    ]], { recipientCid, limit }) or {}
+    ]], { recipient, limit }) or {}
     for i = 1, #rows do rows[i].created_ms = (tonumber(rows[i].created_s) or 0) * 1000 end
     return rows
 end
 
 ---Marks every unseen notification seen.
----@param recipientCid string
-function store.markNotificationsSeen(recipientCid)
-    MySQL.update.await('UPDATE phone_birdy_notifications SET seen = 1 WHERE recipient_cid = ? AND seen = 0', { recipientCid })
+---@param recipient string
+function store.markNotificationsSeen(recipient)
+    MySQL.update.await('UPDATE phone_birdy_notifications SET seen = 1 WHERE recipient = ? AND seen = 0', { recipient })
 end
 
 ---Unseen-notification count, for the Bell tab and the springboard badge. Read-only.
----@param recipientCid string
+---@param recipient string
 ---@return integer
-function store.unseenNotificationCount(recipientCid)
+function store.unseenNotificationCount(recipient)
     return tonumber(MySQL.scalar.await(
-        'SELECT COUNT(*) FROM phone_birdy_notifications WHERE recipient_cid = ? AND seen = 0', { recipientCid }
+        'SELECT COUNT(*) FROM phone_birdy_notifications WHERE recipient = ? AND seen = 0', { recipient }
     )) or 0
 end
 

--- a/server/migrate/port/sessions.lua
+++ b/server/migrate/port/sessions.lua
@@ -34,8 +34,9 @@ function M.run(ctx)
         if not app or not cid then
             skipped = skipped + 1
         elseif app == 'birdy' then
-            -- Squawk is still one account per character; its porter arrives with the
-            -- multi-account refactor and these rows are picked up then.
+            -- Squawk accepts multiple accounts now, but nothing has ported lb's Twitter profiles
+            -- across yet, so there is no account to attach these logins to. The Squawk porter
+            -- picks them up.
             deferred = deferred + 1
         else
             rows[#rows + 1] = { app, cid, l.username }

--- a/web/src/admin/adminApi.ts
+++ b/web/src/admin/adminApi.ts
@@ -49,8 +49,8 @@ export const adminBirdyPosts = (opts: { cursor?: string | null; q?: string; cid?
 export const adminBirdyDeletePost = (id: string) =>
     call<void>('sd-phone:admin:birdyDeletePost', { id });
 
-export const adminBirdySetVerified = (cid: string, verified: boolean) =>
-    call<void>('sd-phone:admin:birdySetVerified', { cid, verified });
+export const adminBirdySetVerified = (handle: string, verified: boolean) =>
+    call<void>('sd-phone:admin:birdySetVerified', { handle, verified });
 
 export const adminContent = (app: string, cursor?: string | null, q?: string) =>
     call<{ items: AdminContentItem[]; nextCursor?: string | null; deletable: boolean }>('sd-phone:admin:content', { app, cursor, q });

--- a/web/src/admin/pages/PlayerDetail.tsx
+++ b/web/src/admin/pages/PlayerDetail.tsx
@@ -13,7 +13,7 @@ import {
 import { acceptedNumberLengths } from '@/lib/phone';
 import {
     fmtPhone, fmtTime, scopeLabel,
-    type AdminBirdyPost, type AdminCall, type AdminMessage, type AdminMute, type AdminOverview,
+    type AdminBirdyPost, type AdminBirdyProfile, type AdminCall, type AdminMessage, type AdminMute, type AdminOverview,
 } from '../types';
 import { Badge, Btn, Card, CenterNote, ConfirmModal, LoadMore, OnlineDot, PromptModal, Spinner } from '../ui';
 import { usePaged } from '../usePaged';
@@ -264,22 +264,21 @@ function OverviewTab({ ov, toast, reload, onOpenTab, onOpenGallery }: {
                         onOpen={onOpenGallery ? () => onOpenGallery(ov.citizenid) : undefined} />
                     <CountRow label="Contacts"      count={c?.contacts ?? 0} />
                 </Card>
-                <Card title="Birdy profile">
-                    {ov.birdy ? (
-                        <>
-                            <InfoRow label="Handle">
-                                <span className="inline-flex items-center gap-1">
-                                    @{ov.birdy.handle}
-                                    {ov.birdy.verified && <BadgeCheck size={14} className="text-ios-blue" />}
-                                </span>
-                            </InfoRow>
-                            <InfoRow label="Display name">{ov.birdy.displayName}</InfoRow>
-                            <InfoRow label="Signed in">{ov.birdy.loggedIn ? 'Yes' : 'No'}</InfoRow>
-                            <InfoRow label="Created">{fmtTime(ov.birdy.createdAt)}</InfoRow>
-                        </>
-                    ) : (
-                        <div className="px-4 py-3 text-[13px] text-zinc-500">No Birdy profile.</div>
+                <Card title="Squawk accounts">
+                    {ov.birdy.length === 0 && (
+                        <div className="px-4 py-3 text-[13px] text-zinc-500">No Squawk account.</div>
                     )}
+                    {ov.birdy.map(b => (
+                        <InfoRow key={b.handle} label={`@${b.handle}`}>
+                            <span className="inline-flex items-center gap-1.5">
+                                {b.displayName}
+                                {b.verified && <BadgeCheck size={14} className="text-ios-blue" />}
+                                <span className="text-zinc-500">
+                                    {b.loggedIn ? 'signed in' : fmtTime(b.createdAt)}
+                                </span>
+                            </span>
+                        </InfoRow>
+                    ))}
                 </Card>
             </div>
         </div>
@@ -499,10 +498,9 @@ function BirdyTab({ ov, onChanged, toast }: {
 
     const { items, loading, hasMore, loadMore, setItems } = usePaged<AdminBirdyPost, string>(fetchPage, `birdy-player:${cid}`);
 
-    const toggleVerified = async () => {
-        if (!ov.birdy) return;
-        const res = await adminBirdySetVerified(cid, !ov.birdy.verified);
-        if (res.success) { toast(ov.birdy.verified ? 'Verification removed' : 'Profile verified'); onChanged(); }
+    const toggleVerified = async (profile: AdminBirdyProfile) => {
+        const res = await adminBirdySetVerified(profile.handle, !profile.verified);
+        if (res.success) { toast(profile.verified ? 'Verification removed' : 'Profile verified'); onChanged(); }
         else toast(res.message ?? 'Failed', true);
     };
 
@@ -512,20 +510,22 @@ function BirdyTab({ ov, onChanged, toast }: {
         else toast(res.message ?? 'Delete failed', true);
     };
 
-    if (!ov.birdy) return <CenterNote>This player has no Birdy profile.</CenterNote>;
+    if (ov.birdy.length === 0) return <CenterNote>This player has no Squawk account.</CenterNote>;
 
     return (
         <div className="space-y-4">
-            <Card className="flex items-center justify-between px-4 py-3">
-                <div className="flex items-center gap-2 text-[13px]">
-                    <span className="font-bold text-zinc-100">{ov.birdy.displayName}</span>
-                    {ov.birdy.verified && <BadgeCheck size={14} className="text-ios-blue" />}
-                    <span className="text-zinc-500">@{ov.birdy.handle}</span>
-                </div>
-                <Btn variant={ov.birdy.verified ? 'ghost' : 'primary'} onClick={() => void toggleVerified()}>
-                    <BadgeCheck size={14} /> {ov.birdy.verified ? 'Remove verification' : 'Verify profile'}
-                </Btn>
-            </Card>
+            {ov.birdy.map(b => (
+                <Card key={b.handle} className="flex items-center justify-between px-4 py-3">
+                    <div className="flex items-center gap-2 text-[13px]">
+                        <span className="font-bold text-zinc-100">{b.displayName}</span>
+                        {b.verified && <BadgeCheck size={14} className="text-ios-blue" />}
+                        <span className="text-zinc-500">@{b.handle}</span>
+                    </div>
+                    <Btn variant={b.verified ? 'ghost' : 'primary'} onClick={() => void toggleVerified(b)}>
+                        <BadgeCheck size={14} /> {b.verified ? 'Remove verification' : 'Verify profile'}
+                    </Btn>
+                </Card>
+            ))}
 
             <Card title={`Posts (${ov.counts?.birdyPosts ?? items.length})`}>
                 {items.map(p => (

--- a/web/src/admin/types.ts
+++ b/web/src/admin/types.ts
@@ -50,15 +50,7 @@ export interface AdminOverview {
         updatedAt?:    number;
     } | null;
     accounts: AdminAccount[];
-    birdy?: {
-        handle:      string;
-        displayName: string;
-        bio:         string;
-        verified:    boolean;
-        loggedIn:    boolean;
-        protected:   boolean;
-        createdAt?:  number;
-    } | null;
+    birdy: AdminBirdyProfile[];
     counts?: {
         birdyPosts: number;
         messages:   number;
@@ -103,6 +95,16 @@ export interface AdminSimLookup {
     ownerName?:   string | null;
     boundProfile: boolean;
     holder?: { cid?: string | null; name?: string | null; active: boolean } | null;
+}
+
+export interface AdminBirdyProfile {
+    handle:      string;
+    displayName: string;
+    bio:         string;
+    verified:    boolean;
+    loggedIn:    boolean;
+    protected:   boolean;
+    createdAt?:  number;
 }
 
 export interface AdminBirdyPost {

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -7,8 +7,9 @@ import { useAppAuth } from '@/hooks/useAppAuth';
 import { useIosPush } from '@/hooks/useIosPush';
 import { useDidEnter } from '@/hooks/useDidEnter';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
-import { useSessionState } from '@/hooks/useSessionState';
+import { clearSessionState, useSessionState } from '@/hooks/useSessionState';
 import { useDeckActive } from '@/shell/deckActive';
+import { AccountSwitcher } from '@/shared/AccountSwitcher';
 import { AppAuth } from '@/shared/AppAuth';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { MAIL_DOMAIN, accountsConfirmReset, accountsRequestReset, accountsSavePassword, accountsSuggestCode } from '@/core/accountsApi';
@@ -47,6 +48,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
     const [profileOpen,    setProfileOpen]    = useSessionState('birdy:profileOpen', false);
     const [profileTarget,  setProfileTarget]  = useSessionState<string | null>('birdy:profileTarget', null);
     const [editingProfile, setEditingProfile] = useState(false);
+    const [switching,      setSwitching]      = useState(false);
     const [profile,        setProfile]        = useState<BirdyProfile | null>(null);
     const [sendError,      setSendError]      = useState<string | null>(null);
 
@@ -240,6 +242,15 @@ export function Birdy({ onClose }: { onClose: () => void }) {
         void sendMessage(openConvoId, { kind: 'money', body: `$${amount}`, amount });
     }
 
+    function switchedAccount() {
+        clearSessionState('birdy:');
+        setProfileOpen(false); setProfileTarget(null); setProfile(null);
+        setOpenPostId(null); setOpenConvoId(null); setOpenConvo(null);
+        setPosts(null); setConvos([]); setNotifCount(0); setTab('home'); setFeed('all');
+        void apiMe().then(s => { if (s.me) setMe(s.me); });
+        refreshFeed();
+    }
+
     function selectTab(t: Tab) {
         setTab(t);
         setOpenPostId(null);
@@ -429,8 +440,17 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     profile={profile}
                     onCancel={() => setEditingProfile(false)}
                     onSaved={p => { setProfile(p); setMe({ name: p.name, handle: p.handle, verified: p.verified }); setEditingProfile(false); }}
-                    onSignOut={() => { setEditingProfile(false); setProfileOpen(false); setAuthed(false); }}
-                    onDeleted={() => { setEditingProfile(false); setProfileOpen(false); setAuthed(false); }}
+                    onSignOut={() => { setEditingProfile(false); setProfileOpen(false); clearSessionState('birdy:'); setAuthed(false); }}
+                    onSwitchAccount={() => { setEditingProfile(false); setSwitching(true); }}
+                    onDeleted={() => { setEditingProfile(false); setProfileOpen(false); clearSessionState('birdy:'); setAuthed(false); }}
+                />
+            )}
+
+            {switching && (
+                <AccountSwitcher
+                    app="birdy"
+                    onClose={() => setSwitching(false)}
+                    onSwitched={switchedAccount}
                 />
             )}
 

--- a/web/src/apps/birdy/birdyApi.ts
+++ b/web/src/apps/birdy/birdyApi.ts
@@ -128,7 +128,7 @@ export async function apiDmMarkRead(id: string): Promise<void> {
 
 export interface DmSendResult { message: BirdyMessage | null; error?: string }
 
-export async function apiDmSend(toCid: string, draft: MessageDraft): Promise<DmSendResult> {
+export async function apiDmSend(to: string, draft: MessageDraft): Promise<DmSendResult> {
     if (!isFiveM) {
         return { message: {
             id: newId('m'), fromMe: true, body: draft.body, at: clock(), ts: Date.now(),
@@ -138,7 +138,7 @@ export async function apiDmSend(toCid: string, draft: MessageDraft): Promise<DmS
             wpCode: draft.wpCode, wpSub: draft.wpSub,
         } };
     }
-    const r = await apiCall<{ message: BirdyMessage }>('sd-phone:birdy:dmSend', { toCid, ...draft });
+    const r = await apiCall<{ message: BirdyMessage }>('sd-phone:birdy:dmSend', { to, ...draft });
     if (r.success && r.data?.message) return { message: r.data.message };
     return { message: null, error: r.message };
 }

--- a/web/src/apps/birdy/profile/EditProfile.tsx
+++ b/web/src/apps/birdy/profile/EditProfile.tsx
@@ -12,12 +12,13 @@ import { BG, BLUE, type BirdyProfile } from '../data';
 
 const RED = '#ff3b30';
 
-export function EditProfile({ profile, onCancel, onSaved, onSignOut, onDeleted }: {
-    profile:   BirdyProfile;
-    onCancel:  () => void;
-    onSaved:   (p: BirdyProfile) => void;
-    onSignOut: () => void;
-    onDeleted: () => void;
+export function EditProfile({ profile, onCancel, onSaved, onSignOut, onSwitchAccount, onDeleted }: {
+    profile:         BirdyProfile;
+    onCancel:        () => void;
+    onSaved:         (p: BirdyProfile) => void;
+    onSignOut:       () => void;
+    onSwitchAccount: () => void;
+    onDeleted:       () => void;
 }) {
     const [name,       setName]       = useState(profile.name);
     const [bio,        setBio]        = useState(profile.bio);
@@ -117,6 +118,7 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onDeleted }
 
                 <div className="flex flex-col gap-3 px-4 py-6">
                     <button type="button" onClick={() => setPwOpen(true)} className="w-full rounded-[12px] bg-white py-4 text-[18px] font-semibold active:opacity-70" style={{ color: BLUE }}>{t('squawk.changePassword', 'Change Password')}</button>
+                    <button type="button" onClick={() => dismiss(onSwitchAccount)} className="w-full rounded-[12px] bg-white py-4 text-[18px] font-semibold active:opacity-70" style={{ color: BLUE }}>{t('accounts.switchAccount', 'Switch account')}</button>
                     <button type="button" onClick={() => setConfirmSignOut(true)} className="w-full rounded-[12px] bg-white py-4 text-[18px] font-semibold active:opacity-70" style={{ color: RED }}>{t('squawk.signOut', 'Sign Out')}</button>
                     <button type="button" onClick={() => setConfirmDel(true)} className="w-full rounded-[12px] bg-white py-4 text-[18px] font-semibold active:opacity-70" style={{ color: RED }}>{t('squawk.deleteAccount', 'Delete Account')}</button>
                 </div>


### PR DESCRIPTION
Squawk was the last account app stuck at one account per character, because `phone_birdy_profiles` was keyed `PRIMARY KEY (citizenid)` and all six other Birdy tables followed suit: posts, likes, reposts, follows, DMs and notifications each addressed a *character* rather than an *account*.

This moves the identity to the handle, which is what the accounts engine already treats as the account username.

## The re-key

`handle` was already `UNIQUE KEY uq_phone_birdy_handle`, so promoting it to the primary key is lossless: no row is dropped by the swap. `citizenid` stays on the profile as the creator stamp and gains an index.

| table | was | now |
|---|---|---|
| `phone_birdy_profiles` | PK `citizenid` | PK `handle`, `citizenid` indexed |
| `phone_birdy_posts` | `author_cid` | `author` |
| `phone_birdy_likes` / `_reposts` | `citizenid` | `handle` |
| `phone_birdy_follows` | `follower_cid` / `target_cid` | `follower` / `target` |
| `phone_birdy_dms` | `from_cid` / `to_cid` | `from_handle` / `to_handle` |
| `phone_birdy_notifications` | `recipient_cid` / `actor_cid` | `recipient` / `actor` |

## Three things that are not mechanical

**Rate limits and mutes stay on the citizenid.** `throttle()` and `moderation.guard()` are deliberately keyed by character, not account. Keying them by account would make the feature its own exploit: switch to an alt to reset a daily post budget or shed a mute. `viewer()` now returns `(profile, cid)` so callers have both identities to hand.

**Pushes cannot resolve a recipient with `getSourceByIdentifier` any more**, because one account can be open on several characters at once. Birdy borrows the `sourcesFor(handle)` fan-out Photogram and Vibez already use over `phone_app_sessions`, and `init.lua`'s `pushTo` now takes a handle and reaches every source. The money DM is the one place that still needs a *character*, since the cash lands in a character's bank account, so it resolves whichever citizen currently has the recipient's account open.

**The migration has to rewrite JSON, not just run DDL.** `phone_birdy_dms.reactions` stores `{emoji: [citizenid, ...]}`. No `ALTER TABLE` can reach inside that column, so a pure DDL migration would leave every reaction's "is this mine?" flag pointing at a dead identity. `birdy_handle_rekey` (via `util.runOnce`) rewrites the blob in Lua, then re-keys each table, and runs **before** the `CREATE TABLE IF NOT EXISTS` statements: those are no-ops on an existing install, so an old-shape database would otherwise keep its old columns while the code selected new ones. Rows whose citizenid owns no profile cannot be attributed to an account and are dropped. The profile PK swap is last, so a failure part-way through leaves the old shape in place and the whole thing retries on the next boot.

## Switching

Squawk joins the in-app account switcher through a new `SWITCH_APPS` whitelist rather than `DIRECT_APPS`. It is not a direct app on purpose: it owns its own register/login because it writes a profile row alongside the account, and the generic `accounts:register` would happily mint a Squawk account with no profile behind it. Switching only moves a session, which is safe. The per-app cap from #0ebd602 already applied, since `createAccount` enforces it for every caller.

## Admin

Player detail now lists **every** Squawk account a character created or is signed into, rather than picking one arbitrarily with `MySQL.single`. Verify addresses one account at a time (`birdySetVerified` takes a handle), post counts and the posts filter span all of the character's handles, and "signed in" is derived from live sessions instead of the legacy per-profile flag, which cannot say who is in an account right now.

`wipeCid` moves Birdy out of the citizenid-keyed sweep into an account-scoped block like Photogram's, deleting the engine account by username so accounts predating the `created_by` column do not survive as a login pointing at a profile that is gone.

One latent bug fixed along the way: `migrateLegacy`'s Squawk session import gains a `NOT EXISTS` guard. The session key is `(app, citizenid, account_id)`, so `INSERT IGNORE` does **not** deduplicate per character. Once switching exists, a player who moved to a second account would collect a *second* session row on the next boot, and `getSessionAccount`'s `LIMIT 1` would then choose between them arbitrarily, silently flipping them back.

## Gates

| gate | result |
|---|---|
| `luac -p` (11 touched Lua files) | pass |
| `tests/lua/run.lua` | 398 passed, 3 failed - identical on `main`, all in unrelated battery/settings suites (verified by stashing) |
| migration test (12 assertions, not committed) | pass - covers the upgrade path, the reaction rewrite, the fresh-install no-op, and the migration-before-CREATE ordering |
| `vitest` | 405 passed / 32 files |
| `oxlint src` | 0 errors, 0 warnings in touched files |
| `knip` | clean |
| `tsc --noEmit` | clean |
| `vite build` | built in 3.19s |

UI verified by mounting `EditProfile` from the Vite module graph: button order renders `Cancel, Save, Change Password, Switch account, Sign Out, Delete Account`, with the new entry styled to match `Change Password` and the layout unchanged.

## Follow-up

This unblocks the lb-phone twitter -> Squawk porter. `server/migrate/port/sessions.lua` still defers those logins, correctly: multi-account exists now, but nothing has ported lb's Twitter profiles across yet, so there is no account to attach them to.