### PR TITLE
fix(settings): gate island pets on the default shell

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -3987,6 +3987,7 @@
     "islandPetMoodSleep": "Naps when the battery is low",
     "islandPetMoodStartle": "Jumps at calls and alarms",
     "islandPetMoods": "Moods",
+    "islandPetNeedsIsland": "Needs the default Rounded shell",
     "islandPetSub": "Pick a pixel pet for the Dynamic Island",
     "language": "Language",
     "languageRegion": "Language & Region",

--- a/web/src/apps/settings/Settings.tsx
+++ b/web/src/apps/settings/Settings.tsx
@@ -23,6 +23,9 @@ import { useSimStore } from '@/stores/simStore';
 import { BluetoothPage } from './bluetooth/BluetoothPage';
 import { WifiPage } from './wifi/WifiPage';
 import { useWifiConfigured, useWifiConnected } from '@/stores/wifiStore';
+import { shellHostsPet } from '@/shell/chassis';
+import { shellFor } from '@/shell/shells';
+import { useTheme } from '@/stores/themeStore';
 import { useBluetoothConfigured } from '@/stores/bluetoothStore';
 
 type SubPage = 'general' | 'display' | 'island-pet' | 'wallpaper' | 'app-icons' | 'notifications' | 'sound-haptics' | 'face-unlock' | 'phone' | 'battery' | 'privacy' | 'sim' | 'wifi' | 'bluetooth' | null;
@@ -35,11 +38,23 @@ export function Settings({ onClose }: { onClose: () => void }) {
     const bluetoothConfigured = useBluetoothConfigured();
     const wifi = useWifiConnected();
 
+    const { shell } = useTheme('shell');
+    const petHost = shellHostsPet(shellFor(shell, device.id));
+
     // The SIM & Backup row only exists while the server runs unique phones.
     const settingsGroups = getSettingsGroups()
         .map(g => simEnabled ? g : { ...g, rows: g.rows.filter(r => r.id !== 'sim') })
         .map(g => device.calls ? g : { ...g, rows: g.rows.filter(r => r.id !== 'phone') })
+        // A device with no shells to choose from (the tablet) simply has no island, so the row
+        // goes. A phone on a chassis whose cutout cannot hold the pill keeps the row, greyed, so
+        // the pets stay discoverable and it is obvious the shell is what put them out of reach.
         .map(g => device.screen.island ? g : { ...g, rows: g.rows.filter(r => r.id !== 'island-pet') })
+        .map(g => petHost ? g : {
+            ...g,
+            rows: g.rows.map(r => (r.id === 'island-pet'
+                ? { ...r, disabled: true, subtitle: t('settings.islandPetNeedsIsland', 'Needs the default Rounded shell') }
+                : r)),
+        })
         .map(g => wifiConfigured ? g : { ...g, rows: g.rows.filter(r => r.id !== 'wifi') })
         .map(g => bluetoothConfigured ? g : { ...g, rows: g.rows.filter(r => r.id !== 'bluetooth') })
         .map(g => ({

--- a/web/src/apps/settings/SettingsRow.tsx
+++ b/web/src/apps/settings/SettingsRow.tsx
@@ -28,9 +28,12 @@ export function SettingsRow({ row, divider, onPress }: { row: SettingsRowDef; di
     return (
         <button
             type="button"
-            onClick={onPress}
+            onClick={row.disabled ? undefined : onPress}
+            disabled={row.disabled}
+            aria-disabled={row.disabled}
             className={[
-                'relative flex w-full items-center gap-3.5 px-4 text-left active:bg-black/5 dark:active:bg-white/5',
+                'relative flex w-full items-center gap-3.5 px-4 text-left',
+                row.disabled ? 'opacity-40' : 'active:bg-black/5 dark:active:bg-white/5',
                 hasSubtitle ? 'py-3' : 'py-2.5',
             ].join(' ')}
         >

--- a/web/src/apps/settings/data.ts
+++ b/web/src/apps/settings/data.ts
@@ -19,6 +19,7 @@ export interface SettingsRowDef {
     status?:   string;
     badge?:    number;
     toggle?:   boolean;
+    disabled?: boolean;
 }
 
 export interface SettingsGroup {

--- a/web/src/shell/PhoneShell.tsx
+++ b/web/src/shell/PhoneShell.tsx
@@ -906,7 +906,7 @@ export function PhoneShell({ children, cameraActive = false, entering = false, l
                     />
                 )}
 
-                {hostsIsland && islandPet !== 'none' && (
+                {pillInCutout && islandPet !== 'none' && (
                     <IslandPet
                         id={islandPet}
                         stage={petStageNow}

--- a/web/src/shell/chassis.ts
+++ b/web/src/shell/chassis.ts
@@ -292,6 +292,10 @@ function resolveRail(
     return { marks, grips, caps };
 }
 
+export function shellHostsPet(shell: Shell | null): boolean {
+    return chassisMetrics(shell).pillInCutout;
+}
+
 export function chassisMetrics(shell: Shell | null): ChassisMetrics {
     const bez = shell?.bezel ?? device.screen.bezel;
     const BS = typeof bez === 'number' ? bez : bez.side;

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -19,7 +19,8 @@ import type { CustomTone, ToneKind } from '@/apps/settings/tones';
 import { warmYouTube } from '@/apps/settings/tonePlayer';
 import { clampRecipe, isCustomPaletteId, MAX_CUSTOM_PALETTES, PALETTE_NAME_MAX } from '@/apps/settings/appearance/paletteRamp';
 import { DEFAULT_ACCENT, isAccentChoice } from '@/apps/settings/appearance/accentRamp';
-import { DEFAULT_SHELL, isShellId, SHELLS } from '@/shell/shells';
+import { DEFAULT_SHELL, isShellId, SHELLS, shellFor } from '@/shell/shells';
+import { shellHostsPet } from '@/shell/chassis';
 import type { PaletteMode, PaletteRecipe } from '@/apps/settings/appearance/paletteRamp';
 
 export type Theme = 'light' | 'dark';
@@ -468,11 +469,17 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
         else saveAccentLocal(next);
     },
 
+    // Only a shell whose cutout is big enough to hold the whole island pill can carry a pet. On
+    // any other chassis the pill floats below the status bar, where a pet reads as a loose sprite,
+    // so switching to one puts the pet away rather than leaving it somewhere it does not belong.
     setShell: (next) => {
         if (!isShellId(next)) return;
         set({ shell: next });
         if (isFiveM) void fetchNui('sd-phone:settings:setShell', { shell: next }).catch(() => {});
         else saveShellLocal(next);
+        if (get().islandPet !== 'none' && !shellHostsPet(shellFor(next, device.id))) {
+            get().setIslandPet('none');
+        }
     },
 
     saveCustomPalette: async (palette) => {


### PR DESCRIPTION
Island pets ride the Dynamic Island content pill, which is 126x37. Only the default `ios` shell has a cutout big enough to hold it; on every other shell the pill floats below the status bar, where a pet reads as a loose sprite rather than something living in the hardware.

Gated on the real capability (`chassisMetrics().pillInCutout`) rather than an id list, so the two cannot drift.

## Three layers

1. **The Settings row greys out** instead of vanishing, with its subtitle swapped to "Needs the default Rounded shell", so the pets stay discoverable and the reason is obvious. The tablet still drops the row entirely, since it has no shells to switch to.
2. **Changing shell puts the pet away.** `setShell` clears `islandPet` to `none` and persists when the new chassis cannot host one.
3. **The renderer will not draw it regardless.** The guard moved from `hostsIsland` (true on every phone shell) to `pillInCutout`. Without this, anyone already saved on a non-island shell with a pet would still render it on the floating pill, and the store fix only covers changes made from here on.

`SettingsRowDef` gained an optional `disabled` flag; `SettingsRow` renders it at 40% opacity with the button actually disabled, so a greyed row cannot be pressed.

## Which shells host a pet

| shell | cutout | hosts pet |
|---|---|---|
| ios | island 126x37 | yes |
| classic | notch 104x28 | no |
| all others | punch / notch / none | no |

## Gates

- `tsc --noEmit`: clean
- `oxlint`: 0 errors
- `vitest`: 515 passing, including 4 new asserting `shellHostsPet` agrees with `chassisMetrics`
- `knip`: clean
- `npm run build`: passes