### PR TITLE
feat(admin): seed the staff panel with dev data outside FiveM

### DIFF
--- a/web/src/admin/adminApi.ts
+++ b/web/src/admin/adminApi.ts
@@ -1,80 +1,128 @@
 import { apiCall, type Envelope } from '@/core/api';
+import { isFiveM } from '@/core/nui';
 import type {
     AdminAuditEntry, AdminBirdyPost, AdminCall, AdminContentItem,
     AdminMessage, AdminMute, AdminNumberRow, AdminOverview, AdminPlayerHit, AdminSimLookup, AdminStats,
 } from './types';
+import {
+    DEV_AUDIT, DEV_MUTES, DEV_PLAYERS, DEV_STATS, devBirdyPosts, devCalls, devContent,
+    devMessages, devNumbers, devOverview, devSearch, devSimLookup,
+} from './devData';
 
 function call<T>(event: string, payload?: unknown): Promise<Envelope<T>> {
     return apiCall<T>(event, payload);
 }
 
+// Outside FiveM every callback would answer `{ ok: true }`, which reads as a
+// failed envelope and leaves every page empty. The browser demo is the only
+// place the panel is ever seen by someone who cannot open a real one, so it
+// serves a full dataset instead: every page populated, every action a no-op
+// that reports success.
+function seed<T>(data: T): Promise<Envelope<T>> {
+    return Promise.resolve({ success: true, data });
+}
+
+const ok = () => Promise.resolve({ success: true } as Envelope<void>);
+
 export const adminStats = () =>
-    call<AdminStats>('sd-phone:admin:stats');
+    isFiveM ? call<AdminStats>('sd-phone:admin:stats') : seed(DEV_STATS);
 
 // Empty q lists the most recently active phones (string keyset cursor); a real
 // query searches with a numeric offset cursor. Both return 20 per page.
 export const adminSearch = (q: string, cursor?: string | number | null) =>
-    call<{ players: AdminPlayerHit[]; nextCursor?: string | number | null }>('sd-phone:admin:search', { q, cursor });
+    isFiveM
+        ? call<{ players: AdminPlayerHit[]; nextCursor?: string | number | null }>('sd-phone:admin:search', { q, cursor })
+        : seed({ players: devSearch(q), nextCursor: null });
 
 export const adminOverview = (cid: string) =>
-    call<AdminOverview>('sd-phone:admin:overview', { cid });
+    isFiveM ? call<AdminOverview>('sd-phone:admin:overview', { cid }) : seed(devOverview(cid));
 
 export const adminSetNumber = (cid: string, number: string) =>
-    call<{ number: string }>('sd-phone:admin:setNumber', { cid, number });
+    isFiveM ? call<{ number: string }>('sd-phone:admin:setNumber', { cid, number }) : seed({ number });
 
 export const adminSimLookup = (number: string) =>
-    call<AdminSimLookup>('sd-phone:admin:simLookup', { number });
+    isFiveM ? call<AdminSimLookup>('sd-phone:admin:simLookup', { number }) : seed(devSimLookup(number));
 
 export const adminNumbers = (q: string, cursor?: number | null) =>
-    call<{ numbers: AdminNumberRow[]; nextCursor?: number | null }>('sd-phone:admin:numbers', { q, cursor });
+    isFiveM
+        ? call<{ numbers: AdminNumberRow[]; nextCursor?: number | null }>('sd-phone:admin:numbers', { q, cursor })
+        : seed({ numbers: devNumbers(q), nextCursor: null });
 
 export const adminGiveSim = (cid: string, bind: boolean) =>
-    call<{ number: string }>('sd-phone:admin:giveSim', { cid, bind });
+    isFiveM ? call<{ number: string }>('sd-phone:admin:giveSim', { cid, bind }) : seed({ number: '5551204' });
 
 export const adminResetPasscode = (cid: string) =>
-    call<void>('sd-phone:admin:resetPasscode', { cid });
+    isFiveM ? call<void>('sd-phone:admin:resetPasscode', { cid }) : ok();
 
 export const adminSetApp = (cid: string, id: string, install: boolean) =>
-    call<{ installed: string[] }>('sd-phone:admin:setApp', { cid, id, install });
+    isFiveM
+        ? call<{ installed: string[] }>('sd-phone:admin:setApp', { cid, id, install })
+        : seed({ installed: (devOverview(cid).settings?.installedApps ?? []).concat(install ? [id] : []) });
 
 export const adminResetAccountPassword = (accountId: number, password: string) =>
-    call<void>('sd-phone:admin:resetAccountPassword', { accountId, password });
+    isFiveM ? call<void>('sd-phone:admin:resetAccountPassword', { accountId, password }) : ok();
 
 export const adminForceLogout = (cid: string, app?: string) =>
-    call<void>('sd-phone:admin:forceLogout', { cid, app });
+    isFiveM ? call<void>('sd-phone:admin:forceLogout', { cid, app }) : ok();
 
 export const adminBirdyPosts = (opts: { cursor?: string | null; q?: string; cid?: string }) =>
-    call<{ posts: AdminBirdyPost[]; nextCursor?: string | null }>('sd-phone:admin:birdyPosts', opts);
+    isFiveM
+        ? call<{ posts: AdminBirdyPost[]; nextCursor?: string | null }>('sd-phone:admin:birdyPosts', opts)
+        : seed({ posts: devBirdyPosts(opts.q, opts.cid), nextCursor: null });
 
 export const adminBirdyDeletePost = (id: string) =>
-    call<void>('sd-phone:admin:birdyDeletePost', { id });
+    isFiveM ? call<void>('sd-phone:admin:birdyDeletePost', { id }) : ok();
 
 export const adminBirdySetVerified = (handle: string, type: string | null) =>
-    call<void>('sd-phone:admin:birdySetVerified', { handle, type });
+    isFiveM ? call<void>('sd-phone:admin:birdySetVerified', { handle, type }) : ok();
 
 export const adminContent = (app: string, cursor?: string | null, q?: string) =>
-    call<{ items: AdminContentItem[]; nextCursor?: string | null; deletable: boolean }>('sd-phone:admin:content', { app, cursor, q });
+    isFiveM
+        ? call<{ items: AdminContentItem[]; nextCursor?: string | null; deletable: boolean }>('sd-phone:admin:content', { app, cursor, q })
+        : seed({ ...devContent(app, q), nextCursor: null });
 
 export const adminContentDelete = (app: string, id: string) =>
-    call<void>('sd-phone:admin:contentDelete', { app, id });
+    isFiveM ? call<void>('sd-phone:admin:contentDelete', { app, id }) : ok();
 
 export const adminMessages = (cid: string, cursor?: string | null) =>
-    call<{ messages: AdminMessage[]; nextCursor?: string | null }>('sd-phone:admin:messages', { cid, cursor });
+    isFiveM
+        ? call<{ messages: AdminMessage[]; nextCursor?: string | null }>('sd-phone:admin:messages', { cid, cursor })
+        : seed({ messages: devMessages(cid), nextCursor: null });
 
 export const adminCalls = (cid: string, cursor?: string | null) =>
-    call<{ calls: AdminCall[]; nextCursor?: string | null }>('sd-phone:admin:calls', { cid, cursor });
+    isFiveM
+        ? call<{ calls: AdminCall[]; nextCursor?: string | null }>('sd-phone:admin:calls', { cid, cursor })
+        : seed({ calls: devCalls(), nextCursor: null });
 
 export const adminMute = (cid: string, scopes: string[], duration: number | null, reason: string) =>
-    call<{ mutes: AdminMute[] }>('sd-phone:admin:mute', { cid, scopes, duration, reason });
+    isFiveM
+        ? call<{ mutes: AdminMute[] }>('sd-phone:admin:mute', { cid, scopes, duration, reason })
+        : seed({
+            mutes: scopes.map((scope, i) => ({
+                id:        900 + i,
+                citizenid: cid,
+                name:      DEV_PLAYERS.find(p => p.citizenid === cid)?.name,
+                online:    false,
+                scope,
+                reason,
+                adminName: 'Demo Admin',
+                expiresAt: duration ? Math.floor(Date.now() / 1000) + duration : null,
+                createdAt: Math.floor(Date.now() / 1000),
+            })),
+        });
 
 export const adminUnmute = (cid: string, scope?: string) =>
-    call<{ mutes: AdminMute[] }>('sd-phone:admin:unmute', { cid, scope });
+    isFiveM ? call<{ mutes: AdminMute[] }>('sd-phone:admin:unmute', { cid, scope }) : seed({ mutes: [] });
 
 export const adminMutes = (cursor?: number | null) =>
-    call<{ mutes: AdminMute[]; nextCursor?: number | null }>('sd-phone:admin:mutes', { cursor });
+    isFiveM
+        ? call<{ mutes: AdminMute[]; nextCursor?: number | null }>('sd-phone:admin:mutes', { cursor })
+        : seed({ mutes: DEV_MUTES, nextCursor: null });
 
 export const adminWipePhone = (cid: string, confirm: string) =>
-    call<{ rows: number }>('sd-phone:admin:wipePhone', { cid, confirm });
+    isFiveM ? call<{ rows: number }>('sd-phone:admin:wipePhone', { cid, confirm }) : seed({ rows: 1284 });
 
 export const adminAudit = (cursor?: number | null) =>
-    call<{ entries: AdminAuditEntry[]; nextCursor?: number | null }>('sd-phone:admin:audit', { cursor });
+    isFiveM
+        ? call<{ entries: AdminAuditEntry[]; nextCursor?: number | null }>('sd-phone:admin:audit', { cursor })
+        : seed({ entries: DEV_AUDIT, nextCursor: null });

--- a/web/src/admin/devData.ts
+++ b/web/src/admin/devData.ts
@@ -1,0 +1,305 @@
+import type {
+    AdminAuditEntry, AdminBirdyPost, AdminCall, AdminContentItem,
+    AdminMessage, AdminMute, AdminNumberRow, AdminOverview, AdminPlayerHit, AdminSimLookup, AdminStats,
+} from './types';
+
+const HOUR = 3600;
+const DAY = 86400;
+
+const now = () => Math.floor(Date.now() / 1000);
+const ago = (seconds: number) => now() - seconds;
+
+interface DevPlayer {
+    citizenid: string;
+    name:      string;
+    number:    string;
+    online:    boolean;
+    handle:    string;
+    display:   string;
+    bio:       string;
+    verified:  string | null;
+}
+
+export const DEV_PLAYERS: DevPlayer[] = [
+    { citizenid: 'C3106S6K', name: 'Samuel Black',   number: '5550142', online: true,  handle: 'sblack',    display: 'Samuel Black',   bio: 'Runs the yard on Popular St.',           verified: 'blue' },
+    { citizenid: 'A7742J1M', name: 'Dana Kovac',     number: '5550198', online: true,  handle: 'danak',     display: 'Dana K',         bio: 'Street racer. Two podiums, one engine.',  verified: null },
+    { citizenid: 'B2210K9P', name: 'Marcus Reyes',   number: '5550233', online: false, handle: 'mreyes',    display: 'M. Reyes',       bio: 'Mechanic, Mirror Park.',                  verified: null },
+    { citizenid: 'D5518L3Q', name: 'Tola Okafor',    number: '5550317', online: true,  handle: 'tokafor',   display: 'Tola',           bio: 'Weazel News, city desk.',                 verified: 'gold' },
+    { citizenid: 'E9903M7R', name: 'Jonas Lindqvist',number: '5550451', online: false, handle: 'jlind',     display: 'Jonas L',        bio: 'Taxi driver. Ask me about the tunnel.',   verified: null },
+    { citizenid: 'F1147N2S', name: 'Priya Raman',    number: '5550566', online: true,  handle: 'praman',    display: 'Priya',          bio: 'EMS. Off shift, mostly.',                 verified: 'grey' },
+    { citizenid: 'G6634P8T', name: 'Ade Balogun',    number: '5550619', online: false, handle: 'adeb',      display: 'Ade',            bio: 'Buying anything with four wheels.',       verified: null },
+    { citizenid: 'H8871Q4V', name: 'Nina Sokolova',  number: '5550702', online: true,  handle: 'nsokol',    display: 'Nina',           bio: 'Photographer. DMs open.',                 verified: null },
+    { citizenid: 'J2295R6W', name: 'Curtis Vaughn',  number: '5550833', online: false, handle: 'cvaughn',   display: 'Curtis',         bio: 'Bank job? Never heard of it.',            verified: null },
+    { citizenid: 'K4408T1X', name: 'Elena Marchetti',number: '5550947', online: true,  handle: 'emarch',    display: 'Elena',          bio: 'Defence attorney. Rates negotiable.',     verified: 'blue' },
+];
+
+const byCid = (cid: string) => DEV_PLAYERS.find(p => p.citizenid === cid) ?? DEV_PLAYERS[0];
+
+export const DEV_STATS: AdminStats = {
+    phones:      DEV_PLAYERS.length,
+    appAccounts: 34,
+    birdyPosts:  128,
+    messages:    2417,
+    activeMutes: 3,
+    online:      DEV_PLAYERS.filter(p => p.online).length,
+};
+
+export function devSearch(q: string): AdminPlayerHit[] {
+    const term = q.trim().toLowerCase();
+    return DEV_PLAYERS
+        .filter(p => !term
+            || p.name.toLowerCase().includes(term)
+            || p.citizenid.toLowerCase().includes(term)
+            || p.number.includes(term))
+        .map(p => ({
+            citizenid:   p.citizenid,
+            name:        p.name,
+            phoneNumber: p.number,
+            online:      p.online,
+            matchedOn:   term && p.number.includes(term) ? 'number' : undefined,
+        }));
+}
+
+const APPS = [
+    'phone', 'messages', 'mail', 'camera', 'photos', 'settings', 'appstore', 'maps',
+    'bank', 'garages', 'birdy', 'photogram', 'music', 'weather', 'notes', 'racing',
+];
+
+const DOWNLOADABLE = [
+    { id: 'vibez', label: 'Vibez' }, { id: 'cherry', label: 'Cherry' },
+    { id: 'darkchat', label: 'Dark Chat' }, { id: 'marketplace', label: 'Marketplace' },
+    { id: 'pages', label: 'Pages' }, { id: 'stocks', label: 'Stocks' },
+    { id: 'wordle', label: 'Wordle' }, { id: 'chess', label: 'Chess' },
+];
+
+export const DEV_MUTES: AdminMute[] = [
+    { id: 1, citizenid: 'J2295R6W', name: 'Curtis Vaughn',  online: false, scope: 'birdy',    reason: 'Repeated slurs in replies after a warning.', adminName: 'Demo Admin', expiresAt: now() + 5 * DAY, createdAt: ago(2 * DAY) },
+    { id: 2, citizenid: 'G6634P8T', name: 'Ade Balogun',    online: false, scope: 'sms',      reason: 'Mass advertising to random numbers.',        adminName: 'Demo Admin', expiresAt: now() + 12 * HOUR, createdAt: ago(6 * HOUR) },
+    { id: 3, citizenid: 'B2210K9P', name: 'Marcus Reyes',   online: false, scope: 'darkchat', reason: 'Selling real currency. Permanent.',          adminName: 'S. Nicol',   expiresAt: null, createdAt: ago(11 * DAY) },
+];
+
+export function devOverview(cid: string): AdminOverview {
+    const p = byCid(cid);
+    return {
+        citizenid: p.citizenid,
+        name:      p.name,
+        online:    p.online,
+        settings: {
+            phoneNumber:   p.number,
+            hasPasscode:   true,
+            faceId:        true,
+            airplane:      false,
+            locale:        'en',
+            theme:         'dark',
+            darkTheme:     'graphite',
+            cardName:      p.name,
+            cardEmail:     `${p.handle}@lifeinvader.com`,
+            installedApps: APPS,
+            updatedAt:     ago(3 * HOUR),
+        },
+        accounts: [
+            { id: 101, app: 'birdy',      username: p.handle,          displayName: p.display, email: `${p.handle}@lifeinvader.com`, phone: p.number, createdAt: ago(90 * DAY) },
+            { id: 102, app: 'photogram',  username: `${p.handle}_pics`, displayName: p.display, email: `${p.handle}@lifeinvader.com`, phone: p.number, createdAt: ago(61 * DAY) },
+            { id: 103, app: 'mail',       username: p.handle,          displayName: p.name,    email: `${p.handle}@lifeinvader.com`, phone: null,     createdAt: ago(120 * DAY) },
+            { id: 104, app: 'marketplace', username: p.handle,         displayName: p.display, email: null,                          phone: p.number, createdAt: ago(30 * DAY) },
+        ],
+        birdy: [{
+            handle:       p.handle,
+            displayName:  p.display,
+            bio:          p.bio,
+            verified:     p.verified !== null,
+            verifiedType: p.verified,
+            loggedIn:     p.online,
+            protected:    false,
+            createdAt:    ago(90 * DAY),
+        }],
+        counts: { birdyPosts: 23, messages: 412, calls: 68, photos: 51, contacts: 34 },
+        mutes: DEV_MUTES.filter(m => m.citizenid === p.citizenid),
+        downloadable: DOWNLOADABLE,
+        sim: {
+            mode: 'tray',
+            sims: [
+                { number: p.number,   identity: `SIM-${p.citizenid}-1`, ownerCid: p.citizenid, createdAt: ago(120 * DAY) },
+                { number: '5551180',  identity: `SIM-${p.citizenid}-2`, ownerCid: p.citizenid, createdAt: ago(14 * DAY) },
+            ],
+            backup: { profiles: 2, enabled: true, hasPassword: true },
+            activeNumber: p.online ? p.number : null,
+            carried: [
+                { number: p.number,  color: 'black', active: true },
+                { number: '5551180', color: 'blue',  active: false },
+            ],
+        },
+    };
+}
+
+export function devNumbers(q: string): AdminNumberRow[] {
+    const term = q.trim().toLowerCase();
+    return DEV_PLAYERS
+        .filter(p => !term || p.number.includes(term) || p.name.toLowerCase().includes(term))
+        .map((p, i) => ({
+            number:       p.number,
+            identity:     `SIM-${p.citizenid}-1`,
+            ownerCid:     p.citizenid,
+            ownerName:    p.name,
+            createdAt:    ago((i + 4) * DAY),
+            boundProfile: i % 3 !== 0,
+            holder:       p.online ? { cid: p.citizenid, name: p.name } : null,
+        }));
+}
+
+export function devSimLookup(number: string): AdminSimLookup {
+    const p = DEV_PLAYERS.find(x => x.number === number.replace(/\D/g, '')) ?? DEV_PLAYERS[0];
+    return {
+        number:       p.number,
+        identity:     `SIM-${p.citizenid}-1`,
+        ownerCid:     p.citizenid,
+        ownerName:    p.name,
+        boundProfile: true,
+        holder:       { cid: p.citizenid, name: p.name, active: p.online },
+    };
+}
+
+const POST_BODIES = [
+    'anyone else lose power on Elgin last night or just me',
+    'selling the Sultan. two owners, one honest. DMs open.',
+    'the tunnel is closed AGAIN. third time this week.',
+    'photo dump from the Vinewood meet, link in replies',
+    'reminder that the racing board resets at midnight',
+    'lost a black duffel near the pier. reward, no questions.',
+    'whoever keeps parking across two bays at the hospital, we know',
+    'new track went live tonight. 14 checkpoints, all corners.',
+    'coffee at Bean Machine has doubled in price. rioting.',
+    'if you called me at 4am you know what you did',
+    'finally hit 1500 MMR. only took nine months.',
+    'PSA the ATM on Vespucci eats cards. use the one inside.',
+];
+
+export function devBirdyPosts(q?: string, cid?: string): AdminBirdyPost[] {
+    const term = (q ?? '').trim().toLowerCase();
+    return POST_BODIES.map((body, i) => {
+        const p = DEV_PLAYERS[i % DEV_PLAYERS.length];
+        return {
+            id:           `post-${i + 1}`,
+            authorCid:    p.citizenid,
+            authorName:   p.name,
+            authorOnline: p.online,
+            body,
+            parentId:     i % 5 === 4 ? `post-${i}` : null,
+            images:       i % 4 === 3 ? ['/phone-art/phone-front.webp'] : null,
+            views:        420 + i * 137,
+            likes:        3 + (i * 7) % 41,
+            replies:      (i * 3) % 9,
+            handle:       p.handle,
+            display:      p.display,
+            verified:     p.verified !== null,
+            verifiedType: p.verified,
+            createdAt:    ago(i * 5 * HOUR + HOUR),
+        };
+    }).filter(post => (!cid || post.authorCid === cid)
+        && (!term || post.body.toLowerCase().includes(term) || (post.handle ?? '').includes(term)));
+}
+
+const TEXTS = [
+    'you around later?', 'on my way, five minutes', 'did you pick up the parts',
+    'call me when you can', 'thanks again for the tow', 'the meet moved to the docks',
+    'sending the money now', 'no worries, take your time', 'did you see the news',
+    'my phone died sorry', 'bring the spare key', 'that was quick',
+];
+
+export function devMessages(cid: string): AdminMessage[] {
+    const p = byCid(cid);
+    return TEXTS.map((body, i): AdminMessage => {
+        const other = DEV_PLAYERS[(i + 1) % DEV_PLAYERS.length];
+        return {
+            id:           `msg-${i + 1}`,
+            conversation: other.number,
+            sender:       i % 2 === 0 ? p.number : other.number,
+            direction:    i % 2 === 0 ? 'out' : 'in',
+            kind:         i % 6 === 5 ? 'image' : 'text',
+            body:         i % 6 === 5 ? null : body,
+            createdAt:    ago(i * 90 * 60 + 600),
+        };
+    });
+}
+
+export function devCalls(): AdminCall[] {
+    return DEV_PLAYERS.slice(0, 8).map((other, i) => ({
+        id:        `call-${i + 1}`,
+        number:    other.number,
+        name:      other.name,
+        direction: i % 3 === 0 ? 'in' : i % 3 === 1 ? 'out' : 'missed',
+        duration:  i % 3 === 2 ? 0 : 45 + i * 73,
+        calledAt:  ago(i * 4 * HOUR + HOUR),
+    }));
+}
+
+const CONTENT: Record<string, { label: string; titles: string[]; bodies: string[]; priced?: boolean; imaged?: boolean }> = {
+    messages:    { label: 'Text',    titles: [], bodies: TEXTS },
+    darkchat:    { label: 'Message', titles: [], bodies: ['anyone moving tonight', 'price list is up', 'not here. DM.', 'room is getting watched', 'new drop location posted', 'stop using real names'] },
+    photogram:   { label: 'Post',    titles: [], bodies: ['sunset off the pier', 'new wheels finally on', 'coffee and a long shift', 'found this alley downtown', 'race night', 'no filter, promise'], imaged: true },
+    vibez:       { label: 'Vibe',    titles: [], bodies: ['drift compilation', 'day in the life of a paramedic', 'how to lose $40k in 90 seconds', 'tunnel run at 3am', 'my garage tour', 'worst parking job in the city'], imaged: true },
+    cherry:      { label: 'Profile', titles: ['Dana, 27', 'Marcus, 31', 'Tola, 24', 'Jonas, 35', 'Priya, 29', 'Ade, 26'], bodies: ['Looking for someone who drives.', 'Mechanic. Ask me anything.', 'Journalist, terrible cook.', 'Taxi driver, great stories.', 'EMS. I work nights.', 'Car guy. Obviously.'] },
+    marketplace: { label: 'Listing', titles: ['Sultan RS', 'Set of 18s', 'Apartment sublet', 'Toolbox, full', 'Camera body', 'Spare engine'], bodies: ['Two owners, clean.', 'Kerb mark on one lip.', 'Two months, Mirror Park.', 'Everything in the photo.', 'Barely used.', 'Pulled from a runner.'], priced: true },
+    pages:       { label: 'Post',    titles: ['Mechanic wanted', 'Lost dog', 'Race night Friday', 'Room to let', 'Selling my spot', 'Tow service'], bodies: ['Popular St yard, ask for Sam.', 'Answers to Bruno. Reward.', 'Meet at the docks, 11pm.', 'Quiet building, no pets.', 'Vinewood, good views.', '24/7, fair rates.'] },
+    gallery:     { label: 'Photo',   titles: [], bodies: [], imaged: true },
+};
+
+export function devContent(app: string, q?: string): { items: AdminContentItem[]; deletable: boolean } {
+    const cfg = CONTENT[app] ?? CONTENT.pages;
+    const term = (q ?? '').trim().toLowerCase();
+    const count = app === 'gallery' ? 12 : Math.max(cfg.bodies.length, cfg.titles.length, 6);
+
+    const items: AdminContentItem[] = Array.from({ length: count }, (_, i) => {
+        const p = DEV_PLAYERS[i % DEV_PLAYERS.length];
+        return {
+            id:           `${app}-${i + 1}`,
+            createdAt:    ago(i * 7 * HOUR + HOUR),
+            authorCid:    p.citizenid,
+            authorName:   p.name,
+            authorOnline: p.online,
+            label:        cfg.label,
+            title:        cfg.titles[i % Math.max(cfg.titles.length, 1)] ?? null,
+            body:         cfg.bodies[i % Math.max(cfg.bodies.length, 1)] ?? null,
+            kind:         app === 'messages' ? (i % 6 === 5 ? 'image' : 'text') : null,
+            images:       cfg.imaged ? 1 + (i % 3) : null,
+            imageUrl:     cfg.imaged ? '/phone-art/phone-front.webp' : null,
+            price:        cfg.priced ? 1500 + i * 2750 : null,
+        };
+    });
+
+    const filtered = term
+        ? items.filter(it => `${it.title ?? ''} ${it.body ?? ''} ${it.authorName ?? ''}`.toLowerCase().includes(term))
+        : items;
+
+    return { items: filtered, deletable: app !== 'messages' };
+}
+
+const AUDIT_ACTIONS: [string, string][] = [
+    ['mute',                'birdy for 5d: Repeated slurs in replies after a warning.'],
+    ['birdySetVerified',    'sblack -> blue'],
+    ['contentDelete',       'marketplace listing marketplace-3'],
+    ['resetPasscode',       'passcode cleared'],
+    ['setNumber',           '5550233 -> 5550241'],
+    ['giveSim',             'new SIM issued, bound to profile'],
+    ['forceLogout',         'signed out of photogram'],
+    ['setApp',              'installed darkchat'],
+    ['unmute',              'sms lifted early'],
+    ['wipePhone',           '1284 rows removed'],
+    ['racingSetFlag',       'Devils Gambit marked verified'],
+    ['racingDelete',        'Harbour Sprint deleted'],
+    ['resetAccountPassword','photogram account 102'],
+    ['birdyDeletePost',     'post-7'],
+];
+
+export const DEV_AUDIT: AdminAuditEntry[] = AUDIT_ACTIONS.map(([action, detail], i) => {
+    const p = DEV_PLAYERS[i % DEV_PLAYERS.length];
+    return {
+        id:        1000 - i,
+        adminCid:  'C3106S6K',
+        adminName: i % 4 === 3 ? 'S. Nicol' : 'Demo Admin',
+        action,
+        targetCid: p.citizenid,
+        detail,
+        createdAt: ago(i * 3 * HOUR + 900),
+    };
+});


### PR DESCRIPTION
`adminApi.ts` sent every call straight to `apiCall`. Outside FiveM `fetchNui` answers `{ ok: true }`, which reads as a failed envelope, so every page of the staff panel rendered empty in `vite dev` and in the browser demo on the website.

Each endpoint now branches on `isFiveM` and serves a full dataset from a new `admin/devData.ts`: ten players with numbers, SIM rows and online state, app accounts, installed apps, three active mutes with real reasons and expiries, twelve Squawk posts with likes and reply counts, texts, calls, per-app moderation content for all eight content pages, and fourteen audit entries. Writes are no-ops that report success, so the flows can be walked end to end.

In game nothing changes: every path still goes through `apiCall`.

## Gates

| Gate | Result |
|---|---|
| `npm run build` (includes `tsc --noEmit`) | pass |
| `npm run lint` (oxlint) | 0 errors |
| `npm run test` (vitest) | 525 passed |
| `npm run knip` | clean |