### PR TITLE
feat(accounts): the account switcher tracks live sessions

### DIFF
--- a/client/apps/accounts.lua
+++ b/client/apps/accounts.lua
@@ -9,6 +9,7 @@ proxyCallback('sd-phone:accounts:logout',       'sd-phone:server:accounts:logout
 proxyCallback('sd-phone:accounts:signOutAll',   'sd-phone:server:accounts:signOutAll')
 proxyCallback('sd-phone:accounts:capacity',     'sd-phone:server:accounts:capacity')
 proxyCallback('sd-phone:accounts:me',           'sd-phone:server:accounts:me')
+proxyCallback('sd-phone:accounts:signInOptions', 'sd-phone:server:accounts:signInOptions')
 proxyCallback('sd-phone:accounts:switchable',   'sd-phone:server:accounts:switchable')
 proxyCallback('sd-phone:accounts:switch',       'sd-phone:server:accounts:switch')
 proxyCallback('sd-phone:accounts:requestReset', 'sd-phone:server:accounts:requestReset')

--- a/locales/en.json
+++ b/locales/en.json
@@ -4836,6 +4836,7 @@
     "signOutAllConfirm": "Log Out",
     "signOutAllMessage": "Every account you have in this app will be signed out. Saved passwords are kept.",
     "signOutAllTitle": "Log out of all accounts?",
+    "signOutSwitchMessage": "You'll be switched to {name}.",
     "switchAccount": "Switch account",
     "switchFailed": "Could not switch account"
   }

--- a/server/accounts/actions.lua
+++ b/server/accounts/actions.lua
@@ -348,6 +348,32 @@ function actions.switchable(source, payload)
     return ok({ accounts = out, active = signedIn[1] and signedIn[1].username or nil })
 end
 
+---Accounts the caller could sign into for `app`: saved-password entries they do NOT already hold
+---a session for. The sign-in screen's picker, and the complement of `switchable`, which lists the
+---sessions they already have.
+---@param source number player server id
+---@param payload table|nil client-supplied { app }
+---@return table envelope on success data = { accounts }
+function actions.signInOptions(source, payload)
+    local app = payload and payload.app
+    if not SWITCH_APPS[app] then return fail('Unknown app') end
+    local cid = player.getIdentifier(source); if not cid then return fail('Player not found') end
+
+    local held = {}
+    for _, acc in ipairs(store.listSessionAccounts(app, cid)) do held[acc.username:lower()] = true end
+
+    local out = {}
+    for _, row in ipairs(store.listVaultEntries(cid)) do
+        if row.app == app and not held[row.username:lower()] then
+            local acc = store.getAccount(app, row.username)
+            if acc then
+                out[#out + 1] = { username = acc.username, name = acc.displayName, email = acc.email }
+            end
+        end
+    end
+    return ok({ accounts = out })
+end
+
 ---Signs the caller into another of their own saved accounts without retyping the password. The
 ---vault is a convenience, not an authority: its stored password is verified against the account,
 ---so a stale entry fails rather than granting access.

--- a/server/accounts/actions.lua
+++ b/server/accounts/actions.lua
@@ -251,11 +251,20 @@ end
 function actions.logout(source, payload)
     local app = payload and payload.app
     -- SWITCH_APPS rather than DIRECT_APPS: Squawk registers itself, but it still needs a plain
-    -- logout, or its only exit is signOutOrSwitch and it can never reach a signed-out state.
+    -- logout, or the switcher is its only way out of an account.
     if not SWITCH_APPS[app] then return fail('Unknown app') end
     local cid = player.getIdentifier(source)
-    if cid then store.clearSession(app, cid) end
-    return ok()
+    if not cid then return ok({ switchedTo = nil }) end
+
+    -- Ends this account's session only. Any other account the player is signed into stays that
+    -- way, and the next most recently used one becomes active, so they land on it rather than
+    -- at the sign-in screen.
+    local current = store.getSessionAccount(app, cid)
+    if not current then return ok({ switchedTo = nil }) end
+    store.clearAccountSession(app, cid, current.id)
+
+    local next_ = store.getSessionAccount(app, cid)
+    return ok({ switchedTo = next_ and next_.username or nil, me = next_ and publicAccount(next_) or nil })
 end
 
 ---Signs `cid` out of every account in one app, or out of every account app at once when `app` is
@@ -329,17 +338,14 @@ function actions.switchable(source, payload)
     if not SWITCH_APPS[app] then return fail('Unknown app') end
     local cid = player.getIdentifier(source); if not cid then return fail('Player not found') end
 
-    local current = store.getSessionAccount(app, cid)
+    -- Live sessions, not vault entries: the switcher moves between accounts the player is
+    -- actually signed into, so signing out of one drops it from the list until they add it back.
+    local signedIn = store.listSessionAccounts(app, cid)
     local out = {}
-    for _, row in ipairs(store.listVaultEntries(cid)) do
-        if row.app == app then
-            local acc = store.getAccount(app, row.username)
-            if acc then
-                out[#out + 1] = { username = acc.username, name = acc.displayName, email = acc.email }
-            end
-        end
+    for i = 1, #signedIn do
+        out[i] = { username = signedIn[i].username, name = signedIn[i].displayName, email = signedIn[i].email }
     end
-    return ok({ accounts = out, active = current and current.username or nil })
+    return ok({ accounts = out, active = signedIn[1] and signedIn[1].username or nil })
 end
 
 ---Signs the caller into another of their own saved accounts without retyping the password. The
@@ -358,6 +364,16 @@ function actions.switchAccount(source, payload)
     local username = trim(payload.username):lower()
     if username == '' then return fail('Pick an account') end
 
+    -- Already signed into it: switching is just making that session the active one, so no
+    -- password is involved. This is the path the switcher takes.
+    for _, held in ipairs(store.listSessionAccounts(app, cid)) do
+        if held.username:lower() == username then
+            store.setSession(app, cid, held.id)
+            return ok({ me = publicAccount(held) })
+        end
+    end
+
+    -- Not signed in: signing in again needs the saved password, verified against the account.
     local saved
     for _, row in ipairs(store.listVaultEntries(cid)) do
         if row.app == app and row.username:lower() == username then saved = row break end

--- a/server/accounts/init.lua
+++ b/server/accounts/init.lua
@@ -28,6 +28,7 @@ lib.callback.register('sd-phone:server:accounts:logout',       function(src, pay
 lib.callback.register('sd-phone:server:accounts:signOutAll',   function(src, payload) return actions.signOutAll(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:capacity',     function(src, payload) return actions.capacity(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:me',           function(src, payload) return actions.me(src, payload) end)
+lib.callback.register('sd-phone:server:accounts:signInOptions', function(src, payload) return actions.signInOptions(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:switchable',   function(src, payload) return actions.switchable(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:switch',       function(src, payload) return actions.switchAccount(src, payload) end)
 lib.callback.register('sd-phone:server:accounts:requestReset', function(src, payload) return actions.requestReset(src, payload) end)

--- a/server/accounts/store.lua
+++ b/server/accounts/store.lua
@@ -71,6 +71,14 @@ function store.ensureSchema()
     -- An account is identified by its contacts alone, which cannot say who owns it: an account
     -- with only an email is unattributable, and an email need not be the holder's, so counting a
     -- quota by contact would let a stranger consume it. The creator is stamped instead.
+    -- A player may hold several sessions per app at once; the most recently used one is the
+    -- active account. A timestamp rather than a flag, so switching is a single-row write that
+    -- cannot leave two rows both claiming to be active.
+    util.ensureColumns('phone_app_sessions', {
+        last_used = 'last_used TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+    })
+    util.ensureIndex('phone_app_sessions', 'idx_app_sessions_active', '(app, citizenid, last_used)')
+
     util.ensureColumns('phone_app_accounts', {
         created_by = 'created_by VARCHAR(64) NULL',
     })
@@ -185,19 +193,38 @@ function store.deleteAccount(id)
     end
 end
 
----Signs a citizen into an account, replacing any prior session for (app, citizenid).
+---Signs a citizen into an account and makes it the active one. Sessions the citizen already
+---holds in the app are kept, so several accounts stay signed in at once and the switcher can
+---move between them without a password.
 ---@param app string account app key
 ---@param citizenid string framework per-character id
 ---@param accountId number account row id
 function store.setSession(app, citizenid, accountId)
-    MySQL.update.await('DELETE FROM phone_app_sessions WHERE app = ? AND citizenid = ?', { app, citizenid })
-    MySQL.insert.await(
-        'INSERT INTO phone_app_sessions (app, citizenid, account_id) VALUES (?, ?, ?)',
-        { app, citizenid, accountId }
-    )
+    MySQL.query.await([[
+        INSERT INTO phone_app_sessions (app, citizenid, account_id, last_used)
+        VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+        ON DUPLICATE KEY UPDATE last_used = CURRENT_TIMESTAMP
+    ]], { app, citizenid, accountId })
 end
 
----Sign a citizen out of an app (idempotent: no rows is a no-op).
+---Every account the citizen is currently signed into for `app`, most recently used first, so
+---the head of the list is the active account. Read-only.
+---@param app string account app key
+---@param citizenid string framework per-character id
+---@return table[] accounts
+function store.listSessionAccounts(app, citizenid)
+    local rows = MySQL.query.await([[
+        SELECT a.* FROM phone_app_sessions s
+        JOIN phone_app_accounts a ON a.id = s.account_id
+        WHERE s.app = ? AND s.citizenid = ?
+        ORDER BY s.last_used DESC, a.id ASC
+    ]], { app, citizenid }) or {}
+    local out = {}
+    for i = 1, #rows do out[i] = rowToAccount(rows[i]) end
+    return out
+end
+
+---Ends every session a citizen holds in an app (idempotent: no rows is a no-op).
 ---@param app string account app key
 ---@param citizenid string framework per-character id
 ---@return integer cleared sessions removed
@@ -205,6 +232,18 @@ function store.clearSession(app, citizenid)
     return MySQL.update.await(
         'DELETE FROM phone_app_sessions WHERE app = ? AND citizenid = ?',
         { app, citizenid }
+    ) or 0
+end
+
+---Ends one account's session, leaving the citizen's other sessions in the app signed in.
+---@param app string account app key
+---@param citizenid string framework per-character id
+---@param accountId number account row id
+---@return integer cleared sessions removed
+function store.clearAccountSession(app, citizenid, accountId)
+    return MySQL.update.await(
+        'DELETE FROM phone_app_sessions WHERE app = ? AND citizenid = ? AND account_id = ?',
+        { app, citizenid, accountId }
     ) or 0
 end
 
@@ -229,7 +268,8 @@ function store.sessionCitizens(app, accountId)
     return out
 end
 
----First (only, for single-session apps) account this citizen is signed into. Read-only.
+---The citizen's active account in an app: the session they most recently signed into or
+---switched to. Nil when they hold no session. Read-only.
 ---@param app string account app key
 ---@param citizenid string framework per-character id
 ---@return table|nil account
@@ -238,6 +278,7 @@ function store.getSessionAccount(app, citizenid)
         SELECT a.* FROM phone_app_sessions s
         JOIN phone_app_accounts a ON a.id = s.account_id
         WHERE s.app = ? AND s.citizenid = ?
+        ORDER BY s.last_used DESC, a.id ASC
         LIMIT 1
     ]], { app, citizenid })
     return rowToAccount(row)

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -12,8 +12,9 @@ import { useDeckActive } from '@/shell/deckActive';
 import { AccountSwitcher } from '@/shared/AccountSwitcher';
 import { AppAuth } from '@/shared/AppAuth';
 import { AlertDialog } from '@/ui/AlertDialog';
-import { MAIL_DOMAIN, accountsConfirmReset, accountsLogout, accountsRequestReset, accountsSavePassword, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
+import { MAIL_DOMAIN, accountsConfirmReset, accountsRequestReset, accountsSavePassword, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { signOutAllForApp } from '@/shared/signOutAll';
+import { logOutOrSwitch, switchTargetLabel } from '@/shared/logOutOrSwitch';
 import { toggleReactionLocal } from '@/shared/chat/messagesApi';
 import type { MessageDraft } from '@/shared/chat/ChatView';
 import {
@@ -454,11 +455,13 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     profile={profile}
                     onCancel={() => setEditingProfile(false)}
                     onSaved={p => { setProfile(p); setMe({ name: p.name, handle: p.handle, verified: p.verified }); setEditingProfile(false); }}
+                    switchTo={switchTargetLabel(savedAccounts[0])}
                     onSignOut={() => {
                         setEditingProfile(false);
                         setProfileOpen(false);
-                        void accountsLogout('birdy').then(() => {
-                            clearSessionState('birdy:'); refreshAccounts(); setAuthed(false);
+                        void logOutOrSwitch('birdy', savedAccounts[0]).then(switched => {
+                            if (switched) switchedAccount();
+                            else { clearSessionState('birdy:'); refreshAccounts(); setAuthed(false); }
                         });
                     }}
                     onSignOutAll={() => {

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -459,7 +459,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     onSignOut={() => {
                         setEditingProfile(false);
                         setProfileOpen(false);
-                        void logOutOrSwitch('birdy', savedAccounts[0]).then(switched => {
+                        void logOutOrSwitch('birdy').then(switched => {
                             if (switched) switchedAccount();
                             else { clearSessionState('birdy:'); refreshAccounts(); setAuthed(false); }
                         });

--- a/web/src/apps/birdy/profile/EditProfile.tsx
+++ b/web/src/apps/birdy/profile/EditProfile.tsx
@@ -11,11 +11,12 @@ import { BG, BLUE, type BirdyProfile } from '../data';
 
 const RED = '#ff3b30';
 
-export function EditProfile({ profile, onCancel, onSaved, onSignOut, onSignOutAll, onSwitchAccount, onDeleted }: {
+export function EditProfile({ profile, onCancel, onSaved, onSignOut, onSignOutAll, onSwitchAccount, onDeleted, switchTo }: {
     profile:         BirdyProfile;
     onCancel:        () => void;
     onSaved:         (p: BirdyProfile) => void;
     onSignOut:       () => void;
+    switchTo?:       string | null;
     onSignOutAll:    () => void;
     onSwitchAccount: () => void;
     onDeleted:       () => void;
@@ -127,7 +128,9 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onSignOutAl
             {confirmSignOut && (
                 <AlertDialog
                     title={t('squawk.signOutTitle', 'Sign out of Squawk?')}
-                    message={t('squawk.signOutMessage', 'You can sign back in anytime.')}
+                    message={switchTo
+                        ? t('accounts.signOutSwitchMessage', "You'll be switched to {name}.", { name: switchTo })
+                        : t('squawk.signOutMessage', 'You can sign back in anytime.')}
                     confirmLabel={t('squawk.signOut', 'Sign Out')}
                     onCancel={() => setConfirmSignOut(false)}
                     onConfirm={signOut}

--- a/web/src/apps/cherry/Cherry.tsx
+++ b/web/src/apps/cherry/Cherry.tsx
@@ -14,6 +14,7 @@ import { AccountSwitcher } from '@/shared/AccountSwitcher';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { MAIL_DOMAIN, accountsConfirmReset, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { signOutAllForApp } from '@/shared/signOutAll';
+import { logOutOrSwitch, switchTargetLabel } from '@/shared/logOutOrSwitch';
 import { appendThreadMessage, patchThreadMessage, toggleReactionLocal } from '@/shared/chat/messagesApi';
 import type { Message, Reaction } from '@/shared/chat/data';
 import type { MessageDraft } from '@/shared/chat/ChatView';
@@ -360,9 +361,11 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                             <EditProfile
                                 profile={profile}
                                 onChange={setProfile}
+                                switchTo={switchTargetLabel(savedAccounts[0])}
                                 onSignOut={() => {
-                                    void accountsLogout('cherry').then(() => {
-                                        clearSessionState('cherry:'); refreshAccounts(); setAuthed(false);
+                                    void logOutOrSwitch('cherry', savedAccounts[0]).then(switched => {
+                                        if (switched) afterAccountChange();
+                                        else { clearSessionState('cherry:'); refreshAccounts(); setAuthed(false); }
                                     });
                                 }}
                                 onSignOutAll={() => {

--- a/web/src/apps/cherry/Cherry.tsx
+++ b/web/src/apps/cherry/Cherry.tsx
@@ -363,7 +363,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
                                 onChange={setProfile}
                                 switchTo={switchTargetLabel(savedAccounts[0])}
                                 onSignOut={() => {
-                                    void logOutOrSwitch('cherry', savedAccounts[0]).then(switched => {
+                                    void logOutOrSwitch('cherry').then(switched => {
                                         if (switched) afterAccountChange();
                                         else { clearSessionState('cherry:'); refreshAccounts(); setAuthed(false); }
                                     });

--- a/web/src/apps/cherry/EditProfile.tsx
+++ b/web/src/apps/cherry/EditProfile.tsx
@@ -13,11 +13,12 @@ import { CHERRY, type Gender, type InterestedIn, type MyProfile } from './data';
 
 const MAX_PHOTOS = 6;
 
-export function EditProfile({ profile, onChange, onSignOut, onSignOutAll, onSwitchAccount, onDeleteAccount }: {
+export function EditProfile({ profile, onChange, onSignOut, onSignOutAll, onSwitchAccount, onDeleteAccount, switchTo }: {
     onSwitchAccount?: () => void;
     profile:         MyProfile;
     onChange:        (p: MyProfile) => void;
     onSignOut:       () => void;
+    switchTo?:       string | null;
     onSignOutAll:    () => void;
     onDeleteAccount: () => void;
 }) {
@@ -225,7 +226,9 @@ export function EditProfile({ profile, onChange, onSignOut, onSignOutAll, onSwit
             {confirming === 'logout' && (
                 <AlertDialog
                     title={t('cherry.logOutTitle', 'Log Out?')}
-                    message={t('cherry.logOutMessage', "You'll need to sign in again to use Cherry.")}
+                    message={switchTo
+                        ? t('accounts.signOutSwitchMessage', "You'll be switched to {name}.", { name: switchTo })
+                        : t('cherry.logOutMessage', "You'll need to sign in again to use Cherry.")}
                     cancelLabel={t('cherry.cancel', 'Cancel')}
                     confirmLabel={t('cherry.logOutConfirm', 'Log Out')}
                     onCancel={() => setConfirming(null)}

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -441,7 +441,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                     switchTo={switchTargetLabel(savedAccounts[0])}
                     onSignOut={() => {
                         setEditing(false);
-                        void logOutOrSwitch('photogram', savedAccounts[0]).then(switched => {
+                        void logOutOrSwitch('photogram').then(switched => {
                             if (switched) afterAccountChange();
                             else { clearSessionState('photogram:'); refreshAccounts(); setAuthed(false); }
                         });

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -13,6 +13,7 @@ import { AppAuth } from '@/shared/AppAuth';
 import { AccountSwitcher } from '@/shared/AccountSwitcher';
 import { MAIL_DOMAIN, accountsConfirmReset, accountsLogin, accountsLogout, accountsMe, accountsRegister, accountsRequestReset, accountsSavePassword, accountsSuggestCode, accountsSwitch } from '@/core/accountsApi';
 import { signOutAllForApp } from '@/shared/signOutAll';
+import { logOutOrSwitch, switchTargetLabel } from '@/shared/logOutOrSwitch';
 import { IG, type Comment as IGComment, type Post, type ProfileData, type User } from './data';
 import {
     apiActivity, apiAddComment, apiAddStory, apiComments, apiCounts, apiCreate, apiDeleteAccount, apiDeletePost, apiDismissNotification, apiExplore, apiFeed,
@@ -437,10 +438,12 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
                     profile={{ name: me.name, bio: me.bio, avatar: me.avatar, private: me.isPrivate } as ProfileData}
                     onCancel={() => setEditing(false)}
                     onSave={async p => { const updated = await apiUpdateProfile({ name: p.name, bio: p.bio, avatar: p.avatar, private: p.private }); if (updated) setMe(updated); setEditing(false); }}
+                    switchTo={switchTargetLabel(savedAccounts[0])}
                     onSignOut={() => {
                         setEditing(false);
-                        void accountsLogout('photogram').then(() => {
-                            clearSessionState('photogram:'); refreshAccounts(); setAuthed(false);
+                        void logOutOrSwitch('photogram', savedAccounts[0]).then(switched => {
+                            if (switched) afterAccountChange();
+                            else { clearSessionState('photogram:'); refreshAccounts(); setAuthed(false); }
                         });
                     }}
                     onSignOutAll={() => {

--- a/web/src/apps/photogram/profile/EditProfile.tsx
+++ b/web/src/apps/photogram/profile/EditProfile.tsx
@@ -7,7 +7,7 @@ import { ChangePasswordPage } from '@/shared/ChangePasswordPage';
 import { Toggle } from '@/ui/Toggle';
 import { IG, type ProfileData } from '../data';
 
-export function EditProfile({ profile, onCancel, onSave, onSignOut, onSignOutAll, onSwitchAccount, onDelete }: {
+export function EditProfile({ profile, onCancel, onSave, onSignOut, onSignOutAll, onSwitchAccount, onDelete, switchTo }: {
     onSwitchAccount: () => void;
     profile:      ProfileData;
     onCancel:     () => void;
@@ -15,6 +15,7 @@ export function EditProfile({ profile, onCancel, onSave, onSignOut, onSignOutAll
     onSignOut:    () => void;
     onSignOutAll: () => void;
     onDelete:     () => void;
+    switchTo?:    string | null;
 }) {
     const [name,   setName]   = useState(profile.name);
     const [bio,    setBio]    = useState(profile.bio);
@@ -111,7 +112,9 @@ export function EditProfile({ profile, onCancel, onSave, onSignOut, onSignOutAll
             {confirmOut && (
                 <AlertDialog
                     title={t('photogram.signOutTitle', 'Sign out of Photogram?')}
-                    message={t('photogram.signOutMessage', 'You can sign back in anytime.')}
+                    message={switchTo
+                        ? t('accounts.signOutSwitchMessage', "You'll be switched to {name}.", { name: switchTo })
+                        : t('photogram.signOutMessage', 'You can sign back in anytime.')}
                     confirmLabel={t('photogram.signOut', 'Sign Out')}
                     onCancel={() => setConfirmOut(false)}
                     onConfirm={onSignOut}

--- a/web/src/apps/ryde/account/Account.tsx
+++ b/web/src/apps/ryde/account/Account.tsx
@@ -15,6 +15,7 @@ import {
     accountsSwitchable, type SwitchableAccount,
 } from '@/core/accountsApi';
 import { signOutAllForApp } from '@/shared/signOutAll';
+import { logOutOrSwitch, switchTargetLabel } from '@/shared/logOutOrSwitch';
 import { driverStats, useRyde } from '../store';
 import { money } from '../data';
 import { rydeDeleteAccount } from '../rydeApi';
@@ -103,8 +104,9 @@ export function Account({ onClose }: { onClose: () => void }) {
     if (!authed) return authScreen;
 
     async function signOut() {
-        await accountsLogout('ryde');
+        const switched = await logOutOrSwitch('ryde', savedAccounts[0]);
         setConfirmSignOut(false);
+        if (switched) { afterAccountChange(); return; }
         g.wipeAccount();
         setAuth(false, null);
         refreshAccounts();
@@ -232,7 +234,9 @@ export function Account({ onClose }: { onClose: () => void }) {
             {confirmSignOut && (
                 <AlertDialog
                     title={t('ryde.signOutTitle', 'Sign out of Ryde?')}
-                    message={t('ryde.signOutMessage', "You'll need to log in again to view your account.")}
+                    message={switchTargetLabel(savedAccounts[0])
+                        ? t('accounts.signOutSwitchMessage', "You'll be switched to {name}.", { name: switchTargetLabel(savedAccounts[0]) as string })
+                        : t('ryde.signOutMessage', "You'll need to log in again to view your account.")}
                     confirmLabel={t('ryde.signOutConfirm', 'Sign Out')}
                     destructive
                     onCancel={() => setConfirmSignOut(false)}

--- a/web/src/apps/ryde/account/Account.tsx
+++ b/web/src/apps/ryde/account/Account.tsx
@@ -104,7 +104,7 @@ export function Account({ onClose }: { onClose: () => void }) {
     if (!authed) return authScreen;
 
     async function signOut() {
-        const switched = await logOutOrSwitch('ryde', savedAccounts[0]);
+        const switched = await logOutOrSwitch('ryde');
         setConfirmSignOut(false);
         if (switched) { afterAccountChange(); return; }
         g.wipeAccount();

--- a/web/src/apps/ryde/account/Account.tsx
+++ b/web/src/apps/ryde/account/Account.tsx
@@ -11,8 +11,8 @@ import { t } from '@/i18n';
 import {
     MAIL_DOMAIN, accountsConfirmReset, accountsLogin, accountsLogout,
     accountsMe, accountsMyEmail, accountsMyNumber, accountsRegister, accountsRequestReset,
-    accountsSavePassword, accountsSavedLogin, accountsSuggestCode, accountsSwitch,
-    accountsSwitchable, type SwitchableAccount,
+    accountsSavePassword, accountsSavedLogin, accountsSignInOptions, accountsSuggestCode, accountsSwitch,
+    type SwitchableAccount,
 } from '@/core/accountsApi';
 import { signOutAllForApp } from '@/shared/signOutAll';
 import { logOutOrSwitch, switchTargetLabel } from '@/shared/logOutOrSwitch';
@@ -37,7 +37,7 @@ export function Account({ onClose }: { onClose: () => void }) {
 
     const refreshAccounts = useCallback(() => {
         void accountsSavedLogin('ryde').then(setSavedLogin);
-        void accountsSwitchable('ryde').then(d => setSavedAccounts(d.accounts.filter(a => a.username !== d.active)));
+        void accountsSignInOptions('ryde').then(setSavedAccounts);
     }, []);
 
     // Ryde keeps rides and the driver profile locally and only syncs them on mount, so without

--- a/web/src/core/accountsApi.ts
+++ b/web/src/core/accountsApi.ts
@@ -34,9 +34,10 @@ export async function accountsLogin(app: string, values: Record<string, string>)
     return res.success ? { ok: true } : { ok: false, message: res.message };
 }
 
-export async function accountsLogout(app: string): Promise<void> {
-    if (!isFiveM) { devSessions[app] = null; return; }
-    await fetchNui('sd-phone:accounts:logout', { app });
+export async function accountsLogout(app: string): Promise<{ switchedTo: string | null }> {
+    if (!isFiveM) { devSessions[app] = null; return { switchedTo: null }; }
+    const d = await apiData<{ switchedTo?: string | null }>('sd-phone:accounts:logout', { app });
+    return { switchedTo: d?.switchedTo ?? null };
 }
 
 export const ACCOUNT_APPS = ['photogram', 'cherry', 'vibez', 'ryde', 'birdy', 'mail'] as const;

--- a/web/src/core/accountsApi.ts
+++ b/web/src/core/accountsApi.ts
@@ -150,6 +150,12 @@ export interface SwitchableAccount {
     email?:   string;
 }
 
+export async function accountsSignInOptions(app: string): Promise<SwitchableAccount[]> {
+    if (!isFiveM) return DEV_VAULT.filter(e => e.app === app).map(e => ({ username: e.username }));
+    const d = await apiData<{ accounts?: SwitchableAccount[] }>('sd-phone:accounts:signInOptions', { app });
+    return d?.accounts ?? [];
+}
+
 export async function accountsSwitchable(app: string): Promise<{ accounts: SwitchableAccount[]; active: string | null }> {
     if (!isFiveM) {
         const mine = DEV_VAULT.filter(e => e.app === app);

--- a/web/src/hooks/useAppAuth.ts
+++ b/web/src/hooks/useAppAuth.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { accountsMyEmail, accountsMyNumber, accountsSavedLogin, accountsSwitchable, type SwitchableAccount } from '@/core/accountsApi';
+import { accountsMyEmail, accountsMyNumber, accountsSavedLogin, accountsSignInOptions, type SwitchableAccount } from '@/core/accountsApi';
 
 export interface AppAuthState {
     authed:        boolean;
@@ -34,12 +34,10 @@ export function useAppAuth(appId: string, checkSession: () => Promise<boolean>):
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // The picker must never offer the account already in use, and which one that is changes on
-    // every sign-in, switch and sign-out, so this refetches on the same nonce those bump.
+    // The sign-in picker offers accounts this player could sign into: saved logins they do not
+    // already hold a session for. The switcher is the complement and lists the sessions instead.
     useEffect(() => {
-        void accountsSwitchable(appId).then(d => {
-            setSavedAccounts(d.accounts.filter(a => a.username !== d.active));
-        });
+        void accountsSignInOptions(appId).then(setSavedAccounts);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [authed, accountsNonce]);
 

--- a/web/src/shared/logOutOrSwitch.ts
+++ b/web/src/shared/logOutOrSwitch.ts
@@ -1,4 +1,4 @@
-import { accountsLogout, accountsSwitch } from '@/core/accountsApi';
+import { accountsLogout } from '@/core/accountsApi';
 
 export interface SwitchTarget {
     username: string;
@@ -10,11 +10,7 @@ export function switchTargetLabel(next: SwitchTarget | null | undefined): string
     return next.name || next.username;
 }
 
-export async function logOutOrSwitch(app: string, next: SwitchTarget | null | undefined): Promise<string | null> {
-    if (next) {
-        const res = await accountsSwitch(app, next.username);
-        if (res.ok) return next.username;
-    }
-    await accountsLogout(app);
-    return null;
+export async function logOutOrSwitch(app: string): Promise<string | null> {
+    const { switchedTo } = await accountsLogout(app);
+    return switchedTo;
 }

--- a/web/src/shared/logOutOrSwitch.ts
+++ b/web/src/shared/logOutOrSwitch.ts
@@ -1,0 +1,20 @@
+import { accountsLogout, accountsSwitch } from '@/core/accountsApi';
+
+export interface SwitchTarget {
+    username: string;
+    name?:    string;
+}
+
+export function switchTargetLabel(next: SwitchTarget | null | undefined): string | null {
+    if (!next) return null;
+    return next.name || next.username;
+}
+
+export async function logOutOrSwitch(app: string, next: SwitchTarget | null | undefined): Promise<string | null> {
+    if (next) {
+        const res = await accountsSwitch(app, next.username);
+        if (res.ok) return next.username;
+    }
+    await accountsLogout(app);
+    return null;
+}


### PR DESCRIPTION
Reworks the switcher to list the accounts you are **actually signed into**, instead of every account whose password you have saved. Signing out of an account drops it from the switcher; "Add account" signs it back in.

## The problem

The switcher was backed by the Passwords vault, so it listed accounts you had signed out of and never shrank. That made Log Out pointless in these apps: it could only ever swap you to another account, which is what Switch Account already did.

Underneath, these apps were **single-session**: `setSession` deleted every existing row before inserting, so only one account could be signed in at a time. With one session, "log out of all accounts" and "log out" were literally the same call (`store.clearSession`), which is why those two buttons behaved identically everywhere except Mail.

## The change

`phone_app_sessions` already allowed several rows per (app, citizenid); only `setSession` prevented it. It now keeps siblings and stamps `last_used`, so a player can hold several sessions per app and the most recent one is active. A timestamp rather than a flag, so switching is a single-row write that cannot leave two rows both claiming to be active.

| Action | Now does |
| --- | --- |
| **Switch Account** | makes another live session active; no password, nothing signed out |
| **Log Out** | ends this account's session and lands you on the next live one, or the sign-in screen if it was your last |
| **Log Out of All Accounts** | ends every session for the app, genuinely distinct from Log Out at last |
| **Add account** (in the switcher) | signs a new account in, joining the others |

Switching to an account you already hold takes no password at all. Switching to one you do not hold falls back to the vault, verified server-side, so the Passwords app keeps its role as a convenience for signing back in rather than as the definition of who is signed in.

## Notes

- Existing players hold exactly one session row each, so the `last_used` migration is a no-op and nothing needs re-authenticating.
- Unlike Mail, these apps still act as the *active* account only, so a backgrounded account does not collect notifications in parallel. "Signed in" here means the session is kept so switching is instant.
- Vibez is left out of the Log Out change on request; it has no confirm step, so a switch there would be silent.

## Verification

- New Lua suite over the session model, covering multi-session switchable, active ordering, logout promoting the next session, logout of the last session, a signed-out account leaving the switcher, password-free switching between held accounts, vault fallback for unheld ones, and sign-out-all clearing everything: `20 passed`.
- Existing accounts suite still `19 passed`, full vitest `424 passed`, knip clean, `oxlint` 0 errors, `tsc --noEmit` clean, `vite build` succeeds.
- `sd-phone` and `sd-tablet` both rebuilt.
