### PR TITLE
fix(jobs): drop the QBox job membership when a job is removed

### DIFF
--- a/bridge/server/job.lua
+++ b/bridge/server/job.lua
@@ -195,7 +195,7 @@ end
 ---@param jobName string
 ---@return boolean
 function job.leave(source, jobName)
-    if framework.name ~= 'qb' then return false end
+    if framework.name ~= 'qbx' then return false end
     local p = player_mod.get(source)
     local cid = p and p.PlayerData and p.PlayerData.citizenid
     if not cid then return false end


### PR DESCRIPTION
Closes #164. Thanks to @boppescripting for spotting it.

## The bug

`job.leave` guarded on `framework.name ~= 'qb'`, which admits only plain QBCore. That is the one framework **without** `qbx_core`, while QBox, the only framework that has `RemovePlayerFromJob`, was rejected outright. The `pcall` then swallowed the missing-export error on QBCore, so the function never errored and never worked.

The docblock two lines above already described the intended behaviour ("via qbx_core's ... export. No-op on plain QBCore and ESX"); the guard just had the wrong literal. `framework.qb` being true for both QB flavours is what makes `'qb'` vs `'qbx'` easy to transpose here.

## Player-visible symptom

On QBox the `player_groups` row survived removing or quitting a job. `jobs.list` re-seeds the saved map from `job.getAll`, which reads `PlayerData.jobs` off `player_groups`, so the removed job was written straight back in the same response meant to confirm its removal and reappeared in the Jobs tab. Affected both `jobs.remove` and the quit path in `actions.lua`.

## Behaviour by framework

| Framework | Before | After |
| --- | --- | --- |
| QBox (`qbx`) | rejected by guard, export never called | export called, membership dropped |
| QBCore (`qb`) | passed guard, missing export threw, `pcall` ate it, returned false | returns false immediately |
| ESX | returns false | returns false |

Nothing changes for QBCore or ESX. The no-op is correct there rather than merely harmless: neither has a framework-level multi-job membership to drop, and on QBCore `getAll` reports the active job only, so a job the phone dropped from its own store is never re-seeded.

## Verification

- New bridge-level Lua suite covering all three frameworks plus the unresolvable-player guard: fails 6 assertions before the change, `13 passed, 0 failed` after.
- Full Lua suite: `398 passed, 3 failed`. Those 3 are pre-existing and identical on unmodified `HEAD` (their subject files are not on this branch; none load `job.lua`).
- `luac -p bridge/server/job.lua` clean.

No frontend change, so the JS gates are not implicated.

## Follow-ups, not in this PR

- `pcall` discards qbx's real `success, errorResult`, so `job.leave` reports `true` whenever the call merely did not throw. Both callers ignore the return value today, but the export is reachable for the first time now.
- `sd-banking` carries the identical bug in its own copy of `bridge/server/job.lua`.
