### PR TITLE
feat(mail): add a mailbox without signing out of the first

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -708,7 +708,7 @@
     "recoverAccount": "Forgot your password? Tap here to recover your account",
     "required": "Required",
     "resetAppPassword": "Reset {appName} password",
-    "resetHelp": "Enter the email or phone number linked to your account and we will text or email you a code.",
+    "resetHelp": "Enter your username, or the email or phone number linked to your account, and we will text or email you a code.",
     "resetYourPassword": "Reset your password",
     "save": "Save",
     "savePasswordsBody": "Keep your {appName} username and password in the Passwords app so you can always find them.",

--- a/server/accounts/actions.lua
+++ b/server/accounts/actions.lua
@@ -333,31 +333,51 @@ local REQUEST_WINDOW = 600
 ---@return string key
 local function resetKey(app, accountId) return app .. ':' .. accountId end
 
----Resolves a recovery identity (the email or phone number on file) to the single matching
----account and its delivery channel; ambiguity or no match returns an error.
+---Resolves a recovery identity (a username, or the email or phone number on file) to the single
+---matching account and its delivery channel; ambiguity or no match returns an error.
 ---@param app string account app key
 ---@param raw string trimmed client-supplied identity
----@return table|nil acc, string|nil channel ('email'|'sms'), string|nil err
+---@return table|nil acc matched account
+---@return string|nil channel 'email' or 'sms'
+---@return string|nil err
 local function resolveRecovery(app, raw)
-    if raw == '' then return nil, nil, 'Enter the email or phone number on the account' end
+    if raw == '' then return nil, nil, 'Enter the username, email or phone number on the account' end
+
+    -- A username names exactly one account, so it is the only identity that still resolves once
+    -- several accounts share a recovery contact. Identity and delivery are separate here: the
+    -- name picks the account, its stored contact decides where the code goes. Mail usernames are
+    -- addresses, which is why an address identifies the mailbox rather than being the
+    -- destination - a code sent to the mailbox you are locked out of is no use.
+    local named = raw:lower()
+    if app == 'mail' and not named:find('@', 1, true) then named = named .. '@' .. MAIL_DOMAIN end
+    local byName = store.getAccount(app, named)
+    if byName then
+        local canEmail = app ~= 'mail' and byName.email and byName.email ~= ''
+        local canSms   = byName.phone and byName.phone ~= ''
+        if canEmail then return byName, 'email', nil end
+        if canSms   then return byName, 'sms',   nil end
+        return nil, nil, 'That account has no email or phone number to send a code to'
+    end
 
     local email, phone, channel
     if raw:find('@', 1, true) or raw:match('%a') then
         if app == 'mail' then
-            return nil, nil, 'Use the phone number linked to the account'
+            return nil, nil, 'No Mail account uses that address'
         end
         local e = raw:lower()
         if not e:find('@', 1, true) then e = e .. '@' .. MAIL_DOMAIN end
         email, channel = e, 'email'
     else
         local p = digits(raw)
-        if #p < 7 or #p > 15 then return nil, nil, 'Enter the email or phone number on the account' end
+        if #p < 7 or #p > 15 then return nil, nil, 'Enter the username, email or phone number on the account' end
         phone, channel = p, 'sms'
     end
 
     local matches = store.findAccountsByContact(app, email, phone)
     if #matches == 0 then return nil, nil, 'No account uses that contact' end
-    if #matches > 1 then return nil, nil, 'More than one account uses that contact. Ask an admin for help' end
+    if #matches > 1 then
+        return nil, nil, 'More than one account uses that contact. Enter the account username instead'
+    end
     return matches[1], channel, nil
 end
 

--- a/server/accounts/actions.lua
+++ b/server/accounts/actions.lua
@@ -579,15 +579,48 @@ function actions.myNumber(source)
     return ok({ number = settings.getPhoneNumber(cid) })
 end
 
----Returns the first mail account this character is signed into; nil when signed out of Mail.
+---Every mail address this character is signed into, for the recovery-email quick fill. `email` is
+---the first and is kept so an older UI build still fills something.
 ---@param source number player server id
----@return table envelope data = { email? }
+---@return table envelope data = { email?, emails }
 function actions.myEmail(source)
     local cid = player.getIdentifier(source)
-    if not cid then return ok({}) end
-    local accounts = mailStore.listAccountsForCitizen(cid)
-    local first = accounts[1]
-    return ok({ email = first and first.email or nil })
+    if not cid then return ok({ emails = {} }) end
+    local emails = {}
+    for _, acc in ipairs(mailStore.listAccountsForCitizen(cid)) do
+        if acc.email and acc.email ~= '' then emails[#emails + 1] = acc.email end
+    end
+    return ok({ email = emails[1], emails = emails })
+end
+
+---Signs the caller out of one app, moving them to another of their own saved accounts when they
+---have one rather than dropping them at the sign-in screen. Returns the account they landed on,
+---or nil when there was nowhere to go and the session was cleared.
+---@param source number player server id
+---@param payload table|nil client-supplied { app }
+---@return table envelope data = { switchedTo?, me? }
+function actions.signOutOrSwitch(source, payload)
+    local app = payload and payload.app
+    if not SWITCH_APPS[app] then return fail('Unknown app') end
+    local cid = player.getIdentifier(source); if not cid then return fail('Player not found') end
+
+    local current = store.getSessionAccount(app, cid)
+
+    -- The vault is a convenience, not an authority: each saved password is verified against the
+    -- account before it is used, exactly as switchAccount does, so a stale entry is skipped
+    -- rather than granting access.
+    for _, row in ipairs(store.listVaultEntries(cid)) do
+        if row.app == app and (not current or row.username:lower() ~= current.username:lower()) then
+            local acc = store.getAccount(app, row.username)
+            if acc and actions.verifyPassword(acc, row.password) then
+                store.setSession(app, cid, acc.id)
+                return ok({ switchedTo = acc.username, me = publicAccount(acc) })
+            end
+        end
+    end
+
+    store.clearSession(app, cid)
+    return ok({ switchedTo = nil })
 end
 
 ---Resolves an export-supplied (app, username) pair to a full account row, nil for an unknown

--- a/server/accounts/init.lua
+++ b/server/accounts/init.lua
@@ -28,6 +28,7 @@ lib.callback.register('sd-phone:server:accounts:logout',       function(src, pay
 lib.callback.register('sd-phone:server:accounts:me',           function(src, payload) return actions.me(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:switchable',   function(src, payload) return actions.switchable(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:switch',       function(src, payload) return actions.switchAccount(src, payload) end)
+lib.callback.register('sd-phone:server:accounts:signOut',      function(src, payload) return actions.signOutOrSwitch(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:requestReset', function(src, payload) return actions.requestReset(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:confirmReset', function(src, payload) return actions.confirmReset(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:changePassword', function(src, payload) return actions.changePassword(src, payload) end)

--- a/server/accounts/init.lua
+++ b/server/accounts/init.lua
@@ -38,40 +38,102 @@ lib.callback.register('sd-phone:server:accounts:savePassword',   function(src, p
 lib.callback.register('sd-phone:server:accounts:listPasswords',  function(src)          return actions.listPasswords(src) end)
 lib.callback.register('sd-phone:server:accounts:deletePassword', function(src, payload) return actions.deletePassword(src, payload) end)
 
----@type string[] Tables truncated by /wipephoneaccounts.
-local WIPE_TABLES = {
-    'phone_app_accounts',
-    'phone_app_sessions',
-    'phone_passwords',
-    'phone_mail_accounts',
-    'phone_birdy_profiles',
-    'phone_birdy_posts',
-    'phone_birdy_likes',
-    'phone_birdy_reposts',
-    'phone_birdy_follows',
-    'phone_birdy_dms',
-    'phone_birdy_notifications',
+---@type table<string, string[]> Every content table an account app owns, children before parents.
+---Order matters: these are DELETEs, not TRUNCATEs, because MySQL refuses to truncate any table a
+---foreign key points at, and three constraints point at phone_birdy_posts alone.
+local APP_TABLES = {
+    mail = {
+        'phone_mail_saved_emails', 'phone_mail_sessions', 'phone_mail_accounts',
+    },
+    birdy = {
+        'phone_birdy_notifications', 'phone_birdy_dms', 'phone_birdy_follows',
+        'phone_birdy_reposts', 'phone_birdy_likes', 'phone_birdy_posts', 'phone_birdy_profiles',
+    },
+    photogram = {
+        'phone_photogram_story_views', 'phone_photogram_stories', 'phone_photogram_comment_likes',
+        'phone_photogram_comments', 'phone_photogram_saves', 'phone_photogram_likes',
+        'phone_photogram_dms', 'phone_photogram_notifications', 'phone_photogram_follows',
+        'phone_photogram_posts', 'phone_photogram_profiles',
+    },
+    cherry = {
+        'phone_cherry_messages', 'phone_cherry_matches', 'phone_cherry_swipes',
+        'phone_cherry_blocks', 'phone_cherry_profiles',
+    },
+    vibez = {
+        'phone_vibez_comment_likes', 'phone_vibez_comments', 'phone_vibez_saves',
+        'phone_vibez_likes', 'phone_vibez_notifications', 'phone_vibez_follows',
+        'phone_vibez_posts', 'phone_vibez_profiles',
+    },
+    ryde = { 'phone_ryde_rides', 'phone_ryde_drivers' },
 }
 
----/wipephoneaccounts - truncates every table in WIPE_TABLES (admin-only), each TRUNCATE
----pcall-guarded; runnable from the server console.
----@param source integer player server id (0 from console)
-lib.addCommand('wipephoneaccounts', {
-    help = 'Wipe EVERY phone app account (mail, birdy, photogram, cherry, vibez), all birdy content, and the passwords vault',
-    restricted = 'group.admin',
-}, function(source)
-    local wiped, failed = 0, 0
-    for i = 1, #WIPE_TABLES do
-        local okTruncate = pcall(function()
-            MySQL.query.await('TRUNCATE TABLE ' .. WIPE_TABLES[i])
+---@type string[] APP_TABLES keys in a stable order, for the help text and the wipe-everything pass.
+local APP_ORDER = { 'mail', 'birdy', 'photogram', 'cherry', 'vibez', 'ryde' }
+
+---Empties one table, swallowing the error when it does not exist on this install.
+---@param tbl string table name
+---@return integer removed rows deleted (0 on failure)
+local function clearTable(tbl)
+    local okDel, res = pcall(function() return MySQL.update.await('DELETE FROM ' .. tbl) end)
+    return okDel and (tonumber(res) or 0) or 0
+end
+
+---Wipes one app: its content tables, then its credentials, sessions and saved vault logins.
+---@param app string account app key
+---@return integer removed
+local function wipeApp(app)
+    local removed = 0
+    for _, tbl in ipairs(APP_TABLES[app]) do removed = removed + clearTable(tbl) end
+    for _, tbl in ipairs({ 'phone_app_accounts', 'phone_app_sessions', 'phone_passwords' }) do
+        local okDel, res = pcall(function()
+            return MySQL.update.await(('DELETE FROM %s WHERE app = ?'):format(tbl), { app })
         end)
-        if okTruncate then wiped = wiped + 1 else failed = failed + 1 end
+        removed = removed + (okDel and (tonumber(res) or 0) or 0)
+    end
+    return removed
+end
+
+---/wipephoneaccounts [app] - wipes every phone app account, or one app's, along with all of that
+---app's content and its saved Passwords-app logins. Admin-only, runnable from the server console.
+---Content goes too on purpose: these apps key their rows by username, so leaving them behind means
+---re-registering a name silently inherits the old account's posts, matches and messages.
+---@param source integer player server id (0 from console)
+---@param args table { app?: string }
+lib.addCommand('wipephoneaccounts', {
+    help = 'Wipe phone app accounts and all their content. No argument wipes every app; pass one of mail, birdy, photogram, cherry, vibez, ryde to wipe just that one.',
+    params = {
+        { name = 'app', type = 'string', help = 'mail | birdy | photogram | cherry | vibez | ryde (blank = all)', optional = true },
+    },
+    restricted = 'group.admin',
+}, function(source, args)
+    local app = args and args.app and args.app:lower() or nil
+    if app == '' or app == 'all' then app = nil end
+
+    if app and not APP_TABLES[app] then
+        local msg = ('unknown app "%s". Use one of: %s'):format(app, table.concat(APP_ORDER, ', '))
+        print(('^1[sd-phone:accounts]^0 %s'):format(msg))
+        if source and source > 0 then
+            TriggerClientEvent('ox_lib:notify', source, {
+                title = 'Phone accounts', description = msg, type = 'error',
+            })
+        end
+        return
     end
 
-    local msg = ('wiped %d account table%s%s'):format(
-        wiped, wiped == 1 and '' or 's',
-        failed > 0 and (' (%d missing/failed)'):format(failed) or ''
-    )
+    local removed = 0
+    if app then
+        removed = wipeApp(app)
+    else
+        for _, key in ipairs(APP_ORDER) do removed = removed + wipeApp(key) end
+        -- Anything left in the shared tables belongs to an app with no content of its own.
+        removed = removed + clearTable('phone_app_sessions')
+        removed = removed + clearTable('phone_app_accounts')
+        removed = removed + clearTable('phone_passwords')
+    end
+
+    local msg = ('wiped %s (%d row%s)'):format(
+        app and (app .. ' accounts') or 'every phone app account',
+        removed, removed == 1 and '' or 's')
     print(('^3[sd-phone:accounts]^0 %s'):format(msg))
     if source and source > 0 then
         TriggerClientEvent('ox_lib:notify', source, {
@@ -80,27 +142,20 @@ lib.addCommand('wipephoneaccounts', {
     end
 end)
 
----/wipephotogram - deletes Photogram accounts, their sessions, and saved Passwords-app logins,
----leaving every other app's accounts intact (admin-only).
+---/wipephotogram - kept for the muscle memory; identical to `/wipephoneaccounts photogram`. It
+---used to leave the content tables behind, which meant re-registering a username inherited the
+---old account's posts and followers.
 ---@param source integer player server id (0 from console)
 lib.addCommand('wipephotogram', {
-    help = 'Wipe ALL Photogram accounts (plus their sessions and saved logins). Everyone must re-register.',
+    help = 'Wipe ALL Photogram accounts and their content. Same as /wipephoneaccounts photogram.',
     restricted = 'group.admin',
 }, function(source)
-    local removed = 0
-    local ok = pcall(function()
-        removed = MySQL.update.await('DELETE FROM phone_app_accounts WHERE app = ?', { 'photogram' }) or 0
-        MySQL.update.await('DELETE FROM phone_app_sessions WHERE app = ?', { 'photogram' })
-        MySQL.update.await('DELETE FROM phone_passwords   WHERE app = ?', { 'photogram' })
-    end)
-
-    local msg = ok
-        and ('wiped %d Photogram account%s'):format(removed, removed == 1 and '' or 's')
-        or  'failed to wipe Photogram accounts (see server console)'
+    local removed = wipeApp('photogram')
+    local msg = ('wiped photogram accounts (%d row%s)'):format(removed, removed == 1 and '' or 's')
     print(('^3[sd-phone:accounts]^0 %s'):format(msg))
     if source and source > 0 then
         TriggerClientEvent('ox_lib:notify', source, {
-            title = 'Photogram', description = msg, type = ok and 'success' or 'error',
+            title = 'Photogram', description = msg, type = 'success',
         })
     end
 end)

--- a/server/mail/actions.lua
+++ b/server/mail/actions.lua
@@ -324,10 +324,8 @@ function actions.signUp(source, payload)
     if phone ~= '' and (#phone < 7 or #phone > 15) then
         return fail('That phone number looks invalid')
     end
-    if phone ~= '' and #acctStore.findAccountsByContact('mail', nil, phone) > 0 then
-        return fail('That phone number is already in use')
-    end
-
+    -- The number is deliberately NOT unique: one person runs several mailboxes off one phone.
+    -- Recovery stays possible because a reset is identified by the address, not by the number.
     if store.getAccount(email) then
         return fail('That email is already registered')
     end

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -12,7 +12,7 @@ import { useDeckActive } from '@/shell/deckActive';
 import { AccountSwitcher } from '@/shared/AccountSwitcher';
 import { AppAuth } from '@/shared/AppAuth';
 import { AlertDialog } from '@/ui/AlertDialog';
-import { MAIL_DOMAIN, accountsConfirmReset, accountsRequestReset, accountsSavePassword, accountsSuggestCode } from '@/core/accountsApi';
+import { MAIL_DOMAIN, accountsConfirmReset, accountsRequestReset, accountsSavePassword, accountsSignOut, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { toggleReactionLocal } from '@/shared/chat/messagesApi';
 import type { MessageDraft } from '@/shared/chat/ChatView';
 import {
@@ -33,7 +33,7 @@ type Tab = 'home' | 'search' | 'notifications' | 'messages';
 
 export function Birdy({ onClose }: { onClose: () => void }) {
     const [me,          setMe]          = useState<BirdyAuthor>(CURRENT_USER);
-    const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmail, savedLogin } = useAppAuth('birdy',
+    const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmails, savedLogin, savedAccounts, refreshAccounts } = useAppAuth('birdy',
         () => apiMe().then(s => { if (s.me) setMe(s.me); return s.loggedIn; }));
     // null = not fetched yet (the feed shows skeletons instead of a false "no posts" flash).
     const [posts,       setPosts]       = useState<BirdyPost[] | null>(null);
@@ -245,6 +245,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
 
     function switchedAccount() {
         clearSessionState('birdy:');
+        refreshAccounts();
         setProfileOpen(false); setProfileTarget(null); setProfile(null);
         setOpenPostId(null); setOpenConvoId(null); setOpenConvo(null);
         setPosts(null); setConvos([]); setNotifCount(0); setTab('home'); setFeed('all');
@@ -327,7 +328,9 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     welcomeText: 'dark',
                 }}
                 myNumber={myNumber}
-                myEmail={myEmail}
+                myEmails={myEmails}
+                savedAccounts={savedAccounts}
+                onPickAccount={u => accountsSwitch('birdy', u)}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
                 modal={adding}
@@ -448,7 +451,14 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     profile={profile}
                     onCancel={() => setEditingProfile(false)}
                     onSaved={p => { setProfile(p); setMe({ name: p.name, handle: p.handle, verified: p.verified }); setEditingProfile(false); }}
-                    onSignOut={() => { setEditingProfile(false); setProfileOpen(false); clearSessionState('birdy:'); setAuthed(false); }}
+                    onSignOut={() => {
+                        setEditingProfile(false);
+                        setProfileOpen(false);
+                        void accountsSignOut('birdy').then(r => {
+                            if (r.switchedTo) switchedAccount();
+                            else { clearSessionState('birdy:'); refreshAccounts(); setAuthed(false); }
+                        });
+                    }}
                     onSwitchAccount={() => { setEditingProfile(false); setSwitching(true); }}
                     onDeleted={() => { setEditingProfile(false); setProfileOpen(false); clearSessionState('birdy:'); setAuthed(false); }}
                 />

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -316,8 +316,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
     if (!authChecked) {
         return <div className="absolute inset-0 z-10" style={{ background: BG }} />;
     }
-    if (!authed || adding) {
-        return (
+    const authScreen = (
             <AppAuth
                 appName="Birdy"
                 tagline={t('squawk.tagline', 'Where the city starts conversations.')}
@@ -331,6 +330,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                 myEmail={myEmail}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
+                modal={adding}
                 fields={[
                     { key: 'username', label: t('squawk.username', 'Username') },
                     { key: 'name',     label: t('squawk.name', 'Name') },
@@ -358,8 +358,9 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                 onSuggestCode={(id) => accountsSuggestCode('birdy', id)}
                 onSaveCredentials={(vals) => accountsSavePassword('birdy', vals)}
             />
-        );
-    }
+    );
+
+    if (!authed) return authScreen;
 
     return (
         <div className={`absolute inset-0 z-10 flex flex-col text-black ${justAuthed ? 'animate-swipe-in-left' : ''}`} style={{ background: BG }}>
@@ -479,6 +480,8 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                 aria-label={t('squawk.closeBirdy', 'Close Squawk')}
                 className="absolute inset-x-0 bottom-0 z-[5] h-5 cursor-default"
             />
+
+            {adding && <div className="absolute inset-0 z-[70]">{authScreen}</div>}
         </div>
     );
 }

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -49,6 +49,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
     const [profileTarget,  setProfileTarget]  = useSessionState<string | null>('birdy:profileTarget', null);
     const [editingProfile, setEditingProfile] = useState(false);
     const [switching,      setSwitching]      = useState(false);
+    const [adding,         setAdding]         = useState(false);
     const [profile,        setProfile]        = useState<BirdyProfile | null>(null);
     const [sendError,      setSendError]      = useState<string | null>(null);
 
@@ -315,7 +316,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
     if (!authChecked) {
         return <div className="absolute inset-0 z-10" style={{ background: BG }} />;
     }
-    if (!authed) {
+    if (!authed || adding) {
         return (
             <AppAuth
                 appName="Birdy"
@@ -328,7 +329,8 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                 }}
                 myNumber={myNumber}
                 myEmail={myEmail}
-                savedLogin={savedLogin}
+                savedLogin={adding ? null : savedLogin}
+                onDismiss={adding ? () => setAdding(false) : undefined}
                 fields={[
                     { key: 'username', label: t('squawk.username', 'Username') },
                     { key: 'name',     label: t('squawk.name', 'Name') },
@@ -345,7 +347,12 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     const r = await apiLogin({ username: vals.username ?? '', password: vals.password ?? '' });
                     return { ok: r.ok, message: r.message };
                 }}
-                onAuthed={() => { setAuthed(true); setJustAuthed(true); void apiMe().then(s => { if (s.me) setMe(s.me); }); }}
+                onAuthed={() => {
+                    setAuthed(true);
+                    setJustAuthed(true);
+                    if (adding) { setAdding(false); switchedAccount(); }
+                    else void apiMe().then(s => { if (s.me) setMe(s.me); });
+                }}
                 onRequestReset={(id) => accountsRequestReset('birdy', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('birdy', id, code, pw)}
                 onSuggestCode={(id) => accountsSuggestCode('birdy', id)}
@@ -451,6 +458,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     app="birdy"
                     onClose={() => setSwitching(false)}
                     onSwitched={switchedAccount}
+                    onAdd={() => setAdding(true)}
                 />
             )}
 

--- a/web/src/apps/birdy/birdyApi.ts
+++ b/web/src/apps/birdy/birdyApi.ts
@@ -46,11 +46,6 @@ export async function apiLogin(input: { username: string; password: string }): P
     return res.success ? { ok: true, me: res.data?.me } : { ok: false, message: res.message };
 }
 
-export async function apiLogout(): Promise<void> {
-    if (!isFiveM) { devLoggedIn = false; return; }
-    await fetchNui('sd-phone:birdy:logout');
-}
-
 /** Subscribe/unsubscribe this phone to the feed push. The server only pushes to watchers, so a
  * phone that is closed or backgrounded no longer pays to receive and discard one. */
 export function apiWatch(on: boolean): void {

--- a/web/src/apps/birdy/profile/EditProfile.tsx
+++ b/web/src/apps/birdy/profile/EditProfile.tsx
@@ -5,7 +5,7 @@ import { t } from '@/i18n';
 import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { Toggle } from '@/ui/Toggle';
-import { apiDeleteAccount, apiLogout, apiUpdateProfile } from '../birdyApi';
+import { apiDeleteAccount, apiUpdateProfile } from '../birdyApi';
 import { accountsForgetPassword } from '@/core/accountsApi';
 import { ChangePasswordPage } from '@/shared/ChangePasswordPage';
 import { BG, BLUE, type BirdyProfile } from '../data';
@@ -46,8 +46,7 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onSwitchAcc
         if (p) dismiss(() => onSaved(p));
     }
 
-    async function signOut() {
-        await apiLogout();
+    function signOut() {
         onSignOut();
     }
 

--- a/web/src/apps/cherry/Cherry.tsx
+++ b/web/src/apps/cherry/Cherry.tsx
@@ -44,6 +44,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
     const [matches, setMatches] = useState<Match[]>([]);
     const [sendError, setSendError] = useState<string | null>(null);
     const [switching, setSwitching] = useState(false);
+    const [adding,    setAdding]    = useState(false);
     const [lockedIds, setLockedIds] = useState<string[]>([]);
     const [incomingMatch, setIncomingMatch] = useState<Match | null>(null);
 
@@ -249,7 +250,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
     if (!authChecked) {
         return <div className="absolute inset-0 z-10 bg-[#e5e5e5]" />;
     }
-    if (!authed) {
+    if (!authed || adding) {
         return (
             <AppAuth
                 appName="Cherry"
@@ -263,7 +264,8 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                 }}
                 myNumber={myNumber}
                 myEmail={myEmail}
-                savedLogin={savedLogin}
+                savedLogin={adding ? null : savedLogin}
+                onDismiss={adding ? () => setAdding(false) : undefined}
                 fields={[
                     { key: 'username', label: t('cherry.username', 'Username') },
                     { key: 'name',     label: t('cherry.name', 'Name') },
@@ -283,7 +285,11 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                     }
                     return res;
                 }}
-                onAuthed={() => { setAuthed(true); setJustAuthed(true); }}
+                onAuthed={() => {
+                    setAuthed(true);
+                    setJustAuthed(true);
+                    if (adding) { setAdding(false); void refreshDeck(); }
+                }}
                 onRequestReset={(id) => accountsRequestReset('cherry', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('cherry', id, code, pw)}
                 onSuggestCode={(id) => accountsSuggestCode('cherry', id)}
@@ -392,6 +398,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                     app="cherry"
                     onClose={() => setSwitching(false)}
                     onSwitched={() => { void refreshDeck(); }}
+                    onAdd={() => setAdding(true)}
                 />
             )}
         </div>

--- a/web/src/apps/cherry/Cherry.tsx
+++ b/web/src/apps/cherry/Cherry.tsx
@@ -12,7 +12,7 @@ import { useAppAuth } from '@/hooks/useAppAuth';
 import { AppAuth } from '@/shared/AppAuth';
 import { AccountSwitcher } from '@/shared/AccountSwitcher';
 import { AlertDialog } from '@/ui/AlertDialog';
-import { MAIL_DOMAIN, accountsConfirmReset, accountsForgetPassword, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSuggestCode } from '@/core/accountsApi';
+import { MAIL_DOMAIN, accountsConfirmReset, accountsForgetPassword, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSignOut, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { appendThreadMessage, patchThreadMessage, toggleReactionLocal } from '@/shared/chat/messagesApi';
 import type { Message, Reaction } from '@/shared/chat/data';
 import type { MessageDraft } from '@/shared/chat/ChatView';
@@ -30,7 +30,7 @@ import { MatchChat } from './MatchChat';
 type View = 'deck' | 'profile' | 'matches' | { chatId: string };
 
 export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
-    const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmail, savedLogin } = useAppAuth('cherry',
+    const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmails, savedLogin, savedAccounts, refreshAccounts } = useAppAuth('cherry',
         () => accountsMe('cherry').then(s => s.loggedIn));
 
     useStatusBarLight(authed ? false : null);
@@ -262,7 +262,9 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                     welcomeCtaWhite: true,
                 }}
                 myNumber={myNumber}
-                myEmail={myEmail}
+                myEmails={myEmails}
+                savedAccounts={savedAccounts}
+                onPickAccount={u => accountsSwitch('cherry', u)}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
                 modal={adding}
@@ -288,7 +290,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                 onAuthed={() => {
                     setAuthed(true);
                     setJustAuthed(true);
-                    if (adding) { setAdding(false); void refreshDeck(); }
+                    if (adding) { setAdding(false); refreshAccounts(); void refreshDeck(); }
                 }}
                 onRequestReset={(id) => accountsRequestReset('cherry', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('cherry', id, code, pw)}
@@ -340,7 +342,13 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                             <EditProfile
                                 profile={profile}
                                 onChange={setProfile}
-                                onSignOut={() => { void accountsLogout('cherry'); setAuthed(false); }}
+                                onSignOut={() => {
+                                    void accountsSignOut('cherry').then(r => {
+                                        refreshAccounts();
+                                        if (r.switchedTo) setStateNonce(n => n + 1);
+                                        else setAuthed(false);
+                                    });
+                                }}
                                 onSwitchAccount={() => setSwitching(true)}
                                 onDeleteAccount={() => {
                                     void (async () => {
@@ -398,7 +406,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                 <AccountSwitcher
                     app="cherry"
                     onClose={() => setSwitching(false)}
-                    onSwitched={() => { void refreshDeck(); }}
+                    onSwitched={() => { refreshAccounts(); void refreshDeck(); }}
                     onAdd={() => setAdding(true)}
                 />
             )}

--- a/web/src/apps/cherry/Cherry.tsx
+++ b/web/src/apps/cherry/Cherry.tsx
@@ -250,8 +250,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
     if (!authChecked) {
         return <div className="absolute inset-0 z-10 bg-[#e5e5e5]" />;
     }
-    if (!authed || adding) {
-        return (
+    const authScreen = (
             <AppAuth
                 appName="Cherry"
                 tagline={t('cherry.tagline', 'Find your person in Los Santos.')}
@@ -266,6 +265,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                 myEmail={myEmail}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
+                modal={adding}
                 fields={[
                     { key: 'username', label: t('cherry.username', 'Username') },
                     { key: 'name',     label: t('cherry.name', 'Name') },
@@ -295,8 +295,9 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                 onSuggestCode={(id) => accountsSuggestCode('cherry', id)}
                 onSaveCredentials={(vals) => accountsSavePassword('cherry', vals)}
             />
-        );
-    }
+    );
+
+    if (!authed) return authScreen;
 
     return (
         <div className={`absolute inset-0 flex flex-col bg-[#e5e5e5] font-sf ${justAuthed ? 'animate-swipe-in-left' : ''}`}>
@@ -401,6 +402,8 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                     onAdd={() => setAdding(true)}
                 />
             )}
+
+            {adding && <div className="absolute inset-0 z-[70]">{authScreen}</div>}
         </div>
     );
 }

--- a/web/src/apps/mail/Mail.tsx
+++ b/web/src/apps/mail/Mail.tsx
@@ -43,6 +43,7 @@ export function Mail({ onClose }: { onClose: () => void }) {
     const [savedEmails,     setSavedEmails]     = useState<string[]>([]);
     const [declinedEmails,  setDeclinedEmails]  = useState<string[]>([]);
     const [savedPageOpen,   setSavedPageOpen]   = useState(false);
+    const [adding,          setAdding]          = useState(false);
     const [savePromptQueue, setSavePromptQueue] = useState<string[]>([]);
 
     const applySavedState = useCallback((s: SavedEmailState) => {
@@ -55,6 +56,7 @@ export function Mail({ onClose }: { onClose: () => void }) {
         setAccounts(next.accounts);
         setMessages(next.messages);
         setAuthChecked(true);
+        return next;
     }, []);
 
     useEffect(() => { void refresh(); }, [refresh]);
@@ -217,12 +219,6 @@ export function Mail({ onClose }: { onClose: () => void }) {
 
     const [pwOpen, setPwOpen] = useState(false);
 
-    function handleAccountAdded(account: MailAccount) {
-        setAccounts(prev => prev.some(a => a.email === account.email) ? prev : [...prev, account]);
-        selectAccount(account.id);
-        void refresh();
-    }
-
     async function handleSignOut(id: string) {
         const target = accounts.find(a => a.id === id);
         if (!target) return;
@@ -282,7 +278,7 @@ export function Mail({ onClose }: { onClose: () => void }) {
         ?? (nav.stage === 'list' || nav.stage === 'detail' ? nav.accountId : undefined)
         ?? accounts[0]?.id;
 
-    if (locked || (authChecked && accounts.length === 0)) {
+    if (locked || adding || (authChecked && accounts.length === 0)) {
         return (
             <AppAuth
                 appName={t('mail.appName', 'Mail')}
@@ -290,7 +286,8 @@ export function Mail({ onClose }: { onClose: () => void }) {
                 icon="mail"
                 theme={{ accent: '#0A84FF', welcomeBg: '#f2f2f7', welcomeText: 'dark' }}
                 myNumber={myNumber}
-                savedLogin={savedLogin}
+                savedLogin={adding ? null : savedLogin}
+                onDismiss={adding ? () => setAdding(false) : undefined}
                 fields={[
                     { key: 'email',    label: t('mail.fieldEmail', 'Email'), suffix: `@${MAIL_DOMAIN}` },
                     { key: 'name',     label: t('mail.fieldName', 'Name'), createOnly: true },
@@ -303,7 +300,17 @@ export function Mail({ onClose }: { onClose: () => void }) {
                         : await mailSignIn({ email: vals.email ?? '', password: vals.password ?? '' });
                     return typeof r === 'string' ? { ok: false, message: r } : { ok: true };
                 }}
-                onAuthed={() => { unlockMail('mail', {}); setLocked(false); setJustAuthed(true); void refresh(); }}
+                onAuthed={() => {
+                    unlockMail('mail', {});
+                    setLocked(false);
+                    setJustAuthed(true);
+                    const known = new Set(accounts.map(a => a.id));
+                    void refresh().then(next => {
+                        const added = next.accounts.find(a => !known.has(a.id));
+                        if (added) selectAccount(added.id);
+                        setAdding(false);
+                    });
+                }}
                 onRequestReset={(id) => accountsRequestReset('mail', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('mail', id, code, pw)}
                 onSuggestCode={(id) => accountsSuggestCode('mail', id)}
@@ -334,7 +341,7 @@ export function Mail({ onClose }: { onClose: () => void }) {
                     });
                 }}
                 onCompose={() => setComposeFor({ accountId: activeAccount?.id })}
-                onAccountAdded={handleAccountAdded}
+                onAddAccount={() => setAdding(true)}
                 onSignOut={handleSignOut}
                 onReorderFolders={handleReorderFolders}
                 onLockApp={() => { lockMail('mail'); setLocked(true); }}

--- a/web/src/apps/mail/Mail.tsx
+++ b/web/src/apps/mail/Mail.tsx
@@ -278,8 +278,7 @@ export function Mail({ onClose }: { onClose: () => void }) {
         ?? (nav.stage === 'list' || nav.stage === 'detail' ? nav.accountId : undefined)
         ?? accounts[0]?.id;
 
-    if (locked || adding || (authChecked && accounts.length === 0)) {
-        return (
+    const authScreen = (
             <AppAuth
                 appName={t('mail.appName', 'Mail')}
                 tagline={t('mail.tagline', 'All your email in one place.')}
@@ -288,6 +287,7 @@ export function Mail({ onClose }: { onClose: () => void }) {
                 myNumber={myNumber}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
+                modal={adding}
                 fields={[
                     { key: 'email',    label: t('mail.fieldEmail', 'Email'), suffix: `@${MAIL_DOMAIN}` },
                     { key: 'name',     label: t('mail.fieldName', 'Name'), createOnly: true },
@@ -320,8 +320,9 @@ export function Mail({ onClose }: { onClose: () => void }) {
                     email:    `${vals.email ?? ''}@${MAIL_DOMAIN}`,
                 })}
             />
-        );
-    }
+    );
+
+    if (locked || (authChecked && accounts.length === 0)) return authScreen;
 
     return (
         <div className={`absolute inset-0 z-10 overflow-hidden bg-[#d4d4d4] dark:bg-base ${justAuthed ? 'animate-swipe-in-left' : ''}`}>
@@ -446,6 +447,8 @@ export function Mail({ onClose }: { onClose: () => void }) {
                 aria-label={t('mail.closeMail', 'Close Mail')}
                 className="absolute inset-x-0 bottom-0 z-50 h-7 cursor-default"
             />
+
+            {adding && <div className="absolute inset-0 z-[70]">{authScreen}</div>}
         </div>
     );
 }

--- a/web/src/apps/mail/MailboxList.tsx
+++ b/web/src/apps/mail/MailboxList.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import {
-    AlertOctagon, BookUser, ChevronRight, FileText, Flag, GripVertical, Inbox, Send, SquarePen, Trash2,
+    AlertOctagon, AtSign, BookUser, Check, ChevronRight, FileText, Flag, GripVertical, Inbox, Plus,
+    Send, SquarePen, Trash2,
 } from 'lucide-react';
 import type { ComponentType } from 'react';
 
@@ -18,7 +19,7 @@ interface Props {
     onSelectAccount:  (id: string) => void;
     onOpenFolder:     (f: Folder) => void;
     onCompose:        () => void;
-    onAccountAdded:   (account: MailAccount) => void;
+    onAddAccount:     () => void;
     onSignOut:        (id: string) => void;
     onReorderFolders: (next: Folder[]) => void;
     onLockApp:        () => void;
@@ -37,7 +38,7 @@ const FOLDER_ICONS: Record<Folder, ComponentType<{ className?: string }>> = {
 };
 
 export function MailboxList({
-    activeAccount, messages, folderOrder, onOpenFolder, onCompose, onReorderFolders, onLockApp, onDeleteAccount, onChangePassword, onOpenSavedEmails,
+    accounts, activeAccount, messages, folderOrder, onSelectAccount, onOpenFolder, onCompose, onAddAccount, onSignOut, onReorderFolders, onLockApp, onDeleteAccount, onChangePassword, onOpenSavedEmails,
 }: Props) {
     const [editing, setEditing] = useState(false);
     const [confirmOut, setConfirmOut] = useState(false);
@@ -236,6 +237,56 @@ export function MailboxList({
                         </div>
                     </button>
                 )}
+
+                <div className="mt-6 px-4 pb-1.5 text-[13px] font-medium uppercase tracking-wide text-ios-gray">
+                    {t('mail.accounts', 'Accounts')}
+                </div>
+                <div className="overflow-hidden rounded-[10px] bg-[#e5e5e5] dark:bg-surface">
+                    {accounts.map((a, i) => (
+                        <div key={a.id}>
+                            <div className="relative flex w-full items-center gap-4 px-4 py-[13px]">
+                                <AtSign className="h-[25px] w-[25px] shrink-0 text-ios-blue" />
+                                <button
+                                    type="button"
+                                    onClick={() => !editing && onSelectAccount(a.id)}
+                                    disabled={editing}
+                                    className="flex min-w-0 flex-1 items-center gap-2 text-left active:opacity-60 disabled:active:opacity-100"
+                                >
+                                    <span className="flex min-w-0 flex-1 flex-col">
+                                        <span className="truncate text-[18px]">{a.name}</span>
+                                        <span className="truncate text-[13px] text-ios-gray">{a.email}</span>
+                                    </span>
+                                    {!editing && a.id === activeAccount?.id && (
+                                        <Check className="h-[19px] w-[19px] shrink-0 text-ios-blue" strokeWidth={2.6} />
+                                    )}
+                                </button>
+                                {editing && (
+                                    <button
+                                        type="button"
+                                        onClick={() => onSignOut(a.id)}
+                                        className="shrink-0 text-[15px] font-medium text-ios-red active:opacity-60"
+                                    >
+                                        {t('mail.signOut', 'Sign Out')}
+                                    </button>
+                                )}
+                            </div>
+                            {i < accounts.length - 1 && (
+                                <div className="pointer-events-none bg-black/12 dark:bg-white/10" style={{ marginLeft: 60, height: '0.5px' }} />
+                            )}
+                        </div>
+                    ))}
+                    {accounts.length > 0 && (
+                        <div className="pointer-events-none bg-black/12 dark:bg-white/10" style={{ marginLeft: 60, height: '0.5px' }} />
+                    )}
+                    <button
+                        type="button"
+                        onClick={onAddAccount}
+                        className="flex w-full items-center gap-4 px-4 py-[15px] text-left active:bg-black/5 dark:active:bg-white/5"
+                    >
+                        <Plus className="h-[25px] w-[25px] shrink-0 text-ios-blue" strokeWidth={2.2} />
+                        <span className="flex-1 text-[18px] text-ios-blue">{t('mail.addMailbox', 'Add Mailbox')}</span>
+                    </button>
+                </div>
 
                 {activeAccount && (
                     <button

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -68,6 +68,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
     const [follows,    setFollows]    = useSessionState<{ handle: string; kind: 'followers' | 'following' } | null>('photogram:follows', null);
     const [storyMenu,  setStoryMenu]  = useState(false);
     const [switching,  setSwitching]  = useState(false);
+    const [adding,     setAdding]     = useState(false);
     const [liveEnabled, setLiveEnabled] = useState(!isFiveM);
 
     useEffect(() => {
@@ -257,7 +258,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
 
     if (!authChecked) return <div className="absolute inset-0 z-10 bg-[#f2f2f2]" />;
 
-    if (!authed) {
+    if (!authed || adding) {
         return (
             <AppAuth
                 appName="Photogram"
@@ -266,7 +267,8 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                 theme={{ accent: IG.blue, welcomeBg: '#f2f2f2', welcomeText: 'dark' }}
                 myNumber={myNumber}
                 myEmail={myEmail}
-                savedLogin={savedLogin}
+                savedLogin={adding ? null : savedLogin}
+                onDismiss={adding ? () => setAdding(false) : undefined}
                 fields={[
                     { key: 'username', label: t('photogram.username', 'Username') },
                     { key: 'name',     label: t('photogram.name', 'Name') },
@@ -275,7 +277,11 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                     { key: 'phone',    label: t('photogram.phone', 'Phone'),    type: 'tel',   createOnly: true },
                 ]}
                 onSubmit={(mode, vals) => (mode === 'create' ? accountsRegister('photogram', vals) : accountsLogin('photogram', vals))}
-                onAuthed={() => { setAuthed(true); setJustAuthed(true); }}
+                onAuthed={() => {
+                    setAuthed(true);
+                    setJustAuthed(true);
+                    if (adding) { setAdding(false); clearSessionState('photogram:'); refreshHome(); }
+                }}
                 onRequestReset={(id) => accountsRequestReset('photogram', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('photogram', id, code, pw)}
                 onSuggestCode={(id) => accountsSuggestCode('photogram', id)}
@@ -355,6 +361,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                     app="photogram"
                     onClose={() => setSwitching(false)}
                     onSwitched={() => { clearSessionState('photogram:'); refreshHome(); }}
+                    onAdd={() => setAdding(true)}
                 />
             )}
             {sharePost && <SharePostSheet post={sharePost} onClose={() => setSharePost(null)} />}

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -258,8 +258,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
 
     if (!authChecked) return <div className="absolute inset-0 z-10 bg-[#f2f2f2]" />;
 
-    if (!authed || adding) {
-        return (
+    const authScreen = (
             <AppAuth
                 appName="Photogram"
                 tagline={t('photogram.tagline', 'Sign up to see photos from your friends.')}
@@ -269,6 +268,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                 myEmail={myEmail}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
+                modal={adding}
                 fields={[
                     { key: 'username', label: t('photogram.username', 'Username') },
                     { key: 'name',     label: t('photogram.name', 'Name') },
@@ -287,8 +287,9 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                 onSuggestCode={(id) => accountsSuggestCode('photogram', id)}
                 onSaveCredentials={(vals) => accountsSavePassword('photogram', vals)}
             />
-        );
-    }
+    );
+
+    if (!authed) return authScreen;
 
     return (
         <div className={`absolute inset-0 flex flex-col bg-[#f2f2f2] font-sf ${justAuthed ? 'animate-swipe-in-left' : ''}`}>
@@ -412,6 +413,8 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                     onDelete={() => { setEditing(false); clearSessionState('photogram:'); void apiDeleteAccount(); void accountsForgetPassword('photogram'); void accountsLogout('photogram'); setAuthed(false); }}
                 />
             )}
+
+            {adding && <div className="absolute inset-0 z-[70]">{authScreen}</div>}
         </div>
     );
 }

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -11,7 +11,7 @@ import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { useAppAuth } from '@/hooks/useAppAuth';
 import { AppAuth } from '@/shared/AppAuth';
 import { AccountSwitcher } from '@/shared/AccountSwitcher';
-import { MAIL_DOMAIN, accountsConfirmReset, accountsForgetPassword, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSuggestCode } from '@/core/accountsApi';
+import { MAIL_DOMAIN, accountsConfirmReset, accountsForgetPassword, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSignOut, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { IG, type Comment as IGComment, type Post, type ProfileData, type User } from './data';
 import {
     apiActivity, apiAddComment, apiAddStory, apiComments, apiCounts, apiCreate, apiDeleteAccount, apiDeletePost, apiDismissNotification, apiExplore, apiFeed,
@@ -40,7 +40,7 @@ import { LiveViewer } from './live/LiveViewer';
 import { AlertDialog } from '@/ui/AlertDialog';
 
 export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
-    const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmail, savedLogin } = useAppAuth('photogram',
+    const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmails, savedLogin, savedAccounts, refreshAccounts } = useAppAuth('photogram',
         () => accountsMe('photogram').then(s => s.loggedIn));
 
     useStatusBarLight(authed ? false : null);
@@ -265,7 +265,9 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                 icon="photogram"
                 theme={{ accent: IG.blue, welcomeBg: '#f2f2f2', welcomeText: 'dark' }}
                 myNumber={myNumber}
-                myEmail={myEmail}
+                myEmails={myEmails}
+                savedAccounts={savedAccounts}
+                onPickAccount={u => accountsSwitch('photogram', u)}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
                 modal={adding}
@@ -280,7 +282,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                 onAuthed={() => {
                     setAuthed(true);
                     setJustAuthed(true);
-                    if (adding) { setAdding(false); clearSessionState('photogram:'); refreshHome(); }
+                    if (adding) { setAdding(false); clearSessionState('photogram:'); refreshAccounts(); refreshMe(); void refreshHome(); refreshCounts(); }
                 }}
                 onRequestReset={(id) => accountsRequestReset('photogram', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('photogram', id, code, pw)}
@@ -361,7 +363,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                 <AccountSwitcher
                     app="photogram"
                     onClose={() => setSwitching(false)}
-                    onSwitched={() => { clearSessionState('photogram:'); refreshHome(); }}
+                    onSwitched={() => { clearSessionState('photogram:'); refreshAccounts(); refreshMe(); void refreshHome(); refreshCounts(); }}
                     onAdd={() => setAdding(true)}
                 />
             )}
@@ -408,7 +410,15 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                     profile={{ name: me.name, bio: me.bio, avatar: me.avatar, private: me.isPrivate } as ProfileData}
                     onCancel={() => setEditing(false)}
                     onSave={async p => { const updated = await apiUpdateProfile({ name: p.name, bio: p.bio, avatar: p.avatar, private: p.private }); if (updated) setMe(updated); setEditing(false); }}
-                    onSignOut={() => { setEditing(false); clearSessionState('photogram:'); void accountsLogout('photogram'); setAuthed(false); }}
+                    onSignOut={() => {
+                        setEditing(false);
+                        clearSessionState('photogram:');
+                        void accountsSignOut('photogram').then(r => {
+                            refreshAccounts();
+                            if (r.switchedTo) { refreshMe(); void refreshHome(); refreshCounts(); }
+                            else setAuthed(false);
+                        });
+                    }}
                     onSwitchAccount={() => { setEditing(false); setSwitching(true); }}
                     onDelete={() => { setEditing(false); clearSessionState('photogram:'); void apiDeleteAccount(); void accountsForgetPassword('photogram'); void accountsLogout('photogram'); setAuthed(false); }}
                 />

--- a/web/src/apps/ryde/account/Account.tsx
+++ b/web/src/apps/ryde/account/Account.tsx
@@ -44,8 +44,7 @@ export function Account({ onClose }: { onClose: () => void }) {
         return <div className="absolute inset-0 bg-ios-gray6 dark:bg-base" />;
     }
 
-    if (!authed || adding) {
-        return (
+    const authScreen = (
             <AppAuth
                 appName="Ryde"
                 tagline={t('ryde.tagline', 'Your ride, your schedule.')}
@@ -69,13 +68,15 @@ export function Account({ onClose }: { onClose: () => void }) {
                 }}
                 onAuthed={() => { setAdding(false); void accountsMe('ryde').then(s => setAuth(true, s.me)); }}
                 onDismiss={adding ? () => setAdding(false) : onClose}
+                modal={adding}
                 onRequestReset={(id) => accountsRequestReset('ryde', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('ryde', id, code, pw)}
                 onSuggestCode={(id) => accountsSuggestCode('ryde', id)}
                 onSaveCredentials={(vals) => accountsSavePassword('ryde', vals)}
             />
-        );
-    }
+    );
+
+    if (!authed) return authScreen;
 
     async function signOut() {
         await accountsLogout('ryde');
@@ -218,6 +219,8 @@ export function Account({ onClose }: { onClose: () => void }) {
                     onClose={() => setPwOpen(false)}
                 />
             )}
+
+            {adding && <div className="absolute inset-0 z-[70]">{authScreen}</div>}
         </div>
     );
 }

--- a/web/src/apps/ryde/account/Account.tsx
+++ b/web/src/apps/ryde/account/Account.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Car, ChevronRight, KeyRound, LogOut, Star, Trash2, Users, X } from 'lucide-react';
 
 import { AppAuth } from '@/shared/AppAuth';
@@ -11,7 +11,8 @@ import { t } from '@/i18n';
 import {
     MAIL_DOMAIN, accountsConfirmReset, accountsForgetPassword, accountsLogin, accountsLogout,
     accountsMe, accountsMyEmail, accountsMyNumber, accountsRegister, accountsRequestReset,
-    accountsSavePassword, accountsSavedLogin, accountsSuggestCode,
+    accountsSavePassword, accountsSavedLogin, accountsSignOut, accountsSuggestCode, accountsSwitch,
+    accountsSwitchable, type SwitchableAccount,
 } from '@/core/accountsApi';
 import { driverStats, useRyde } from '../store';
 import { money } from '../data';
@@ -22,7 +23,8 @@ export function Account({ onClose }: { onClose: () => void }) {
 
     const { authChecked, authed, me, setAuth } = g;
     const [myNumber,    setMyNumber]    = useState<string | null>(null);
-    const [myEmail,     setMyEmail]     = useState<string | null>(null);
+    const [myEmails,    setMyEmails]    = useState<string[]>([]);
+    const [savedAccounts, setSavedAccounts] = useState<SwitchableAccount[]>([]);
     const [savedLogin,  setSavedLogin]  = useState<{ username: string; password: string } | null>(null);
     const [confirmSignOut, setConfirmSignOut] = useState(false);
     const [switching,      setSwitching]      = useState(false);
@@ -30,11 +32,16 @@ export function Account({ onClose }: { onClose: () => void }) {
     const [confirmDelete, setConfirmDelete] = useState(false);
     const [pwOpen, setPwOpen] = useState(false);
 
+    const refreshAccounts = useCallback(() => {
+        void accountsSavedLogin('ryde').then(setSavedLogin);
+        void accountsSwitchable('ryde').then(d => setSavedAccounts(d.accounts.filter(a => a.username !== d.active)));
+    }, []);
+
     useEffect(() => {
         void accountsMyNumber().then(setMyNumber);
-        void accountsMyEmail().then(setMyEmail);
-        void accountsSavedLogin('ryde').then(setSavedLogin);
-    }, []);
+        void accountsMyEmail().then(setMyEmails);
+        refreshAccounts();
+    }, [refreshAccounts, authed]);
 
     const done = g.rides.filter(r => r.role === 'rider' && r.status === 'completed');
     const spent = Math.round(done.reduce((s, r) => s + r.fare, 0) * 100) / 100;
@@ -51,8 +58,10 @@ export function Account({ onClose }: { onClose: () => void }) {
                 icon="ryde"
                 theme={{ accent: '#111111', welcomeBg: '#ffffff', welcomeText: 'dark' }}
                 myNumber={myNumber}
-                myEmail={myEmail}
                 savedLogin={adding ? null : savedLogin}
+                myEmails={myEmails}
+                savedAccounts={savedAccounts}
+                onPickAccount={u => accountsSwitch('ryde', u)}
                 fields={[
                     { key: 'username', label: t('ryde.fieldUsername', 'Username') },
                     { key: 'name',     label: t('ryde.fieldName', 'Name') },
@@ -79,10 +88,15 @@ export function Account({ onClose }: { onClose: () => void }) {
     if (!authed) return authScreen;
 
     async function signOut() {
-        await accountsLogout('ryde');
+        const res = await accountsSignOut('ryde');
         setConfirmSignOut(false);
-        setAuth(false, null);
-        void accountsSavedLogin('ryde').then(setSavedLogin);
+        if (res.switchedTo) {
+            const s = await accountsMe('ryde');
+            setAuth(s.loggedIn, s.me);
+        } else {
+            setAuth(false, null);
+        }
+        refreshAccounts();
     }
 
     async function deleteAccount() {
@@ -182,7 +196,7 @@ export function Account({ onClose }: { onClose: () => void }) {
                 <AccountSwitcher
                     app="ryde"
                     onClose={() => setSwitching(false)}
-                    onSwitched={() => { void accountsMe('ryde').then(s => setAuth(s.loggedIn, s.me)); }}
+                    onSwitched={() => { void accountsMe('ryde').then(s => setAuth(s.loggedIn, s.me)); refreshAccounts(); }}
                     onAdd={() => setAdding(true)}
                 />
             )}

--- a/web/src/apps/ryde/account/Account.tsx
+++ b/web/src/apps/ryde/account/Account.tsx
@@ -26,6 +26,7 @@ export function Account({ onClose }: { onClose: () => void }) {
     const [savedLogin,  setSavedLogin]  = useState<{ username: string; password: string } | null>(null);
     const [confirmSignOut, setConfirmSignOut] = useState(false);
     const [switching,      setSwitching]      = useState(false);
+    const [adding,         setAdding]         = useState(false);
     const [confirmDelete, setConfirmDelete] = useState(false);
     const [pwOpen, setPwOpen] = useState(false);
 
@@ -43,7 +44,7 @@ export function Account({ onClose }: { onClose: () => void }) {
         return <div className="absolute inset-0 bg-ios-gray6 dark:bg-base" />;
     }
 
-    if (!authed) {
+    if (!authed || adding) {
         return (
             <AppAuth
                 appName="Ryde"
@@ -52,7 +53,7 @@ export function Account({ onClose }: { onClose: () => void }) {
                 theme={{ accent: '#111111', welcomeBg: '#ffffff', welcomeText: 'dark' }}
                 myNumber={myNumber}
                 myEmail={myEmail}
-                savedLogin={savedLogin}
+                savedLogin={adding ? null : savedLogin}
                 fields={[
                     { key: 'username', label: t('ryde.fieldUsername', 'Username') },
                     { key: 'name',     label: t('ryde.fieldName', 'Name') },
@@ -66,8 +67,8 @@ export function Account({ onClose }: { onClose: () => void }) {
                         : await accountsLogin('ryde', vals);
                     return { ok: r.ok, message: r.message };
                 }}
-                onAuthed={() => { void accountsMe('ryde').then(s => setAuth(true, s.me)); }}
-                onDismiss={onClose}
+                onAuthed={() => { setAdding(false); void accountsMe('ryde').then(s => setAuth(true, s.me)); }}
+                onDismiss={adding ? () => setAdding(false) : onClose}
                 onRequestReset={(id) => accountsRequestReset('ryde', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('ryde', id, code, pw)}
                 onSuggestCode={(id) => accountsSuggestCode('ryde', id)}
@@ -181,6 +182,7 @@ export function Account({ onClose }: { onClose: () => void }) {
                     app="ryde"
                     onClose={() => setSwitching(false)}
                     onSwitched={() => { void accountsMe('ryde').then(s => setAuth(s.loggedIn, s.me)); }}
+                    onAdd={() => setAdding(true)}
                 />
             )}
 

--- a/web/src/apps/vibez/Vibez.tsx
+++ b/web/src/apps/vibez/Vibez.tsx
@@ -57,6 +57,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
     const [unread,        setUnread]        = useState(0);
     const [refreshKey,    setRefreshKey]    = useState(0);
     const [switching,     setSwitching]     = useState(false);
+    const [adding,        setAdding]        = useState(false);
     const [me,            setMe]            = useState<VProfile | null>(null);
 
     const viewedRef = useRef(new Set<string>());
@@ -191,7 +192,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
     if (!authChecked) {
         return <div className="absolute inset-0 z-10 bg-black" />;
     }
-    if (!authed) {
+    if (!authed || adding) {
         return (
             <AppAuth
                 appName="vibez"
@@ -200,7 +201,8 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                 theme={{ accent: ACCENT, welcomeBg: '#0a0518', welcomeText: 'light' }}
                 myNumber={myNumber}
                 myEmail={myEmail}
-                savedLogin={savedLogin}
+                savedLogin={adding ? null : savedLogin}
+                onDismiss={adding ? () => setAdding(false) : undefined}
                 fields={[
                     { key: 'username', label: t('vibez.username', 'Username') },
                     { key: 'name',     label: t('vibez.name', 'Name') },
@@ -209,7 +211,11 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                     { key: 'phone',    label: t('vibez.phone', 'Phone'), type: 'tel',   createOnly: true },
                 ]}
                 onSubmit={(mode, vals) => (mode === 'create' ? accountsRegister('vibez', vals) : accountsLogin('vibez', vals))}
-                onAuthed={() => { setAuthed(true); setJustAuthed(true); }}
+                onAuthed={() => {
+                    setAuthed(true);
+                    setJustAuthed(true);
+                    if (adding) { setAdding(false); bumpRefresh(); }
+                }}
                 onRequestReset={(id) => accountsRequestReset('vibez', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('vibez', id, code, pw)}
                 onSuggestCode={(id) => accountsSuggestCode('vibez', id)}
@@ -298,6 +304,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                     forceDark
                     onClose={() => setSwitching(false)}
                     onSwitched={bumpRefresh}
+                    onAdd={() => setAdding(true)}
                 />
             )}
 

--- a/web/src/apps/vibez/Vibez.tsx
+++ b/web/src/apps/vibez/Vibez.tsx
@@ -13,7 +13,7 @@ import { useAppAuth } from '@/hooks/useAppAuth';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { AppAuth } from '@/shared/AppAuth';
 import { AccountSwitcher } from '@/shared/AccountSwitcher';
-import { MAIL_DOMAIN, accountsConfirmReset, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSuggestCode } from '@/core/accountsApi';
+import { MAIL_DOMAIN, accountsConfirmReset, accountsLogin, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSignOut, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { t } from '@/i18n';
 import { ACCENT, GRAD_FROM, GRAD_TO, fmt, type VLive, type VPost, type VProfile } from './data';
 import {
@@ -34,7 +34,7 @@ type Tab = 'home' | 'discover' | 'inbox' | 'profile';
 interface ViewerState { posts: VPost[]; index: number }
 
 export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
-    const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmail, savedLogin } = useAppAuth('vibez',
+    const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmails, savedLogin, savedAccounts, refreshAccounts } = useAppAuth('vibez',
         () => accountsMe('vibez').then(s => s.loggedIn));
 
     useStatusBarLight(authed ? true : null);
@@ -199,7 +199,9 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                 icon="vibez"
                 theme={{ accent: ACCENT, welcomeBg: '#0a0518', welcomeText: 'light' }}
                 myNumber={myNumber}
-                myEmail={myEmail}
+                myEmails={myEmails}
+                savedAccounts={savedAccounts}
+                onPickAccount={u => accountsSwitch('vibez', u)}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
                 modal={adding}
@@ -214,7 +216,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                 onAuthed={() => {
                     setAuthed(true);
                     setJustAuthed(true);
-                    if (adding) { setAdding(false); bumpRefresh(); }
+                    if (adding) { setAdding(false); refreshAccounts(); bumpRefresh(); }
                 }}
                 onRequestReset={(id) => accountsRequestReset('vibez', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('vibez', id, code, pw)}
@@ -254,7 +256,13 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                 {tab === 'profile' && (
                     <Profile
                         onOpenPost={openPostList}
-                        onSignOut={() => { void accountsLogout('vibez'); setAuthed(false); }}
+                        onSignOut={() => {
+                            void accountsSignOut('vibez').then(r => {
+                                refreshAccounts();
+                                if (r.switchedTo) bumpRefresh();
+                                else setAuthed(false);
+                            });
+                        }}
                         onSwitchAccount={() => setSwitching(true)}
                         refreshKey={refreshKey}
                     />
@@ -304,7 +312,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                     app="vibez"
                     forceDark
                     onClose={() => setSwitching(false)}
-                    onSwitched={bumpRefresh}
+                    onSwitched={() => { refreshAccounts(); bumpRefresh(); }}
                     onAdd={() => setAdding(true)}
                 />
             )}

--- a/web/src/apps/vibez/Vibez.tsx
+++ b/web/src/apps/vibez/Vibez.tsx
@@ -192,8 +192,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
     if (!authChecked) {
         return <div className="absolute inset-0 z-10 bg-black" />;
     }
-    if (!authed || adding) {
-        return (
+    const authScreen = (
             <AppAuth
                 appName="vibez"
                 tagline={t('vibez.tagline', 'Catch the vibe. Share yours.')}
@@ -203,6 +202,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                 myEmail={myEmail}
                 savedLogin={adding ? null : savedLogin}
                 onDismiss={adding ? () => setAdding(false) : undefined}
+                modal={adding}
                 fields={[
                     { key: 'username', label: t('vibez.username', 'Username') },
                     { key: 'name',     label: t('vibez.name', 'Name') },
@@ -221,8 +221,9 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                 onSuggestCode={(id) => accountsSuggestCode('vibez', id)}
                 onSaveCredentials={(vals) => accountsSavePassword('vibez', vals)}
             />
-        );
-    }
+    );
+
+    if (!authed) return authScreen;
 
     return (
         <div className={`absolute inset-0 z-10 flex flex-col select-none overflow-hidden bg-black text-white ${justAuthed ? 'animate-swipe-in-left' : ''}`}>
@@ -389,6 +390,8 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
 
             {liveHost && <LiveHost onClose={() => { setLiveHost(false); refetchLives(); }} />}
             {liveJoin && <LiveViewer liveId={liveJoin.liveId} host={liveJoin.user} onClose={() => setLiveJoin(null)} />}
+
+            {adding && <div className="absolute inset-0 z-[70]">{authScreen}</div>}
         </div>
     );
 }

--- a/web/src/core/accountsApi.ts
+++ b/web/src/core/accountsApi.ts
@@ -162,7 +162,19 @@ export async function accountsMyNumber(): Promise<string | null> {
     return (await apiData<{ number?: string }>('sd-phone:accounts:myNumber'))?.number ?? null;
 }
 
-export async function accountsMyEmail(): Promise<string | null> {
-    if (!isFiveM) return `dev@${MAIL_DOMAIN}`;
-    return (await apiData<{ email?: string }>('sd-phone:accounts:myEmail'))?.email ?? null;
+export async function accountsMyEmail(): Promise<string[]> {
+    if (!isFiveM) return [`dev@${MAIL_DOMAIN}`, `you@${MAIL_DOMAIN}`, `work@${MAIL_DOMAIN}`];
+    return (await apiData<{ emails?: string[] }>('sd-phone:accounts:myEmail'))?.emails ?? [];
+}
+
+/** Leaves the current account, landing on another saved one when there is a usable one. */
+export async function accountsSignOut(app: string): Promise<{ switchedTo: string | null }> {
+    if (!isFiveM) {
+        const active = devSessions[app]?.username ?? null;
+        const next = DEV_VAULT.find(e => e.app === app && e.username !== active);
+        devSessions[app] = next ? { username: next.username, name: next.username } : null;
+        return { switchedTo: next?.username ?? null };
+    }
+    const d = await apiData<{ switchedTo?: string | null }>('sd-phone:accounts:signOut', { app });
+    return { switchedTo: d?.switchedTo ?? null };
 }

--- a/web/src/hooks/useAppAuth.ts
+++ b/web/src/hooks/useAppAuth.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import { accountsMyEmail, accountsMyNumber, accountsSavedLogin } from '@/core/accountsApi';
+import { accountsMyEmail, accountsMyNumber, accountsSavedLogin, accountsSwitchable, type SwitchableAccount } from '@/core/accountsApi';
 
 export interface AppAuthState {
     authed:        boolean;
@@ -9,8 +9,11 @@ export interface AppAuthState {
     justAuthed:    boolean;
     setJustAuthed: (v: boolean) => void;
     myNumber:      string | null;
-    myEmail:       string | null;
+    myEmails:      string[];
     savedLogin:    { username: string; password: string } | null;
+    /** Saved logins for this app, minus whichever one is in use. */
+    savedAccounts: SwitchableAccount[];
+    refreshAccounts: () => void;
 }
 
 export function useAppAuth(appId: string, checkSession: () => Promise<boolean>): AppAuthState {
@@ -18,16 +21,29 @@ export function useAppAuth(appId: string, checkSession: () => Promise<boolean>):
     const [authChecked, setAuthChecked] = useState(false);
     const [justAuthed,  setJustAuthed]  = useState(false);
     const [myNumber,    setMyNumber]    = useState<string | null>(null);
-    const [myEmail,     setMyEmail]     = useState<string | null>(null);
+    const [myEmails,    setMyEmails]    = useState<string[]>([]);
     const [savedLogin,  setSavedLogin]  = useState<{ username: string; password: string } | null>(null);
+    const [savedAccounts, setSavedAccounts] = useState<SwitchableAccount[]>([]);
+    const [accountsNonce, setAccountsNonce] = useState(0);
 
     useEffect(() => {
         void checkSession().then(ok => { setAuthed(ok); setAuthChecked(true); });
         void accountsMyNumber().then(setMyNumber);
-        void accountsMyEmail().then(setMyEmail);
+        void accountsMyEmail().then(setMyEmails);
         void accountsSavedLogin(appId).then(setSavedLogin);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    return { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmail, savedLogin };
+    // The picker must never offer the account already in use, and which one that is changes on
+    // every sign-in, switch and sign-out, so this refetches on the same nonce those bump.
+    useEffect(() => {
+        void accountsSwitchable(appId).then(d => {
+            setSavedAccounts(d.accounts.filter(a => a.username !== d.active));
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [authed, accountsNonce]);
+
+    const refreshAccounts = useCallback(() => setAccountsNonce(n => n + 1), []);
+
+    return { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmails, savedLogin, savedAccounts, refreshAccounts };
 }

--- a/web/src/shared/AccountSwitcher.tsx
+++ b/web/src/shared/AccountSwitcher.tsx
@@ -38,7 +38,13 @@ export function AccountSwitcher({ app, forceDark = false, onClose, onSwitched, o
     const label = forceDark ? 'text-white' : 'text-black dark:text-white';
 
     return (
-        <Sheet onClose={onClose} title={t('accounts.switchAccount', 'Switch account')} forceDark={forceDark}>
+        <Sheet
+            onClose={onClose}
+            fit="content"
+            title={t('accounts.switchAccount', 'Switch account')}
+            forceDark={forceDark}
+            className="bg-[#ececec] dark:bg-surface"
+        >
             {() => (
             <div className="flex flex-col gap-1 px-2 pb-3">
                 {accounts.length === 0 && (

--- a/web/src/shared/AppAuth.tsx
+++ b/web/src/shared/AppAuth.tsx
@@ -34,6 +34,7 @@ export interface AppAuthProps {
     fields:   AppAuthField[];
     onAuthed: (values: Record<string, string>) => void;
     onDismiss?: () => void;
+    modal?:   boolean;
     onSubmit?: (mode: 'create' | 'login', values: Record<string, string>) => Promise<{ ok: boolean; message?: string; field?: string }>;
     onRequestReset?: (identity: string) => Promise<{ ok: boolean; message?: string; channel?: 'email' | 'sms' }>;
     onConfirmReset?: (identity: string, code: string, password: string) => Promise<{ ok: boolean; message?: string }>;
@@ -46,7 +47,9 @@ export interface AppAuthProps {
 
 type Screen = 'welcome' | 'create' | 'login' | 'reset' | 'resetCode' | 'success';
 
-export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDismiss, onSubmit, onRequestReset, onConfirmReset, onSuggestCode, onSaveCredentials, savedLogin, myNumber, myEmail }: AppAuthProps) {
+const MODAL_OUT_MS = 300;
+
+export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDismiss, modal = false, onSubmit, onRequestReset, onConfirmReset, onSuggestCode, onSaveCredentials, savedLogin, myNumber, myEmail }: AppAuthProps) {
     const [screen, setScreen] = useSessionState<Screen>(`auth:${appName}:screen`, 'welcome');
     const [resetIdentity, setResetIdentity] = useSessionState<string>(`auth:${appName}:resetIdentity`, '');
     const [notice, setNotice] = useState<string | null>(null);
@@ -63,11 +66,25 @@ export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDis
     const onAuthedRef = useRef(onAuthed); onAuthedRef.current = onAuthed;
     const onSaveRef   = useRef(onSaveCredentials); onSaveRef.current = onSaveCredentials;
 
+    const [dismissing, setDismissing] = useState(false);
+
     function finishAuth(save: boolean) {
         if (save) void onSaveRef.current?.(pendingValues.current);
         setSavePrompt(false);
         clearSessionState(`auth:${appName}:`);
+        if (modal) {
+            setDismissing(true);
+            window.setTimeout(() => onAuthedRef.current(pendingValues.current), MODAL_OUT_MS);
+            return;
+        }
         onAuthedRef.current(pendingValues.current);
+    }
+
+    function requestDismiss() {
+        if (!onDismiss || dismissing) return;
+        if (!modal) { onDismiss(); return; }
+        setDismissing(true);
+        window.setTimeout(onDismiss, MODAL_OUT_MS);
     }
 
     useEffect(() => {
@@ -108,7 +125,15 @@ export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDis
     }
 
     return (
-        <div className="absolute inset-0 z-10 overflow-hidden">
+        <div
+            className={`absolute inset-0 z-10 overflow-hidden ${modal ? 'rounded-t-[14px] shadow-[0_-8px_28px_rgba(0,0,0,0.28)]' : ''}`}
+            style={modal ? {
+                animation: dismissing
+                    ? `ios-sheet-down ${MODAL_OUT_MS}ms cubic-bezier(0.32,0,0.68,1) forwards`
+                    : 'ios-sheet-up 0.42s cubic-bezier(0.32,0.72,0,1)',
+                willChange: 'transform',
+            } : undefined}
+        >
             <div
                 className="flex h-full w-[200%] transition-transform duration-300 ease-out"
                 style={{ transform: showingDetail ? 'translateX(-50%)' : 'translateX(0)' }}
@@ -122,7 +147,7 @@ export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDis
                         onCreate={() => go('create')}
                         onLogin={() => go('login')}
                         onForgot={onRequestReset ? () => go('reset') : undefined}
-                        onDismiss={onDismiss}
+                        onDismiss={onDismiss ? requestDismiss : undefined}
                     />
                 </div>
                 <div className="h-full w-1/2 shrink-0">

--- a/web/src/shared/AppAuth.tsx
+++ b/web/src/shared/AppAuth.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { AtSign, ChevronLeft, Eye, EyeOff, KeyRound, Phone, ShieldCheck, X } from 'lucide-react';
+import { AtSign, ChevronLeft, Eye, EyeOff, KeyRound, Phone, ShieldCheck, UserRound, X } from 'lucide-react';
 
 import { t } from '@/i18n';
 import { useStatusBarLight } from '@/shell/useStatusBarLight';
@@ -42,14 +42,17 @@ export interface AppAuthProps {
     onSaveCredentials?: (values: Record<string, string>) => void | Promise<unknown>;
     savedLogin?: { username: string; password: string } | null;
     myNumber?: string | null;
-    myEmail?: string | null;
+    myEmails?: string[] | null;
+    /** Saved logins for this app, already minus the one in use. Empty hides the picker. */
+    savedAccounts?: { username: string; name?: string }[];
+    onPickAccount?: (username: string) => Promise<{ ok: boolean; message?: string }>;
 }
 
 type Screen = 'welcome' | 'create' | 'login' | 'reset' | 'resetCode' | 'success';
 
 const MODAL_OUT_MS = 300;
 
-export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDismiss, modal = false, onSubmit, onRequestReset, onConfirmReset, onSuggestCode, onSaveCredentials, savedLogin, myNumber, myEmail }: AppAuthProps) {
+export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDismiss, modal = false, onSubmit, onRequestReset, onConfirmReset, onSuggestCode, onSaveCredentials, savedLogin, myNumber, myEmails, savedAccounts, onPickAccount }: AppAuthProps) {
     const [screen, setScreen] = useSessionState<Screen>(`auth:${appName}:screen`, 'welcome');
     const [resetIdentity, setResetIdentity] = useSessionState<string>(`auth:${appName}:resetIdentity`, '');
     const [notice, setNotice] = useState<string | null>(null);
@@ -148,6 +151,9 @@ export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDis
                         onLogin={() => go('login')}
                         onForgot={onRequestReset ? () => go('reset') : undefined}
                         onDismiss={onDismiss ? requestDismiss : undefined}
+                        savedAccounts={savedAccounts}
+                        onPickAccount={onPickAccount}
+                        onAuthed={() => beginSuccess('login', {})}
                     />
                 </div>
                 <div className="h-full w-1/2 shrink-0">
@@ -182,7 +188,7 @@ export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDis
                             fields={fields}
                             notice={notice}
                             myNumber={myNumber}
-                            myEmail={myEmail}
+                            myEmails={myEmails}
                             savedUsername={savedLogin?.username}
                             quickBusy={quickBusy}
                             onQuickLogin={savedLogin ? () => void quickLogin() : undefined}
@@ -208,7 +214,7 @@ export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDis
     );
 }
 
-function Welcome({ appName, tagline, icon, theme, onCreate, onLogin, onForgot, onDismiss }: {
+function Welcome({ appName, tagline, icon, theme, onCreate, onLogin, onForgot, onDismiss, savedAccounts, onPickAccount, onAuthed }: {
     appName:  string;
     tagline:  string;
     icon?:    string;
@@ -217,9 +223,26 @@ function Welcome({ appName, tagline, icon, theme, onCreate, onLogin, onForgot, o
     onLogin:  () => void;
     onForgot?: () => void;
     onDismiss?: () => void;
+    savedAccounts?: { username: string; name?: string }[];
+    onPickAccount?: (username: string) => Promise<{ ok: boolean; message?: string }>;
+    onAuthed: () => void;
 }) {
     const light    = theme.welcomeText === 'light';
     const ctaWhite = !!theme.welcomeCtaWhite;
+
+    const [picking, setPicking] = useState<string | null>(null);
+    const [pickError, setPickError] = useState<string | null>(null);
+    const accounts = onPickAccount ? (savedAccounts ?? []) : [];
+
+    async function pick(username: string) {
+        if (picking || !onPickAccount) return;
+        setPicking(username);
+        setPickError(null);
+        const res = await onPickAccount(username);
+        setPicking(null);
+        if (res.ok) onAuthed();
+        else setPickError(res.message ?? t('common.couldNotSignIn', 'Could not sign in to that account'));
+    }
     return (
         <div
             className={`relative flex h-full flex-col ${light ? 'text-white' : 'text-black'}`}
@@ -252,6 +275,40 @@ function Welcome({ appName, tagline, icon, theme, onCreate, onLogin, onForgot, o
                 </p>
             </div>
             <div className="px-6 pb-10">
+                {accounts.length > 0 && (
+                    <div className="mb-4">
+                        <p className="px-1 pb-2 text-[13px] font-semibold uppercase tracking-wide" style={{ color: light ? 'rgba(255,255,255,0.6)' : 'rgba(0,0,0,0.45)' }}>
+                            {t('common.continueAs', 'Continue as')}
+                        </p>
+                        <div className="overflow-hidden rounded-[14px]" style={{ background: light ? 'rgba(255,255,255,0.10)' : 'rgba(0,0,0,0.05)' }}>
+                            {accounts.map((a, i) => (
+                                <button
+                                    key={a.username}
+                                    type="button"
+                                    onClick={() => void pick(a.username)}
+                                    disabled={!!picking}
+                                    className="flex w-full items-center gap-3 px-4 py-3 text-left active:opacity-70 disabled:opacity-50"
+                                    style={i > 0 ? { borderTop: `0.5px solid ${light ? 'rgba(255,255,255,0.14)' : 'rgba(0,0,0,0.10)'}` } : undefined}
+                                >
+                                    <span
+                                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full"
+                                        style={{ background: light ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.07)' }}
+                                    >
+                                        <UserRound className="h-[18px] w-[18px]" strokeWidth={2.2} />
+                                    </span>
+                                    <span className="flex min-w-0 flex-1 flex-col">
+                                        <span className="truncate text-[16px] font-semibold">{a.name || a.username}</span>
+                                        <span className="truncate text-[13px]" style={{ color: light ? 'rgba(255,255,255,0.6)' : 'rgba(0,0,0,0.5)' }}>@{a.username}</span>
+                                    </span>
+                                    <span className="shrink-0 text-[15px] font-bold" style={{ color: ctaWhite ? '#ffffff' : theme.accent }}>
+                                        {picking === a.username ? t('common.pleaseWait', 'Please wait…') : t('common.logIn', 'Log in')}
+                                    </span>
+                                </button>
+                            ))}
+                        </div>
+                        {pickError && <p className="px-1 pt-2 text-[13px]" style={{ color: '#e0245e' }}>{pickError}</p>}
+                    </div>
+                )}
                 <button
                     type="button"
                     onClick={onCreate}
@@ -333,7 +390,7 @@ function generateStrongPassword() {
     return `${group(0)}-${group(6)}-${group(12)}`;
 }
 
-function AuthForm({ mode, appName, icon, theme, fields, notice, myNumber, myEmail, savedUsername, quickBusy, onQuickLogin, onBack, onAuthed, onSubmit }: {
+function AuthForm({ mode, appName, icon, theme, fields, notice, myNumber, myEmails, savedUsername, quickBusy, onQuickLogin, onBack, onAuthed, onSubmit }: {
     mode:     'create' | 'login';
     appName:  string;
     icon?:    string;
@@ -341,7 +398,7 @@ function AuthForm({ mode, appName, icon, theme, fields, notice, myNumber, myEmai
     fields:   AppAuthField[];
     notice?:  string | null;
     myNumber?: string | null;
-    myEmail?: string | null;
+    myEmails?: string[] | null;
     savedUsername?: string;
     quickBusy?: boolean;
     onQuickLogin?: () => void;
@@ -374,12 +431,26 @@ function AuthForm({ mode, appName, icon, theme, fields, notice, myNumber, myEmai
         if (focusingNewPw) setSuggestedPw(generateStrongPassword());
     }, [focusedKey]);
 
-    let fill: { value: string; display: string; sub: string; icon: React.ReactNode } | null = null;
+    // One Mail account is the common case; several is why the bar cycles rather than picking for
+    // you, since only the player knows which address they want on this account.
+    const emails = myEmails ?? [];
+    const [emailPick, setEmailPick] = useState(0);
+    const chosenEmail = emails.length > 0 ? emails[emailPick % emails.length] : null;
+
+    let fill: { value: string; display: string; sub: string; icon: React.ReactNode; onCycle?: () => void } | null = null;
     if (focusedField && !(values[focusedField.key] ?? '')) {
         if (focusedField.type === 'tel' && myNumber) {
             fill = { value: myNumber, display: formatPhone(myNumber), sub: t('common.fromYourPhoneNumber', 'From your phone number'), icon: <Phone className="h-[20px] w-[20px]" strokeWidth={2.2} /> };
-        } else if (focusedField.suffix && myEmail) {
-            fill = { value: myEmail.split('@')[0], display: myEmail, sub: t('common.fromYourMailAccount', 'From your Mail account'), icon: <AtSign className="h-[20px] w-[20px]" strokeWidth={2.2} /> };
+        } else if (focusedField.suffix && chosenEmail) {
+            fill = {
+                value: chosenEmail.split('@')[0],
+                display: chosenEmail,
+                sub: emails.length > 1
+                    ? t('common.fromYourMailAccountN', 'Mail account {n} of {total} · tap to change', { n: String((emailPick % emails.length) + 1), total: String(emails.length) })
+                    : t('common.fromYourMailAccount', 'From your Mail account'),
+                icon: <AtSign className="h-[20px] w-[20px]" strokeWidth={2.2} />,
+                onCycle: emails.length > 1 ? () => setEmailPick(i => i + 1) : undefined,
+            };
         } else if (focusingNewPw && suggestedPw) {
             fill = { value: suggestedPw, display: t('common.useStrongPassword', 'Use a strong password'), sub: t('common.createdFor', 'Created for {appName}', { appName }), icon: <KeyRound className="h-[20px] w-[20px]" strokeWidth={2.2} /> };
         }
@@ -582,6 +653,7 @@ function AuthForm({ mode, appName, icon, theme, fields, notice, myNumber, myEmai
                 main={fill?.display ?? ''}
                 sub={fill?.sub ?? ''}
                 accent={theme.accent}
+                onCycle={fill?.onCycle}
                 onPick={() => {
                     if (!focusedField || !fill) return;
                     if (focusedField.type === 'password') fillGenerated(fill.value);
@@ -994,13 +1066,14 @@ function Field({ label, value, onChange, type, last, suffix, onFocus, onBlur, re
     );
 }
 
-function SuggestionBar({ show, icon, main, sub, accent, onPick }: {
+function SuggestionBar({ show, icon, main, sub, accent, onPick, onCycle }: {
     show: boolean;
     icon: React.ReactNode;
     main: string;
     sub:  string;
     accent: string;
     onPick: () => void;
+    onCycle?: () => void;
 }) {
     const [mounted, setMounted] = useState(false);
     useEffect(() => { if (show) setMounted(true); }, [show]);
@@ -1030,10 +1103,16 @@ function SuggestionBar({ show, icon, main, sub, accent, onPick }: {
                 >
                     {c.icon}
                 </span>
-                <span className="min-w-0 flex-1">
+                <button
+                    type="button"
+                    onMouseDown={e => e.preventDefault()}
+                    onClick={onCycle}
+                    disabled={!onCycle}
+                    className="min-w-0 flex-1 text-left disabled:active:opacity-100 active:opacity-60"
+                >
                     <span className="block truncate text-[18px] font-bold text-black">{c.main}</span>
                     <span className="block text-[14.5px] font-medium text-black/55">{c.sub}</span>
-                </span>
+                </button>
                 <button
                     type="button"
                     onMouseDown={e => e.preventDefault()}

--- a/web/src/shared/AppAuth.tsx
+++ b/web/src/shared/AppAuth.tsx
@@ -696,7 +696,7 @@ function ResetForm({ phase, appName, icon, theme, identity, onIdentity, myNumber
                         </div>
 
                         <p className="mt-3 px-2 text-[15px] leading-snug text-black/60">
-                            {t('common.resetHelp', 'Enter the email or phone number linked to your account and we will text or email you a code.')}
+                            {t('common.resetHelp', 'Enter your username, or the email or phone number linked to your account, and we will text or email you a code.')}
                         </p>
 
                         {error && <div className="mt-3 text-[13px]" style={{ color: '#e0245e' }}>{error}</div>}

--- a/web/src/shell/CustomAppFrame.tsx
+++ b/web/src/shell/CustomAppFrame.tsx
@@ -432,7 +432,7 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
             )}
 
             {ctxMenu && (
-                <Sheet fit="content" onClose={() => settleCtx(undefined)} title={ctxMenu.title}>
+                <Sheet fit="content" onClose={() => settleCtx(undefined)} title={ctxMenu.title} className="bg-[#ececec] dark:bg-base">
                     {({ close }) => (
                         <div className="px-4 pb-2">
                             {ctxMenu.description && (
@@ -468,7 +468,7 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
             )}
 
             {emojiOpen && (
-                <Sheet fit="content" onClose={() => settleEmoji(null)} title={t('common.emoji', 'Emoji')} forceDark={theme === 'dark'}>
+                <Sheet fit="content" onClose={() => settleEmoji(null)} title={t('common.emoji', 'Emoji')} forceDark={theme === 'dark'} className="bg-[#ececec] dark:bg-surface">
                     {({ close }) => (
                         <div className="px-1 pb-1">
                             <EmojiPanel isDark={theme === 'dark'} onSelect={e => { const r = emojiResolve.current; emojiResolve.current = null; if (r) r(e); close(); }} />
@@ -503,7 +503,7 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
             )}
 
             {colorReq && (
-                <Sheet fit="content" onClose={() => settleColor(null)} title={t('customApps.pickColor', 'Pick a Color')}>
+                <Sheet fit="content" onClose={() => settleColor(null)} title={t('customApps.pickColor', 'Pick a Color')} className="bg-[#ececec] dark:bg-base">
                     {({ close }) => (
                         <div className="px-5 pb-3">
                             <div className="grid grid-cols-7 gap-3 pb-4">


### PR DESCRIPTION
Follow-up to #176. Squawk can now hold several accounts, which surfaced a gap in Mail.

## The bug

Mail's server has always supported several mailboxes per character. `signUp` and `signIn` both check `MaxAccountsPerPlayer` and then **add** a session rather than replacing one, `MAX_ACCOUNTS_CREATED` caps lifetime creation at 10, and `listAccountsForCitizen` returns the whole set.

The phone could not reach any of it:

- `Mail.tsx:285` renders the sign-in screen only when `accounts.length === 0`, so the door closes the moment you have one mailbox
- `MailboxList` rendered a single active account, with no list and no add

So `configs/mail.lua` advertises 5, the server delivers 5, and the phone gave you 1. Signing out dropped you to zero and let you make *another* one, but you could never hold two.

## Why it matters now

Recovery identifies an account by its contact. `resolveRecovery` refuses with `More than one account uses that contact. Ask an admin for help` when two accounts **in the same app** share a recovery email, so a player running three Squawk handles off one address silently loses self-service password reset on all three. One mailbox per account is the way out, and until now the phone could not create the second mailbox.

## The change

`MailboxList` already declared `accounts`, `onSelectAccount`, `onSignOut` and `onAccountAdded` in its props, and `Mail.tsx` already passed working handlers for all four. The section that consumed them was never written. This writes it:

- an **Accounts** list, one row per mailbox, tick on the active one, tap to select
- per-mailbox **Sign Out**, revealed by the existing Edit mode, so hitting the cap of 5 is not a dead end
- an **Add Mailbox** row

Add Mailbox reopens the normal `AppAuth` flow with two adjustments:

- `onDismiss` is set, so it can be backed out of. `AppAuth` already had the prop and a close control built for it; nothing used it until now. The form screens reach it through their existing back chevron.
- `savedLogin` is suppressed. The saved login is the mailbox you already hold, and offering quick-login there would sign you straight back into it.

On success the new mailbox becomes active, resolved by diffing account ids against the set held before the add rather than trusting list order.

`onAccountAdded` took a `MailAccount` that the add flow never has in hand, so it is replaced by a plain `onAddAccount` trigger; the `refresh()` that follows re-reads the set from the server anyway.

## Not changed

Mail still has no modal "Switch account" like Photogram, Cherry, Vibez, Ryde and Squawk, and should not: it signs you into every mailbox at once and you pick the active one from this list, the way iOS Mail does. There is nothing to switch because none of them are switched off.

## Gates

| gate | result |
|---|---|
| `tsc --noEmit` | clean |
| `oxlint src` | 0 warnings in `src/apps/mail` |
| `knip` | clean |
| `vitest` | 405 passed / 32 files |
| `vite build` (sd-phone) | built in 3.65s |
| `vite build` (sd-tablet) | built in 4.50s |

UI verified by mounting `MailboxList` from the Vite module graph with two mailboxes: renders `ACCOUNTS → Los Santos → LS Alt → Add Mailbox` in the right place, the tick svg is present on the active row and absent on the other, and clicking Edit reveals a per-row Sign Out.

sd-tablet is rebuilt too, since its `vite.config.ts` aliases `@` at `sd-phone/web/src` and it compiles the same Mail screens.