### PR TITLE
feat(settings): scope settings to the device they were changed on

### DIFF
--- a/server/migrations.lua
+++ b/server/migrations.lua
@@ -31,6 +31,7 @@ local COLUMNS = {
         icon_custom       = 'icon_custom LONGTEXT NULL',
         show_app_names    = 'show_app_names TINYINT(1) NULL',
         island_pet        = 'island_pet VARCHAR(16) NULL',
+        device            = "device VARCHAR(16) NOT NULL DEFAULT 'phone'",
     },
 
     phone_documents = {

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -137,11 +137,24 @@ end)
 
 ---Returns the caller's full settings snapshot: tone selections, custom tones, airplane mode,
 ---clock preferences, wallpaper, chat text scale, locale and lock security. Read-only.
-lib.callback.register('sd-phone:server:settings:get', function(source)
+---@type table<string, boolean> Devices that own a settings row. An id outside this set is the
+---phone, so a hand-edited client cannot mint rows for devices that do not exist.
+local SETTINGS_DEVICES = { phone = true, tablet = true }
+
+---Which device a settings call came from. The UI stamps it on every sd-phone:settings:* payload;
+---an absent or unknown one is the phone, which is what keeps older NUI bundles working unchanged.
+---@param payload table|nil client-supplied payload
+---@return string device
+local function deviceOf(payload)
+    local d = type(payload) == 'table' and payload.device or nil
+    return (type(d) == 'string' and SETTINGS_DEVICES[d]) and d or 'phone'
+end
+
+lib.callback.register('sd-phone:server:settings:get', function(source, payload)
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     -- One row read, not one per field: this used to issue 16 single-column PK lookups.
-    local data = store.snapshot(cid)
+    local data = store.snapshot(cid, deviceOf(payload))
     data.customRingtones         = store.listCustomTones(cid, 'ringtone')
     data.customNotificationTones = store.listCustomTones(cid, 'notification')
     -- Face Unlock only works for the SIM's first activator - a stolen phone still asks the
@@ -157,7 +170,7 @@ lib.callback.register('sd-phone:server:settings:setWallpaper', function(source, 
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'wallpaper') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setWallpaper(cid, payload.lock or payload.wallpaper, payload.home)
+    store.setWallpaper(cid, payload.lock or payload.wallpaper, payload.home, deviceOf(payload))
     return { success = true }
 end)
 
@@ -167,7 +180,7 @@ lib.callback.register('sd-phone:server:settings:setBlur', function(source, paylo
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
-    coalesce(cid, 'blur', function() store.setBlur(cid, payload.lock, payload.home) end)
+    coalesce(cid, 'blur', function() store.setBlur(cid, payload.lock, payload.home, deviceOf(payload)) end)
     return { success = true }
 end)
 
@@ -177,7 +190,7 @@ lib.callback.register('sd-phone:server:settings:setIslandPet', function(source, 
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
-    coalesce(cid, 'islandPet', function() store.setIslandPet(cid, payload.pet) end)
+    coalesce(cid, 'islandPet', function() store.setIslandPet(cid, payload.pet, deviceOf(payload)) end)
     return { success = true }
 end)
 
@@ -216,7 +229,7 @@ lib.callback.register('sd-phone:server:settings:setSecurity', function(source, p
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'security') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setSecurity(cid, payload.passcode, payload.faceId == true)
+    store.setSecurity(cid, payload.passcode, payload.faceId == true, deviceOf(payload))
     return { success = true }
 end)
 
@@ -225,7 +238,7 @@ lib.callback.register('sd-phone:server:settings:setLockClock', function(source, 
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     local cfg = type(payload) == 'table' and payload or {}
-    coalesce(cid, 'lockClock', function() store.setLockClock(cid, cfg) end)
+    coalesce(cid, 'lockClock', function() store.setLockClock(cid, cfg, deviceOf(payload)) end)
     return { success = true }
 end)
 
@@ -234,7 +247,7 @@ lib.callback.register('sd-phone:server:settings:setChatTextScale', function(sour
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
-    coalesce(cid, 'chatTextScale', function() store.setChatTextScale(cid, payload.scale) end)
+    coalesce(cid, 'chatTextScale', function() store.setChatTextScale(cid, payload.scale, deviceOf(payload)) end)
     return { success = true }
 end)
 
@@ -255,7 +268,7 @@ lib.callback.register('sd-phone:server:settings:setPhoneScale', function(source,
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
-    coalesce(cid, 'phoneScale', function() store.setPhoneScale(cid, payload.scale) end)
+    coalesce(cid, 'phoneScale', function() store.setPhoneScale(cid, payload.scale, deviceOf(payload)) end)
     return { success = true }
 end)
 
@@ -264,7 +277,7 @@ lib.callback.register('sd-phone:server:settings:setBrightness', function(source,
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
-    coalesce(cid, 'brightness', function() store.setBrightness(cid, payload.brightness) end)
+    coalesce(cid, 'brightness', function() store.setBrightness(cid, payload.brightness, deviceOf(payload)) end)
     return { success = true }
 end)
 
@@ -274,7 +287,7 @@ lib.callback.register('sd-phone:server:settings:setPhoneAlign', function(source,
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'phoneAlign') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setPhoneAlign(cid, payload.align)
+    store.setPhoneAlign(cid, payload.align, deviceOf(payload))
     return { success = true }
 end)
 
@@ -283,7 +296,7 @@ lib.callback.register('sd-phone:server:settings:setVolumes', function(source, pa
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     payload = type(payload) == 'table' and payload or {}
-    coalesce(cid, 'volumes', function() store.setVolumes(cid, payload.ringtone, payload.call) end)
+    coalesce(cid, 'volumes', function() store.setVolumes(cid, payload.ringtone, payload.call, deviceOf(payload)) end)
     return { success = true }
 end)
 
@@ -293,7 +306,7 @@ lib.callback.register('sd-phone:server:settings:setLocale', function(source, pay
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'locale') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setLocale(cid, payload.locale)
+    store.setLocale(cid, payload.locale, deviceOf(payload))
     return { success = true }
 end)
 
@@ -304,7 +317,7 @@ lib.callback.register('sd-phone:server:settings:setAirplane', function(source, p
     if not writeAllowed(cid, 'airplane') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
     local on = payload.on == true
-    store.setAirplane(cid, on)
+    store.setAirplane(cid, on, deviceOf(payload))
     if not on then TriggerEvent('sd-phone:server:airplane:released', source) end
     return { success = true }
 end)
@@ -321,11 +334,11 @@ end)
 
 ---Marks the caller's profile as having completed first-run setup (one-way; the wipe path
 ---deletes the whole settings row, which is what un-sets it).
-lib.callback.register('sd-phone:server:settings:setSetupDone', function(source)
+lib.callback.register('sd-phone:server:settings:setSetupDone', function(source, payload)
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'setupDone') then return BUSY end
-    store.setSetupDone(cid)
+    store.setSetupDone(cid, deviceOf(payload))
     return { success = true }
 end)
 
@@ -335,7 +348,7 @@ lib.callback.register('sd-phone:server:settings:setReopenApp', function(source, 
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'reopenApp') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setReopenApp(cid, payload.on == true)
+    store.setReopenApp(cid, payload.on == true, deviceOf(payload))
     return { success = true }
 end)
 
@@ -345,7 +358,7 @@ lib.callback.register('sd-phone:server:settings:setTheme', function(source, payl
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'theme') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setTheme(cid, payload.theme)
+    store.setTheme(cid, payload.theme, deviceOf(payload))
     return { success = true }
 end)
 
@@ -355,7 +368,7 @@ lib.callback.register('sd-phone:server:settings:setDarkTheme', function(source, 
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'darkTheme') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setDarkTheme(cid, payload.darkTheme)
+    store.setDarkTheme(cid, payload.darkTheme, deviceOf(payload))
     return { success = true }
 end)
 
@@ -365,7 +378,7 @@ lib.callback.register('sd-phone:server:settings:setIconTheme', function(source, 
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'iconTheme') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setIconTheme(cid, payload.iconTheme)
+    store.setIconTheme(cid, payload.iconTheme, deviceOf(payload))
     return { success = true }
 end)
 
@@ -400,7 +413,7 @@ lib.callback.register('sd-phone:server:settings:setShowAppNames', function(sourc
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'showAppNames') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setShowAppNames(cid, payload.on == true)
+    store.setShowAppNames(cid, payload.on == true, deviceOf(payload))
     return { success = true }
 end)
 
@@ -410,7 +423,7 @@ lib.callback.register('sd-phone:server:settings:setTones', function(source, payl
     if not cid then return { success = false, message = 'Player not found' } end
     if not writeAllowed(cid, 'tones') then return BUSY end
     payload = type(payload) == 'table' and payload or {}
-    store.setTones(cid, payload.ringtone, payload.notificationTone)
+    store.setTones(cid, payload.ringtone, payload.notificationTone, deviceOf(payload))
     return { success = true }
 end)
 
@@ -466,7 +479,7 @@ end)
 
 ---Factory reset (Settings > Erase All Content): uninstalls every downloadable app, clears the
 ---saved home layout, and signs the caller out of all app accounts and mailboxes.
-lib.callback.register('sd-phone:server:settings:factoryReset', function(source)
+lib.callback.register('sd-phone:server:settings:factoryReset', function(source, payload)
     local cid = player.getIdentifier(source)
     if not cid then return { success = false, message = 'Player not found' } end
     -- Two unindexed mail scans plus a badge recompute, and a character erases their phone once
@@ -474,7 +487,7 @@ lib.callback.register('sd-phone:server:settings:factoryReset', function(source)
     if not util.cooldown(cid, 'settings:factoryReset', 30000) then
         return { success = false, message = 'Please wait a moment before trying again' }
     end
-    store.setInstalledApps(cid, {})
+    store.setInstalledApps(cid, {}, deviceOf(payload))
     store.setHomeLayout(cid, '')
     accounts.signOutEverywhere(cid)
     badges.push(source)
@@ -526,5 +539,7 @@ exports('isAirplaneMode', function(source)
     if type(source) ~= 'number' then return false end
     local cid = player.getIdentifier(source)
     if not cid then return false end
+    -- Always the phone's radio: a caller asking whether this player is reachable means the device
+    -- that takes calls and texts, and a tablet has none.
     return store.isAirplane(cid)
 end)

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -981,6 +981,15 @@ end
 ---@type table<string, boolean> Cached airplane-mode flag per citizenid.
 local airplaneCache = {}
 
+---Cache key for one device's airplane flag. Keyed by citizenid AND device because the column is
+---per-device: a shared key would let the tablet answer with the phone's radio state.
+---@param citizenid string framework per-character id
+---@param device string device id
+---@return string key
+local function airplaneKey(citizenid, device)
+    return citizenid .. '\0' .. device
+end
+
 ---Returns true if a player currently has airplane mode on, lazily warming the cache from the DB
 ---on first read.
 ---@param citizenid string framework per-character id

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -52,6 +52,7 @@ function store.ensureSchema()
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_settings (
             citizenid          VARCHAR(64) NOT NULL,
+            device             VARCHAR(16) NOT NULL DEFAULT 'phone',
             phone_number       VARCHAR(20) NULL,
             active_group_id    VARCHAR(16) NULL,
             ringtone           VARCHAR(64) NULL,
@@ -89,13 +90,26 @@ function store.ensureSchema()
             locale             VARCHAR(8)   NULL,
             updated_at         TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
                 ON UPDATE CURRENT_TIMESTAMP,
-            PRIMARY KEY (citizenid)
+            PRIMARY KEY (citizenid, device)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
     -- Columns added since v0.9.0 live in server/migrations.lua; everything above is the current
     -- shape, which every fresh install gets from the CREATE TABLE directly.
     migrations.apply('phone_settings')
+
+    -- Settings became per-device, so the key widened. Existing rows already carry device='phone'
+    -- from the column default, which is what makes this safe: every row a player had stays their
+    -- phone's, and a tablet mints its own row on first use. Keyed off the second PK column rather
+    -- than a version flag, so it is a no-op on every boot after the first.
+    local pkSecond = MySQL.scalar.await([[
+        SELECT COLUMN_NAME FROM information_schema.statistics
+        WHERE table_schema = DATABASE() AND table_name = 'phone_settings'
+          AND index_name = 'PRIMARY' AND SEQ_IN_INDEX = 2
+    ]])
+    if pkSecond ~= 'device' then
+        MySQL.query.await('ALTER TABLE phone_settings DROP PRIMARY KEY, ADD PRIMARY KEY (citizenid, device)')
+    end
 
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_custom_ringtones (
@@ -261,8 +275,8 @@ end
 function store.getCard(citizenid)
     if not citizenid or citizenid == '' then return {} end
     local row = MySQL.single.await(
-        'SELECT card_name, card_avatar, card_email, card_address FROM phone_settings WHERE citizenid = ?',
-        { citizenid }
+        'SELECT card_name, card_avatar, card_email, card_address FROM phone_settings WHERE citizenid = ? AND device = ?',
+        { citizenid, 'phone' }
     )
     if not row then return {} end
     return {
@@ -281,8 +295,8 @@ function store.setCard(citizenid, fields)
     if not citizenid or citizenid == '' then return end
     fields = fields or {}
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, card_name, card_avatar, card_email, card_address)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO phone_settings (citizenid, device, card_name, card_avatar, card_email, card_address)
+        VALUES (?, ?, ?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
             card_name    = VALUES(card_name),
             card_avatar  = VALUES(card_avatar),
@@ -290,6 +304,7 @@ function store.setCard(citizenid, fields)
             card_address = VALUES(card_address)
     ]], {
         citizenid,
+        'phone',
         trimClamp(fields.name, 64),
         trimClamp(fields.avatar, 512),
         trimClamp(fields.email, 128),
@@ -301,11 +316,12 @@ end
 ---yields {}.
 ---@param citizenid string framework per-character id
 ---@return string[] ids installed app ids ({} when unset or unparseable)
-function store.getInstalledApps(citizenid)
+function store.getInstalledApps(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return {} end
     local row = MySQL.single.await(
-        'SELECT installed_apps FROM phone_settings WHERE citizenid = ?',
-        { citizenid }
+        'SELECT installed_apps FROM phone_settings WHERE citizenid = ? AND device = ?',
+        { citizenid, device }
     )
     if not row or not row.installed_apps or row.installed_apps == '' then return {} end
     local ok, decoded = pcall(json.decode, row.installed_apps)
@@ -316,12 +332,13 @@ end
 ---Persists a player's installed downloadable app ids, leaving other settings intact.
 ---@param citizenid string framework per-character id
 ---@param ids string[] installed app ids
-function store.setInstalledApps(citizenid, ids)
+function store.setInstalledApps(citizenid, ids, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, installed_apps) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, installed_apps) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE installed_apps = VALUES(installed_apps)
-    ]], { citizenid, json.encode(ids or {}) })
+    ]], { citizenid, device, json.encode(ids or {}) })
 end
 
 ---Reads a player's saved home-screen layout JSON, or nil if unset. Read-only.
@@ -330,8 +347,8 @@ end
 function store.getHomeLayout(citizenid)
     if not citizenid or citizenid == '' then return nil end
     local row = MySQL.single.await(
-        'SELECT home_layout FROM phone_settings WHERE citizenid = ?',
-        { citizenid }
+        'SELECT home_layout FROM phone_settings WHERE citizenid = ? AND device = ?',
+        { citizenid, 'phone' }
     )
     if not row or not row.home_layout or row.home_layout == '' then return nil end
     return row.home_layout
@@ -343,9 +360,9 @@ end
 function store.setHomeLayout(citizenid, layout)
     if not citizenid or citizenid == '' then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, home_layout) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, home_layout) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE home_layout = VALUES(home_layout)
-    ]], { citizenid, layout })
+    ]], { citizenid, 'phone', layout })
 end
 
 ---Reads a player's phone number, or nil if not yet assigned. Read-only.
@@ -354,8 +371,8 @@ end
 function store.getPhoneNumber(citizenid)
     if not citizenid or citizenid == '' then return nil end
     local row = MySQL.single.await(
-        'SELECT phone_number FROM phone_settings WHERE citizenid = ?',
-        { citizenid }
+        'SELECT phone_number FROM phone_settings WHERE citizenid = ? AND device = ?',
+        { citizenid, 'phone' }
     )
     return row and row.phone_number or nil
 end
@@ -393,9 +410,9 @@ function store.setPhoneNumber(citizenid, number)
     if not citizenid or citizenid == '' then return end
     local clean = (tostring(number or ''):gsub('%D', ''))
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, phone_number) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, phone_number) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE phone_number = VALUES(phone_number)
-    ]], { citizenid, clean })
+    ]], { citizenid, 'phone', clean })
 end
 
 ---Clears a phone identity's number mirror (device mode: a phone whose SIM was pulled has no
@@ -403,7 +420,7 @@ end
 ---@param citizenid string phone data identity
 function store.clearPhoneNumber(citizenid)
     if not citizenid or citizenid == '' then return end
-    MySQL.update.await('UPDATE phone_settings SET phone_number = NULL WHERE citizenid = ?', { citizenid })
+    MySQL.update.await("UPDATE phone_settings SET phone_number = NULL WHERE citizenid = ? AND device = 'phone'", { citizenid })
 end
 
 ---True when a phone identity already has a settings row (used by device-mode identity minting to
@@ -413,7 +430,7 @@ end
 ---@return boolean hasData
 function store.hasData(citizenid)
     if not citizenid or citizenid == '' then return false end
-    return MySQL.scalar.await('SELECT 1 FROM phone_settings WHERE citizenid = ? LIMIT 1', { citizenid }) ~= nil
+    return MySQL.scalar.await("SELECT 1 FROM phone_settings WHERE citizenid = ? AND device = 'phone' LIMIT 1", { citizenid }) ~= nil
 end
 
 ---Returns a player's number, generating and saving a unique one on first access; tries 20
@@ -462,7 +479,7 @@ function store.numbersFor(cids)
     if #list == 0 then return {} end
     local placeholders = ('?,'):rep(#list):sub(1, -2)
     local rows = MySQL.query.await(
-        'SELECT citizenid, phone_number FROM phone_settings WHERE citizenid IN (' .. placeholders .. ')', list) or {}
+        "SELECT citizenid, phone_number FROM phone_settings WHERE device = 'phone' AND citizenid IN (" .. placeholders .. ')', list) or {}
     local out = {}
     for i = 1, #rows do out[rows[i].citizenid] = (tostring(rows[i].phone_number or ''):gsub('%D', '')) end
     return out
@@ -501,9 +518,10 @@ end
 ---unparseable. Read-only.
 ---@param citizenid string framework per-character id
 ---@return { font: string|nil, layout: string|nil, color: string|nil }|nil
-function store.getLockClock(citizenid)
+function store.getLockClock(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return nil end
-    local row = MySQL.single.await('SELECT lock_clock FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT lock_clock FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if not row or not row.lock_clock or row.lock_clock == '' then return nil end
     local ok, decoded = pcall(json.decode, row.lock_clock)
     if not ok or type(decoded) ~= 'table' then return nil end
@@ -514,7 +532,8 @@ end
 ---sanitised fields; a fully-invalid payload is ignored.
 ---@param citizenid string framework per-character id
 ---@param cfg { font?: string, layout?: string, color?: string, scale?: number }
-function store.setLockClock(citizenid, cfg)
+function store.setLockClock(citizenid, cfg, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' or type(cfg) ~= 'table' then return end
     local clean = {
         font   = sanitizeSlug(cfg.font),
@@ -524,9 +543,9 @@ function store.setLockClock(citizenid, cfg)
     }
     if not clean.font and not clean.layout and not clean.color and not clean.scale then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, lock_clock) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, lock_clock) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE lock_clock = VALUES(lock_clock)
-    ]], { citizenid, json.encode(clean) })
+    ]], { citizenid, device, json.encode(clean) })
 end
 
 ---Validates a wallpaper image URL: http(s) scheme, no whitespace or control chars, within the
@@ -556,11 +575,12 @@ end
 ---mirrors the lock one client-side) plus the per-screen blur flags. Read-only.
 ---@param citizenid string framework per-character id
 ---@return { lock: string|nil, home: string|nil, blurLock: boolean, blurHome: boolean }
-function store.getWallpapers(citizenid)
+function store.getWallpapers(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return { blurLock = false, blurHome = false } end
     local row = MySQL.single.await(
-        'SELECT wallpaper, wallpaper_home, blur_lock, blur_home FROM phone_settings WHERE citizenid = ?',
-        { citizenid })
+        'SELECT wallpaper, wallpaper_home, blur_lock, blur_home FROM phone_settings WHERE citizenid = ? AND device = ?',
+        { citizenid, device })
     if not row then return { blurLock = false, blurHome = false } end
     return {
         lock     = row.wallpaper ~= '' and row.wallpaper or nil,
@@ -575,17 +595,18 @@ end
 ---@param citizenid string framework per-character id
 ---@param lock any lock-screen wallpaper key
 ---@param home any home-screen wallpaper key
-function store.setWallpaper(citizenid, lock, home)
+function store.setWallpaper(citizenid, lock, home, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     local l = sanitizeWallpaper(lock)
     local h = sanitizeWallpaper(home)
     if not l and not h then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, wallpaper, wallpaper_home) VALUES (?, ?, ?)
+        INSERT INTO phone_settings (citizenid, device, wallpaper, wallpaper_home) VALUES (?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
             wallpaper      = COALESCE(VALUES(wallpaper), wallpaper),
             wallpaper_home = COALESCE(VALUES(wallpaper_home), wallpaper_home)
-    ]], { citizenid, l, h })
+    ]], { citizenid, device, l, h })
 end
 
 ---Persists a player's per-screen wallpaper blur flags (upsert); a nil field leaves that
@@ -593,17 +614,18 @@ end
 ---@param citizenid string framework per-character id
 ---@param lockOn any blur the lock screen wallpaper
 ---@param homeOn any blur the home screen wallpaper
-function store.setBlur(citizenid, lockOn, homeOn)
+function store.setBlur(citizenid, lockOn, homeOn, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     if lockOn == nil and homeOn == nil then return end
     local l = lockOn ~= nil and (lockOn == true and 1 or 0) or nil
     local h = homeOn ~= nil and (homeOn == true and 1 or 0) or nil
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, blur_lock, blur_home) VALUES (?, ?, ?)
+        INSERT INTO phone_settings (citizenid, device, blur_lock, blur_home) VALUES (?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
             blur_lock = COALESCE(VALUES(blur_lock), blur_lock),
             blur_home = COALESCE(VALUES(blur_home), blur_home)
-    ]], { citizenid, l, h })
+    ]], { citizenid, device, l, h })
 end
 
 ---@type table<string, boolean> Pets the island offers. An id from an older or hand-edited client
@@ -617,13 +639,14 @@ local ISLAND_PETS = {
 ---Saves the character's Dynamic Island pet.
 ---@param citizenid string
 ---@param pet any
-function store.setIslandPet(citizenid, pet)
+function store.setIslandPet(citizenid, pet, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     local id = type(pet) == 'string' and ISLAND_PETS[pet] and pet or 'none'
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, island_pet) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, island_pet) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE island_pet = VALUES(island_pet)
-    ]], { citizenid, id })
+    ]], { citizenid, device, id })
 end
 
 ---@type integer Cap on saved custom wallpapers per character.
@@ -634,7 +657,7 @@ local MAX_CUSTOM_WALLPAPERS = 24
 ---@param list string[] wallpaper URLs
 local function writeCustomWallpapers(citizenid, list)
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, custom_wallpapers) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, custom_wallpapers) VALUES (?, 'phone', ?)
         ON DUPLICATE KEY UPDATE custom_wallpapers = VALUES(custom_wallpapers)
     ]], { citizenid, json.encode(list) })
 end
@@ -646,7 +669,7 @@ end
 function store.getCustomWallpapers(citizenid)
     if not citizenid or citizenid == '' then return {} end
     local row = MySQL.single.await(
-        'SELECT custom_wallpapers FROM phone_settings WHERE citizenid = ?', { citizenid })
+        "SELECT custom_wallpapers FROM phone_settings WHERE citizenid = ? AND device = 'phone'", { citizenid })
     if not row or not row.custom_wallpapers or row.custom_wallpapers == '' then return {} end
     local ok, decoded = pcall(json.decode, row.custom_wallpapers)
     if not ok or type(decoded) ~= 'table' then return {} end
@@ -701,9 +724,10 @@ end
 ---Read-only.
 ---@param citizenid string framework per-character id
 ---@return number|nil scale saved multiplier
-function store.getChatTextScale(citizenid)
+function store.getChatTextScale(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return nil end
-    local row = MySQL.single.await('SELECT chat_text_scale FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT chat_text_scale FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if not row or row.chat_text_scale == nil then return nil end
     return tonumber(row.chat_text_scale)
 end
@@ -712,14 +736,15 @@ end
 ---out-of-range / non-numeric value is ignored.
 ---@param citizenid string framework per-character id
 ---@param scale number multiplier (clamped to 0.8-1.5)
-function store.setChatTextScale(citizenid, scale)
+function store.setChatTextScale(citizenid, scale, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     local clean = clampChatTextScale(scale)
     if not clean then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, chat_text_scale) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, chat_text_scale) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE chat_text_scale = VALUES(chat_text_scale)
-    ]], { citizenid, clean })
+    ]], { citizenid, device, clean })
 end
 
 ---Clamps a 0-100 slider value to an integer; nil for non-numbers and NaN, out-of-range values
@@ -738,9 +763,10 @@ end
 ---Read-only.
 ---@param citizenid string framework per-character id
 ---@return number|nil scale saved slider value
-function store.getPhoneScale(citizenid)
+function store.getPhoneScale(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return nil end
-    local row = MySQL.single.await('SELECT phone_scale FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT phone_scale FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if not row or row.phone_scale == nil then return nil end
     return tonumber(row.phone_scale)
 end
@@ -749,22 +775,24 @@ end
 ---non-numeric value is ignored.
 ---@param citizenid string framework per-character id
 ---@param scale number slider value (clamped to 0-100)
-function store.setPhoneScale(citizenid, scale)
+function store.setPhoneScale(citizenid, scale, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     local clean = clampSlider(scale)
     if not clean then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, phone_scale) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, phone_scale) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE phone_scale = VALUES(phone_scale)
-    ]], { citizenid, clean })
+    ]], { citizenid, device, clean })
 end
 
 ---Reads a player's screen brightness (slider value 0-100), or nil when never set.
 ---@param citizenid string framework per-character id
 ---@return number|nil brightness
-function store.getBrightness(citizenid)
+function store.getBrightness(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return nil end
-    local row = MySQL.single.await('SELECT brightness FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT brightness FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if not row or row.brightness == nil then return nil end
     return tonumber(row.brightness)
 end
@@ -774,14 +802,15 @@ end
 ---compared against nil rather than tested for truthiness.
 ---@param citizenid string framework per-character id
 ---@param brightness number slider value (clamped to 0-100)
-function store.setBrightness(citizenid, brightness)
+function store.setBrightness(citizenid, brightness, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     local clean = clampSlider(brightness)
     if clean == nil then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, brightness) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, brightness) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE brightness = VALUES(brightness)
-    ]], { citizenid, clean })
+    ]], { citizenid, device, clean })
 end
 
 -- Mirrors the PhoneAlign union in web/src/stores/themeStore.tsx.
@@ -795,9 +824,10 @@ local PHONE_ALIGNS = {
 ---Reads a player's phone anchor position, or nil if unset. Read-only.
 ---@param citizenid string framework per-character id
 ---@return string|nil align saved anchor position
-function store.getPhoneAlign(citizenid)
+function store.getPhoneAlign(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return nil end
-    local row = MySQL.single.await('SELECT phone_align FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT phone_align FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if not row or not row.phone_align or row.phone_align == '' then return nil end
     return row.phone_align
 end
@@ -805,13 +835,14 @@ end
 ---Persists a player's phone anchor position, whitelist-checked against PHONE_ALIGNS.
 ---@param citizenid string framework per-character id
 ---@param align any client-supplied anchor position
-function store.setPhoneAlign(citizenid, align)
+function store.setPhoneAlign(citizenid, align, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     if type(align) ~= 'string' or not PHONE_ALIGNS[align] then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, phone_align) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, phone_align) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE phone_align = VALUES(phone_align)
-    ]], { citizenid, align })
+    ]], { citizenid, device, align })
 end
 
 ---Clamps a volume to an integer 0-100; nil for non-numbers and NaN, out-of-range values fall to
@@ -830,10 +861,11 @@ end
 ---0 is returned as 0. Read-only.
 ---@param citizenid string framework per-character id
 ---@return { ringtone: number|nil, call: number|nil }
-function store.getVolumes(citizenid)
+function store.getVolumes(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return {} end
     local row = MySQL.single.await(
-        'SELECT ringtone_volume, call_volume FROM phone_settings WHERE citizenid = ?', { citizenid })
+        'SELECT ringtone_volume, call_volume FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if not row then return {} end
     return {
         ringtone = row.ringtone_volume ~= nil and tonumber(row.ringtone_volume) or nil,
@@ -846,18 +878,19 @@ end
 ---@param citizenid string framework per-character id
 ---@param ringtone any ringtone-and-alert volume 0-100
 ---@param call any call volume 0-100
-function store.setVolumes(citizenid, ringtone, call)
+function store.setVolumes(citizenid, ringtone, call, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     local r = clampVolume(ringtone)
     local c = clampVolume(call)
     if r == nil and c == nil then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, ringtone_volume, call_volume)
-        VALUES (?, ?, ?)
+        INSERT INTO phone_settings (citizenid, device, ringtone_volume, call_volume)
+        VALUES (?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
             ringtone_volume = COALESCE(VALUES(ringtone_volume), ringtone_volume),
             call_volume     = COALESCE(VALUES(call_volume), call_volume)
-    ]], { citizenid, r, c })
+    ]], { citizenid, device, r, c })
 end
 
 -- Mirrors SUPPORTED_LOCALES in web/src/i18n/index.ts.
@@ -870,9 +903,10 @@ local SUPPORTED_LOCALES = {
 ---Reads a player's saved phone language, or nil if unset. Read-only.
 ---@param citizenid string framework per-character id
 ---@return string|nil locale saved locale code
-function store.getLocale(citizenid)
+function store.getLocale(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return nil end
-    local row = MySQL.single.await('SELECT locale FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT locale FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if not row or not row.locale or row.locale == '' then return nil end
     return row.locale
 end
@@ -880,13 +914,14 @@ end
 ---Persists a player's chosen phone language, whitelist-checked against SUPPORTED_LOCALES.
 ---@param citizenid string framework per-character id
 ---@param locale any client-supplied locale code
-function store.setLocale(citizenid, locale)
+function store.setLocale(citizenid, locale, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     if type(locale) ~= 'string' or not SUPPORTED_LOCALES[locale] then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, locale) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, locale) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE locale = VALUES(locale)
-    ]], { citizenid, locale })
+    ]], { citizenid, device, locale })
 end
 
 ---Clamps a passcode to a bare 4-6 digit string, or nil.
@@ -901,9 +936,10 @@ end
 ---set and `faceId` is forced false whenever no passcode exists. Read-only.
 ---@param citizenid string framework per-character id
 ---@return { passcode: string|nil, faceId: boolean }
-function store.getSecurity(citizenid)
+function store.getSecurity(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return { passcode = nil, faceId = false } end
-    local row = MySQL.single.await('SELECT passcode, face_id FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT passcode, face_id FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if not row then return { passcode = nil, faceId = false } end
     local pin = sanitizePin(row.passcode)
     return { passcode = pin, faceId = pin ~= nil and isTruthy(row.face_id) }
@@ -914,24 +950,26 @@ end
 ---@param citizenid string framework per-character id
 ---@param passcode string|nil 4-6 digit code, nil to clear
 ---@param faceId boolean Face Unlock enabled (only honoured alongside a valid passcode)
-function store.setSecurity(citizenid, passcode, faceId)
+function store.setSecurity(citizenid, passcode, faceId, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     local pin = sanitizePin(passcode)
     local face = pin ~= nil and faceId == true
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, passcode, face_id) VALUES (?, ?, ?)
+        INSERT INTO phone_settings (citizenid, device, passcode, face_id) VALUES (?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE passcode = VALUES(passcode), face_id = VALUES(face_id)
-    ]], { citizenid, pin, face and 1 or 0 })
+    ]], { citizenid, device, pin, face and 1 or 0 })
 end
 
 ---Reads a player's saved tone selections; fields are nil when unset. Read-only.
 ---@param citizenid string framework per-character id
 ---@return { ringtone: string|nil, notificationTone: string|nil }
-function store.getTones(citizenid)
+function store.getTones(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return {} end
     local row = MySQL.single.await(
-        'SELECT ringtone, notification_tone FROM phone_settings WHERE citizenid = ?',
-        { citizenid }
+        'SELECT ringtone, notification_tone FROM phone_settings WHERE citizenid = ? AND device = ?',
+        { citizenid, device }
     )
     return {
         ringtone         = row and row.ringtone or nil,
@@ -947,27 +985,29 @@ local airplaneCache = {}
 ---on first read.
 ---@param citizenid string framework per-character id
 ---@return boolean on
-function store.isAirplane(citizenid)
+function store.isAirplane(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return false end
-    local cached = airplaneCache[citizenid]
+    local cached = airplaneCache[airplaneKey(citizenid, device)]
     if cached ~= nil then return cached end
-    local row = MySQL.single.await('SELECT airplane_mode FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT airplane_mode FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     local on = row ~= nil and isTruthy(row.airplane_mode)
-    airplaneCache[citizenid] = on
+    airplaneCache[airplaneKey(citizenid, device)] = on
     return on
 end
 
 ---Sets a player's airplane mode: cache first, then the DB write-through.
 ---@param citizenid string framework per-character id
 ---@param on boolean airplane mode enabled
-function store.setAirplane(citizenid, on)
+function store.setAirplane(citizenid, on, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     on = on == true
-    airplaneCache[citizenid] = on
+    airplaneCache[airplaneKey(citizenid, device)] = on
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, airplane_mode) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, airplane_mode) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE airplane_mode = VALUES(airplane_mode)
-    ]], { citizenid, on and 1 or 0 })
+    ]], { citizenid, device, on and 1 or 0 })
 end
 
 ---The server default 24-hour preference for a player who has never toggled it
@@ -981,9 +1021,10 @@ end
 ---the hour24 column is NULL. Read-only.
 ---@param citizenid string framework per-character id
 ---@return boolean hour24
-function store.getHour24(citizenid)
+function store.getHour24(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return defaultHour24() end
-    local row = MySQL.single.await('SELECT hour24 FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT hour24 FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if row and row.hour24 ~= nil then
         return row.hour24 == true or tonumber(row.hour24) == 1
     end
@@ -994,20 +1035,22 @@ end
 ---localStorage flag, so a cleared FiveM cache or another PC never re-runs Hello. Read-only.
 ---@param citizenid string framework per-character id
 ---@return boolean done
-function store.getSetupDone(citizenid)
+function store.getSetupDone(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return false end
-    local row = MySQL.single.await('SELECT setup_done FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT setup_done FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     return row ~= nil and (row.setup_done == true or tonumber(row.setup_done) == 1)
 end
 
 ---Marks this profile's first-run setup as completed (upsert, one-way).
 ---@param citizenid string framework per-character id
-function store.setSetupDone(citizenid)
+function store.setSetupDone(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, setup_done) VALUES (?, 1)
+        INSERT INTO phone_settings (citizenid, device, setup_done) VALUES (?, ?, 1)
         ON DUPLICATE KEY UPDATE setup_done = 1
-    ]], { citizenid })
+    ]], { citizenid, device })
 end
 
 ---Persists a player's 24-hour time preference (upsert), coerced to a strict boolean.
@@ -1025,9 +1068,10 @@ end
 ---false when the reopen_app column is NULL. Read-only.
 ---@param citizenid string framework per-character id
 ---@return boolean reopenApp
-function store.getReopenApp(citizenid)
+function store.getReopenApp(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return false end
-    local row = MySQL.single.await('SELECT reopen_app FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT reopen_app FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if row and row.reopen_app ~= nil then
         return row.reopen_app == true or tonumber(row.reopen_app) == 1
     end
@@ -1037,41 +1081,45 @@ end
 ---Persists a player's reopen-into-app preference (upsert), coerced to a strict boolean.
 ---@param citizenid string framework per-character id
 ---@param on boolean reopen into the holstered app
-function store.setReopenApp(citizenid, on)
+function store.setReopenApp(citizenid, on, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, reopen_app) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, reopen_app) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE reopen_app = VALUES(reopen_app)
-    ]], { citizenid, on == true and 1 or 0 })
+    ]], { citizenid, device, on == true and 1 or 0 })
 end
 
 ---Returns a player's light/dark theme, defaulting to 'light'. Read-only.
 ---@param citizenid string framework per-character id
 ---@return string theme 'light' | 'dark'
-function store.getTheme(citizenid)
+function store.getTheme(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return 'light' end
-    local row = MySQL.single.await('SELECT theme FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT theme FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     return row and row.theme == 'dark' and 'dark' or 'light'
 end
 
 ---Persists a player's light/dark theme (upsert), whitelisted to the known values.
 ---@param citizenid string framework per-character id
 ---@param theme string 'light' | 'dark'
-function store.setTheme(citizenid, theme)
+function store.setTheme(citizenid, theme, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     theme = theme == 'dark' and 'dark' or 'light'
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, theme) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, theme) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE theme = VALUES(theme)
-    ]], { citizenid, theme })
+    ]], { citizenid, device, theme })
 end
 
 ---Returns a player's selected dark-mode palette, defaulting to 'graphite'. Read-only.
 ---@param citizenid string framework per-character id
 ---@return string darkTheme 'graphite' | 'black' | 'warm'
-function store.getDarkTheme(citizenid)
+function store.getDarkTheme(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return 'graphite' end
-    local row = MySQL.single.await('SELECT dark_theme FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT dark_theme FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     local v = row and row.dark_theme
     if v == 'graphite' or v == 'black' or v == 'warm' then return v end
     return 'graphite'
@@ -1080,13 +1128,14 @@ end
 ---Persists a player's dark-mode palette (upsert), whitelisted to the known values.
 ---@param citizenid string framework per-character id
 ---@param theme string 'graphite' | 'black' | 'warm'
-function store.setDarkTheme(citizenid, theme)
+function store.setDarkTheme(citizenid, theme, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     if theme ~= 'graphite' and theme ~= 'black' and theme ~= 'warm' then theme = 'graphite' end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, dark_theme) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, dark_theme) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE dark_theme = VALUES(dark_theme)
-    ]], { citizenid, theme })
+    ]], { citizenid, device, theme })
 end
 
 -- Mirrors the IconThemeId union in web/src/stores/iconThemeStore.ts.
@@ -1133,9 +1182,10 @@ end
 ---Returns a player's home-screen icon theme, defaulting to 'default'. Read-only.
 ---@param citizenid string framework per-character id
 ---@return string iconTheme a built-in id or a 'custom:' one
-function store.getIconTheme(citizenid)
+function store.getIconTheme(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return 'default' end
-    local row = MySQL.single.await('SELECT icon_theme FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT icon_theme FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     local v = row and row.icon_theme
     if isStorableIconTheme(v) then return v end
     return 'default'
@@ -1145,13 +1195,14 @@ end
 ---well-formed custom id.
 ---@param citizenid string framework per-character id
 ---@param theme any client-supplied icon theme id
-function store.setIconTheme(citizenid, theme)
+function store.setIconTheme(citizenid, theme, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     if not isStorableIconTheme(theme) then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, icon_theme) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, icon_theme) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE icon_theme = VALUES(icon_theme)
-    ]], { citizenid, theme })
+    ]], { citizenid, device, theme })
 end
 
 ---A trimmed name's length in characters, or nil when the string is not valid UTF-8.
@@ -1429,7 +1480,7 @@ end
 ---@return table[] themes
 function store.getCustomIconThemes(citizenid)
     if not citizenid or citizenid == '' then return {} end
-    local row = MySQL.single.await('SELECT icon_custom FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await("SELECT icon_custom FROM phone_settings WHERE citizenid = ? AND device = 'phone'", { citizenid })
     if not row then return {} end
     return decodeCustomIconThemes(row.icon_custom)
 end
@@ -1450,7 +1501,7 @@ function store.saveCustomIconTheme(citizenid, theme)
     if not at and #list >= MAX_CUSTOM_ICON_THEMES then return false, 'limit' end
     list[at or (#list + 1)] = clean
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, icon_custom) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, icon_custom) VALUES (?, 'phone', ?)
         ON DUPLICATE KEY UPDATE icon_custom = VALUES(icon_custom)
     ]], { citizenid, json.encode(list) })
     return true, nil
@@ -1482,9 +1533,10 @@ end
 ---true when the show_app_names column is NULL. Read-only.
 ---@param citizenid string framework per-character id
 ---@return boolean showAppNames
-function store.getShowAppNames(citizenid)
+function store.getShowAppNames(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return true end
-    local row = MySQL.single.await('SELECT show_app_names FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT show_app_names FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
     if row and row.show_app_names ~= nil then
         return isTruthy(row.show_app_names)
     end
@@ -1494,12 +1546,13 @@ end
 ---Persists a player's show-app-names preference (upsert), coerced to a strict boolean.
 ---@param citizenid string framework per-character id
 ---@param on boolean print app names under the home-screen icons
-function store.setShowAppNames(citizenid, on)
+function store.setShowAppNames(citizenid, on, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, show_app_names) VALUES (?, ?)
+        INSERT INTO phone_settings (citizenid, device, show_app_names) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE show_app_names = VALUES(show_app_names)
-    ]], { citizenid, on == true and 1 or 0 })
+    ]], { citizenid, device, on == true and 1 or 0 })
 end
 
 ---Persists a player's tone selections, leaving any other settings intact; a nil or invalid
@@ -1507,18 +1560,19 @@ end
 ---@param citizenid string framework per-character id
 ---@param ringtone string|nil ringtone slug
 ---@param notificationTone string|nil notification tone slug
-function store.setTones(citizenid, ringtone, notificationTone)
+function store.setTones(citizenid, ringtone, notificationTone, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     local r = sanitizeTone(ringtone)
     local n = sanitizeTone(notificationTone)
     if not r and not n then return end
     MySQL.update.await([[
-        INSERT INTO phone_settings (citizenid, ringtone, notification_tone)
-        VALUES (?, ?, ?)
+        INSERT INTO phone_settings (citizenid, device, ringtone, notification_tone)
+        VALUES (?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
             ringtone          = COALESCE(VALUES(ringtone), ringtone),
             notification_tone = COALESCE(VALUES(notification_tone), notification_tone)
-    ]], { citizenid, r, n })
+    ]], { citizenid, device, r, n })
 end
 
 ---@type integer Cap on saved custom tones per character per kind.
@@ -1603,14 +1657,23 @@ end
 ---separate. Read-only apart from warming the airplane cache.
 ---@param citizenid string framework per-character id
 ---@return table snapshot the settings:get payload shape
-function store.snapshot(citizenid)
+function store.snapshot(citizenid, device)
+    device = device or 'phone'
     if not citizenid or citizenid == '' then return {} end
-    local row = MySQL.single.await('SELECT * FROM phone_settings WHERE citizenid = ?', { citizenid })
+    local row = MySQL.single.await('SELECT * FROM phone_settings WHERE citizenid = ? AND device = ?', { citizenid, device })
 
-    local airplane = airplaneCache[citizenid]
+    -- Uploaded wallpapers and player-designed icon packs are a library, not this device's look, so
+    -- they live on the phone's row and both devices read the same one. Which wallpaper and which
+    -- pack are ACTIVE stay on the device row above.
+    local shared = row
+    if device ~= 'phone' then
+        shared = MySQL.single.await("SELECT custom_wallpapers, icon_custom FROM phone_settings WHERE citizenid = ? AND device = 'phone'", { citizenid })
+    end
+
+    local airplane = airplaneCache[airplaneKey(citizenid, device)]
     if airplane == nil then
         airplane = row ~= nil and isTruthy(row.airplane_mode) or false
-        airplaneCache[citizenid] = airplane
+        airplaneCache[airplaneKey(citizenid, device)] = airplane
     end
 
     local pin = row and sanitizePin(row.passcode) or nil
@@ -1644,7 +1707,7 @@ function store.snapshot(citizenid)
         theme            = (row and row.theme == 'dark') and 'dark' or 'light',
         darkTheme        = dark,
         iconTheme        = icons,
-        customIconThemes = row and decodeCustomIconThemes(row.icon_custom) or {},
+        customIconThemes = shared and decodeCustomIconThemes(shared.icon_custom) or {},
         showAppNames     = showAppNames,
         lockClock        = row and decodeColumn(row.lock_clock, nil) or nil,
         wallpaper        = (row and row.wallpaper ~= '') and row.wallpaper or nil,
@@ -1652,7 +1715,7 @@ function store.snapshot(citizenid)
         blurLock         = row ~= nil and isTruthy(row.blur_lock),
         blurHome         = row ~= nil and isTruthy(row.blur_home),
         islandPet        = (row and row.island_pet ~= '') and row.island_pet or nil,
-        customWallpapers = row and decodeColumn(row.custom_wallpapers, {}) or {},
+        customWallpapers = shared and decodeColumn(shared.custom_wallpapers, {}) or {},
         chatTextScale    = (row and row.chat_text_scale ~= nil) and tonumber(row.chat_text_scale) or nil,
         phoneScale       = (row and row.phone_scale ~= nil) and tonumber(row.phone_scale) or nil,
         brightness       = (row and row.brightness ~= nil) and tonumber(row.brightness) or nil,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -272,7 +272,11 @@ function AppContent() {
     // Server-side twin of the localStorage flag (phone_settings.setup_done): survives a cleared
     // FiveM cache / another PC. null = this profile's hydrate hasn't answered yet.
     const serverSetupDone = useThemeStore(s => s.setupDone);
-    const setupCompleted = setup.completed || serverSetupDone === true;
+    // In game the server row decides, and the localStorage flag is only the dev fallback where
+    // there is no server to ask. ORing the two let the client cache outvote the server, so
+    // nothing server-side could ever un-complete setup: a wiped phone and a fresh device both
+    // kept reading "done" from a flag the wipe never touched.
+    const setupCompleted = isFiveM ? serverSetupDone === true : setup.completed;
     // Theme and wallpaper are NOT re-applied from the saved setup on launch. Both
     // persist server-side (phone_settings) and hydrate via settings:get on mount;
     // re-applying the localStorage setup value every launch clobbered the player's

--- a/web/src/core/nui.ts
+++ b/web/src/core/nui.ts
@@ -31,7 +31,15 @@ const resourceName: string = parseResourceName(currentWindow);
 /** The resource serving this NUI page. Custom-app iframes load their SDK from it. */
 export const hostResource = resourceName;
 
-export async function fetchNui<TResp = unknown>(event: string, payload?: unknown): Promise<TResp> {
+function withDevice(event: string, payload?: unknown): unknown {
+    if (!event.startsWith('sd-phone:settings:')) return payload;
+    if (payload !== undefined && (typeof payload !== 'object' || payload === null || Array.isArray(payload))) return payload;
+    return { ...(payload as Record<string, unknown> | undefined), device: device.id };
+}
+
+export async function fetchNui<TResp = unknown>(event: string, rawPayload?: unknown): Promise<TResp> {
+    const payload = withDevice(event, rawPayload);
+
     if (!isFiveM) {
         console.debug('[sd-phone:dev] fetchNui ->', event, payload);
         return { ok: true } as unknown as TResp;


### PR DESCRIPTION
Settings are now per device. Changing the icon style, scale, theme or wallpaper on the tablet no longer changes them on the phone.

Needs the matching sd-tablet change (`setup: true`) to give the tablet its own first-run wizard.

## What changed

`phone_settings` was keyed on `citizenid` alone, so one row served both devices. Its primary key is now `(citizenid, device)`.

| | Scope | Why |
| --- | --- | --- |
| Scale, align, brightness, theme, dark theme, icon theme, app names, wallpapers, blurs, lock clock, island pet, reopen-app, 24h, airplane, chat text scale, tones, volumes, locale, passcode, Face Unlock, installed apps, setup-done | **per device** | these describe *this* device |
| Phone number, contact card | **shared** | identity, not a device. The tablet shows the same number |
| Uploaded wallpapers, player-designed icon packs | **shared** | a library you authored. Upload once, use on both. *Which* one is active stays per-device |
| Home layout | **already per-device** | it was, inside a `{ devices: { phone, tablet } }` envelope in the column |

## Migration

Existing rows take `device = 'phone'` from the column default, so every player keeps their phone exactly as it was, and a tablet mints its own row on first use. The primary-key swap is keyed off the second PK column rather than a version flag, so it is a no-op on every boot after the first.

## How the device reaches the server

The UI already knows which device it is (`@device`, `id` of `'phone'` or `'tablet'`). Rather than editing 35 call sites, `fetchNui` stamps `device` onto any `sd-phone:settings:*` action, which also covers every call site added later. The server validates it against a `{ phone, tablet }` set, so a hand-edited client cannot mint rows for devices that do not exist, and an absent or unknown value is the phone, so older NUI bundles keep working unchanged.

## Things worth a second pair of eyes

- **Identity queries are now pinned to the phone's row.** `getPhoneNumber` and friends selected `WHERE citizenid = ?` with no device predicate; once a player has two rows, `MySQL.single` could have returned the tablet's row where `phone_number` is NULL. Every identity read and write now names `device = 'phone'` explicitly.
- **The airplane-mode cache key widened** to `citizenid + device`. It was keyed on citizenid alone, so the two devices would have shared a radio state in memory even though the column had split.
- **`isAirplaneMode` (the public export) always asks the phone**, since a resource asking whether a player is reachable means the device that takes calls.
- **`getHour24` was nearly missed**: its writer was device-scoped by the sweep but the reader was named `getHour24` rather than `getHour`, so the two would have disagreed. Caught by an audit of remaining unscoped queries, not by the tests.

## Verification

- New vitest over the `fetchNui` stamp: settings writes and the no-payload hydrate both carry the device, non-settings actions are untouched, and non-object or array payloads pass through rather than being corrupted. `6 passed`.
- Every `INSERT INTO phone_settings` checked mechanically for matching column and placeholder counts: 26 inserts, 0 mismatched. Every device-predicated statement checked for a matching `device` param.
- Full vitest `445 passed (38 files)`, Lua suites pass, `tsc --noEmit` clean, `oxlint` 0 errors, `luac -p` clean, both bundles rebuilt.

Not yet exercised against a live database; the migration path is the part to watch on first boot.
