### PR TITLE
feat(settings): option to show in-game time instead of the PC clock

### DIFF
--- a/client/apps/settings.lua
+++ b/client/apps/settings.lua
@@ -28,6 +28,7 @@ writeCallback('sd-phone:settings:setDarkTheme', 'sd-phone:server:settings:setDar
 writeCallback('sd-phone:settings:setLightTheme', 'sd-phone:server:settings:setLightTheme')
 writeCallback('sd-phone:settings:setAccent', 'sd-phone:server:settings:setAccent')
 writeCallback('sd-phone:settings:setShell', 'sd-phone:server:settings:setShell')
+writeCallback('sd-phone:settings:setGameTime', 'sd-phone:server:settings:setGameTime')
 writeCallback('sd-phone:settings:setIconTheme',    'sd-phone:server:settings:setIconTheme')
 writeCallback('sd-phone:settings:saveCustomIconTheme',   'sd-phone:server:settings:saveCustomIconTheme')
 writeCallback('sd-phone:settings:deleteCustomIconTheme', 'sd-phone:server:settings:deleteCustomIconTheme')

--- a/client/gameclock.lua
+++ b/client/gameclock.lua
@@ -1,0 +1,63 @@
+---@type table Game-clock module; the table returned at end of file.
+---The NUI has no way to read the game clock: `Date` inside CEF is the player's PC clock, and there
+---is no native reachable from the browser. So the client watches GetClock* and pushes a change to
+---the UI, which decides whether to show it based on the player's Date & Time setting.
+local M = {}
+
+---@type integer How often the game clock is sampled (ms). A GTA minute is roughly two real
+---seconds at the default cycle, so this catches every minute change without spinning.
+local SAMPLE_MS = 500
+
+---@type table<string, integer>|nil Last pushed value, so an unchanged minute costs nothing.
+local last = nil
+
+---@return table clock the current in-game date and time
+local function read()
+    return {
+        hour   = GetClockHours(),
+        minute = GetClockMinutes(),
+        day    = GetClockDayOfMonth(),
+        month  = GetClockMonth() + 1,
+        year   = GetClockYear(),
+    }
+end
+
+---@param a table|nil
+---@param b table
+---@return boolean
+local function same(a, b)
+    if not a then return false end
+    return a.hour == b.hour and a.minute == b.minute
+        and a.day == b.day and a.month == b.month and a.year == b.year
+end
+
+---Pushes the current game clock to the UI whether or not it changed. Called on open so the phone
+---never shows a stale minute while waiting for the next sample.
+function M.push()
+    local now = read()
+    last = now
+    SendNUIMessage({ action = 'sd-phone:gameClock', data = now })
+end
+
+---Starts the sampler. Runs only while the phone is up: a closed phone cannot show a clock, and
+---this is the one loop that would otherwise tick for every player all session.
+---@param isOpen fun(): boolean phone open predicate
+function M.start(isOpen)
+    CreateThread(function()
+        while true do
+            if isOpen() then
+                local now = read()
+                if not same(last, now) then
+                    last = now
+                    SendNUIMessage({ action = 'sd-phone:gameClock', data = now })
+                end
+                Wait(SAMPLE_MS)
+            else
+                last = nil
+                Wait(1000)
+            end
+        end
+    end)
+end
+
+return M

--- a/client/main.lua
+++ b/client/main.lua
@@ -76,6 +76,8 @@ local service = require 'client.service'
 local wifiClient = require 'client.wifi'
 ---@type table Bluetooth (client.bluetooth): the radio switch + connected devices, mirrored server-side.
 local bluetoothClient = require 'client.bluetooth'
+---@type table Game-clock sampler (client.gameclock): pushes GetClock* to the UI while open.
+local gameclock = require 'client.gameclock'
 
 -- Loaded for side effects: each app module registers its own NUI callbacks, net events and
 -- server proxies.
@@ -364,6 +366,7 @@ local function OpenPhone()
     phoneState.open   = true
     phoneState.locked = true
     companion.phoneOpen = true
+    gameclock.push()
 
     CreateThread(function()
         while phoneState.open do
@@ -710,6 +713,8 @@ end)
 RegisterNUICallback('sd-phone:weather:get', function(_data, cb)
     cb(weatherBridge.read())
 end)
+
+gameclock.start(phoneState.isOpen)
 
 -- Cosmetic battery drain: one percent every 30s while the phone is open, pushed to the React app.
 CreateThread(function()

--- a/locales/en.json
+++ b/locales/en.json
@@ -3766,6 +3766,8 @@
     "dateTime": "Date & Time",
     "dateTime24Hour": "24-Hour Time",
     "dateTimeAutoFooter": "When enabled, your phone automatically sets the time based on your current time zone.",
+    "dateTimeGameTime": "Use Game Time",
+    "dateTimeGameTimeFooter": "Shows the time in Los Santos instead of the clock on your computer.",
     "dateTimeSetAutomatically": "Set Automatically",
     "dateTimeZone": "Time Zone",
     "default": "Default",

--- a/server/migrations.lua
+++ b/server/migrations.lua
@@ -21,6 +21,7 @@ local COLUMNS = {
         light_theme       = 'light_theme VARCHAR(16) NULL',
         accent            = 'accent VARCHAR(16) NULL',
         shell             = 'shell VARCHAR(16) NULL',
+        game_time         = 'game_time TINYINT(1) NULL',
         reopen_app        = 'reopen_app TINYINT(1) NULL',
         setup_done        = 'setup_done TINYINT(1) NULL',
         custom_wallpapers = 'custom_wallpapers TEXT NULL',

--- a/server/settings/init.lua
+++ b/server/settings/init.lua
@@ -392,6 +392,16 @@ lib.callback.register('sd-phone:server:settings:setAccent', function(source, pay
     return { success = true }
 end)
 
+---Persists whether the caller's phone shows game time rather than their PC clock.
+lib.callback.register('sd-phone:server:settings:setGameTime', function(source, payload)
+    local cid = player.getIdentifier(source)
+    if not cid then return { success = false, message = 'Player not found' } end
+    if not writeAllowed(cid, 'gameTime') then return BUSY end
+    payload = type(payload) == 'table' and payload or {}
+    store.setGameTime(cid, payload.on == true, deviceOf(payload))
+    return { success = true }
+end)
+
 ---Persists the caller's phone shell. The store drops anything the config does not allow.
 lib.callback.register('sd-phone:server:settings:setShell', function(source, payload)
     local cid = player.getIdentifier(source)

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -85,6 +85,7 @@ function store.ensureSchema()
             light_theme        VARCHAR(16)  NULL,
             accent             VARCHAR(16)  NULL,
             shell              VARCHAR(16)  NULL,
+            game_time          TINYINT(1)   NULL,
             palette_custom     LONGTEXT     NULL,
             icon_theme         VARCHAR(16)  NULL,
             icon_custom        LONGTEXT     NULL,
@@ -1287,6 +1288,18 @@ function store.setLightTheme(citizenid, theme, device)
     ]], { citizenid, device, theme })
 end
 
+---Persists whether the phone shows the in-game clock instead of the player's PC clock.
+---@param citizenid string framework per-character id
+---@param on boolean true to show game time
+function store.setGameTime(citizenid, on, device)
+    device = device or 'phone'
+    if not citizenid or citizenid == '' then return end
+    MySQL.update.await([[
+        INSERT INTO phone_settings (citizenid, device, game_time) VALUES (?, ?, ?)
+        ON DUPLICATE KEY UPDATE game_time = VALUES(game_time)
+    ]], { citizenid, device, on and 1 or 0 })
+end
+
 ---Persists the accent colour applied over whichever palette is active.
 ---@param citizenid string framework per-character id
 ---@param accent string a key of ACCENTS or `custom:<hue>`
@@ -1972,6 +1985,7 @@ function store.snapshot(citizenid, device)
         lightTheme       = light,
         accent           = accent,
         shell            = shell,
+        gameTime         = row ~= nil and isTruthy(row.game_time) or false,
         shellChoice      = shellChoice,
         shellsAllowed    = allowedShells(),
         iconTheme        = icons,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ import { SetupFlow }   from '@/shell/SetupFlow';
 import type { SetupResult } from '@/shell/SetupFlow';
 import { isKeyboardCaptured } from '@/hooks/useKeyboardCapture';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
+import { isGameClock, useGameClockStore } from '@/stores/gameClockStore';
 import { seedSessionState } from '@/hooks/useSessionState';
 import { onOpenMail, onOpenMaps, onOpenMessages } from '@/shell/deeplink';
 import { fetchNui, isFiveM } from '@/core/nui';
@@ -194,6 +195,10 @@ function AppContent() {
     const customApps = useCustomApps();
     const customDefs = useMemo(() => customApps.map(customToAppDef), [customApps]);
     useEffect(() => { useCustomAppsStore.getState().hydrate(); }, []);
+    useNuiEvent('sd-phone:gameClock', useCallback((data) => {
+        if (isGameClock(data)) useGameClockStore.getState().setClock(data);
+    }, []));
+
     useNuiEvent('customApps:set', useCallback((data) => {
         useCustomAppsStore.getState().setAll(data ?? []);
     }, []));

--- a/web/src/apps/settings/appearance/WallpaperPage.tsx
+++ b/web/src/apps/settings/appearance/WallpaperPage.tsx
@@ -4,7 +4,7 @@ import { Camera, ChevronRight, Flashlight } from 'lucide-react';
 
 import { device } from '@device';
 import { t } from '@/i18n';
-import { formatClockTime, formatLongDate, useClock } from '@/hooks/useClock';
+import { formatClockTime, formatLongDate, useDisplayClock } from '@/hooks/useClock';
 import { useIosPush } from '@/hooks/useIosPush';
 import { PushLayer } from '../SettingsSubPage';
 import { useTheme } from '@/stores/themeStore';
@@ -46,7 +46,7 @@ export function WallpaperPage({ onBack }: { onBack: () => void }) {
         useTheme('wallpaperLock', 'wallpaperHome', 'blurLock', 'setBlurLock', 'blurHome', 'setBlurHome', 'lockClock', 'hour24');
     const [pickerTarget, setPickerTarget] = useState<WallpaperTarget | null>(null);
 
-    const now  = useClock();
+    const now  = useDisplayClock();
     const time = formatClockTime(now, hour24);
     const date = formatLongDate(now);
 

--- a/web/src/apps/settings/general/DateTimePage.tsx
+++ b/web/src/apps/settings/general/DateTimePage.tsx
@@ -2,16 +2,17 @@ import { t } from '@/i18n';
 import { GroupCard, ListGroup, ListRow, ToggleRow } from '@/ui/ListGroup';
 import { SubPage } from '../SettingsSubPage';
 import { useTheme } from '@/stores/themeStore';
-import { formatClockTime, formatLongDate, useClock } from '@/hooks/useClock';
+import { formatClockTime, formatLongDate, useDisplayClock } from '@/hooks/useClock';
 
 export function DateTimePage({ onBack }: { onBack: () => void }) {
-    const { hour24, setHour24 } = useTheme('hour24', 'setHour24');
-    const now = useClock();
+    const { hour24, setHour24, gameTime, setGameTime } = useTheme('hour24', 'setHour24', 'gameTime', 'setGameTime');
+    const now = useDisplayClock();
 
     return (
         <SubPage title={t('settings.dateTime', 'Date & Time')} onBack={onBack}>
             <ListGroup footer={t('settings.dateTimeAutoFooter', 'When enabled, your phone automatically sets the time based on your current time zone.')}>
                 <ToggleRow label={t('settings.dateTime24Hour', '24-Hour Time')} on={hour24} onToggle={() => setHour24(!hour24)} divider />
+                <ToggleRow label={t('settings.dateTimeGameTime', 'Use Game Time')} on={gameTime} onToggle={() => setGameTime(!gameTime)} divider />
                 <ToggleRow label={t('settings.dateTimeSetAutomatically', 'Set Automatically')} defaultOn />
             </ListGroup>
 

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -1,4 +1,5 @@
 
+import type { GameClock } from '@/stores/gameClockStore';
 import type { BirdyMessage } from '@/apps/birdy/data';
 import type { DocFile } from '@/apps/documents/data';
 import type { Bulletin, Call, ChatMsg, Unit } from '@/apps/mdt/data';
@@ -252,6 +253,7 @@ export type NuiMessage =
     | { action: 'sd-phone:wifi'; data: WifiState }
     | { action: 'sd-phone:weather'; data: WeatherPayload }
     | { action: 'sd-phone:session'; data: SessionPayload }
+    | { action: 'sd-phone:gameClock'; data: GameClock }
     | { action: 'sd-phone:health';  data: HealthPayload }
     | { action: 'sd-phone:bank:received'; data: { amount: number; from: string } }
     | { action: 'sd-phone:bank:txAdded' }

--- a/web/src/hooks/useClock.ts
+++ b/web/src/hooks/useClock.ts
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 
+import { gameClockDate, useGameClockStore } from '@/stores/gameClockStore';
+import { useTheme } from '@/stores/themeStore';
+
 export { formatClockTime, formatLongDate } from '@/lib/time';
 
 // Default is minute granularity: every current consumer renders HH:MM, so
@@ -25,4 +28,17 @@ export function useClock(granularity: 'minute' | 'second' = 'minute'): Date {
     }, [granularity]);
 
     return now;
+}
+
+// The wall clock the phone SHOWS, which is the player's PC clock unless they have asked for game
+// time in Date & Time. Seconds always come from the real clock so sweeping hands and second
+// readouts keep moving between the client's minute pushes.
+//
+// Display surfaces only. Anything doing arithmetic against a real timestamp (timers counting down,
+// alarms) must keep using useClock, or it will misfire the moment game time is switched on.
+export function useDisplayClock(granularity: 'minute' | 'second' = 'minute'): Date {
+    const real = useClock(granularity);
+    const gameTime = useTheme('gameTime').gameTime;
+    const clock = useGameClockStore(s => s.clock);
+    return gameTime && clock ? gameClockDate(clock, real) : real;
 }

--- a/web/src/shell/Lockscreen.tsx
+++ b/web/src/shell/Lockscreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { PointerEvent as ReactPointerEvent, MouseEvent as ReactMouseEvent, CSSProperties } from 'react';
 import { Camera, Check, Delete, Flashlight, Lock, ScanFace } from 'lucide-react';
 
-import { formatClockTime, formatLongDate, useClock } from '@/hooks/useClock';
+import { formatClockTime, formatLongDate, useDisplayClock } from '@/hooks/useClock';
 import { useKeypadInput } from '@/hooks/useKeypadInput';
 import { fetchNui, isFiveM } from '@/core/nui';
 import { resolveWallpaper } from './wallpapers';
@@ -29,7 +29,7 @@ export interface LockscreenProps {
 }
 
 export function Lockscreen({ use24h, showDate, wallpaper, unlockTrigger, onUnlock, launchTrigger, onLaunch, notifications, onOpenNotif, onDismissNotif, flashlightOn, onToggleFlashlight, onOpenCamera }: LockscreenProps) {
-    const now  = useClock();
+    const now  = useDisplayClock();
     const time = formatClockTime(now, use24h);
     const date = formatLongDate(now);
     const [exiting, setExiting] = useState(false);

--- a/web/src/shell/StatusBar.tsx
+++ b/web/src/shell/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { formatClockTime, useClock } from '@/hooks/useClock';
+import { formatClockTime, useDisplayClock } from '@/hooks/useClock';
 import { t } from '@/i18n';
 import { signalBarOpacities } from '@/lib/signal';
 
@@ -17,7 +17,7 @@ export interface StatusBarProps {
 }
 
 export function StatusBar({ use24h, signal, showWifi, wifiBars = null, battery, airplane = false, noSim = false, noService = false, light = true, controlHint = false, editing = false }: StatusBarProps) {
-    const time  = formatClockTime(useClock(), use24h);
+    const time  = formatClockTime(useDisplayClock(), use24h);
     const color = light ? '#ffffff' : '#000000';
 
     return (

--- a/web/src/shell/widgets/ClockWidget.tsx
+++ b/web/src/shell/widgets/ClockWidget.tsx
@@ -1,5 +1,5 @@
 import type { WidgetAlign, WidgetSize, WidgetTheme } from '@/apps/appstore/appsApi';
-import { formatClockTime, formatLongDate, useClock } from '@/hooks/useClock';
+import { formatClockTime, formatLongDate, useDisplayClock } from '@/hooks/useClock';
 import { t } from '@/i18n';
 import { useTheme } from '@/stores/themeStore';
 import { WidgetTile, alignClasses, palette } from './WidgetTile';
@@ -66,7 +66,7 @@ export function ClockWidget({ size, width, height, align = 'left', theme = 'dark
     align?: WidgetAlign; theme?: WidgetTheme; digital?: boolean;
 }) {
     const al = alignClasses(align);
-    const d = useClock('second');
+    const d = useDisplayClock('second');
     const { hour24 } = useTheme('hour24');
 
     const p     = palette(theme);

--- a/web/src/stores/gameClockStore.ts
+++ b/web/src/stores/gameClockStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+export interface GameClock {
+    hour:   number;
+    minute: number;
+    day:    number;
+    month:  number;
+    year:   number;
+}
+
+interface GameClockState {
+    clock: GameClock | null;
+    setClock: (c: GameClock) => void;
+}
+
+export const useGameClockStore = create<GameClockState>(set => ({
+    clock: null,
+    setClock: (c) => set({ clock: c }),
+}));
+
+export function isGameClock(v: unknown): v is GameClock {
+    if (!v || typeof v !== 'object') return false;
+    const c = v as Record<string, unknown>;
+    return ['hour', 'minute', 'day', 'month', 'year'].every(k => typeof c[k] === 'number' && Number.isFinite(c[k]));
+}
+
+export function gameClockDate(clock: GameClock, real: Date): Date {
+    const d = new Date(real);
+    d.setFullYear(clock.year, clock.month - 1, clock.day);
+    d.setHours(clock.hour, clock.minute);
+    return d;
+}

--- a/web/src/stores/themeStore.tsx
+++ b/web/src/stores/themeStore.tsx
@@ -91,6 +91,13 @@ function loadShellLocal(): string {
 function saveShellLocal(v: string) {
     try { window.localStorage.setItem(SHELL_KEY, v); } catch { /* ignore */ }
 }
+const GAME_TIME_KEY = 'sd-phone:gameTime';
+function loadGameTimeLocal(): boolean {
+    try { return window.localStorage.getItem(GAME_TIME_KEY) === '1'; } catch { return false; }
+}
+function saveGameTimeLocal(v: boolean) {
+    try { window.localStorage.setItem(GAME_TIME_KEY, v ? '1' : '0'); } catch { /* ignore */ }
+}
 const ACCENT_KEY = 'sd-phone:accent';
 function loadAccentLocal(): string {
     try {
@@ -284,6 +291,8 @@ interface ThemeState {
     setAirplaneMode:   (on: boolean) => void;
     hour24:            boolean;
     setHour24:         (on: boolean) => void;
+    gameTime:          boolean;
+    setGameTime:       (on: boolean) => void;
     reopenLastApp:     boolean;
     setReopenLastApp:  (on: boolean) => void;
     ringtone:            string;
@@ -378,6 +387,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     callVol: 60,
     airplaneMode: false,
     hour24: false,
+    gameTime: isFiveM ? false : loadGameTimeLocal(),
     reopenLastApp: false,
     ringtone: DEFAULT_RINGTONE,
     // The website demo opens on Chime, which carries better than the stock
@@ -578,6 +588,12 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
         void fetchNui('sd-phone:settings:setHour24', { on }).catch(() => {});
     },
 
+    setGameTime: (on) => {
+        set({ gameTime: on });
+        if (isFiveM) void fetchNui('sd-phone:settings:setGameTime', { on }).catch(() => {});
+        else saveGameTimeLocal(on);
+    },
+
     setReopenLastApp: (on) => {
         set({ reopenLastApp: on });
         void fetchNui('sd-phone:settings:setReopenApp', { on }).catch(() => {});
@@ -679,7 +695,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
             }
         };
         const keyAtRequest = wallpaperProfileKey;
-        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; wallpaperHome?: string; blurLock?: boolean; blurHome?: boolean; islandPet?: string; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; brightness?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string; lightTheme?: string; accent?: string; shell?: string; shellChoice?: boolean; shellsAllowed?: unknown[]; customPalettes?: unknown; iconTheme?: string; showAppNames?: boolean; customIconThemes?: unknown } }>('sd-phone:settings:get')
+        void fetchNui<{ data?: { ringtone?: string; notificationTone?: string; customRingtones?: CustomTone[]; customNotificationTones?: CustomTone[]; airplaneMode?: boolean; hour24?: boolean; gameTime?: boolean; reopenApp?: boolean; setupDone?: boolean; lockClock?: Partial<LockClock>; passcode?: string | null; faceId?: boolean; wallpaper?: string; wallpaperHome?: string; blurLock?: boolean; blurHome?: boolean; islandPet?: string; customWallpapers?: string[]; chatTextScale?: number; phoneScale?: number; brightness?: number; phoneAlign?: string; ringtoneVol?: number; callVol?: number; theme?: string; darkTheme?: string; lightTheme?: string; accent?: string; shell?: string; shellChoice?: boolean; shellsAllowed?: unknown[]; customPalettes?: unknown; iconTheme?: string; showAppNames?: boolean; customIconThemes?: unknown } }>('sd-phone:settings:get')
             .then(res => {
                 if (!res?.data) { retry(); return; }
                 const d = res.data;
@@ -702,6 +718,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
                 if (d.notificationTone) patch.notificationTone = d.notificationTone;
                 if (typeof d.airplaneMode === 'boolean') patch.airplaneMode = d.airplaneMode;
                 if (typeof d.hour24 === 'boolean') patch.hour24 = d.hour24;
+                if (typeof d.gameTime === 'boolean') patch.gameTime = d.gameTime;
                 if (typeof d.reopenApp === 'boolean') patch.reopenLastApp = d.reopenApp;
                 // Always assigned (true/false, never left null) - the per-profile answer is
                 // what lets the Hello gate decide, and a stale previous-profile value may not leak.


### PR DESCRIPTION
Requested in Discord: the phone shows the player's PC clock, and there is no way to make it show Los Santos time.

The NUI genuinely cannot read the game clock. `Date` inside CEF is the host machine's clock, and no native is reachable from the browser, so the client has to sample it and push.

## How it works

`client/gameclock.lua` samples `GetClockHours/Minutes/DayOfMonth/Month/Year` every 500ms and pushes only when the value changes, and only while the phone is open. A GTA minute is roughly two real seconds at the default cycle, so that catches every change without spinning, and a closed phone costs nothing. `main.lua` also pushes once on open so the clock is never stale for a beat.

New toggle at Settings > General > Date & Time > **Use Game Time**, persisted as a `game_time` column added by the boot migration. Follows the `hour24` path end to end: store setter, NUI callback, client proxy, server callback, snapshot, hydrate.

## Why useClock was left alone

`TimersWidget` uses `useClock` for countdown arithmetic against a real `endsAt` timestamp. Returning game time from it would have made timers misfire the moment the setting was switched on.

So there is a new `useDisplayClock()`, used only by surfaces that display wall-clock time: StatusBar, Lockscreen, ClockWidget and the two settings previews. Timers and alarms keep real time.

It also keeps **real seconds** while taking hours and minutes from the game, so ClockWidget's second hand keeps sweeping between the client's minute pushes instead of freezing at `:00`.

## Known, worth deciding separately

- Alarms and timers still run on real time. A 7am alarm fires at real 7am even with game time displayed.
- The setting is per character. Servers cannot currently force it for everyone.

## Gates

- `tsc --noEmit`: clean
- `oxlint`: 0 errors
- `vitest`: 522 passing, including 7 new for the clock conversion
- `knip`: clean
- `npm run build`: passes
- `luac -p` on every changed Lua file: clean