### PR TITLE
fix(mail): cap mailboxes at the same number as every other app

### DIFF
--- a/configs/mail.lua
+++ b/configs/mail.lua
@@ -8,9 +8,10 @@ return {
     -- on any other domain are rejected.
     Domain = 'lifeinvader.com',
 
-    -- Per-player cap on simultaneously logged-in accounts. Prevents one
-    -- player hoarding hundreds of inboxes.
-    MaxAccountsPerPlayer = 5,
+    -- Per-player cap on simultaneously logged-in accounts. How many a character may CREATE is
+    -- configs/accounts.lua (Accounts.PerApp.mail, else MaxPerApp), shared with every other app;
+    -- keep this at or above that or a player cannot hold all the mailboxes they are allowed.
+    MaxAccountsPerPlayer = 3,
 
     -- Hard cap on stored messages per account. Once exceeded, the oldest
     -- messages are pruned. Tunes the JSON row size.

--- a/server/accounts/actions.lua
+++ b/server/accounts/actions.lua
@@ -114,6 +114,23 @@ local function accountLimit(app)
     return n < 0 and 0 or math.floor(n)
 end
 
+---@type fun(app: string): integer Public alias, so an app that owns its own registration (Mail)
+---caps itself from configs/accounts.lua instead of carrying a second number of its own.
+actions.accountLimit = accountLimit
+
+---The refusal to hand back when `cid` has already created as many accounts in `app` as the
+---config allows; nil while there is room. 0 configured means unlimited.
+---@param app string account app key
+---@param count integer accounts this character has created in the app
+---@return string|nil refusal
+function actions.accountCapMessage(app, count)
+    local limit = accountLimit(app)
+    if limit <= 0 or count < limit then return nil end
+    return limit == 1
+        and 'You already have an account for this app'
+        or ('You can have at most %d accounts for this app'):format(limit)
+end
+
 ---Validates an optional recovery phone: nil when blank, otherwise 7-15 digits.
 ---@param raw any client-supplied phone number
 ---@return string|nil phone, string|nil err
@@ -159,12 +176,8 @@ function actions.createAccount(app, payload, cid)
     -- Accounts may share a recovery email and number; what caps a character is how many they
     -- have created here. Usernames stay unique per app, so the accounts remain distinguishable.
     if cid then
-        local limit = accountLimit(app)
-        if limit > 0 and store.countAccountsFor(app, cid) >= limit then
-            return fail(limit == 1
-                and 'You already have an account for this app'
-                or ('You can have at most %d accounts for this app'):format(limit))
-        end
+        local capped = actions.accountCapMessage(app, store.countAccountsFor(app, cid))
+        if capped then return fail(capped) end
     end
 
     local id = store.insertAccount(app, username, displayName, store.hashPassword(password), email, phone, cid)

--- a/server/mail/actions.lua
+++ b/server/mail/actions.lua
@@ -45,9 +45,6 @@ local DRAFT_GAP_MS = 1000
 ---@type integer Minimum gap between accepted sign-ups, per character.
 local SIGNUP_GAP_MS = 30000
 
----@type integer Accounts one character may ever create. MaxAccountsPerPlayer only caps how many
----are signed in at once, and signing out leaves the row behind, so the loop re-arms it forever.
-local MAX_ACCOUNTS_CREATED = 10
 
 ---@type integer Rolling window over the per-message mailbox writes, and the calls allowed inside
 ---it. Each one decodes and re-encodes the whole messages blob, so the byte ceiling alone leaves
@@ -316,9 +313,13 @@ function actions.signUp(source, payload)
     if not util.cooldown(me.cid, 'mail:signUp', SIGNUP_GAP_MS) then
         return fail('Please wait before creating another account')
     end
-    if store.countAccountsCreatedBy(me.cid) >= MAX_ACCOUNTS_CREATED then
-        return fail(('You can create at most %d accounts'):format(MAX_ACCOUNTS_CREATED))
-    end
+    -- The same cap every other app gets, from configs/accounts.lua, but counted off Mail's own
+    -- created_by_cid: it predates the accounts engine, so it is accurate for mailboxes made
+    -- before the engine existed. Checked here rather than left to createAccount below, whose
+    -- refusal that call discards - which is how a 4th mailbox used to get written with no
+    -- engine account behind it, unrecoverable and missing from the Passwords app.
+    local capped = acctActions.accountCapMessage('mail', store.countAccountsCreatedBy(me.cid))
+    if capped then return fail(capped) end
 
     local phone = (tostring(payload.phone or '')):gsub('%D', '')
     if phone ~= '' and (#phone < 7 or #phone > 15) then
@@ -340,10 +341,17 @@ function actions.signUp(source, payload)
     end
     store.addSession(email, me.cid)
 
-    acctActions.createAccount('mail', {
+    -- Ordered after the mail row on purpose: createAccount validates the recovery email against
+    -- phone_mail_accounts, so the mailbox has to exist first. A refusal here leaves a mailbox
+    -- with no engine account, which cannot be recovered or saved to Passwords, so it is undone.
+    local acctRes = acctActions.createAccount('mail', {
         username = email, password = password, name = displayName,
         email = email, phone = phone ~= '' and phone or nil,
     }, me.cid)
+    if not acctRes.success then
+        store.deleteAccount(email)
+        return acctRes
+    end
 
     local acc = store.getAccount(email)
     if not acc then return fail('Account vanished after creation') end


### PR DESCRIPTION
Mail allowed more mailboxes than the other account apps. It turned out to be carrying **three** overlapping limits.

| limit | value | what it capped |
|---|---|---|
| `configs/mail.lua` → `MaxAccountsPerPlayer` | 5 | signed in at once |
| `MAX_ACCOUNTS_CREATED`, hardcoded in `mail/actions.lua` | 10 | created, ever |
| `configs/accounts.lua` → `MaxPerApp` | 3 | created per app — what every other app obeys |

## The engine's cap was already running, and being ignored

`signUp` called `acctActions.createAccount('mail', …)` **without reading the result**. So at three accounts the engine refused, and the mailbox was written to `phone_mail_accounts` anyway — just with no `phone_app_accounts` row behind it.

Those mailboxes work, which is why this stayed invisible. But with no engine account they cannot be recovered and never reach the Passwords app, so they are also invisible to the switcher. Silently worse than being refused.

## The fix

Mail asks for the shared cap up front and refuses with the same wording as everywhere else (`You can have at most 3 accounts for this app`). The count still comes from Mail's own `created_by_cid`, which predates the accounts engine and is therefore accurate for mailboxes made before it existed — `phone_app_accounts.created_by` is not, for those.

`createAccount` keeps its position after the insert on purpose: it validates the recovery address against `phone_mail_accounts`, so the row has to exist first. But its result is now checked, and a failure deletes the mailbox instead of leaving it half registered.

`MAX_ACCOUNTS_CREATED` is gone — the engine cap is the same semantic (accounts created per character per app), so keeping a second number invited exactly this drift.

`MaxAccountsPerPlayer` drops to 3 to match, so a player can still hold every mailbox they are allowed to create. It stays configurable: raise `Accounts.PerApp.mail` and this alongside it if you want Mail to differ.

## Gates

| gate | result |
|---|---|
| `luac -p` | clean on all three touched files |
| `tests/lua/run.lua` | 398 passed, 3 pre-existing failures (battery/settings, unrelated) |
| `tsc --noEmit` | clean |
| `vitest` | 405 passed / 32 files |
| `knip` | clean |
| `vite build` (sd-phone / sd-tablet) | 3.50s / 5.81s |

Worth testing that a 4th mailbox is now refused *before* anything is written — check `phone_mail_accounts` has no extra row after the refusal.