### PR TITLE
fix(accounts): reload the whole app when the account changes

### DIFF
--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -249,6 +249,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
         setProfileOpen(false); setProfileTarget(null); setProfile(null);
         setOpenPostId(null); setOpenConvoId(null); setOpenConvo(null);
         setPosts(null); setConvos([]); setNotifCount(0); setTab('home'); setFeed('all');
+        setComposing(false); setEditingProfile(false);
         void apiMe().then(s => { if (s.me) setMe(s.me); });
         refreshFeed();
     }

--- a/web/src/apps/cherry/Cherry.tsx
+++ b/web/src/apps/cherry/Cherry.tsx
@@ -5,7 +5,7 @@ import { isFiveM } from '@/core/nui';
 import { t } from '@/i18n';
 import { readJson, writeJson } from '@/lib/storage';
 import { useStatusBarLight } from '@/shell/useStatusBarLight';
-import { useSessionState } from '@/hooks/useSessionState';
+import { clearSessionState, useSessionState } from '@/hooks/useSessionState';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { useDeckActive } from '@/shell/deckActive';
 import { useAppAuth } from '@/hooks/useAppAuth';
@@ -200,6 +200,22 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
         if (s) { setDeck(s.deck); setCanReset(s.canReset); }
     }, []);
 
+    // A new account changes who you are, not just what the deck holds, so this reloads the whole
+    // cherryState (me, profile, deck, matches) and drops the screen you were on: an open chat or
+    // a half-scrolled deck belongs to the account you just left.
+    const afterAccountChange = useCallback(() => {
+        clearSessionState('cherry:');
+        setView('deck');
+        setProfile(null);
+        setDeck([]);
+        setMatches([]);
+        setLockedIds([]);
+        setIncomingMatch(null);
+        setSendError(null);
+        refreshAccounts();
+        setStateNonce(n => n + 1);
+    }, [refreshAccounts, setView]);
+
     const openChatRef = useRef<string | null>(null);
     useEffect(() => { openChatRef.current = typeof view === 'object' ? view.chatId : null; }, [view]);
 
@@ -290,7 +306,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                 onAuthed={() => {
                     setAuthed(true);
                     setJustAuthed(true);
-                    if (adding) { setAdding(false); refreshAccounts(); void refreshDeck(); }
+                    if (adding) { setAdding(false); afterAccountChange(); }
                 }}
                 onRequestReset={(id) => accountsRequestReset('cherry', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('cherry', id, code, pw)}
@@ -344,9 +360,8 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                                 onChange={setProfile}
                                 onSignOut={() => {
                                     void accountsSignOut('cherry').then(r => {
-                                        refreshAccounts();
-                                        if (r.switchedTo) setStateNonce(n => n + 1);
-                                        else setAuthed(false);
+                                        if (r.switchedTo) afterAccountChange();
+                                        else { clearSessionState('cherry:'); refreshAccounts(); setAuthed(false); }
                                     });
                                 }}
                                 onSwitchAccount={() => setSwitching(true)}
@@ -406,7 +421,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                 <AccountSwitcher
                     app="cherry"
                     onClose={() => setSwitching(false)}
-                    onSwitched={() => { refreshAccounts(); void refreshDeck(); }}
+                    onSwitched={afterAccountChange}
                     onAdd={() => setAdding(true)}
                 />
             )}

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -122,6 +122,31 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
         refreshCounts();
     }, [authed, refreshMe, refreshHome, refreshCounts]);
 
+    // Everything on screen belongs to the account that was signed in, so a change refetches all
+    // of it and closes whatever was open: a post detail or a profile drill-in from the previous
+    // account would otherwise sit there looking like this account's.
+    const afterAccountChange = useCallback(() => {
+        clearSessionState('photogram:');
+        setTab('home');
+        setDetail(null);
+        setViewHandle(null);
+        setFollows(null);
+        setCommentId(null);
+        setDmOpen(false);
+        setCreateOpen(false);
+        setEditing(false);
+        setActivity([]);
+        setRequests([]);
+        setExplore([]);
+        setComments({});
+        refreshAccounts();
+        refreshMe();
+        void refreshHome();
+        refreshCounts();
+        refreshActivity();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [refreshAccounts, refreshMe, refreshHome, refreshCounts, refreshActivity]);
+
     useEffect(() => { if (authed) refreshCounts(); }, [dmOpen, authed, refreshCounts]);
 
     // Content pushes reach only the phones showing Photogram, so the subscription follows the
@@ -282,7 +307,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                 onAuthed={() => {
                     setAuthed(true);
                     setJustAuthed(true);
-                    if (adding) { setAdding(false); clearSessionState('photogram:'); refreshAccounts(); refreshMe(); void refreshHome(); refreshCounts(); }
+                    if (adding) { setAdding(false); afterAccountChange(); }
                 }}
                 onRequestReset={(id) => accountsRequestReset('photogram', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('photogram', id, code, pw)}
@@ -363,7 +388,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                 <AccountSwitcher
                     app="photogram"
                     onClose={() => setSwitching(false)}
-                    onSwitched={() => { clearSessionState('photogram:'); refreshAccounts(); refreshMe(); void refreshHome(); refreshCounts(); }}
+                    onSwitched={afterAccountChange}
                     onAdd={() => setAdding(true)}
                 />
             )}
@@ -412,11 +437,9 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                     onSave={async p => { const updated = await apiUpdateProfile({ name: p.name, bio: p.bio, avatar: p.avatar, private: p.private }); if (updated) setMe(updated); setEditing(false); }}
                     onSignOut={() => {
                         setEditing(false);
-                        clearSessionState('photogram:');
                         void accountsSignOut('photogram').then(r => {
-                            refreshAccounts();
-                            if (r.switchedTo) { refreshMe(); void refreshHome(); refreshCounts(); }
-                            else setAuthed(false);
+                            if (r.switchedTo) afterAccountChange();
+                            else { clearSessionState('photogram:'); refreshAccounts(); setAuthed(false); }
                         });
                     }}
                     onSwitchAccount={() => { setEditing(false); setSwitching(true); }}

--- a/web/src/apps/ryde/account/Account.tsx
+++ b/web/src/apps/ryde/account/Account.tsx
@@ -37,6 +37,15 @@ export function Account({ onClose }: { onClose: () => void }) {
         void accountsSwitchable('ryde').then(d => setSavedAccounts(d.accounts.filter(a => a.username !== d.active)));
     }, []);
 
+    // Ryde keeps rides and the driver profile locally and only syncs them on mount, so without
+    // this wipe the new account inherits the previous one's history, earnings and driver status.
+    const afterAccountChange = useCallback(() => {
+        g.wipeAccount();
+        void accountsMe('ryde').then(s => setAuth(s.loggedIn, s.me));
+        refreshAccounts();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [refreshAccounts, setAuth]);
+
     useEffect(() => {
         void accountsMyNumber().then(setMyNumber);
         void accountsMyEmail().then(setMyEmails);
@@ -75,7 +84,10 @@ export function Account({ onClose }: { onClose: () => void }) {
                         : await accountsLogin('ryde', vals);
                     return { ok: r.ok, message: r.message };
                 }}
-                onAuthed={() => { setAdding(false); void accountsMe('ryde').then(s => setAuth(true, s.me)); }}
+                onAuthed={() => {
+                    if (adding) { setAdding(false); afterAccountChange(); }
+                    else void accountsMe('ryde').then(s => setAuth(true, s.me));
+                }}
                 onDismiss={adding ? () => setAdding(false) : onClose}
                 modal={adding}
                 onRequestReset={(id) => accountsRequestReset('ryde', id)}
@@ -91,12 +103,12 @@ export function Account({ onClose }: { onClose: () => void }) {
         const res = await accountsSignOut('ryde');
         setConfirmSignOut(false);
         if (res.switchedTo) {
-            const s = await accountsMe('ryde');
-            setAuth(s.loggedIn, s.me);
+            afterAccountChange();
         } else {
+            g.wipeAccount();
             setAuth(false, null);
+            refreshAccounts();
         }
-        refreshAccounts();
     }
 
     async function deleteAccount() {
@@ -196,7 +208,7 @@ export function Account({ onClose }: { onClose: () => void }) {
                 <AccountSwitcher
                     app="ryde"
                     onClose={() => setSwitching(false)}
-                    onSwitched={() => { void accountsMe('ryde').then(s => setAuth(s.loggedIn, s.me)); refreshAccounts(); }}
+                    onSwitched={afterAccountChange}
                     onAdd={() => setAdding(true)}
                 />
             )}

--- a/web/src/apps/vibez/Vibez.tsx
+++ b/web/src/apps/vibez/Vibez.tsx
@@ -5,7 +5,7 @@ import { useStatusBarLight } from '@/shell/useStatusBarLight';
 import { useDeckActive } from '@/shell/deckActive';
 import { setLaunchIntent } from '@/shell/launchIntent';
 import { useRefreshOnReconnect } from '@/hooks/useRefreshOnReconnect';
-import { useSessionState } from '@/hooks/useSessionState';
+import { clearSessionState, useSessionState } from '@/hooks/useSessionState';
 import { isVideoUrl } from '@/core/photosApi';
 import { useAsyncData } from '@/hooks/useAsyncData';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
@@ -84,6 +84,25 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
     );
 
     const bumpRefresh = useCallback(() => setRefreshKey(k => k + 1), []);
+
+    // bumpRefresh alone reloads the feeds but leaves the inbox count, the open viewer and the
+    // profile you had drilled into, all of which belong to the account being left.
+    const afterAccountChange = useCallback(() => {
+        clearSessionState('vibez:');
+        setTab('home');
+        setFeedTab('foryou');
+        setUpload(false);
+        setViewer(null);
+        setProfileHandle(null);
+        setCommentsPost(null);
+        setPosts([]);
+        setMe(null);
+        setUnread(0);
+        refreshAccounts();
+        bumpRefresh();
+        void apiCounts().then(setUnread);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [refreshAccounts, bumpRefresh]);
 
     // Content pushes reach only the phones showing Vibez, so the subscription follows the
     // foreground. AppDeck keeps this subtree alive, so returning to it is not a remount.
@@ -216,7 +235,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                 onAuthed={() => {
                     setAuthed(true);
                     setJustAuthed(true);
-                    if (adding) { setAdding(false); refreshAccounts(); bumpRefresh(); }
+                    if (adding) { setAdding(false); afterAccountChange(); }
                 }}
                 onRequestReset={(id) => accountsRequestReset('vibez', id)}
                 onConfirmReset={(id, code, pw) => accountsConfirmReset('vibez', id, code, pw)}
@@ -258,9 +277,8 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                         onOpenPost={openPostList}
                         onSignOut={() => {
                             void accountsSignOut('vibez').then(r => {
-                                refreshAccounts();
-                                if (r.switchedTo) bumpRefresh();
-                                else setAuthed(false);
+                                if (r.switchedTo) afterAccountChange();
+                                else { clearSessionState('vibez:'); refreshAccounts(); setAuthed(false); }
                             });
                         }}
                         onSwitchAccount={() => setSwitching(true)}
@@ -312,7 +330,7 @@ export function Vibez({ onClose: _onClose }: { onClose: () => void }) {
                     app="vibez"
                     forceDark
                     onClose={() => setSwitching(false)}
-                    onSwitched={() => { refreshAccounts(); bumpRefresh(); }}
+                    onSwitched={afterAccountChange}
                     onAdd={() => setAdding(true)}
                 />
             )}


### PR DESCRIPTION
Reported against Cherry: switching accounts left the screen showing the account you just left, and only closing and reopening the app applied the change.

## Cherry

Its switch handler called `refreshDeck`, which sets **only** `deck` and `canReset`:

```ts
const refreshDeck = useCallback(async () => {
    const s = await cherryState();
    if (s) { setDeck(s.deck); setCanReset(s.canReset); }
}, []);
```

But `me`, `profile` and `matches` come from that *same* `cherryState()` call and were never re-read. Reopening the app worked because it remounts and re-runs the load effect. Bumping the state nonce does the same thing without the reopen.

## Three more had the same class of bug

You said the others looked fine, so I checked rather than assumed. They were each stale in a narrower way, which is probably why it never showed:

| app | what was already refreshed | what was left on the old account |
|---|---|---|
| **Photogram** | me, feed, counts | activity, follow requests, explore, cached comments, and an open post detail / profile drill-in |
| **Vibez** | feeds, via the refresh key | the inbox unread count (fetched on an empty dep array, so the key never re-triggers it), plus an open viewer or profile |
| **Ryde** | the account row | rides, earnings and driver status — held locally and synced only on mount, so the next account inherited the previous one's history |
| **Squawk** | everything | just the composer, if left open |

Each app now routes its **switch**, its **add-account success** and its **sign-out-onto-another-account** through one `afterAccountChange`, so the three paths can't drift apart again.

## The part that isn't obvious

`clearSessionState('cherry:')` was already being called in some of these paths and is not sufficient on its own. It drops what's in storage, but a mounted `useSessionState` keeps its in-memory value — so the previous account's open chat, tab or drill-in stays on screen until it's explicitly set back. Every handler now does both.

Ryde is the one behaviour change worth calling out: it now calls `wipeAccount()` on switch, which clears the locally-held rides and driver profile. That is what its own sign-out already did, and without it the earnings on the Account screen belong to whoever was signed in before.

## Gates

| gate | result |
|---|---|
| `tsc --noEmit` | clean |
| `oxlint src` | one pre-existing `setDetail` warning in Photogram, verified identical on `main` |
| `vitest` | 405 passed / 32 files |
| `knip` | clean |
| `vite build` (sd-phone / sd-tablet) | 4.59s / 4.13s |

Checked declaration order in all four apps so the new callback can't be hit in its temporal dead zone: declared L206/L128/L90/L42, first used L309/L310/L238/L88.

Not verified in a browser — the module-mount harness has been unreliable since Vite re-optimized mid-session, and this is state-timing behaviour that only a real switch exercises. Cherry is the one to try first, since that is the reported symptom.