### PR TITLE
fix(admin): fill the panel backdrop and use real photos in the demo

### DIFF
--- a/web/src/admin/AdminPanel.tsx
+++ b/web/src/admin/AdminPanel.tsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import clsx from 'clsx';
 
+import { isDemo } from '@/core/demo';
 import { fetchNui } from '@/core/nui';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { AuditPage } from './pages/AuditPage';
@@ -148,9 +149,17 @@ export function AdminPanel() {
     const contentCfg = CONTENT_PAGES[page];
 
     return (
-        <div className="fixed inset-0 z-[400] flex items-center justify-center p-6 font-sf" onMouseDown={close}>
+        <div
+            className={`fixed inset-0 z-[400] flex items-center justify-center p-6 font-sf${
+                isDemo ? ' bg-[#07080a]' : ''
+            }`}
+            onMouseDown={close}
+        >
             {/* No backdrop-filter here: FiveM's CEF can't sample the game feed behind a
-                transparent NUI page, so backdrop-blur paints a huge black region instead. */}
+                transparent NUI page, so backdrop-blur paints a huge black region instead.
+                The demo build fills instead: on a website there is no game behind the panel,
+                only the phone itself, and a device standing behind a desktop window reads as
+                a bug rather than as context. */}
             <div
                 className="relative flex h-[min(780px,92vh)] w-[min(1180px,94vw)] overflow-hidden rounded-2xl bg-[#101114] shadow-2xl ring-1 ring-white/10"
                 onMouseDown={e => e.stopPropagation()}

--- a/web/src/admin/devData.ts
+++ b/web/src/admin/devData.ts
@@ -2,6 +2,24 @@ import type {
     AdminAuditEntry, AdminBirdyPost, AdminCall, AdminContentItem,
     AdminMessage, AdminMute, AdminNumberRow, AdminOverview, AdminPlayerHit, AdminSimLookup, AdminStats,
 } from './types';
+import bg3 from '@/assets/photos/background3.webp';
+import bg4 from '@/assets/photos/background4.webp';
+import bg5 from '@/assets/photos/background5.webp';
+import bg6 from '@/assets/photos/background6.webp';
+import bg7 from '@/assets/photos/background7.webp';
+import bg8 from '@/assets/photos/background8.webp';
+import bg10 from '@/assets/photos/background10.webp';
+import bg11 from '@/assets/photos/background11.webp';
+import bg12 from '@/assets/photos/background12.webp';
+import bg13 from '@/assets/photos/background13.webp';
+import bg14 from '@/assets/photos/background14.webp';
+import bg15 from '@/assets/photos/background15.webp';
+
+// Real bundled photos rather than a placeholder path: the moderation pages are
+// mostly image grids, and an empty frame makes them look broken.
+const PHOTOS: string[] = [bg3, bg4, bg5, bg6, bg7, bg8, bg10, bg11, bg12, bg13, bg14, bg15];
+
+const photo = (i: number) => PHOTOS[i % PHOTOS.length];
 
 const HOUR = 3600;
 const DAY = 86400;
@@ -185,7 +203,7 @@ export function devBirdyPosts(q?: string, cid?: string): AdminBirdyPost[] {
             authorOnline: p.online,
             body,
             parentId:     i % 5 === 4 ? `post-${i}` : null,
-            images:       i % 4 === 3 ? ['/phone-art/phone-front.webp'] : null,
+            images:       i % 4 === 3 ? [photo(i)] : null,
             views:        420 + i * 137,
             likes:        3 + (i * 7) % 41,
             replies:      (i * 3) % 9,
@@ -262,7 +280,7 @@ export function devContent(app: string, q?: string): { items: AdminContentItem[]
             body:         cfg.bodies[i % Math.max(cfg.bodies.length, 1)] ?? null,
             kind:         app === 'messages' ? (i % 6 === 5 ? 'image' : 'text') : null,
             images:       cfg.imaged ? 1 + (i % 3) : null,
-            imageUrl:     cfg.imaged ? '/phone-art/phone-front.webp' : null,
+            imageUrl:     cfg.imaged ? photo(i) : null,
             price:        cfg.priced ? 1500 + i * 2750 : null,
         };
     });


### PR DESCRIPTION
Two demo-only fixes for the panel on the website.

**The phone showed through the panel.** In game the panel deliberately has no backdrop so the world is visible behind it, which is why `backdrop-filter` is banned there. On a website there is no game behind it, only the phone itself, so a device stood behind a desktop window. The outer layer now fills opaque when `isDemo`. In game nothing changes.

**Moderation pages had no images.** The seeded content pointed at a website path that does not exist inside the phone bundle, so Photogram, Vibez and Gallery rendered empty frames. They now use the bundled `assets/photos` the other apps' dev data already uses.

## Gates

| Gate | Result |
|---|---|
| `npm run build` (includes `tsc --noEmit`) | pass |
| `npm run lint` (oxlint) | 0 errors |
| `npm run test` (vitest) | 525 passed |
| `npm run knip` | clean |