### PR TITLE
fix(accounts): free the name and the quota when an account is deleted

### DIFF
--- a/server/accounts/store.lua
+++ b/server/accounts/store.lua
@@ -173,8 +173,16 @@ end
 ---Deletes an account and its sessions, sessions first.
 ---@param id number account row id
 function store.deleteAccount(id)
+    local acc = store.getAccountById(id)
     MySQL.update.await('DELETE FROM phone_app_sessions WHERE account_id = ?', { id })
     MySQL.update.await('DELETE FROM phone_app_accounts WHERE id = ?', { id })
+    -- Vault rows are keyed by name, not by account id, so they outlive the account: every
+    -- character who saved this login would keep being offered a dead one in the switcher.
+    -- Scoped to this username on purpose, so deleting one account leaves your others alone.
+    if acc then
+        MySQL.update.await('DELETE FROM phone_passwords WHERE app = ? AND username = ?',
+            { acc.app, acc.username })
+    end
 end
 
 ---Signs a citizen into an account, replacing any prior session for (app, citizenid).

--- a/server/mail/actions.lua
+++ b/server/mail/actions.lua
@@ -297,6 +297,28 @@ function actions.list(source)
     return ok({ accounts = outAccounts, messages = outMessages })
 end
 
+---Clears engine accounts left behind by mailboxes deleted before the delete path removed them.
+---Such a row keeps the address reserved and a per-app slot spent against a mailbox that is gone.
+---Only Mail can be repaired this way: phone_mail_accounts IS the mailbox, so its absence is
+---proof. Photogram and Vibez seed their profile row lazily on first open, which makes a deleted
+---account indistinguishable from one that registered and never opened the app.
+---@return boolean ran true when the repair executed on this call
+function actions.repairOrphanAccounts()
+    return util.runOnce('accounts_orphan_mail_cleanup', function()
+        local orphans = MySQL.query.await([[
+            SELECT a.id, a.username FROM phone_app_accounts a
+            LEFT JOIN phone_mail_accounts m
+                   ON m.email = a.username COLLATE utf8mb4_unicode_ci
+            WHERE a.app = 'mail' AND m.email IS NULL
+        ]]) or {}
+        for i = 1, #orphans do acctStore.deleteAccount(orphans[i].id) end
+        if #orphans > 0 then
+            print(('^3[sd-phone:mail]^0 released %d orphaned mail account name(s)'):format(#orphans))
+        end
+        return { removed = #orphans }
+    end)
+end
+
 ---Creates a brand-new email account and signs the caller straight into it. Every field is
 ---validated server-side; the password is hashed and mirrored into the accounts engine.
 ---@param source number

--- a/server/mail/actions.lua
+++ b/server/mail/actions.lua
@@ -934,6 +934,10 @@ function actions.deleteAccount(source, payload)
     local email = trim(payload.email or ''):lower()
     local _, err = requireOwnership(source, email); if err then return err end
     store.deleteAccount(email)
+    -- The engine row owns the name and the per-app quota, so leaving it behind keeps the address
+    -- reserved and the cap spent against an account that no longer exists.
+    local acc = acctStore.getAccount('mail', email)
+    if acc then acctStore.deleteAccount(acc.id) end
     return ok({ email = email })
 end
 

--- a/server/mail/init.lua
+++ b/server/mail/init.lua
@@ -20,6 +20,9 @@ CreateThread(function()
         boot.schemaFailed('mail', err)
         return
     end
+    -- Runs from here, not from the accounts module, because it can only tell a deleted mailbox
+    -- from a live one once phone_mail_accounts exists; the two schemas boot on separate threads.
+    pcall(actions.repairOrphanAccounts)
     boot.schemaReady()
 end)
 

--- a/server/photogram/actions.lua
+++ b/server/photogram/actions.lua
@@ -1196,6 +1196,9 @@ function actions.deleteAccount(src)
     local acc = viewerAccount(src)
     if not acc then return fail('Not signed in') end
     store.wipeUser(acc.username)
+    -- The engine row owns the name and the per-app quota, so leaving it behind keeps the handle
+    -- reserved and the cap spent against an account that no longer exists.
+    acctStore.deleteAccount(acc.id)
     return ok()
 end
 

--- a/server/vibez/actions.lua
+++ b/server/vibez/actions.lua
@@ -770,6 +770,9 @@ function actions.deleteAccount(src)
     local acc = viewerAccount(src)
     if not acc then return fail('Not signed in') end
     store.wipeUser(acc.username)
+    -- The engine row owns the name and the per-app quota, so leaving it behind keeps the handle
+    -- reserved and the cap spent against an account that no longer exists.
+    acctStore.deleteAccount(acc.id)
     return ok()
 end
 

--- a/web/src/apps/birdy/profile/EditProfile.tsx
+++ b/web/src/apps/birdy/profile/EditProfile.tsx
@@ -6,7 +6,6 @@ import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { Toggle } from '@/ui/Toggle';
 import { apiDeleteAccount, apiUpdateProfile } from '../birdyApi';
-import { accountsForgetPassword } from '@/core/accountsApi';
 import { ChangePasswordPage } from '@/shared/ChangePasswordPage';
 import { BG, BLUE, type BirdyProfile } from '../data';
 
@@ -52,7 +51,6 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onSwitchAcc
 
     async function remove() {
         await apiDeleteAccount();
-        await accountsForgetPassword('birdy');
         onDeleted();
     }
 

--- a/web/src/apps/cherry/Cherry.tsx
+++ b/web/src/apps/cherry/Cherry.tsx
@@ -12,7 +12,7 @@ import { useAppAuth } from '@/hooks/useAppAuth';
 import { AppAuth } from '@/shared/AppAuth';
 import { AccountSwitcher } from '@/shared/AccountSwitcher';
 import { AlertDialog } from '@/ui/AlertDialog';
-import { MAIL_DOMAIN, accountsConfirmReset, accountsForgetPassword, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSignOut, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
+import { MAIL_DOMAIN, accountsConfirmReset, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSignOut, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { appendThreadMessage, patchThreadMessage, toggleReactionLocal } from '@/shared/chat/messagesApi';
 import type { Message, Reaction } from '@/shared/chat/data';
 import type { MessageDraft } from '@/shared/chat/ChatView';
@@ -368,8 +368,9 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                                 onDeleteAccount={() => {
                                     void (async () => {
                                         await cherryDeleteAccount();
-                                        await accountsForgetPassword('cherry');
                                         await accountsLogout('cherry');
+                                        clearSessionState('cherry:');
+                                        refreshAccounts();
                                         setAuthed(false);
                                     })();
                                 }}

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -11,7 +11,7 @@ import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { useAppAuth } from '@/hooks/useAppAuth';
 import { AppAuth } from '@/shared/AppAuth';
 import { AccountSwitcher } from '@/shared/AccountSwitcher';
-import { MAIL_DOMAIN, accountsConfirmReset, accountsForgetPassword, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSignOut, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
+import { MAIL_DOMAIN, accountsConfirmReset, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSignOut, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { IG, type Comment as IGComment, type Post, type ProfileData, type User } from './data';
 import {
     apiActivity, apiAddComment, apiAddStory, apiComments, apiCounts, apiCreate, apiDeleteAccount, apiDeletePost, apiDismissNotification, apiExplore, apiFeed,
@@ -443,7 +443,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                         });
                     }}
                     onSwitchAccount={() => { setEditing(false); setSwitching(true); }}
-                    onDelete={() => { setEditing(false); clearSessionState('photogram:'); void apiDeleteAccount(); void accountsForgetPassword('photogram'); void accountsLogout('photogram'); setAuthed(false); }}
+                    onDelete={() => { setEditing(false); clearSessionState('photogram:'); void apiDeleteAccount(); void accountsLogout('photogram'); refreshAccounts(); setAuthed(false); }}
                 />
             )}
 

--- a/web/src/apps/ryde/account/Account.tsx
+++ b/web/src/apps/ryde/account/Account.tsx
@@ -9,7 +9,7 @@ import { AlertDialog } from '@/ui/AlertDialog';
 import { ListGroup } from '@/ui/ListGroup';
 import { t } from '@/i18n';
 import {
-    MAIL_DOMAIN, accountsConfirmReset, accountsForgetPassword, accountsLogin, accountsLogout,
+    MAIL_DOMAIN, accountsConfirmReset, accountsLogin, accountsLogout,
     accountsMe, accountsMyEmail, accountsMyNumber, accountsRegister, accountsRequestReset,
     accountsSavePassword, accountsSavedLogin, accountsSignOut, accountsSuggestCode, accountsSwitch,
     accountsSwitchable, type SwitchableAccount,
@@ -113,12 +113,11 @@ export function Account({ onClose }: { onClose: () => void }) {
 
     async function deleteAccount() {
         await rydeDeleteAccount();
-        await accountsForgetPassword('ryde');
         await accountsLogout('ryde');
         g.wipeAccount();
         setConfirmDelete(false);
         setAuth(false, null);
-        void accountsSavedLogin('ryde').then(setSavedLogin);
+        refreshAccounts();
     }
 
     const displayName = me?.name || me?.username || t('ryde.you', 'You');

--- a/web/src/core/accountsApi.ts
+++ b/web/src/core/accountsApi.ts
@@ -108,13 +108,6 @@ export async function accountsDeletePassword(id: number): Promise<void> {
     await fetchNui('sd-phone:accounts:deletePassword', { id });
 }
 
-export async function accountsForgetPassword(app: string): Promise<void> {
-    const entries = await accountsListPasswords();
-    for (const e of entries) {
-        if (e.app === app) await accountsDeletePassword(e.id);
-    }
-}
-
 export async function accountsSavedLogin(app: string): Promise<{ username: string; password: string } | null> {
     const entries = await accountsListPasswords();
     const e = entries.find(x => x.app === app);


### PR DESCRIPTION
Reported on Mail: delete an account, try to recreate it with the same name, and you get "already registered" — plus the per-app cap still counts the deleted one. You guessed it was wider than Mail. It was.

## Why both symptoms have one cause

`phone_app_accounts` is the row that owns the **username** and that `countAccountsFor` counts for the cap. Mail's `deleteAccount` only removed its own tables:

```lua
local _, err = requireOwnership(source, email); if err then return err end
store.deleteAccount(email)   -- phone_mail_accounts + phone_mail_sessions only
return ok({ email = email })
```

So the engine row survived: name still reserved, quota still spent, against an account that no longer exists.

## Which apps were affected

| app | deleted the engine row |
|---|---|
| Mail | no |
| Photogram | no |
| Vibez | no |
| Squawk | yes |
| Cherry | yes |
| Ryde | yes |

Squawk, Cherry and Ryde already called `acctStore.deleteAccount(acc.id)`, which is why the symptom only surfaced on Mail. Photogram and Vibez both `store.wipeUser(acc.username)` and stop. All three now delete the engine row.

## The mirror problem, in the vault

Vault rows are keyed by `(app, username)` rather than by account id, so they outlive the account too — leaving a dead login in the switcher, including copies other characters saved. `store.deleteAccount` now clears them for that app and username.

That replaces `accountsForgetPassword(app)`, which looped the caller's vault deleting **every** entry for the app:

```ts
for (const e of entries) {
    if (e.app === app) await accountsDeletePassword(e.id);
}
```

With one account per app that was the same thing. With several it meant deleting one Photogram account also wiped the saved logins for your *other* Photogram accounts, quietly breaking the switcher for the survivors. Removed rather than fixed, since the server now does the correctly-scoped version at the only point it matters — and it reaches other characters' copies, which a client-side loop never could.

## Gates

| gate | result |
|---|---|
| `luac -p` | clean on all four touched Lua files |
| `tests/lua/run.lua` | 398 passed, 3 pre-existing failures (battery/settings, unrelated) |
| `tsc --noEmit` | clean |
| `vitest` | 405 passed / 32 files |
| `knip` | clean — it caught `accountsForgetPassword` going unused, which is what prompted removing it rather than leaving it dangling |
| `vite build` (sd-phone / sd-tablet) | 4.04s / 4.71s |

Worth confirming in-game: delete a Mail account, recreate it with the same address (should be accepted), and check the cap counts 2 rather than 3 afterwards. Then delete one Photogram account of two and confirm the other is still listed in the switcher.