### PR TITLE
refactor(client): move to ox_lib modules

### DIFF
--- a/bridge/client/notify.lua
+++ b/bridge/client/notify.lua
@@ -20,7 +20,6 @@ local function chooseBackend()
     if lib ~= nil and USE_OX_LIB then
         return function(data)
             lib.notify({
-                id          = math.random(1, 999999),
                 title       = data.title,
                 description = data.description,
                 type        = data.type or 'inform',

--- a/bridge/server/garages.lua
+++ b/bridge/server/garages.lua
@@ -98,7 +98,7 @@ end
 local function decodeProps(row)
     for _, col in ipairs({ 'mods', 'vehicle', 'modifications' }) do
         local raw = row[col]
-        if type(raw) == 'string' and (raw:sub(1, 1) == '{' or raw:sub(1, 1) == '[') then
+        if type(raw) == 'string' and (lib.string.startsWith(raw, '{') or lib.string.startsWith(raw, '[')) then
             local ok, decoded = pcall(json.decode, raw)
             if ok and type(decoded) == 'table' then return decoded end
         elseif type(raw) == 'table' then
@@ -115,7 +115,7 @@ end
 ---@return string|number|nil model spawn name or hash
 local function modelOf(row, props)
     local raw = row.vehicle
-    if type(raw) == 'string' and raw:sub(1, 1) ~= '{' then return raw end
+    if type(raw) == 'string' and not lib.string.startsWith(raw, '{') then return raw end
     return (props and (props.model or props.modelName)) or row.hash or nil
 end
 
@@ -127,7 +127,7 @@ local function clampPct(n)
     if type(n) ~= 'number' then return nil end
     if n > 100 then n = n / 10 end
     if n < 0 then n = 0 elseif n > 100 then n = 100 end
-    return math.floor(n + 0.5)
+    return lib.math.round(n)
 end
 
 ---Resolve one condition metric (fuel/engine/body): dedicated column first (tried in order,

--- a/bridge/server/housing.lua
+++ b/bridge/server/housing.lua
@@ -463,9 +463,7 @@ ADAPTERS['LNS_Housing'] = function(source, id)
         local isOwner = (p.owner == id)
         local isKeyholder = false
         if not isOwner and p.permissions and type(p.permissions.entry) == 'table' then
-            for _, cid in ipairs(p.permissions.entry) do
-                if cid == id then isKeyholder = true; break end
-            end
+            isKeyholder = lib.table.contains(p.permissions.entry, id)
         end
         if isOwner or isKeyholder then
             local coords = nil
@@ -730,9 +728,7 @@ function housing.keyHolders(src, id)
         local isOwner  = (prop.owner == callerCid)
         local isHolder = false
         if not isOwner and prop.permissions and type(prop.permissions.entry) == 'table' then
-            for _, cid in ipairs(prop.permissions.entry) do
-                if cid == callerCid then isHolder = true; break end
-            end
+            isHolder = lib.table.contains(prop.permissions.entry, callerCid)
         end
         if not isOwner and not isHolder then return {} end
 

--- a/bridge/server/housing.lua
+++ b/bridge/server/housing.lua
@@ -44,7 +44,7 @@ end
 ---@return table|nil decoded
 local function decodeJson(raw)
     if type(raw) == 'table' then return raw end
-    if type(raw) == 'string' and (raw:sub(1, 1) == '{' or raw:sub(1, 1) == '[') then
+    if type(raw) == 'string' and (lib.string.startsWith(raw, '{') or lib.string.startsWith(raw, '[')) then
         local ok, d = pcall(json.decode, raw)
         if ok and type(d) == 'table' then return d end
     end

--- a/client/apps/camera.lua
+++ b/client/apps/camera.lua
@@ -69,29 +69,31 @@ local function sendKey(key)
     SendNUIMessage({ action = 'sd-phone:camera:key', data = { key = key } })
 end
 
+---@type integer[] Every viewfinder key, suppressed for as long as the app is up whether the cursor
+---is on or not: with movement allowed the game still reads them, so E would fire interact scripts
+---and Alt the character wheel while the player reaches for the flash.
+local CONTROLS_VIEWFINDER <const> = {
+    CTRL_CURSOR, CTRL_FLASH, CTRL_SHOOT, CTRL_FLIP, CTRL_PREV,
+    CTRL_NEXT, CTRL_DOWN, CTRL_ZOOM_IN, CTRL_ZOOM_OUT,
+}
+
 ---Runs the viewfinder keyboard loop: disables each control's default action for as long as the
 ---app is up, and relays presses into the NUI while the cursor is off.
+---
+---The set is added once and dropped on the way out rather than reissued per frame, but
+---lib.disableControls still has to be CALLED every frame: IsDisabledControlJustPressed below only
+---reads a control that was disabled this frame. The relays run only while the mouse belongs to the
+---game; with the cursor up the page receives these events itself and the wheel zooms from its own
+---handler.
 local function startInputLoop()
     if inputLoopRunning then return end
     inputLoopRunning = true
     CreateThread(function()
+        lib.disableControls:Add(CONTROLS_VIEWFINDER)
         while active do
             Wait(0)
-            -- Suppress the game's own action on every viewfinder key for as long as the app is up,
-            -- cursor or not: with movement on the game still reads them, so E would fire interact
-            -- scripts and Alt the character wheel while the player reaches for the flash.
-            DisableControlAction(0, CTRL_CURSOR, true)
-            DisableControlAction(0, CTRL_FLASH, true)
-            DisableControlAction(0, CTRL_SHOOT, true)
-            DisableControlAction(0, CTRL_FLIP, true)
-            DisableControlAction(0, CTRL_PREV, true)
-            DisableControlAction(0, CTRL_NEXT, true)
-            DisableControlAction(0, CTRL_DOWN, true)
-            DisableControlAction(0, CTRL_ZOOM_IN, true)
-            DisableControlAction(0, CTRL_ZOOM_OUT, true)
+            lib.disableControls()
 
-            -- Relays only run while the mouse belongs to the game; with the cursor up the page
-            -- receives these events itself, and the wheel zooms from its own handler.
             if not cursorOn then
                 if IsDisabledControlJustPressed(0, CTRL_ZOOM_IN) then
                     sendKey('zoomIn')
@@ -113,6 +115,7 @@ local function startInputLoop()
                 end
             end
         end
+        lib.disableControls:Remove(CONTROLS_VIEWFINDER)
         inputLoopRunning = false
     end)
 end

--- a/client/apps/compass.lua
+++ b/client/apps/compass.lua
@@ -23,7 +23,7 @@ end
 ---Live readout the React app polls while the Compass screen is open: clockwise compass bearing,
 ---anchored lat/lon and altitude.
 RegisterNUICallback('sd-phone:compass:get', function(_, cb)
-    local ped = PlayerPedId()
+    local ped = cache.ped
     local bearing  = (360.0 - GetEntityHeading(ped)) % 360.0
     local c        = GetEntityCoords(ped)
     local lat, lon = gtaToLatLon(c.x, c.y)

--- a/client/apps/garages.lua
+++ b/client/apps/garages.lua
@@ -159,7 +159,7 @@ RegisterNUICallback('sd-phone:garages:mileage', function(payload, cb)
     if type(plate) ~= 'string' or plate == '' then return cb({ success = false }) end
 
     local km
-    local veh = GetVehiclePedIsIn(PlayerPedId(), false)
+    local veh = GetVehiclePedIsIn(cache.ped, false)
     if veh ~= 0 and plateMatches(GetVehicleNumberPlateText(veh), plate) then
         local ok, v = pcall(function() return exports['jg-vehiclemileage']:getMileage() end)
         if ok and type(v) == 'number' then km = v end
@@ -207,10 +207,10 @@ local lastHurt = 0
 
 if VALET.Enabled == true and COMBAT_BLOCK > 0 then
     CreateThread(function()
-        local last = GetEntityHealth(PlayerPedId())
+        local last = GetEntityHealth(cache.ped)
         while true do
             Wait(1000)
-            local hp = GetEntityHealth(PlayerPedId())
+            local hp = GetEntityHealth(cache.ped)
             if hp < last then lastHurt = GetGameTimer() end
             last = hp
         end
@@ -265,7 +265,7 @@ end
 ---@return number dist metres from the player (0 when nothing was found)
 ---@return boolean facing whether the chosen road actually points at the player
 local function findSpawn(minDist)
-    local at = GetEntityCoords(PlayerPedId())
+    local at = GetEntityCoords(cache.ped)
 
     local bestPos, bestHead, bestDist, bestMiss, bestScore
 
@@ -351,16 +351,19 @@ local PROGRESS_STEP = 5.0
 
 ---Drive the delivered car to the player with a valet at the wheel, blipped and re-pointed as they
 ---move. The ped leaves on arrival; a stall or timeout keeps the blip on the abandoned car.
+---
+---lib.requestModel raises rather than returning on a model that never streams, hence the pcall; the
+---2s budget matches the 40x50ms poll it replaces. The vehicle is re-checked after, because the load
+---yields and a car deleted during it would leave the valet spawning into nothing.
 ---@param veh number vehicle entity
 local function driveToPlayer(veh)
     CreateThread(function()
         local model = joaat(VALET_PED)
-        RequestModel(model)
-        for _ = 1, 40 do
-            if HasModelLoaded(model) then break end
-            Wait(50)
+        if not pcall(lib.requestModel, model, 2000) then return end
+        if not DoesEntityExist(veh) then
+            SetModelAsNoLongerNeeded(model)
+            return
         end
-        if not HasModelLoaded(model) or not DoesEntityExist(veh) then return end
 
         local ped = CreatePedInsideVehicle(veh, 4, model, -1, true, false)
         SetModelAsNoLongerNeeded(model)
@@ -377,7 +380,7 @@ local function driveToPlayer(veh)
             TaskVehicleDriveToCoord(ped, veh, to.x, to.y, to.z, 25.0, 0, GetEntityModel(veh), 786603, 3.0, 1)
         end
 
-        local target = GetEntityCoords(PlayerPedId())
+        local target = GetEntityCoords(cache.ped)
         driveTo(target)
 
         local blip = AddBlipForEntity(veh)
@@ -393,7 +396,7 @@ local function driveToPlayer(veh)
         local arrived   = false
 
         while DoesEntityExist(ped) and DoesEntityExist(veh) and GetGameTimer() < deadline do
-            local player = GetEntityCoords(PlayerPedId())
+            local player = GetEntityCoords(cache.ped)
             local gap    = #(GetEntityCoords(veh) - player)
             if gap <= ARRIVE_DIST then arrived = true break end
 

--- a/client/apps/health.lua
+++ b/client/apps/health.lua
@@ -109,7 +109,7 @@ local function pushSnapshot()
         data = {
             steps     = math.floor(stats.steps),
             distanceM = stats.distanceM,
-            heartRate = math.floor(stats.heartRate + 0.5),
+            heartRate = lib.math.round(stats.heartRate),
             state     = stats.state,
         },
     })

--- a/client/apps/health.lua
+++ b/client/apps/health.lua
@@ -3,7 +3,7 @@
 ---@return 'dead'|'vehicle'|'sprinting'|'running'|'walking'|'idle'
 local function detectState(ped)
     if IsEntityDead(ped) or IsPedDeadOrDying(ped, true) then return 'dead' end
-    if IsPedInAnyVehicle(ped, false) then return 'vehicle' end
+    if cache.vehicle then return 'vehicle' end
     if IsPedSprinting(ped) then return 'sprinting' end
     if IsPedRunning(ped)   then return 'running' end
     if IsPedWalking(ped)   then return 'walking' end
@@ -66,7 +66,7 @@ CreateThread(function()
 
     while true do
         Wait(TICK_MS)
-        local ped = PlayerPedId()
+        local ped = cache.ped
         if DoesEntityExist(ped) then
             local now = GetGameTimer()
             local dt  = (now - lastTickMs) / 1000.0

--- a/client/apps/maps.lua
+++ b/client/apps/maps.lua
@@ -52,7 +52,7 @@ RegisterNUICallback('sd-phone:maps:route', function(data, cb)
     end
 
     local nav = config.Navigation or {}
-    local ped = PlayerPedId()
+    local ped = cache.ped
     local c   = GetEntityCoords(ped)
 
     local dist = GetGpsBlipRouteLength()
@@ -63,7 +63,7 @@ RegisterNUICallback('sd-phone:maps:route', function(data, cb)
         dist = #(vector3(c.x, c.y, c.z) - vector3(tx + 0.0, ty + 0.0, c.z))
     end
 
-    local inVeh = IsPedInAnyVehicle(ped, false)
+    local inVeh = cache.vehicle and true or false
     local speed = inVeh and (nav.DriveSpeed or 16.0) or (nav.WalkSpeed or 1.7)
     if speed <= 0 then speed = 16.0 end
 
@@ -80,7 +80,7 @@ end)
 
 ---React -> Lua: the player's current world coords. Read-only.
 RegisterNUICallback('sd-phone:maps:here', function(_, cb)
-    local c = GetEntityCoords(PlayerPedId())
+    local c = GetEntityCoords(cache.ped)
     cb({ success = true, data = { x = c.x, y = c.y } })
 end)
 
@@ -100,7 +100,7 @@ local function startLocationStream()
     streamRunning = true
     CreateThread(function()
         while watching and exports['sd-phone']:isOpen() do
-            local ped = PlayerPedId()
+            local ped = cache.ped
             local c = GetEntityCoords(ped)
             SendNUIMessage({
                 action = 'sd-phone:maps:location',
@@ -147,7 +147,7 @@ RegisterCommand('mapcal', function()
     calArmed = true
     calIndex = calIndex % #CAL_POINTS + 1
     local p = CAL_POINTS[calIndex]
-    local ped = PlayerPedId()
+    local ped = cache.ped
     RequestCollisionAtCoord(p.x, p.y, p.z)
     SetEntityCoords(ped, p.x, p.y, p.z, false, false, false, false)
     notify.show({

--- a/client/apps/photogram.lua
+++ b/client/apps/photogram.lua
@@ -44,7 +44,7 @@ end
 ---Zone name at the player's current position, for pre-filling the New Post location field.
 ---Read-only; ignores its payload entirely.
 RegisterNUICallback('sd-phone:photogram:currentZone', function(_, cb)
-    local coords = GetEntityCoords(PlayerPedId())
+    local coords = GetEntityCoords(cache.ped)
     cb({ success = true, data = { name = zoneName(coords.x, coords.y, coords.z) } })
 end)
 

--- a/client/apps/racing.lua
+++ b/client/apps/racing.lua
@@ -49,7 +49,7 @@ end
 ---class; a class letter is never sent from the client.
 ---@return integer hash
 local function vehicleModelHash()
-    local veh = GetVehiclePedIsIn(PlayerPedId(), false)
+    local veh = GetVehiclePedIsIn(cache.ped, false)
     if veh == 0 then return 0 end
     return GetEntityModel(veh)
 end
@@ -100,7 +100,7 @@ RegisterNUICallback('sd-phone:racing:vehicle', function(_payload, cb)
         data = {
             model  = race.currentVehicleLabel(),
             class  = race.currentClass(),
-            onFoot = GetVehiclePedIsIn(PlayerPedId(), false) == 0,
+            onFoot = not cache.vehicle,
         },
     })
 end)

--- a/client/apps/radio.lua
+++ b/client/apps/radio.lua
@@ -6,7 +6,7 @@ local function freqToChannel(freq)
     local f = tonumber(freq) or 0
     if f < 1.0 then return 0 end
     if f > 999.9 then f = 999.9 end
-    return math.floor(f * 10 + 0.5)
+    return lib.math.round(f * 10)
 end
 
 -- Live session state, seeded from the player's saved prefs on first read. `standby` = left the
@@ -73,7 +73,7 @@ RegisterNUICallback('sd-phone:radio:set', function(payload, cb)
     if payload.freq ~= nil then
         local f = tonumber(payload.freq) or state.freq
         if f < 1.0 then f = 1.0 elseif f > 999.9 then f = 999.9 end
-        newFreq = math.floor(f * 10 + 0.5) / 10
+        newFreq = lib.math.round(f, 1)
     end
     local newOn = state.on
     if payload.on ~= nil then newOn = payload.on == true end

--- a/client/apps/ryde.lua
+++ b/client/apps/ryde.lua
@@ -27,7 +27,7 @@ RegisterNUICallback('sd-phone:ryde:nearPoint', function(payload, cb)
     payload = payload or {}
     local px, py = tonumber(payload.x), tonumber(payload.y)
     if not (px and py) then cb({ near = false, distance = -1 }); return end
-    local c = GetEntityCoords(PlayerPedId())
+    local c = GetEntityCoords(cache.ped)
     local dx, dy = c.x - (px + 0.0), c.y - (py + 0.0)
     local dist = math.sqrt(dx * dx + dy * dy)
     cb({ near = dist <= (tonumber(payload.radius) or 100.0), distance = math.floor(dist + 0.5) })
@@ -57,7 +57,7 @@ local GENERIC_LABELS = {
 ---@param payload table ride request draft from the UI (dropoff label/coords)
 RegisterNUICallback('sd-phone:ryde:requestRide', function(payload, cb)
     payload = payload or {}
-    local coords = GetEntityCoords(PlayerPedId())
+    local coords = GetEntityCoords(cache.ped)
     payload.pickup = { label = zoneName(coords.x, coords.y, coords.z), x = coords.x, y = coords.y }
     local d = payload.dropoff
     if d and d.x and d.y and GENERIC_LABELS[d.label or ''] then

--- a/client/apps/ryde.lua
+++ b/client/apps/ryde.lua
@@ -30,7 +30,7 @@ RegisterNUICallback('sd-phone:ryde:nearPoint', function(payload, cb)
     local c = GetEntityCoords(cache.ped)
     local dx, dy = c.x - (px + 0.0), c.y - (py + 0.0)
     local dist = math.sqrt(dx * dx + dy * dy)
-    cb({ near = dist <= (tonumber(payload.radius) or 100.0), distance = math.floor(dist + 0.5) })
+    cb({ near = dist <= (tonumber(payload.radius) or 100.0), distance = lib.math.round(dist) })
 end)
 
 ---Returns a friendly area name for a world point, falling back to the raw zone code, then

--- a/client/apps/voice.lua
+++ b/client/apps/voice.lua
@@ -42,7 +42,7 @@ local talkLoopGen = 0
 ---talking) when the Mumble native is unavailable.
 ---@return boolean transmitting
 local function isTransmitting()
-    local ok, talking = pcall(MumbleIsPlayerTalking, PlayerId())
+    local ok, talking = pcall(MumbleIsPlayerTalking, cache.playerId)
     if not ok then return true end
     return talking == true or talking == 1
 end

--- a/client/compat/lbphone.lua
+++ b/client/compat/lbphone.lua
@@ -234,11 +234,12 @@ end)
 
 registerLbExport('GetFlashlight', function() return flashlightOn end)
 
----Inbound lb-phone:usePhoneItem: opens the phone; the item payload is ignored.
+---Inbound lb-phone:usePhoneItem: opens the phone; the item payload is ignored. config.Debug
+---prints the breadcrumb at info so the switch still works on its own, while
+---`setr ox:printlevel:sd-phone debug` reaches the same line live without a restart.
 eventCookies[#eventCookies + 1] = RegisterNetEvent('lb-phone:usePhoneItem', function(_item)
-    if config.Debug then
-        print('[sd-phone:lbcompat] usePhoneItem received; opening the phone (item payload ignored)')
-    end
+    local trace = 'lbcompat: usePhoneItem received; opening the phone (item payload ignored)'
+    if config.Debug then lib.print.info(trace) else lib.print.debug(trace) end
     sd:open()
 end)
 

--- a/client/customapps.lua
+++ b/client/customapps.lua
@@ -52,12 +52,12 @@ local PHONE_RESOURCE = GetCurrentResourceName():lower()
 ---@type table Public module surface; the table returned at end of file.
 local M = {}
 
----Prints debug output when config.Debug is enabled.
+---Debug breadcrumb; config.Debug prints at info so it needs no further setup, while
+---`setr ox:printlevel:sd-phone debug` turns the same output on live without a restart.
 ---@param ... any values to print
 local function debugPrint(...)
-    if config.Debug then
-        print('[sd-phone:client]', ...)
-    end
+    if config.Debug then return lib.print.info(...) end
+    lib.print.debug(...)
 end
 
 ---Reduces a widget name to an identifier the saved home-screen layout can key a placement on.

--- a/client/main.lua
+++ b/client/main.lua
@@ -164,12 +164,14 @@ function phoneState.isOpen() return phoneState.open end
 ---@return boolean true while the lockscreen is shown (re-armed on every open)
 function phoneState.isLocked() return phoneState.locked end
 
----Prints debug output when config.Debug is enabled.
+---Debug breadcrumb. Two ways to turn it on, because they answer different questions: config.Debug
+---is the resource's own switch and prints at info so it shows with no further setup, while
+---`setr ox:printlevel:sd-phone debug` turns the same output on live, without editing a config and
+---restarting.
 ---@param ... any values to print
 local function debugPrint(...)
-    if config.Debug then
-        print('[sd-phone:client]', ...)
-    end
+    if config.Debug then return lib.print.info(...) end
+    lib.print.debug(...)
 end
 
 ---@type fun()|nil Weather snapshot push into the NUI (assigned with the weather feed below).
@@ -227,62 +229,102 @@ local function updatePose()
     broadcastHoldState()
 end
 
----@type boolean True while the movement-suppression thread is running.
-local movementThreadRunning = false
+-- The four control sets the phone suppresses, as data. They are handed to ox_lib's
+-- lib.disableControls, which keeps ONE refcounted set and re-asserts all of it in a single call per
+-- frame - so the thread below toggles a group when the state changes rather than reissuing the same
+-- two dozen DisableControlAction calls every frame regardless of whether anything moved.
 
----Runs one thread per open that suppresses combat, mouse-look, weapon-wheel and chat controls
----each frame, and closes the phone when the pause menu activates.
-local function startMovementThread()
-    if not config.Phone.AllowMovement or movementThreadRunning then return end
-    movementThreadRunning = true
+---@type integer[] INPUT_FRONTEND_PAUSE and its alternate; held whenever the phone is on screen.
+local CONTROLS_PAUSE <const> = { 199, 200 }
+
+---@type integer[] Combat, melee, weapon-wheel, cover, chat - and the scroll-wheel fall-throughs
+---under keep-input, because the phone owns the wheel and vehicle radio cycling must not react.
+local CONTROLS_MOVEMENT <const> = {
+    24, 25, 37, 106, 245, 246, 257, 263, 264, 140, 141, 142, 143,
+    14, 15, 16, 17, 81, 82, 83, 84, 85, 99, 100,
+}
+
+---@type integer[] Mouse-look. Dropped while the Camera app aims the lens, or it would be immovable.
+local CONTROLS_LOOK <const> = { 1, 2 }
+
+---@type integer[] The number row, which GTA binds to weapon slots while a digit field is focused.
+local CONTROLS_DIGITS <const> = { 157, 158, 159, 160, 161, 162, 163, 164, 165, 166 }
+
+---@type table<table, true> Groups currently added to lib.disableControls.
+local appliedControls = {}
+
+---Adds or removes a group exactly once per state change. Add/Remove are refcounted, so an
+---unbalanced pair would leave a control disabled for the rest of the session.
+---@param group integer[]
+---@param wanted boolean
+local function setControlGroup(group, wanted)
+    if wanted == (appliedControls[group] or false) then return end
+    appliedControls[group] = wanted or nil
+    if wanted then
+        lib.disableControls:Add(group)
+    else
+        lib.disableControls:Remove(group)
+    end
+end
+
+---@type boolean True while the per-frame input thread is running.
+local inputThreadRunning = false
+
+---Runs ONE per-frame thread per open: holds the pause control down unconditionally, and with
+---AllowMovement on also suppresses combat, mouse-look, weapon-wheel and chat.
+---
+---The mouse-look group is dropped while the Camera app's Alt toggle has the lens, because
+---suppressing it there makes the lens immovable. DisablePlayerFiring is not a control, so it stays
+---a native and stays inside the frame loop.
+---
+---The pause group is held for a few frames past the close, or the closing keypress opens the escape
+---menu. The outer loop exists so a reopen DURING that trailing hold rejoins rather than dying with
+---the flag about to clear, which would leave an open phone suppressing nothing; nothing yields
+---between the break and the flag clearing, so an open can never be refused by a thread on its way
+---out.
+local function startInputThread()
+    if inputThreadRunning then return end
+    inputThreadRunning = true
     CreateThread(function()
-        while phoneState.open do
-            if IsPauseMenuActive() then
-                if ClosePhone then ClosePhone() end
-            elseif (not typingInPhone or typingNumeric) and not cameraFrozen() then
-                DisablePlayerFiring(PlayerId(), true)
-                -- The Camera app's Alt toggle hands the mouse to the game to aim the lens, so
-                -- leave mouse-look alone while it has: suppressing it makes the lens immovable.
-                if not lookMode and not cameraCursorFree then
-                    DisableControlAction(0, 1, true)
-                    DisableControlAction(0, 2, true)
-                end
-                DisableControlAction(0, 24, true)
-                DisableControlAction(0, 25, true)
-                DisableControlAction(0, 257, true)
-                DisableControlAction(0, 263, true)
-                DisableControlAction(0, 264, true)
-                DisableControlAction(0, 140, true)
-                DisableControlAction(0, 141, true)
-                DisableControlAction(0, 142, true)
-                DisableControlAction(0, 143, true)
-                DisableControlAction(0, 37, true)
-                DisableControlAction(0, 106, true)
-                DisableControlAction(0, 245, true)
-                DisableControlAction(0, 246, true)
-                -- Scroll-wheel fall-throughs under keep-input: the phone owns the wheel, so
-                -- vehicle radio cycling, the radio wheel and weapon cycling must not react.
-                DisableControlAction(0, 14, true)
-                DisableControlAction(0, 15, true)
-                DisableControlAction(0, 16, true)
-                DisableControlAction(0, 17, true)
-                DisableControlAction(0, 81, true)
-                DisableControlAction(0, 82, true)
-                DisableControlAction(0, 83, true)
-                DisableControlAction(0, 84, true)
-                DisableControlAction(0, 85, true)
-                DisableControlAction(0, 99, true)
-                DisableControlAction(0, 100, true)
-                if typingNumeric then
-                    -- Digit pad up: the number row must not fire GTA weapon-slot binds.
-                    for control = 157, 166 do
-                        DisableControlAction(0, control, true)
+        while true do
+            while phoneState.open do
+                setControlGroup(CONTROLS_PAUSE, true)
+
+                ---@type boolean Whether the movement suppression applies this frame.
+                local suppress = false
+                if config.Phone.AllowMovement then
+                    if IsPauseMenuActive() then
+                        if ClosePhone then ClosePhone() end
+                    else
+                        suppress = (not typingInPhone or typingNumeric) and not cameraFrozen()
                     end
                 end
+
+                setControlGroup(CONTROLS_MOVEMENT, suppress)
+                setControlGroup(CONTROLS_LOOK, suppress and not lookMode and not cameraCursorFree)
+                setControlGroup(CONTROLS_DIGITS, suppress and typingNumeric)
+
+                if suppress then DisablePlayerFiring(cache.playerId, true) end
+
+                lib.disableControls()
+                Wait(0)
             end
-            Wait(0)
+
+            setControlGroup(CONTROLS_PAUSE, true)
+            setControlGroup(CONTROLS_MOVEMENT, false)
+            setControlGroup(CONTROLS_LOOK, false)
+            setControlGroup(CONTROLS_DIGITS, false)
+
+            local held = 0
+            while held < 15 and not phoneState.open do
+                lib.disableControls()
+                held = held + 1
+                Wait(0)
+            end
+            if not phoneState.open then break end
         end
-        movementThreadRunning = false
+        setControlGroup(CONTROLS_PAUSE, false)
+        inputThreadRunning = false
     end)
 end
 
@@ -349,7 +391,7 @@ local function OpenPhone()
 
     local visibleAppList, visibleDock = visibleApps()
 
-    local ped = PlayerPedId()
+    local ped = cache.ped
 
     if config.Phone.BlockWhileDead and IsEntityDead(ped) then
         notify.show({ description = 'You can\'t use your phone right now.', type = 'error' })
@@ -369,19 +411,6 @@ local function OpenPhone()
     companion.phoneOpen = true
     gameclock.push()
 
-    CreateThread(function()
-        while phoneState.open do
-            DisableControlAction(0, 199, true) -- INPUT_FRONTEND_PAUSE
-            DisableControlAction(0, 200, true) -- INPUT_FRONTEND_PAUSE_ALTERNATE
-            Wait(0)
-        end
-        for i = 1, 15 do
-            DisableControlAction(0, 199, true)
-            DisableControlAction(0, 200, true)
-            Wait(0)
-        end
-    end)
-
     updatePose()
 
     TriggerEvent('sd-phone:client:openState', true)
@@ -392,8 +421,8 @@ local function OpenPhone()
         typingInPhone = false
         typingNumeric = false
         SetNuiFocusKeepInput(true)
-        startMovementThread()
     end
+    startInputThread()
     SendNUIMessage({
         action = 'sd-phone:open',
         data   = {
@@ -502,38 +531,56 @@ local function TogglePhone()
     OpenPhone()
 end
 
--- Keybind wiring; the `-` command is the no-op release half of the +command mapping.
-RegisterCommand('+sdphone_toggle', TogglePhone, false)
-RegisterCommand('-sdphone_toggle', function() end, false)
-RegisterKeyMapping('+sdphone_toggle', 'Toggle Phone', 'keyboard', config.Phone.Keybind)
+-- Keybind wiring. lib.addKeybind registers the +/- command pair and the mapping together, refuses
+-- to fire while the pause menu is up, and clears both halves out of the chat suggestion list. It
+-- invokes the handlers as METHODS, so each is handed the keybind table as a first argument; all of
+-- these take none, so it falls away.
+lib.addKeybind({
+    name        = 'sdphone_toggle',
+    description = 'Toggle Phone',
+    defaultKey  = config.Phone.Keybind,
+    onPressed   = TogglePhone,
+})
 
--- Hold-to-look: the +command frees the mouse for camera rotation, the -command restores the cursor.
-RegisterCommand('+sdphone_look', enterLookMode, false)
-RegisterCommand('-sdphone_look', exitLookMode, false)
-RegisterKeyMapping('+sdphone_look', 'Phone: Hold to look around', 'keyboard', config.Phone.LookKeybind)
+-- Hold-to-look: press frees the mouse for camera rotation, release restores the cursor.
+lib.addKeybind({
+    name        = 'sdphone_look',
+    description = 'Phone: Hold to look around',
+    defaultKey  = config.Phone.LookKeybind,
+    onPressed   = enterLookMode,
+    onReleased  = exitLookMode,
+})
 
 -- Angle lock: stops the body turning with the selfie lens, so the shot can swing around the player
 -- for something other than head-on. Walking is untouched. toggleLock returns nil on the outward
 -- lens, which frames the world and gains nothing from it.
-RegisterCommand('sdphone_camlock', function()
-    if not cameraActive then return end
-    local locked = phonecam.toggleLock()
-    if locked == nil then return end
-    -- The viewfinder's own hint carries the state, so it flips to "Unlock Angle" rather than a
-    -- toast interrupting the shot.
-    SendNUIMessage({ action = 'sd-phone:camera:lock', data = { on = locked } })
-end, false)
-RegisterKeyMapping('sdphone_camlock', 'Phone: Move the selfie camera instead of yourself', 'keyboard', config.Phone.CameraLockKeybind)
+-- The viewfinder's own hint carries the lock state, so it flips to "Unlock Angle" rather than a
+-- toast interrupting the shot.
+lib.addKeybind({
+    name        = 'sdphone_camlock',
+    description = 'Phone: Move the selfie camera instead of yourself',
+    defaultKey  = config.Phone.CameraLockKeybind,
+    onPressed   = function()
+        if not cameraActive then return end
+        local locked = phonecam.toggleLock()
+        if locked == nil then return end
+        SendNUIMessage({ action = 'sd-phone:camera:lock', data = { on = locked } })
+    end,
+})
 
 -- Head tracking: turns the face back toward the lens so an angled selfie still looks at the camera.
 -- Opt-in, because it reads as posed rather than candid and not every shot wants that.
-RegisterCommand('sdphone_camface', function()
-    if not cameraActive then return end
-    local facing = phonecam.toggleFaceCam()
-    if facing == nil then return end
-    SendNUIMessage({ action = 'sd-phone:camera:faceCam', data = { on = facing } })
-end, false)
-RegisterKeyMapping('sdphone_camface', 'Phone: Look at the selfie camera', 'keyboard', config.Phone.CameraFaceKeybind)
+lib.addKeybind({
+    name        = 'sdphone_camface',
+    description = 'Phone: Look at the selfie camera',
+    defaultKey  = config.Phone.CameraFaceKeybind,
+    onPressed   = function()
+        if not cameraActive then return end
+        local facing = phonecam.toggleFaceCam()
+        if facing == nil then return end
+        SendNUIMessage({ action = 'sd-phone:camera:faceCam', data = { on = facing } })
+    end,
+})
 
 ---Opens the phone after a phone item is used, adopting the item variant's frame colour when it
 ---passes the FRAME_COLORS whitelist.
@@ -735,7 +782,7 @@ CreateThread(function()
     local fl = config.Phone.Flashlight
     while true do
         if flashlightOn then
-            local ped = PlayerPedId()
+            local ped = cache.ped
             local pos = GetPedBoneCoords(ped, config.Phone.PropBone, 0.0, 0.0, 0.0)
             local fwd = GetEntityForwardVector(ped)
             DrawSpotLight(
@@ -776,7 +823,7 @@ if config.Phone.PropVisibleToOthers then
 
     AddStateBagChangeHandler('sdPhone', nil, function(bagName, _key, value)
         local source, ped = bagOwner(bagName)
-        if not source or source == GetPlayerServerId(PlayerId()) then return end
+        if not source or source == cache.serverId then return end
         if not value or ped == 0 then
             removeRemoteProp(source)
             return

--- a/client/payphone.lua
+++ b/client/payphone.lua
@@ -42,9 +42,12 @@ AddEventHandler('sd-phone:client:openState', function(open)
     end
 end)
 
----Config-gated console print for the interaction/prop-swap path.
+---Console trace for the interaction/prop-swap path. cfg.Debug prints it at info so the switch
+---still works on its own; `setr ox:printlevel:sd-phone debug` reaches the same output live.
 local function dbg(fmt, ...)
-    if cfg.Debug then print(('[sd-phone:payphone] ' .. fmt):format(...)) end
+    local line = ('payphone: ' .. fmt):format(...)
+    if cfg.Debug then return lib.print.info(line) end
+    lib.print.debug(line)
 end
 
 ---Reverse model lookup for readable debug output.
@@ -92,15 +95,20 @@ for model, variant in pairs((cfg.Scene and cfg.Scene.AnimProps) or {}) do
     animVariants[joaat(model)] = variant
 end
 
+---Both ox_lib requests raise rather than returning, hence the pcalls. They also load in sequence
+---where the hand-rolled pair loaded side by side, so the 3s budget is carried between them rather
+---than handed to each: two 3s waits would stall the booth grab for six on a bad stream.
 ---@param variant string|nil animatable model to load alongside the dict, when swapping
 ---@return boolean loaded
 local function loadSceneAssets(variant)
     local scene = cfg.Scene
-    RequestAnimDict(scene.Dict)
-    if variant then RequestModel(joaat(variant)) end
     local deadline = GetGameTimer() + 3000
-    while (not HasAnimDictLoaded(scene.Dict) or (variant and not HasModelLoaded(joaat(variant)))) and GetGameTimer() < deadline do Wait(10) end
-    return HasAnimDictLoaded(scene.Dict) and (not variant or HasModelLoaded(joaat(variant)))
+
+    if not pcall(lib.requestAnimDict, scene.Dict, 3000) then return false end
+    if not variant then return true end
+
+    local left = deadline - GetGameTimer()
+    return left > 0 and pcall(lib.requestModel, joaat(variant), left)
 end
 
 ---Grabs the booth: hides the world prop, spawns our animatable copy over it, and plays the
@@ -130,7 +138,7 @@ local function beginBoothAnim(entity)
         return
     end
 
-    local ped    = PlayerPedId()
+    local ped    = cache.ped
     local booth  = GetEntityCoords(entity)
     local pos    = GetOffsetFromEntityInWorldCoords(entity, -0.10, -0.85, 0.0)
 
@@ -160,7 +168,7 @@ local function loopBoothAnim()
     local scene = cfg.Scene
     if not animEntity or not scene or scene.Enabled == false then return end
     if not HasAnimDictLoaded(scene.Dict) then return end
-    TaskPlayAnim(PlayerPedId(), scene.Dict, scene.Idle, 8.0, 8.0, -1, 1, 0, false, false, false)
+    TaskPlayAnim(cache.ped, scene.Dict, scene.Idle, 8.0, 8.0, -1, 1, 0, false, false, false)
 end
 
 ---Hangs the handset back up: exit clip on the ped, prop anim stopped, then our copy is
@@ -174,7 +182,7 @@ local function endBoothAnim()
     -- clearing tasks here would cancel whatever the player was actually doing.
     if not worldEntity and not animProp then return end
 
-    local ped = PlayerPedId()
+    local ped = cache.ped
     if scene and scene.Enabled ~= false and HasAnimDictLoaded(scene.Dict) and worldEntity then
         TaskPlayAnim(ped, scene.Dict, scene.Exit, 8.0, 8.0, -1, 1, 0, false, false, false)
         if animProp and DoesEntityExist(animProp) then
@@ -190,7 +198,7 @@ local function endBoothAnim()
         dbg('endBoothAnim cleanup: deleting prop=%s, restoring entity=%s', tostring(prop), tostring(worldEntity))
         if prop and DoesEntityExist(prop) then DeleteEntity(prop) end
         if worldEntity and DoesEntityExist(worldEntity) then SetEntityVisible(worldEntity, true, false) end
-        ClearPedTasks(PlayerPedId())
+        ClearPedTasks(cache.ped)
     end)
 end
 
@@ -469,7 +477,7 @@ end)
 RegisterNetEvent('sd-phone:client:payphone:ringStart', function(data)
     if not cfg.Enabled or not data or not data.location or not data.channel then return end
     local coords = coordsFromKey(data.location)
-    if not coords or #(GetEntityCoords(PlayerPedId()) - coords) > 50.0 then return end
+    if not coords or #(GetEntityCoords(cache.ped) - coords) > 50.0 then return end
 
     local entry = { coords = coords, location = data.location, soundId = nil }
     local booth = boothAt(coords)
@@ -542,7 +550,7 @@ end
 ---Public export: opens the payphone dial UI at the player's position (no booth prop needed),
 ---for any script that wants payphone calling - exports['sd-phone']:openPayphone().
 exports('openPayphone', function()
-    openPayphone(nil, GetEntityCoords(PlayerPedId()))
+    openPayphone(nil, GetEntityCoords(cache.ped))
 end)
 
 ---Public export: true while the payphone UI is up - exports['sd-phone']:isPayphoneOpen().

--- a/client/phonecam.lua
+++ b/client/phonecam.lua
@@ -197,14 +197,14 @@ end
 local function clearFaceCam()
     faceCam = false
     lastLookAt = 0
-    TaskClearLookAt(PlayerPedId())
+    TaskClearLookAt(cache.ped)
 end
 
 ---Places the lens for this frame. When the body is free to turn the player faces whatever the lens
 ---is aimed at, so bystanders see them point the phone at what they are shooting; when it is pinned,
 ---seated or locked, the lens swings off the body within a limit instead.
 local function place()
-    local ped    = PlayerPedId()
+    local ped    = cache.ped
     local view   = GetGameplayCamRot(2)
     local head   = GetPedBoneCoords(ped, HEAD_BONE, 0.0, 0.0, 0.0)
     -- Seated and locked are the same constraint: the body is not going to turn, so the lens has to.

--- a/client/pose.lua
+++ b/client/pose.lua
@@ -68,6 +68,8 @@ local color = config.Phone.DefaultColor or 'black'
 local prop
 ---@type boolean True while a text field in the phone has focus
 local typing = false
+---@type table<integer, true> Prop models this client has already failed to stream.
+local unavailableModels = {}
 
 ---Whether our pose applies: the phone is out (or the torch is lit), and the native cell cam is not
 ---the one framing. That native animates its own pose and spawns its own phone, so ours stands down
@@ -81,7 +83,11 @@ end
 
 ---The clip that should be held right now. Every caller reads the pose through this, so adding a
 ---clip can never leave the watchdog hunting for one the player was never given.
----@return { dict: string, anim: string, blendIn: number, blendOut: number }
+---
+---The vehicle test stays a native rather than `cache.vehicle`: the `true` argument counts a ped
+---climbing in, and the cache only fills once they are seated. Swapping the clip on the way in is
+---the point of asking.
+---@return { dict: string, anim: string, blendIn: number, blendOut: number, flags: integer }
 local function currentClip()
     -- One camera pose covers both lenses: the native cell cam swapped pose on flip, but no
     -- outward-facing clip outside that native is verified to exist. Landscape is the exception:
@@ -92,7 +98,7 @@ local function currentClip()
     elseif typing then
         action = "typing"
     end
-    return CLIPS[action][IsPedInAnyVehicle(PlayerPedId(), true) and 'inCar' or 'onFoot']
+    return CLIPS[action][IsPedInAnyVehicle(cache.ped, true) and 'inCar' or 'onFoot']
 end
 
 ---Where the prop sits in the hand. Landscape lays the phone on its side for the wide viewfinder.
@@ -108,16 +114,26 @@ end
 
 ---Creates a colour-matched local phone prop, disables its collision, and rigidly welds it to the
 ---ped's hand bone.
+---
+---lib.requestModel raises rather than returning on a bad or slow model, and it runs the
+---IsModelValid / IsModelInCdimage pre-check itself, so one pcall covers both failures. The result
+---is memoised because a server running no phone props would otherwise retry on every re-weld, and
+---the model is released on the failure path too, or that branch leaks a streaming reference each
+---time it is taken.
 ---@param ped integer ped to attach the prop to
 ---@param frame string frame colour; must be a key of FRAME_COLORS
 ---@param wide boolean|nil weld it in the landscape grip
 ---@return integer? prop the welded prop entity, or nil if the model wouldn't stream
 function pose.createProp(ped, frame, wide)
     local model = joaat(config.Phone.PropPrefix .. frame)
-    RequestModel(model)
-    local started = GetGameTimer()
-    while not HasModelLoaded(model) and GetGameTimer() - started < 1000 do Wait(0) end
-    if not HasModelLoaded(model) then return nil end
+    if unavailableModels[model] then return nil end
+
+    if not pcall(lib.requestModel, model, 1000) then
+        SetModelAsNoLongerNeeded(model)
+        unavailableModels[model] = true
+        return nil
+    end
+
     local coords = GetEntityCoords(ped)
     local obj = CreateObject(model, coords.x, coords.y, coords.z, false, true, true)
     SetEntityCollision(obj, false, false)
@@ -144,18 +160,28 @@ end
 
 ---Plays the clip the current action calls for and welds the prop, on its own thread: the pose is
 ---cosmetic and must never gate the phone opening.
+---
+---lib.requestAnimDict rather than lib.playAnim, which would load, play and release in one call and
+---forfeit the shouldHold re-check: the load yields, and a phone closed during it must not be
+---answered with a clip that then has to be stopped again. The dict goes back as soon as the task
+---has it, since the task holds its own reference; the hand-rolled path never released and leaked
+---one per clip for the session.
 local function play()
     CreateThread(function()
         local clip = currentClip()
-        RequestAnimDict(clip.dict)
-        local started = GetGameTimer()
-        while not HasAnimDictLoaded(clip.dict) and GetGameTimer() - started < 1000 do Wait(0) end
-        -- The player may have closed the phone, or the native cam taken the pose, during the load.
-        if not pose.shouldHold() then return end
-        local ped = PlayerPedId()
+
+        if not pcall(lib.requestAnimDict, clip.dict, 1000) then return end
+        if not pose.shouldHold() then
+            RemoveAnimDict(clip.dict)
+            return
+        end
+
+        local ped = cache.ped
         if not IsEntityPlayingAnim(ped, clip.dict, clip.anim, 3) then
             TaskPlayAnim(ped, clip.dict, clip.anim, clip.blendIn, clip.blendOut, -1, clip.flags, 0.0, false, false, false)
         end
+        RemoveAnimDict(clip.dict)
+
         attachProp(ped)
     end)
 end
@@ -163,7 +189,7 @@ end
 ---Stops whichever of our clips is playing and removes the prop. Every clip is checked because
 ---entering the viewfinder or a vehicle swaps which one is up.
 function pose.stop()
-    local ped = PlayerPedId()
+    local ped = cache.ped
     for _, contexts in pairs(CLIPS) do
         for _, clip in pairs(contexts) do
             if IsEntityPlayingAnim(ped, clip.dict, clip.anim, 3) then
@@ -190,7 +216,7 @@ end
 function pose.reweld()
     if not pose.shouldHold() then return end
     pose.removeProp()
-    attachProp(PlayerPedId())
+    attachProp(cache.ped)
 end
 
 ---Turns the phone on its side for the landscape viewfinder, or stands it back up. Swaps the held
@@ -219,13 +245,22 @@ end
 CreateThread(function()
     while true do
         if phonecam.rearActive() then
-            SetEntityLocallyInvisible(PlayerPedId())
+            SetEntityLocallyInvisible(cache.ped)
             if prop and DoesEntityExist(prop) then SetEntityLocallyInvisible(prop) end
             Wait(0)
         else
             Wait(200)
         end
     end
+end)
+
+-- A respawn or a ped-model change hands the player a NEW ped, and the prop is still welded to the
+-- old one, which the game does not necessarily delete. The clip re-applies itself on the watchdog
+-- below, but the orphaned prop never would: nothing else ever reads that handle again. ox_lib
+-- already tracks the ped for `cache.ped`, so this subscribes to the change rather than adding a poll.
+lib.onCache('ped', function()
+    pose.removeProp()
+    if pose.shouldHold() then play() end
 end)
 
 -- Re-applies the held clip on a 500ms poll if the game clears it. Movement is what clears it: an
@@ -235,7 +270,7 @@ CreateThread(function()
     while true do
         if pose.shouldHold() then
             local clip = currentClip()
-            if not IsEntityPlayingAnim(PlayerPedId(), clip.dict, clip.anim, 3) then
+            if not IsEntityPlayingAnim(cache.ped, clip.dict, clip.anim, 3) then
                 play()
             end
         end

--- a/client/racing/board.lua
+++ b/client/racing/board.lua
@@ -91,7 +91,7 @@ end
 
 ---@return number|nil hash joaat of the vehicle the player is in, nil on foot
 local function currentModel()
-    local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+    local vehicle = GetVehiclePedIsIn(cache.ped, false)
     if vehicle == 0 then return nil end
     return GetEntityModel(vehicle)
 end
@@ -138,7 +138,7 @@ end
 ---@param entry table board
 ---@return string verdict one of ready, vehicle, turn, backup
 local function readiness(entry)
-    local ped = PlayerPedId()
+    local ped = cache.ped
     if GetVehiclePedIsIn(ped, false) == 0 then return 'vehicle' end
 
     local start = entry.start
@@ -214,7 +214,7 @@ local function drawLoop()
                     SendNUIMessage({ action = 'sd-phone:racing:board:hide' })
                 end
             else
-                local here = GetEntityCoords(PlayerPedId())
+                local here = GetEntityCoords(cache.ped)
                 local entry, distance = nearest(here)
 
                 if entry and distance <= SHOW_DIST then
@@ -270,7 +270,7 @@ local function readyLoop()
 
             local mine = nil
             if not race.active() then
-                local here = GetEntityCoords(PlayerPedId())
+                local here = GetEntityCoords(cache.ped)
                 for i = 1, #Boards do
                     local entry = Boards[i]
                     local start = entry.start

--- a/client/racing/creator.lua
+++ b/client/racing/creator.lua
@@ -82,7 +82,7 @@ end
 ---either side, gateWidth apart, both snapped to the ground.
 ---@return { a: vector3, b: vector3 } gate
 local function currentGate()
-    local ped = PlayerPedId()
+    local ped = cache.ped
     local veh = GetVehiclePedIsIn(ped, false)
     local ent = veh ~= 0 and veh or ped
     local pos = GetEntityCoords(ent)
@@ -269,7 +269,7 @@ local function startCreator()
             local ghost = currentGate()
             drawGatePosts(ghost.a, ghost.b, 80, 230, 140, 110)
 
-            local at = GetEntityCoords(PlayerPedId())
+            local at = GetEntityCoords(cache.ped)
             local previous
             for i = 1, #gates do
                 local gate   = gates[i]

--- a/client/racing/creator.lua
+++ b/client/racing/creator.lua
@@ -19,6 +19,9 @@ local TITLE       = 'Racing'
 local FLAG_MODEL  = joaat(type(CREATOR_CFG.FlagModel) == 'string' and CREATOR_CFG.FlagModel or 'prop_beachflag_01')
 ---@type integer Alpha of a placed flag: transparent, not invisible, so gates read as guides.
 local FLAG_ALPHA  = 130
+---@type integer Milliseconds allowed for the flag prop to stream, matching race.lua's MODEL_BUDGET
+---for the same prop. Named rather than inlined so the two stay visibly paired.
+local MODEL_BUDGET <const> = 3000
 ---@type integer Fewest gates a saveable track may hold.
 local MIN_GATES   = math.max(2, math.floor(tonumber(CREATOR_CFG.MinGates) or 2))
 ---@type integer Most gates one track may hold.
@@ -240,12 +243,28 @@ end
 
 ---Opens the recorder and runs the per-frame loop: keys, the ghost gate, the placed gates, and the
 ---key guide.
+---
+---lib.requestModel runs its own validity pre-check and raises on both that and the timeout, so the
+---pcall keeps a bad FlagModel in configs/racing.lua from aborting the open with the recorder already
+---flagged active and no draw thread behind it. The flag is claimed before the streaming wait so a
+---second toggle closes the recorder instead of starting a rival one, and is released again on the
+---failure path.
 local function startCreator()
     if active then return end
     active = true
     gates = {}
     gateWidth = DEF_WIDTH
-    lib.requestModel(FLAG_MODEL)
+
+    if not pcall(lib.requestModel, FLAG_MODEL, MODEL_BUDGET) then
+        active = false
+        notify.show({
+            title = TITLE,
+            description = 'The gate flag prop could not be loaded.',
+            type = 'error',
+        })
+        return
+    end
+
     notify.show({
         title = TITLE,
         description = 'Track creator open. Drive to a start line and press E.',

--- a/client/racing/creator.lua
+++ b/client/racing/creator.lua
@@ -31,7 +31,7 @@ local MIN_WIDTH   = tonumber(CREATOR_CFG.MinWidth) or 2.0
 ---@type number Widest gate, in metres.
 local MAX_WIDTH   = math.max(tonumber(CREATOR_CFG.MaxWidth) or 50.0, MIN_WIDTH)
 ---@type number Width the recorder opens at, in metres.
-local DEF_WIDTH   = math.min(MAX_WIDTH, math.max(MIN_WIDTH, tonumber(CREATOR_CFG.DefaultWidth) or 12.0))
+local DEF_WIDTH   = lib.math.clamp(tonumber(CREATOR_CFG.DefaultWidth) or 12.0, MIN_WIDTH, MAX_WIDTH)
 ---@type number Metres of width gained or lost per frame while an arrow key is held.
 local WIDTH_STEP  = tonumber(CREATOR_CFG.WidthStep) or 0.15
 ---@type number Metres past which a placed gate stops being drawn.
@@ -62,7 +62,7 @@ local gateWidth = DEF_WIDTH
 ---@param value number
 ---@return number rounded two decimals, which keeps the stored gate JSON compact
 local function round2(value)
-    return math.floor(value * 100 + 0.5) / 100
+    return lib.math.round(value, 2)
 end
 
 ---Ground height at a point near the caller's own z. The probe traces downward from where it

--- a/client/racing/markers.lua
+++ b/client/racing/markers.lua
@@ -78,7 +78,7 @@ local function billboard(target, coords, label, primary)
 
     return {
         label = label,
-        dist  = math.floor(dist + 0.5),
+        dist  = lib.math.round(dist),
         x     = sx,
         y     = sy,
         stem  = stem,

--- a/client/racing/race.lua
+++ b/client/racing/race.lua
@@ -171,7 +171,7 @@ end
 ---decides the class from it; the client never names a class the server has to trust.
 ---@return integer hash
 function race.currentModelHash()
-    local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+    local vehicle = GetVehiclePedIsIn(cache.ped, false)
     return vehicle ~= 0 and GetEntityModel(vehicle) or 0
 end
 
@@ -180,7 +180,7 @@ end
 ---@return string class one of 'D' | 'C' | 'B' | 'A' | 'S'
 function race.currentClass()
     local fallback = vehicleCfg.Default or 'D'
-    local vehicle  = GetVehiclePedIsIn(PlayerPedId(), false)
+    local vehicle  = GetVehiclePedIsIn(cache.ped, false)
     if vehicle == 0 then return fallback end
 
     local override = CLASS_BY_MODEL[GetEntityModel(vehicle)]
@@ -191,7 +191,7 @@ end
 ---Display name of the vehicle the player is in.
 ---@return string label
 function race.currentVehicleLabel()
-    local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+    local vehicle = GetVehiclePedIsIn(cache.ped, false)
     if vehicle == 0 then return 'On Foot' end
 
     local display = GetDisplayNameFromVehicleModel(GetEntityModel(vehicle))
@@ -260,19 +260,14 @@ end
 
 ---Streams the gate prop in, giving up after the budget rather than holding the grid on a model that
 ---is not coming.
+---
+---lib.requestModel runs its own validity pre-check and raises on both that and the timeout, so the
+---pcall covers what the IsModelValid guard and the poll did between them.
 ---@return integer|nil hash model hash, or nil when it did not load
 local function ensureGateModel()
     local hash = joaat(GATE_PROP)
-    if not IsModelValid(hash) then return nil end
-    if HasModelLoaded(hash) then return hash end
-
-    RequestModel(hash)
-    local waited = 0
-    while not HasModelLoaded(hash) and waited < MODEL_BUDGET do
-        Wait(20)
-        waited = waited + 20
-    end
-    return HasModelLoaded(hash) and hash or nil
+    if not pcall(lib.requestModel, hash, MODEL_BUDGET) then return nil end
+    return hash
 end
 
 ---Plants a frozen stack of gate props at one gate edge.
@@ -350,7 +345,7 @@ local function startForcedCamera(mode)
                 SetCinematicModeActive(false)
             end
 
-            if GetVehiclePedIsIn(PlayerPedId(), false) ~= 0 then
+            if GetVehiclePedIsIn(cache.ped, false) ~= 0 then
                 local view = GetFollowVehicleCamViewMode()
                 if forcedCamera == 'first' then
                     if view ~= CAM_FIRST_PERSON then SetFollowVehicleCamViewMode(CAM_FIRST_PERSON) end
@@ -396,12 +391,12 @@ local function startPhasing(data)
         while active and active.id == data.id do
             if endsAt and GetGameTimer() >= endsAt then expired = true break end
 
-            local myPed = PlayerPedId()
+            local myPed = cache.ped
             local myVeh = GetVehiclePedIsIn(myPed, false)
 
             for _, serverId in ipairs(racers) do
                 local player = GetPlayerFromServerId(serverId)
-                if player ~= -1 and player ~= PlayerId() then
+                if player ~= -1 and player ~= cache.playerId then
                     local ped = GetPlayerPed(player)
                     if ped and ped > 0 and DoesEntityExist(ped) then
                         local veh = GetVehiclePedIsIn(ped, false)
@@ -529,7 +524,7 @@ end
 local function runLoop(state)
     CreateThread(function()
         while active and active.id == state.id do
-            local ped = PlayerPedId()
+            local ped = cache.ped
             if IsEntityDead(ped) then
                 race.stop(false)
                 break
@@ -601,7 +596,7 @@ function race.begin(data)
     local mine = epoch
 
     CreateThread(function()
-        local ped     = PlayerPedId()
+        local ped     = cache.ped
         local vehicle = GetVehiclePedIsIn(ped, false)
         local held    = vehicle ~= 0 and vehicle or ped
 

--- a/client/racing/race.lua
+++ b/client/racing/race.lua
@@ -123,7 +123,7 @@ local function merge(settings)
 
         local scale = tonumber(settings.scale)
         if scale then
-            hud.scale = math.min(HUD_SCALE_MAX, math.max(HUD_SCALE_MIN, scale))
+            hud.scale = lib.math.clamp(scale, HUD_SCALE_MIN, HUD_SCALE_MAX)
         end
     end
     markers.setStyle(hud.checkpointColor, hud.closestColor, hud.inAirWaypoints)
@@ -446,7 +446,7 @@ local function pushState(state)
         totalLaps         = state.totalLaps,
         cp                = math.min(state.current, state.cpPerLap),
         cpTotal           = state.cpPerLap,
-        progress          = math.floor((state.doneCount / math.max(1, state.cpPerLap * state.totalLaps)) * 100 + 0.5),
+        progress          = lib.math.round((state.doneCount / math.max(1, state.cpPerLap * state.totalLaps)) * 100),
         bestLapMs         = state.bestLapMs,
         lapStartElapsedMs = state.lapStartedAt - state.startedAt,
         sectors           = sectors,

--- a/client/service.lua
+++ b/client/service.lua
@@ -83,7 +83,7 @@ end
 ---and no messages at all.
 ---@param force boolean|nil push even when nothing changed (used on open)
 local function refresh(force)
-    local pos = GetEntityCoords(PlayerPedId())
+    local pos = GetEntityCoords(cache.ped)
     local level = celltowers.level(pos.x, pos.y, TOWERS)
     local bars  = celltowers.bars(level, CUTOFFS)
     local data  = celltowers.allows(level, 'data', THRESHOLDS)

--- a/client/wifi.lua
+++ b/client/wifi.lua
@@ -217,7 +217,7 @@ function wifiClient.connect(id, password)
 
     joined = net
     declined[net.id] = nil
-    local pos = GetEntityCoords(PlayerPedId())
+    local pos = GetEntityCoords(cache.ped)
     joinedStrength = wifi.strength(pos.x, pos.y, pos.z, net)
     remembered[net.id] = supplied or true
     push(true)
@@ -254,7 +254,7 @@ function refresh(force)
         return
     end
 
-    local pos = GetEntityCoords(PlayerPedId())
+    local pos = GetEntityCoords(cache.ped)
     scanned = wifi.scan(pos.x, pos.y, pos.z, NETWORKS, DROP_BELOW)
     local inReach = {}
     for i = 1, #scanned do

--- a/server/admin/store.lua
+++ b/server/admin/store.lua
@@ -785,7 +785,7 @@ function store.listContent(app, cursor, limit, query)
             label     = r.room_id and ('#' .. r.room_id .. ' as ' .. tostring(r.author))
                 or (r.author and ('@' .. r.author))
                 or (r.username and ('@' .. r.username .. (r.name and (' · ' .. r.name .. ', ' .. tostring(r.age)) or '')))
-                or (r.conversation and ((r.conversation:sub(1, 2) == 'g-') and ('group ' .. r.conversation) or ('to ' .. util.formatNumber(r.conversation))))
+                or (r.conversation and ((lib.string.startsWith(r.conversation, 'g-')) and ('group ' .. r.conversation) or ('to ' .. util.formatNumber(r.conversation))))
                 or nil,
         }
     end

--- a/server/admin/wipe.lua
+++ b/server/admin/wipe.lua
@@ -216,4 +216,100 @@ lib.addCommand('wipemyphone', {
     })
 end)
 
-return { wipeCid = wipeCid }
+---Deletes only the login identities one character owns, leaving the rest of their phone intact.
+---
+---Narrower than wipeCid on purpose, and safer in the one place wipeCid is not: an account another
+---character is still signed into is SKIPPED rather than deleted, because both of these are shared
+---objects. A mail account carries its own messages in the row, so removing it is self-contained;
+---an app account is only reachable through phone_app_sessions, so ownership is "nobody else holds
+---a session". App CONTENT keyed to the handle (posts, photos, matches) is deliberately left alone
+---so this stays predictable; /wipemyphone is the full reset.
+---@param cid string|nil citizenid whose accounts are removed
+---@return table|nil result { mail: string[], apps: string[], skipped: string[] }, nil when unresolvable
+local function wipeAccountsFor(cid)
+    if not cid or cid == '' then return nil end
+
+    local result = { mail = {}, apps = {}, skipped = {} }
+
+    local mails = MySQL.query.await(
+        'SELECT email, logged_in_citizens FROM phone_mail_accounts WHERE created_by_cid = ?', { cid }) or {}
+    for _, m in ipairs(mails) do
+        local signedIn = json.decode(m.logged_in_citizens or '[]') or {}
+        local others = 0
+        for _, c in ipairs(signedIn) do if c ~= cid then others = others + 1 end end
+
+        if others > 0 then
+            result.skipped[#result.skipped + 1] = ('%s (%d other session(s))'):format(m.email, others)
+        else
+            del('DELETE FROM phone_mail_sessions WHERE email = ?', { m.email })
+            del('DELETE FROM phone_mail_accounts WHERE email = ?', { m.email })
+            result.mail[#result.mail + 1] = m.email
+        end
+    end
+
+    local sessions = MySQL.query.await([[
+        SELECT s.account_id, s.app, a.username
+        FROM phone_app_sessions s
+        JOIN phone_app_accounts a ON a.id = s.account_id
+        WHERE s.citizenid = ?
+    ]], { cid }) or {}
+    for _, s in ipairs(sessions) do
+        local shared = tonumber(MySQL.scalar.await(
+            'SELECT COUNT(*) FROM phone_app_sessions WHERE account_id = ? AND citizenid <> ?',
+            { s.account_id, cid })) or 0
+
+        if shared > 0 then
+            result.skipped[#result.skipped + 1] = ('%s:%s (%d other session(s))'):format(s.app, s.username, shared)
+        else
+            del('DELETE FROM phone_app_accounts WHERE id = ?', { s.account_id })
+            result.apps[#result.apps + 1] = ('%s:%s'):format(s.app, s.username)
+        end
+    end
+
+    del('DELETE FROM phone_app_sessions WHERE citizenid = ?', { cid })
+
+    return result
+end
+
+---/wipemyaccounts: deletes the caller's OWN mail and app accounts, then refreshes their phone so
+---the apps drop back to their signed-out state. Console is refused, since the command resolves the
+---target from the caller's own character and there is none behind the console.
+---
+---Restricted to group.admin to match /wipemyphone. Drop the `restricted` field to let any player
+---clear their own accounts, which is safe: the target is always the caller.
+---@param source integer player server id
+lib.addCommand('wipemyaccounts', {
+    help = 'Delete YOUR OWN mail and app accounts (logins only, not your phone settings or content).',
+    restricted = 'group.admin',
+}, function(source)
+    if not source or source <= 0 then
+        lib.print.error('wipemyaccounts must be run by a player, not the console.')
+        return
+    end
+
+    local cid = player.getIdentifier(source)
+    local result = cid and wipeAccountsFor(cid)
+    if not result then
+        TriggerClientEvent('ox_lib:notify', source, {
+            title = 'Phone', description = 'Could not resolve your character.', type = 'error',
+        })
+        return
+    end
+
+    local removed = #result.mail + #result.apps
+    TriggerClientEvent('sd-phone:client:profileReset', source)
+
+    lib.print.info(('wiped %d account(s) for %s%s'):format(
+        removed, cid,
+        #result.skipped > 0 and (', skipped ' .. table.concat(result.skipped, ', ')) or ''))
+
+    TriggerClientEvent('ox_lib:notify', source, {
+        title = 'Accounts cleared',
+        description = removed > 0
+            and ('Removed %d account(s). Reopen the phone to sign in fresh.'):format(removed)
+            or 'You had no accounts of your own to remove.',
+        type = removed > 0 and 'success' or 'inform',
+    })
+end)
+
+return { wipeCid = wipeCid, wipeAccountsFor = wipeAccountsFor }

--- a/server/admin/wipe.lua
+++ b/server/admin/wipe.lua
@@ -220,10 +220,17 @@ end)
 ---
 ---Narrower than wipeCid on purpose, and safer in the one place wipeCid is not: an account another
 ---character is still signed into is SKIPPED rather than deleted, because both of these are shared
----objects. A mail account carries its own messages in the row, so removing it is self-contained;
----an app account is only reachable through phone_app_sessions, so ownership is "nobody else holds
----a session". App CONTENT keyed to the handle (posts, photos, matches) is deliberately left alone
----so this stays predictable; /wipemyphone is the full reset.
+---objects.
+---
+---Ownership is read from the creator COLUMN on both tables, never inferred from a session. Signing
+---out drops the session row, so a session join finds nothing and would leave the account behind
+---forever while it still counts against the per-app cap - which is the whole reason a signed-out
+---account looks unwipeable. phone_app_accounts.created_by is added by util.ensureColumns rather
+---than the CREATE TABLE, so it is easy to miss when reading the schema. Sessions are still unioned
+---in, to catch an account this character uses but did not create.
+---
+---App CONTENT keyed to the handle (posts, photos, matches) is deliberately left alone so this stays
+---predictable; /wipemyphone is the full reset.
 ---@param cid string|nil citizenid whose accounts are removed
 ---@return table|nil result { mail: string[], apps: string[], skipped: string[] }, nil when unresolvable
 local function wipeAccountsFor(cid)
@@ -247,22 +254,25 @@ local function wipeAccountsFor(cid)
         end
     end
 
-    local sessions = MySQL.query.await([[
-        SELECT s.account_id, s.app, a.username
+    local apps = MySQL.query.await([[
+        SELECT id, app, username FROM phone_app_accounts WHERE created_by = ?
+        UNION
+        SELECT a.id, a.app, a.username
         FROM phone_app_sessions s
         JOIN phone_app_accounts a ON a.id = s.account_id
         WHERE s.citizenid = ?
-    ]], { cid }) or {}
-    for _, s in ipairs(sessions) do
+    ]], { cid, cid }) or {}
+    for _, a in ipairs(apps) do
         local shared = tonumber(MySQL.scalar.await(
             'SELECT COUNT(*) FROM phone_app_sessions WHERE account_id = ? AND citizenid <> ?',
-            { s.account_id, cid })) or 0
+            { a.id, cid })) or 0
 
         if shared > 0 then
-            result.skipped[#result.skipped + 1] = ('%s:%s (%d other session(s))'):format(s.app, s.username, shared)
+            result.skipped[#result.skipped + 1] = ('%s:%s (%d other session(s))'):format(a.app, a.username, shared)
         else
-            del('DELETE FROM phone_app_accounts WHERE id = ?', { s.account_id })
-            result.apps[#result.apps + 1] = ('%s:%s'):format(s.app, s.username)
+            del('DELETE FROM phone_app_sessions WHERE account_id = ?', { a.id })
+            del('DELETE FROM phone_app_accounts WHERE id = ?', { a.id })
+            result.apps[#result.apps + 1] = ('%s:%s'):format(a.app, a.username)
         end
     end
 

--- a/server/birdy/actions.lua
+++ b/server/birdy/actions.lua
@@ -470,7 +470,7 @@ function actions.updateProfile(source, payload)
 
     local function imageUrl(v, fallback)
         local u = trimmed(v)
-        if u and u:sub(1, 4) == 'http' then return u:sub(1, 512) end
+        if u and lib.string.startsWith(u, 'http') then return u:sub(1, 512) end
         if v == false then return nil end
         return fallback
     end
@@ -949,13 +949,13 @@ local function sanitizeDmMeta(kind, payload)
         meta.amount = math.max(0, math.floor(amount))
         if payload.requested == true then meta.requested = true end
     elseif kind == 'voice' then
-        meta.duration = math.max(0, math.min(36000, math.floor(tonumber(payload.duration) or 0)))
+        meta.duration = lib.math.clamp(math.floor(tonumber(payload.duration) or 0), 0, 36000)
         local audio = trimmed(payload.audioUrl) or ''
         if audio ~= '' then meta.audio = audio:sub(1, 512) end
         if type(payload.waveform) == 'table' then
             local bars = {}
             for i = 1, math.min(#payload.waveform, 64) do
-                bars[i] = math.max(0, math.min(100, math.floor(tonumber(payload.waveform[i]) or 0)))
+                bars[i] = lib.math.clamp(math.floor(tonumber(payload.waveform[i]) or 0), 0, 100)
             end
             if #bars > 0 then meta.waveform = bars end
         end

--- a/server/birdy/actions.lua
+++ b/server/birdy/actions.lua
@@ -656,8 +656,8 @@ function actions.create(source, payload)
         for _, src in ipairs(sourcesFor(handle, activeSrcs)) do targets[#targets + 1] = src end
     end
 
-    lib.triggerClientEvent('sd-phone:client:birdy:notification', targets, {})
-    lib.triggerClientEvent('sd-phone:client:notify', targets, {
+    util.pushMany('sd-phone:client:birdy:notification', targets, {})
+    util.pushMany('sd-phone:client:notify', targets, {
         app = 'birdy', appId = 'birdy', title = 'Squawk',
         body = ('%s posted: %s'):format(prof.displayName, preview),
         time = 'now', quietInApp = true,

--- a/server/birdy/actions.lua
+++ b/server/birdy/actions.lua
@@ -651,17 +651,19 @@ function actions.create(source, payload)
     -- One pass over the connected players for the whole fan-out; this resolved each follower
     -- separately, and every resolution re-scanned every player on the server.
     local activeSrcs = player.activeCidMap()
+    local targets = {}
     for _, handle in ipairs(followers) do
-        for _, src in ipairs(sourcesFor(handle, activeSrcs)) do
-            TriggerClientEvent('sd-phone:client:birdy:notification', src, {})
-            TriggerClientEvent('sd-phone:client:notify', src, {
-                app = 'birdy', appId = 'birdy', title = 'Squawk',
-                body = ('%s posted: %s'):format(prof.displayName, preview),
-                time = 'now', quietInApp = true,
-            })
-            badges.pushApp(src, 'birdy')
-        end
+        for _, src in ipairs(sourcesFor(handle, activeSrcs)) do targets[#targets + 1] = src end
     end
+
+    lib.triggerClientEvent('sd-phone:client:birdy:notification', targets, {})
+    lib.triggerClientEvent('sd-phone:client:notify', targets, {
+        app = 'birdy', appId = 'birdy', title = 'Squawk',
+        body = ('%s posted: %s'):format(prof.displayName, preview),
+        time = 'now', quietInApp = true,
+    })
+
+    for _, src in ipairs(targets) do badges.pushApp(src, 'birdy') end
 
     return ok({ post = serializePost(store.getPost(id, prof.handle)) })
 end

--- a/server/birdy/init.lua
+++ b/server/birdy/init.lua
@@ -27,9 +27,7 @@ end)
 ---@param payload any
 local function pushTo(handle, event, payload)
     if not handle then return end
-    for _, src in ipairs(actions.sourcesFor(handle)) do
-        TriggerClientEvent(event, src, payload)
-    end
+    lib.triggerClientEvent(event, actions.sourcesFor(handle), payload)
 end
 
 ---Forwards an action result, pinging the `notify` account (wherever it is open) with a

--- a/server/birdy/init.lua
+++ b/server/birdy/init.lua
@@ -27,7 +27,7 @@ end)
 ---@param payload any
 local function pushTo(handle, event, payload)
     if not handle then return end
-    lib.triggerClientEvent(event, actions.sourcesFor(handle), payload)
+    util.pushMany(event, actions.sourcesFor(handle), payload)
 end
 
 ---Forwards an action result, pinging the `notify` account (wherever it is open) with a

--- a/server/cherry/actions.lua
+++ b/server/cherry/actions.lua
@@ -335,7 +335,7 @@ function actions.saveProfile(src, payload)
     -- Push the fresh card to matched partners so their app doesn't keep the old photo.
     local card = partnerCard(acc.username, store.getProfile(acc.username))
     for _, m in ipairs(store.matchesFor(acc.username)) do
-        lib.triggerClientEvent('sd-phone:client:cherry:partner', sourcesFor(partnerOf(m, acc.username)),
+        util.pushMany('sd-phone:client:cherry:partner', sourcesFor(partnerOf(m, acc.username)),
             { username = acc.username, partner = card })
     end
 
@@ -369,7 +369,7 @@ function actions.swipe(src, payload)
 
     if not existing then
         local matched = sourcesFor(target)
-        lib.triggerClientEvent('sd-phone:client:cherry:match', matched, serializeMatch(matchRow, target))
+        util.pushMany('sd-phone:client:cherry:match', matched, serializeMatch(matchRow, target))
         for _, tsrc in ipairs(matched) do
             if not watchers[tsrc] then
                 notify(tsrc, ("It's a match! You and %s liked each other."):format(partnerCard(acc.username).name))
@@ -474,7 +474,7 @@ function actions.send(src, payload)
     local msg = serializeMessage(store.getMessage(id), acc.username)
     local myName = partnerCard(acc.username).name
     local peers = sourcesFor(partner)
-    lib.triggerClientEvent('sd-phone:client:cherry:message', peers, { matchId = m.id, message = msg })
+    util.pushMany('sd-phone:client:cherry:message', peers, { matchId = m.id, message = msg })
     for _, tsrc in ipairs(peers) do
         notify(tsrc, ('%s: %s'):format(myName, previewFor(kind, body, meta)))
     end

--- a/server/cherry/actions.lua
+++ b/server/cherry/actions.lua
@@ -205,16 +205,16 @@ local function sanitizeMeta(kind, payload)
     elseif kind == 'money' then
         local amount = tonumber(payload.amount) or 0
         if amount ~= amount or amount == math.huge or amount == -math.huge then amount = 0 end
-        meta.amount = math.max(0, math.min(1000000000, math.floor(amount)))
+        meta.amount = lib.math.clamp(math.floor(amount), 0, 1000000000)
         if payload.requested == true then meta.requested = true end
     elseif kind == 'voice' then
-        meta.duration = math.max(0, math.min(36000, math.floor(tonumber(payload.duration) or 0)))
+        meta.duration = lib.math.clamp(math.floor(tonumber(payload.duration) or 0), 0, 36000)
         local audio = trim(payload.audioUrl)
         if audio ~= '' then meta.audio = audio:sub(1, 512) end
         if type(payload.waveform) == 'table' then
             local bars = {}
             for i = 1, math.min(#payload.waveform, 64) do
-                bars[i] = math.max(0, math.min(100, math.floor(tonumber(payload.waveform[i]) or 0)))
+                bars[i] = lib.math.clamp(math.floor(tonumber(payload.waveform[i]) or 0), 0, 100)
             end
             if #bars > 0 then meta.waveform = bars end
         end
@@ -318,13 +318,13 @@ function actions.saveProfile(src, payload)
     if type(payload.photos) == 'table' then
         for i = 1, math.min(#payload.photos, 6) do
             local url = trim(payload.photos[i])
-            if url:sub(1, 4) == 'http' then photos[#photos + 1] = url:sub(1, 512) end
+            if lib.string.startsWith(url, 'http') then photos[#photos + 1] = url:sub(1, 512) end
         end
     end
 
     store.upsertProfile(acc.username, {
         name       = name,
-        age        = math.max(18, math.min(99, math.floor(tonumber(payload.age) or 21))),
+        age        = lib.math.clamp(math.floor(tonumber(payload.age) or 21), 18, 99),
         about      = trim(payload.about):sub(1, 300),
         gender     = GENDERS[payload.gender] and payload.gender or 'Man',
         interested = INTERESTS[payload.interestedIn] and payload.interestedIn or 'Everyone',

--- a/server/cherry/actions.lua
+++ b/server/cherry/actions.lua
@@ -335,9 +335,8 @@ function actions.saveProfile(src, payload)
     -- Push the fresh card to matched partners so their app doesn't keep the old photo.
     local card = partnerCard(acc.username, store.getProfile(acc.username))
     for _, m in ipairs(store.matchesFor(acc.username)) do
-        for _, tsrc in ipairs(sourcesFor(partnerOf(m, acc.username))) do
-            TriggerClientEvent('sd-phone:client:cherry:partner', tsrc, { username = acc.username, partner = card })
-        end
+        lib.triggerClientEvent('sd-phone:client:cherry:partner', sourcesFor(partnerOf(m, acc.username)),
+            { username = acc.username, partner = card })
     end
 
     return ok(serializeProfile(store.getProfile(acc.username)))
@@ -369,8 +368,9 @@ function actions.swipe(src, payload)
     local matchRow = store.getMatch(matchId)
 
     if not existing then
-        for _, tsrc in ipairs(sourcesFor(target)) do
-            TriggerClientEvent('sd-phone:client:cherry:match', tsrc, serializeMatch(matchRow, target))
+        local matched = sourcesFor(target)
+        lib.triggerClientEvent('sd-phone:client:cherry:match', matched, serializeMatch(matchRow, target))
+        for _, tsrc in ipairs(matched) do
             if not watchers[tsrc] then
                 notify(tsrc, ("It's a match! You and %s liked each other."):format(partnerCard(acc.username).name))
             end
@@ -473,8 +473,9 @@ function actions.send(src, payload)
 
     local msg = serializeMessage(store.getMessage(id), acc.username)
     local myName = partnerCard(acc.username).name
-    for _, tsrc in ipairs(sourcesFor(partner)) do
-        TriggerClientEvent('sd-phone:client:cherry:message', tsrc, { matchId = m.id, message = msg })
+    local peers = sourcesFor(partner)
+    lib.triggerClientEvent('sd-phone:client:cherry:message', peers, { matchId = m.id, message = msg })
+    for _, tsrc in ipairs(peers) do
         notify(tsrc, ('%s: %s'):format(myName, previewFor(kind, body, meta)))
     end
 

--- a/server/cherry/seed.lua
+++ b/server/cherry/seed.lua
@@ -60,7 +60,7 @@ lib.addCommand('cherryseed', {
         { name = 'count', type = 'number', help = 'How many profiles (default 8, max 50)', optional = true },
     },
 }, function(source, args)
-    local n = math.min(50, math.max(1, math.floor(tonumber(args and args.count) or 8)))
+    local n = lib.math.clamp(math.floor(tonumber(args and args.count) or 8), 1, 50)
     local made = 0
 
     for _ = 1, n do

--- a/server/clock/actions.lua
+++ b/server/clock/actions.lua
@@ -76,8 +76,8 @@ function actions.saveAlarm(src, payload)
         alarmCount[cid] = held + 1
     end
 
-    local hour    = math.max(0, math.min(23, math.floor(tonumber(payload.hour)   or 0)))
-    local minute  = math.max(0, math.min(59, math.floor(tonumber(payload.minute) or 0)))
+    local hour    = lib.math.clamp(math.floor(tonumber(payload.hour)   or 0), 0, 23)
+    local minute  = lib.math.clamp(math.floor(tonumber(payload.minute) or 0), 0, 59)
     local label   = type(payload.label) == 'string' and payload.label:sub(1, 60) or ''
     local days    = type(payload.days)  == 'string' and payload.days:sub(1, 40)  or ''
     local enabled = payload.enabled
@@ -85,7 +85,7 @@ function actions.saveAlarm(src, payload)
     local sound = payload.sound
     if sound == nil then sound = true end
     local snooze     = payload.snooze == true
-    local snoozeSecs = math.max(1, math.min(3600, math.floor(tonumber(payload.snoozeSecs) or 60)))
+    local snoozeSecs = lib.math.clamp(math.floor(tonumber(payload.snoozeSecs) or 60), 1, 3600)
 
     store.upsertAlarm(cid, {
         id = id, hour = hour, minute = minute, label = label, days = days,

--- a/server/contacts/actions.lua
+++ b/server/contacts/actions.lua
@@ -388,7 +388,7 @@ function actions.logCall(source, payload)
 
     local duration = tonumber(payload.duration) or 0
     if duration ~= duration or duration == math.huge or duration == -math.huge then duration = 0 end
-    duration = math.min(math.max(0, math.floor(duration)), 2147483647)
+    duration = lib.math.clamp(math.floor(duration), 0, 2147483647)
 
     local id = store.newId()
     local call = {

--- a/server/darkchat/actions.lua
+++ b/server/darkchat/actions.lua
@@ -248,11 +248,11 @@ function actions.send(src, roomId, payload)
         local url = sanitizeStr(raw.audioUrl, 1024)
         if not url then return { success = false, message = 'Missing audio' } end
         meta.audioUrl = url
-        meta.duration = math.max(1, math.min(600, math.floor(tonumber(raw.duration) or 1)))
+        meta.duration = lib.math.clamp(math.floor(tonumber(raw.duration) or 1), 1, 600)
         if type(raw.waveform) == 'table' then
             local bars = {}
             for i = 1, math.min(#raw.waveform, 64) do
-                bars[i] = math.max(0, math.min(100, math.floor(tonumber(raw.waveform[i]) or 0)))
+                bars[i] = lib.math.clamp(math.floor(tonumber(raw.waveform[i]) or 0), 0, 100)
             end
             if #bars > 0 then meta.waveform = bars end
         end

--- a/server/devseed.lua
+++ b/server/devseed.lua
@@ -199,7 +199,7 @@ lib.addCommand('seedcontacts', {
 }, function(source, args)
     local cid = player.getIdentifier(source)
     if not cid then return end
-    local count = math.min(math.max(tonumber(args.count) or 12, 1), 30)
+    local count = lib.math.clamp(tonumber(args.count) or 12, 1, 30)
     local made = seedContacts(cid, count)
     print(('^2[sd-phone]^0 seeded %d contacts for %s'):format(#made, cid))
     TriggerClientEvent('sd-phone:client:notify', source, {
@@ -217,7 +217,7 @@ lib.addCommand('seedmessages', {
 }, function(source, args)
     local cid = player.getIdentifier(source)
     if not cid then return end
-    local convoCount = math.min(math.max(tonumber(args.count) or 6, 1), 15)
+    local convoCount = lib.math.clamp(tonumber(args.count) or 6, 1, 15)
 
     local partners = {}
     for _, row in ipairs(contactsStore.listContacts(cid)) do

--- a/server/games/blackjack.lua
+++ b/server/games/blackjack.lua
@@ -32,11 +32,7 @@ local function freshDeck()
     for _, s in ipairs(SUITS) do
         for _, r in ipairs(RANKS) do n = n + 1; deck[n] = { rank = r, suit = s } end
     end
-    for i = n, 2, -1 do
-        local j = math.random(i)
-        deck[i], deck[j] = deck[j], deck[i]
-    end
-    return deck
+    return lib.table.shuffle(deck)
 end
 
 ---Draws the top card off a deck (mutates it).
@@ -96,7 +92,7 @@ end
 ---@return integer credit chips to add back to the wallet
 ---@return integer net signed profit (credit - bet)
 local function payoutFor(bet, outcome)
-    if outcome == 'blackjack' then local w = math.floor(bet * 1.5 + 0.5); return bet + w, w end
+    if outcome == 'blackjack' then local w = lib.math.round(bet * 1.5); return bet + w, w end
     if outcome == 'win'  then return bet * 2, bet end
     if outcome == 'push' then return bet, 0 end
     return 0, -bet

--- a/server/games/railrunner.lua
+++ b/server/games/railrunner.lua
@@ -93,9 +93,7 @@ end
 ---@return table profile { best, coins, totalCoins, plays, unlocked, selected }
 local function profileOf(r)
     local unlocked = decodeUnlocked(r.unlocked)
-    local hasDefault = false
-    for _, id in ipairs(unlocked) do if id == DEFAULT_SKIN then hasDefault = true break end end
-    if not hasDefault then table.insert(unlocked, 1, DEFAULT_SKIN) end
+    if not lib.table.contains(unlocked, DEFAULT_SKIN) then table.insert(unlocked, 1, DEFAULT_SKIN) end
     return {
         best       = r.best or 0,
         coins      = r.coins or 0,
@@ -149,7 +147,7 @@ function rr.buy(src, skin)
     if cost == nil then return nil, 'Unknown item' end
     local r = ensureRow(cid, nameOf(src))
     local unlocked = decodeUnlocked(r.unlocked)
-    for _, id in ipairs(unlocked) do if id == skin then return nil, 'Already owned' end end
+    if lib.table.contains(unlocked, skin) then return nil, 'Already owned' end
     if (r.coins or 0) < cost then return nil, 'Not enough coins' end
     unlocked[#unlocked + 1] = skin
     local affected = MySQL.update.await(
@@ -157,7 +155,7 @@ function rr.buy(src, skin)
         { cost, json.encode(unlocked), cid, cost, r.unlocked or '' })
     if not affected or affected == 0 then
         r = ensureRow(cid, nameOf(src))
-        for _, id in ipairs(decodeUnlocked(r.unlocked)) do if id == skin then return nil, 'Already owned' end end
+        if lib.table.contains(decodeUnlocked(r.unlocked), skin) then return nil, 'Already owned' end
         return nil, 'Not enough coins'
     end
     return profileOf(ensureRow(cid, nameOf(src)))
@@ -173,8 +171,7 @@ function rr.select(src, skin)
     local cid = cidOf(src); if not cid then return nil, 'Player not found' end
     if SKINS[skin] == nil then return nil, 'Unknown item' end
     local r = ensureRow(cid, nameOf(src))
-    local owned = skin == DEFAULT_SKIN
-    for _, id in ipairs(decodeUnlocked(r.unlocked)) do if id == skin then owned = true break end end
+    local owned = skin == DEFAULT_SKIN or lib.table.contains(decodeUnlocked(r.unlocked), skin)
     if not owned then return nil, 'Not unlocked' end
     MySQL.update.await('UPDATE phone_railrunner SET selected = ? WHERE citizenid = ?', { skin, cid })
     return profileOf(ensureRow(cid, nameOf(src)))

--- a/server/games/railrunner.lua
+++ b/server/games/railrunner.lua
@@ -38,7 +38,7 @@ local function nameOf(src) return (player.getName(src) or ('Player ' .. tostring
 local function clampRun(v, cap)
     local n = tonumber(v)
     if not n or n ~= n or n == math.huge or n == -math.huge then return 0 end
-    return math.max(0, math.min(cap, math.floor(n)))
+    return lib.math.clamp(math.floor(n), 0, cap)
 end
 
 ---Creates the profile table if it doesn't exist. Runs once at boot.

--- a/server/games/stats.lua
+++ b/server/games/stats.lua
@@ -118,7 +118,7 @@ function stats.record(cid, game, mode, result, name, amount)
     name = type(name) == 'string' and name:sub(1, 64) or nil
     amount = tonumber(amount)
     if not amount or amount ~= amount or amount == math.huge or amount == -math.huge then amount = 0 end
-    amount = math.max(-AMOUNT_MAX, math.min(AMOUNT_MAX, math.floor(amount)))
+    amount = lib.math.clamp(math.floor(amount), -AMOUNT_MAX, AMOUNT_MAX)
     local won  = math.max(amount, 0)
     local lost = math.max(-amount, 0)
     MySQL.query.await((
@@ -141,7 +141,7 @@ function stats.submitScore(cid, game, score, name)
     name = type(name) == 'string' and name:sub(1, 64) or nil
     score = tonumber(score)
     if not score or score ~= score or score == math.huge or score == -math.huge then score = 0 end
-    score = math.max(0, math.min(SCORE_MAX, math.floor(score)))
+    score = lib.math.clamp(math.floor(score), 0, SCORE_MAX)
 
     local prevRow = MySQL.single.await(
         'SELECT high_score, plays FROM phone_game_stats WHERE citizenid = ? AND game = ?', { cid, game })

--- a/server/mail/actions.lua
+++ b/server/mail/actions.lua
@@ -465,11 +465,9 @@ function actions.send(source, payload)
     local sender = store.getAccount(fromEmail)
     if not sender then return fail('Sender account not found') end
 
-    local owns = false
-    for i = 1, #sender.logged_in_citizens do
-        if sender.logged_in_citizens[i] == me.cid then owns = true; break end
+    if not lib.table.contains(sender.logged_in_citizens, me.cid) then
+        return fail('You are not signed into that account')
     end
-    if not owns then return fail('You are not signed into that account') end
 
     local toRaw = payload.to or {}
     if type(toRaw) ~= 'table' or #toRaw == 0 then return fail('At least one recipient is required') end
@@ -669,11 +667,9 @@ function actions.saveDraft(source, payload)
     local sender = store.getAccount(fromEmail)
     if not sender then return fail('Sender account not found') end
 
-    local owns = false
-    for i = 1, #sender.logged_in_citizens do
-        if sender.logged_in_citizens[i] == me.cid then owns = true; break end
+    if not lib.table.contains(sender.logged_in_citizens, me.cid) then
+        return fail('You are not signed into that account')
     end
-    if not owns then return fail('You are not signed into that account') end
 
     local recipients = {}
     local seen = {}
@@ -725,9 +721,7 @@ local function requireOwnership(source, accountEmail)
         return nil, fail('Slow down')
     end
     local acc = store.getAccount(accountEmail); if not acc then return nil, fail('Account not found') end
-    for i = 1, #acc.logged_in_citizens do
-        if acc.logged_in_citizens[i] == me.cid then return me.cid, nil end
-    end
+    if lib.table.contains(acc.logged_in_citizens, me.cid) then return me.cid, nil end
     return nil, fail('You are not signed into that account')
 end
 

--- a/server/mdt/dispatch.lua
+++ b/server/mdt/dispatch.lua
@@ -319,9 +319,7 @@ function dispatch.createCall(data)
     trimBoard()
 
     local fresh = callPublic(calls[id])
-    for _, src in ipairs(access.audience()) do
-        TriggerClientEvent('sd-phone:client:mdt:call', src, { call = fresh })
-    end
+    util.pushMany('sd-phone:client:mdt:call', access.audience(), { call = fresh })
     markDirty()
 
     SetTimeout(ttl * 1000, function() expire(id) end)

--- a/server/mdt/logs.lua
+++ b/server/mdt/logs.lua
@@ -71,7 +71,7 @@ logs.list = access.gated('logs.view', function(_src, payload, me)
     local total = math.floor(tonumber(
         MySQL.scalar.await('SELECT COUNT(*) FROM phone_mdt_audit a' .. clause, params)) or 0)
 
-    local pages = math.min(MAX_PAGE, math.max(1, math.ceil(total / PAGE_SIZE)))
+    local pages = lib.math.clamp(math.ceil(total / PAGE_SIZE), 1, MAX_PAGE)
     local page = math.floor(tonumber(payload.page) or 1)
     if page < 1 then page = 1 end
     if page > pages then page = pages end

--- a/server/mdt/phone.lua
+++ b/server/mdt/phone.lua
@@ -22,7 +22,7 @@ local COUNT_CAP = 5000
 ---@param value any
 ---@return integer
 local function pageOf(value)
-    return math.max(1, math.min(MAX_PAGE, math.floor(tonumber(value) or 1)))
+    return lib.math.clamp(math.floor(tonumber(value) or 1), 1, MAX_PAGE)
 end
 
 ---The citizenid a payload is asking about, or nil when it is not a usable id.

--- a/server/mdt/roster.lua
+++ b/server/mdt/roster.lua
@@ -134,7 +134,7 @@ local function officerRow(member, profile, labels, onlineSrc, seconds, reports, 
         avatar     = profile and profile.avatar or nil,
         online     = onlineSrc ~= nil,
         duty       = duty,
-        hours      = math.floor((seconds / 3600) * 10 + 0.5) / 10,
+        hours      = lib.math.round((seconds / 3600), 1),
         reports    = reports,
         arrests    = arrests,
     }

--- a/server/mdt/warrants.lua
+++ b/server/mdt/warrants.lua
@@ -66,10 +66,7 @@ end
 ---@param citizenid string
 ---@param wanted boolean
 local function announce(citizenid, wanted)
-    local audience = access.audience()
-    for i = 1, #audience do
-        TriggerClientEvent(WANTED_EVENT, audience[i], { citizenid = citizenid, wanted = wanted })
-    end
+    util.pushMany(WANTED_EVENT, access.audience(), { citizenid = citizenid, wanted = wanted })
 end
 
 ---Decodes a stored charge blob back into warrant charge lines.

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -233,7 +233,7 @@ local function buildConversation(viewerCid, viewerNumber, conversation, rows, co
     local messages = {}
     for i = 1, #rows do messages[i] = serializeMessage(rows[i], viewerNumber, viewerCid, reactionsByMid) end
 
-    if conversation:sub(1, 2) == 'g-' then
+    if lib.string.startsWith(conversation, 'g-') then
         local groupId = conversation:sub(3)
         local group   = store.getGroup(groupId)
         return {
@@ -277,14 +277,14 @@ local function sanitizeMeta(kind, payload)
         local rs = trim(payload.requestStatus)
         if rs == 'pending' then meta.requestStatus = rs end
     elseif kind == 'voice' then
-        meta.duration = math.max(0, math.min(36000, math.floor(tonumber(payload.duration) or 0)))
+        meta.duration = lib.math.clamp(math.floor(tonumber(payload.duration) or 0), 0, 36000)
         local audio = trim(payload.audioUrl)
         if audio ~= '' then meta.audio = audio:sub(1, 512) end
         if type(payload.waveform) == 'table' then
             local bars = {}
             for i = 1, math.min(#payload.waveform, 64) do
                 local v = math.floor(tonumber(payload.waveform[i]) or 0)
-                bars[i] = math.max(0, math.min(100, v))
+                bars[i] = lib.math.clamp(v, 0, 100)
             end
             if #bars > 0 then meta.waveform = bars end
         end
@@ -756,7 +756,7 @@ function actions.send(source, payload)
     local meta = sanitizeMeta(kind, payload)
     if not hasContent(kind, body, meta) then return fail('Empty message') end
 
-    local isGroup = conversation:sub(1, 2) == 'g-'
+    local isGroup = lib.string.startsWith(conversation, 'g-')
 
     -- Number-dependent: a phone with no number in service can't send (device mode with the SIM
     -- out; in legacy/stock a resolvable caller always has a number, so this never trips). Gate
@@ -907,7 +907,7 @@ function actions.addGroupMember(source, payload)
     if not cid then return fail('Player not found') end
 
     local key = tostring(payload.conversation or '')
-    if key:sub(1, 2) ~= 'g-' then return fail('Not a group conversation') end
+    if not lib.string.startsWith(key, 'g-') then return fail('Not a group conversation') end
     local groupId = key:sub(3)
     if not store.isGroupMember(groupId, cid) then return fail('You are not in this group') end
 
@@ -973,7 +973,7 @@ function actions.updateGroup(source, payload)
     if not cid then return fail('Player not found') end
 
     local key = tostring(payload.conversation or '')
-    if key:sub(1, 2) ~= 'g-' then return fail('Not a group conversation') end
+    if not lib.string.startsWith(key, 'g-') then return fail('Not a group conversation') end
     local groupId = key:sub(3)
 
     local group = store.getGroup(groupId)
@@ -1026,7 +1026,7 @@ function actions.removeGroupMember(source, payload)
     if not cid then return fail('Player not found') end
 
     local key = tostring(payload.conversation or '')
-    if key:sub(1, 2) ~= 'g-' then return fail('Not a group conversation') end
+    if not lib.string.startsWith(key, 'g-') then return fail('Not a group conversation') end
     local groupId = key:sub(3)
 
     local group = store.getGroup(groupId)
@@ -1104,7 +1104,7 @@ function actions.deleteConversation(source, payload)
 
     store.deleteThread(cid, conversation)
 
-    if conversation:sub(1, 2) == 'g-' then
+    if lib.string.startsWith(conversation, 'g-') then
         local groupId = conversation:sub(3)
         store.removeGroupMember(groupId, cid)
         if store.groupMemberCount(groupId) == 0 then store.deleteGroup(groupId) end
@@ -1196,7 +1196,7 @@ end
 function actions.uploadVoice(source, payload)
     payload = type(payload) == 'table' and payload or {}
     local audio = payload.audio
-    if type(audio) ~= 'string' or audio:sub(1, 11) ~= 'data:audio/' then return fail('Bad audio payload') end
+    if type(audio) ~= 'string' or not lib.string.startsWith(audio, 'data:audio/') then return fail('Bad audio payload') end
 
     local maxBytes = (config.VoiceMemos and config.VoiceMemos.MaxAudioBytes) or (8 * 1024 * 1024)
     if #audio > maxBytes then return fail('Recording is too long') end

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -84,8 +84,8 @@ local ROWS_PER_SECOND = 8000
 ---@return string
 local function estimate(rows)
     local secs = rows / ROWS_PER_SECOND
-    if secs < 90 then return ('~%ds'):format(math.max(1, math.floor(secs + 0.5))) end
-    return ('~%dm'):format(math.max(1, math.floor(secs / 60 + 0.5)))
+    if secs < 90 then return ('~%ds'):format(math.max(1, lib.math.round(secs))) end
+    return ('~%dm'):format(math.max(1, lib.math.round(secs / 60)))
 end
 
 ---Thousands-separated, so six and seven figure counts stay readable in a console. lib.math groups

--- a/server/migrate/init.lua
+++ b/server/migrate/init.lua
@@ -88,13 +88,13 @@ local function estimate(rows)
     return ('~%dm'):format(math.max(1, math.floor(secs / 60 + 0.5)))
 end
 
----Thousands-separated, so six and seven figure counts stay readable in a console.
+---Thousands-separated, so six and seven figure counts stay readable in a console. lib.math groups
+---outward from the first digit rather than inward from the end of the string, so a sign stays
+---ahead of the leading group instead of collecting a separator of its own.
 ---@param n integer
 ---@return string
 local function comma(n)
-    local s = tostring(math.floor(n))
-    local out = s:reverse():gsub('(%d%d%d)', '%1,'):reverse()
-    return (out:gsub('^,', ''))
+    return lib.math.groupdigits(math.floor(n), ',')
 end
 
 ---`3 contacts` / `1 contact`. Nouns ending in a consonant + y, or in a sibilant, do not take a

--- a/server/migrate/port/messages.lua
+++ b/server/migrate/port/messages.lua
@@ -75,7 +75,7 @@ end
 ---@return string
 local function waypointCode(x, y)
     return 'SDW1:' .. b64url(json.encode({
-        l = 'Shared location', x = math.floor(x + 0.5), y = math.floor(y + 0.5),
+        l = 'Shared location', x = lib.math.round(x), y = lib.math.round(y),
         i = 'MapPin', c = '#5c6cf3',
     }))
 end

--- a/server/migrate/port/settings.lua
+++ b/server/migrate/port/settings.lua
@@ -20,7 +20,7 @@ local function pct(v)
     local n = tonumber(v)
     if not n then return nil end
     if n <= 1 then n = n * 100 end
-    n = math.floor(n + 0.5)
+    n = lib.math.round(n)
     if n < 0 then return 0 end
     if n > 100 then return 100 end
     return n

--- a/server/photogram/actions.lua
+++ b/server/photogram/actions.lua
@@ -352,7 +352,7 @@ local function sanitizeImages(list)
     if type(list) ~= 'table' then return out end
     for i = 1, #list do
         local url = trim(list[i])
-        if url:sub(1, 4) == 'http' then
+        if lib.string.startsWith(url, 'http') then
             out[#out + 1] = url:sub(1, 512)
             if #out >= 10 then break end
         end
@@ -368,15 +368,15 @@ local function sanitizeDmMeta(kind, payload)
     local meta = {}
     if kind == 'image' or kind == 'gif' then
         local url = trim(payload.gifUrl)
-        if url:sub(1, 4) == 'http' then meta.gifUrl = url:sub(1, 512) end
+        if lib.string.startsWith(url, 'http') then meta.gifUrl = url:sub(1, 512) end
     elseif kind == 'voice' then
-        meta.duration = math.max(0, math.min(36000, math.floor(tonumber(payload.duration) or 0)))
+        meta.duration = lib.math.clamp(math.floor(tonumber(payload.duration) or 0), 0, 36000)
         local audio = trim(payload.audioUrl)
-        if audio:sub(1, 4) == 'http' then meta.audio = audio:sub(1, 512) end
+        if lib.string.startsWith(audio, 'http') then meta.audio = audio:sub(1, 512) end
         if type(payload.waveform) == 'table' then
             local bars = {}
             for i = 1, math.min(#payload.waveform, 64) do
-                bars[i] = math.max(0, math.min(100, math.floor(tonumber(payload.waveform[i]) or 0)))
+                bars[i] = lib.math.clamp(math.floor(tonumber(payload.waveform[i]) or 0), 0, 100)
             end
             if #bars > 0 then meta.waveform = bars end
         end
@@ -388,8 +388,8 @@ local function sanitizeDmMeta(kind, payload)
             local avatar = trim(p.avatar)
             meta.post = {
                 id      = pid:sub(1, 16),
-                image   = (image:sub(1, 4) == 'http') and image:sub(1, 512) or '',
-                avatar  = (avatar:sub(1, 4) == 'http') and avatar:sub(1, 512) or '',
+                image   = (lib.string.startsWith(image, 'http')) and image:sub(1, 512) or '',
+                avatar  = (lib.string.startsWith(avatar, 'http')) and avatar:sub(1, 512) or '',
                 author  = trim(p.author):sub(1, 64),
                 caption = trim(p.caption):sub(1, 200),
             }
@@ -669,7 +669,7 @@ function actions.addComment(src, payload)
 
     local text   = trim(payload.text):sub(1, 1000)
     local gifUrl = trim(payload.gifUrl)
-    gifUrl = (gifUrl:sub(1, 4) == 'http') and gifUrl:sub(1, 512) or nil
+    gifUrl = (lib.string.startsWith(gifUrl, 'http')) and gifUrl:sub(1, 512) or nil
     if text == '' and not gifUrl then return fail('Empty comment') end
 
     local id = store.newId()
@@ -786,7 +786,7 @@ function actions.updateProfile(src, payload)
     local name = trim(payload.name):sub(1, 64)
     if name == '' then name = existing.display_name end
     local avatar = trim(payload.avatar)
-    avatar = (avatar:sub(1, 4) == 'http') and avatar:sub(1, 512) or nil
+    avatar = (lib.string.startsWith(avatar, 'http')) and avatar:sub(1, 512) or nil
 
     store.upsertProfile(acc.username, {
         displayName = name,
@@ -974,7 +974,7 @@ function actions.addStory(src, payload)
     local slow = throttle(src, 'story'); if slow then return slow end
     ensureProfile(acc)
     local image = trim(payload.image)
-    if image:sub(1, 4) ~= 'http' then return fail('Add a photo') end
+    if not lib.string.startsWith(image, 'http') then return fail('Add a photo') end
     -- Frames expire on their own after STORY_TTL, so this caps the live window rather than the
     -- account: a full tray drains back to zero a day later.
     if store.countActiveStories(acc.username, os.time() - STORY_TTL) >= STORY_CAP then

--- a/server/photogram/actions.lua
+++ b/server/photogram/actions.lua
@@ -130,9 +130,7 @@ local function broadcastPost(author, event, data)
     local names = store.followerUsernames(author)
     names[#names + 1] = author
     for _, u in ipairs(names) do
-        for _, dst in ipairs(sourcesFor(u)) do
-            TriggerClientEvent('sd-phone:client:photogram:' .. event, dst, data)
-        end
+        lib.triggerClientEvent('sd-phone:client:photogram:' .. event, sourcesFor(u), data)
     end
 end
 
@@ -141,9 +139,8 @@ end
 ---@param target string owner handle
 ---@param status string new follow status ('accepted'/'none')
 local function pushFollowStatus(follower, target, status)
-    for _, dst in ipairs(sourcesFor(follower)) do
-        TriggerClientEvent('sd-phone:client:photogram:followChanged', dst, { target = target, status = status })
-    end
+    lib.triggerClientEvent('sd-phone:client:photogram:followChanged', sourcesFor(follower),
+        { target = target, status = status })
 end
 
 ---UI user card from any row carrying profile columns (author/username, avatar, verified,
@@ -317,20 +314,18 @@ local function notify(recipient, kind, actor, postId, preview, ctx)
         actorName = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or actor
         thumb     = postId and store.postThumb(postId) or nil
     end
-    for _, src in ipairs(sources) do
-        TriggerClientEvent('sd-phone:client:photogram:notification', src, {})
-        TriggerClientEvent('sd-phone:client:notify', src, {
-            app = 'photogram', appId = 'photogram', title = 'Photogram',
-            body = notifBanner(actorName, kind, preview), image = thumb,
-            time = 'now', quietInApp = true,
-            link = {
-                ['photogram:tab'] = 'activity',
-                ['photogram:dmOpen'] = false, ['photogram:commentId'] = false,
-                ['photogram:viewHandle'] = false, ['photogram:detail'] = false, ['photogram:follows'] = false,
-            },
-        })
-        badges.pushApp(src, 'photogram')
-    end
+    lib.triggerClientEvent('sd-phone:client:photogram:notification', sources, {})
+    lib.triggerClientEvent('sd-phone:client:notify', sources, {
+        app = 'photogram', appId = 'photogram', title = 'Photogram',
+        body = notifBanner(actorName, kind, preview), image = thumb,
+        time = 'now', quietInApp = true,
+        link = {
+            ['photogram:tab'] = 'activity',
+            ['photogram:dmOpen'] = false, ['photogram:commentId'] = false,
+            ['photogram:viewHandle'] = false, ['photogram:detail'] = false, ['photogram:follows'] = false,
+        },
+    })
+    for _, src in ipairs(sources) do badges.pushApp(src, 'photogram') end
 end
 
 ---Refreshes the badge for a user's online sources.

--- a/server/photogram/actions.lua
+++ b/server/photogram/actions.lua
@@ -130,7 +130,7 @@ local function broadcastPost(author, event, data)
     local names = store.followerUsernames(author)
     names[#names + 1] = author
     for _, u in ipairs(names) do
-        lib.triggerClientEvent('sd-phone:client:photogram:' .. event, sourcesFor(u), data)
+        util.pushMany('sd-phone:client:photogram:' .. event, sourcesFor(u), data)
     end
 end
 
@@ -139,7 +139,7 @@ end
 ---@param target string owner handle
 ---@param status string new follow status ('accepted'/'none')
 local function pushFollowStatus(follower, target, status)
-    lib.triggerClientEvent('sd-phone:client:photogram:followChanged', sourcesFor(follower),
+    util.pushMany('sd-phone:client:photogram:followChanged', sourcesFor(follower),
         { target = target, status = status })
 end
 
@@ -314,8 +314,8 @@ local function notify(recipient, kind, actor, postId, preview, ctx)
         actorName = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or actor
         thumb     = postId and store.postThumb(postId) or nil
     end
-    lib.triggerClientEvent('sd-phone:client:photogram:notification', sources, {})
-    lib.triggerClientEvent('sd-phone:client:notify', sources, {
+    util.pushMany('sd-phone:client:photogram:notification', sources, {})
+    util.pushMany('sd-phone:client:notify', sources, {
         app = 'photogram', appId = 'photogram', title = 'Photogram',
         body = notifBanner(actorName, kind, preview), image = thumb,
         time = 'now', quietInApp = true,

--- a/server/photogram/live.lua
+++ b/server/photogram/live.lua
@@ -200,9 +200,7 @@ end
 ---@param event string event suffix under sd-phone:client:photogram:
 ---@param data table payload
 local function relay(session, event, data)
-    for _, dst in ipairs(participants(session)) do
-        TriggerClientEvent('sd-phone:client:photogram:' .. event, dst, data)
-    end
+    util.pushMany('sd-phone:client:photogram:' .. event, participants(session), data)
 end
 
 ---Push the current (real) viewer count to everyone in the session.

--- a/server/photos/actions.lua
+++ b/server/photos/actions.lua
@@ -90,9 +90,9 @@ local function hostMatchesList(host, list)
     if type(list) ~= 'table' then return false end
     for _, raw in ipairs(list) do
         local entry = tostring(raw):lower()
-        if entry:sub(1, 2) == '*.' then
+        if lib.string.startsWith(entry, '*.') then
             local suffix = entry:sub(2) -- '.domain.com'
-            if host:sub(-#suffix) == suffix or host == entry:sub(3) then return true end
+            if lib.string.endsWith(host, suffix) or host == entry:sub(3) then return true end
         elseif entry ~= '' and host == entry then
             return true
         end
@@ -133,7 +133,7 @@ function actions.saveFromUrl(source, url)
         print('^1[sd-phone:photos]^0 saveFromUrl: empty url')
         return fail('No URL')
     end
-    if not (url:sub(1, 8) == 'https://' or url:sub(1, 7) == 'http://') then
+    if not (lib.string.startsWith(url, 'https://') or lib.string.startsWith(url, 'http://')) then
         print('^1[sd-phone:photos]^0 saveFromUrl: url not http(s)')
         return fail('Invalid URL')
     end

--- a/server/photos/init.lua
+++ b/server/photos/init.lua
@@ -172,11 +172,11 @@ end)
 ---@return boolean accepted false when the callback or payload shape is unusable
 exports('uploadMedia', function(dataUrl, filename, cb)
     if type(cb) ~= 'function' then return false end
-    if type(dataUrl) ~= 'string' or dataUrl:sub(1, 5) ~= 'data:' then
+    if type(dataUrl) ~= 'string' or not lib.string.startsWith(dataUrl, 'data:') then
         cb(nil, 'Expected a base64 data: URL')
         return false
     end
-    local cap = dataUrl:sub(1, 11) == 'data:video/' and MAX_VIDEO_BYTES or MAX_PHOTO_BYTES
+    local cap = lib.string.startsWith(dataUrl, 'data:video/') and MAX_VIDEO_BYTES or MAX_PHOTO_BYTES
     if #dataUrl > cap then
         cb(nil, ('Payload too large (%d bytes, cap %d)'):format(#dataUrl, cap))
         return false

--- a/server/racing/actions.lua
+++ b/server/racing/actions.lua
@@ -220,7 +220,7 @@ local function hudFrom(v)
     return {
         style           = HUD_STYLES[t.style] and t.style or HUD_DEFAULT.style,
         position        = HUD_ANCHORS[t.position] and t.position or HUD_DEFAULT.position,
-        scale           = math.min(HUD_SCALE_MAX, math.max(HUD_SCALE_MIN, scale)),
+        scale           = lib.math.clamp(scale, HUD_SCALE_MIN, HUD_SCALE_MAX),
         checkpointColor = hexColor(t.checkpointColor, HUD_DEFAULT.checkpointColor),
         closestColor    = hexColor(t.closestColor, HUD_DEFAULT.closestColor),
         inAirWaypoints  = t.inAirWaypoints ~= false,

--- a/server/racing/racegen.lua
+++ b/server/racing/racegen.lua
@@ -98,16 +98,9 @@ local function pick(t)
     return t[math.random(#t)]
 end
 
----Fisher-Yates shuffle, in place.
----@param t table
----@return table t
-local function shuffle(t)
-    for i = #t, 2, -1 do
-        local j = math.random(i)
-        t[i], t[j] = t[j], t[i]
-    end
-    return t
-end
+---@type fun(t: table): table Fisher-Yates shuffle, in place, returning the same table. ox_lib's is
+---the same algorithm down to the draw order, so the sequence for a given RNG state is unchanged.
+local shuffle = lib.table.shuffle
 
 ---Applies one of the Config.RateLimits budgets. A block the config does not define never refuses.
 ---@param cid string|nil citizenid the budget is keyed on
@@ -159,7 +152,7 @@ local function circuitLaps(gates)
     local target = tonumber(laps.TargetCheckpoints)
     if not target or gates <= 0 then return rnd(low, high) end
 
-    local count = math.floor(target / gates + 0.5)
+    local count = lib.math.round(target / gates)
     if count < low then return low end
     if count > high then return high end
     return count
@@ -180,7 +173,7 @@ local function rankedPrizePool(class, gates, laps)
 
     local jitter = tonumber(prize.Jitter) or 0
     if jitter > 0 then pool = pool * (1 + (math.random() * 2 - 1) * jitter) end
-    return math.max(0, math.floor(pool / 50 + 0.5) * 50)
+    return math.max(0, lib.math.round(pool / 50) * 50)
 end
 
 ---Rough race length in kilometres, from the gate count. Cosmetic: the tablet shows it next to the
@@ -265,7 +258,7 @@ local function generateBatch()
 
     local low   = math.max(1, int(GEN.StartsInMinMinutes, 10))
     local high  = math.max(low, int(GEN.StartsInMaxMinutes, 75))
-    local count = math.min(math.max(0, int(GEN.RacesPerBatch, 10)), #pool)
+    local count = lib.math.clamp(int(GEN.RacesPerBatch, 10), 0, #pool)
     for i = 1, count do
         createRace(pool[i], rnd(low, high) * 60)
     end

--- a/server/racing/races.lua
+++ b/server/racing/races.lua
@@ -311,10 +311,10 @@ function races.computeMmrDelta(run, citizenid, place)
             end
         end
         if opponents == 0 then return 0 end
-        return math.floor(K * surprise / opponents + 0.5)
+        return lib.math.round(K * surprise / opponents)
     end
 
-    return math.floor(K * (fieldSize - 2 * place + 1) / (fieldSize - 1) + 0.5)
+    return lib.math.round(K * (fieldSize - 2 * place + 1) / (fieldSize - 1))
 end
 
 ---Rating change for a racer who did not finish, whether they timed out or left the server. Same
@@ -342,7 +342,7 @@ function races.computeDnfDelta(run, citizenid)
             end
         end
         if opponents == 0 then return 0 end
-        return math.floor(K * surprise / opponents + 0.5)
+        return lib.math.round(K * surprise / opponents)
     end
 
     return -K
@@ -545,7 +545,7 @@ function races.finish(src, raceId, modelHash, clientMs)
     local payout = 0
     local share  = races.prizeShare(run.isCustom, place)
     if share > 0 and run.prizePool > 0 then
-        payout = math.floor(run.prizePool * share + 0.5)
+        payout = lib.math.round(run.prizePool * share)
         if payout > 0 then money.add(src, CURRENCY, payout, 'Race prize') end
     end
 

--- a/server/racing/store.lua
+++ b/server/racing/store.lua
@@ -148,7 +148,7 @@ end
 ---@return integer
 local function sizeOf(value, fallback)
     local n = math.floor(tonumber(value) or fallback)
-    return math.max(1, math.min(MAX_PER_PAGE, n))
+    return lib.math.clamp(n, 1, MAX_PER_PAGE)
 end
 
 ---A positive row id, or nil when the value is not one.
@@ -815,7 +815,7 @@ function store.racerProfile(citizenid, currentMmr)
         racesCompleted  = math.floor(tonumber(agg.races) or 0),
         racesWon        = math.floor(tonumber(agg.wins) or 0),
         racesDnf        = math.floor(tonumber(agg.dnfs) or 0),
-        avgPosition     = avgPos and math.floor(avgPos * 10 + 0.5) / 10 or 0,
+        avgPosition     = avgPos and lib.math.round(avgPos, 1) or 0,
         mostUsedVehicle = (topVehicle and topVehicle.vehicle) or 'Unknown',
         totalTimeSec    = math.floor((tonumber(agg.total_ms) or 0) / 1000),
         chart           = chart,

--- a/server/radio/actions.lua
+++ b/server/radio/actions.lua
@@ -43,7 +43,7 @@ local function clampFreq(f)
     f = tonumber(f) or DEFAULT_FREQ
     if f ~= f then f = DEFAULT_FREQ end
     if f < 1.0 then f = 1.0 elseif f > 999.9 then f = 999.9 end
-    return math.floor(f * 10 + 0.5) / 10
+    return lib.math.round(f, 1)
 end
 
 ---Clamp a client-supplied volume to an integer 0-100. NaN collapses to the default.

--- a/server/review/actions.lua
+++ b/server/review/actions.lua
@@ -134,7 +134,7 @@ end
 ---Round to one decimal place for the displayed star average.
 ---@param n number raw average
 ---@return number rounded
-local function round1(n) return math.floor(n * 10 + 0.5) / 10 end
+local function round1(n) return lib.math.round(n, 1) end
 
 ---Review row -> UI shape. `mine` is computed against the caller's citizenid; the citizenid itself
 ---is dropped here.

--- a/server/ryde/actions.lua
+++ b/server/ryde/actions.lua
@@ -536,7 +536,7 @@ function actions.complete(src, payload)
 
     local riderSrc  = srcOf(trip.riderCid)
     local driverSrc = srcOf(trip.driverCid)
-    local driverEarn = math.floor(trip.fare * (config.DriverCut or 1.0) + 0.5)
+    local driverEarn = lib.math.round(trip.fare * (config.DriverCut or 1.0))
 
     local paid = false
     if riderSrc and money.get(riderSrc, 'bank') >= trip.fare then
@@ -830,7 +830,7 @@ function actions.leaderboard()
         out[i] = {
             username = r.username,
             name   = (r.display_name and r.display_name ~= '') and r.display_name or r.username,
-            rating = math.floor((tonumber(r.avg_rating) or 5) * 100 + 0.5) / 100,
+            rating = lib.math.round((tonumber(r.avg_rating) or 5), 2),
             trips  = tonumber(r.trips) or 0,
             color  = r.color,
         }
@@ -852,7 +852,7 @@ function actions.me(src)
         name     = acc.name,
         driver   = d and {
             vehicle = d.vehicle, plate = d.plate, color = d.color,
-            rating = math.floor(rating * 100 + 0.5) / 100,
+            rating = lib.math.round(rating, 2),
             trips = d.trips, earnings = d.earnings_total,
         } or nil,
         online = online[acc.username] ~= nil,

--- a/server/services/invoices.lua
+++ b/server/services/invoices.lua
@@ -70,13 +70,15 @@ local ok, fail, digits, trim, finite = util.ok, util.fail, util.digits, util.tri
 local invoices = {}
 
 ---Formats an amount as "$1,234" with thousands separators, sign dropped, for notification copy.
+---
+---Non-finite input falls back to zero. lib.math.groupdigits matches on a digit and indexes the
+---capture, so an infinity or a NaN reaching it raises rather than returning the "$inf" the
+---hand-rolled gsub used to produce.
 ---@param amount number
 ---@return string
 local function formatMoney(amount)
-    local s = tostring(math.floor(math.abs(tonumber(amount) or 0)))
-    local k
-    repeat s, k = s:gsub('^(%d+)(%d%d%d)', '%1,%2') until k == 0
-    return '$' .. s
+    local n = tonumber(amount)
+    return '$' .. lib.math.groupdigits(finite(n) and math.floor(math.abs(n)) or 0, ',')
 end
 
 ---A business's display label: the configured company label, then the framework label, then the

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -769,7 +769,7 @@ end
 local function clampSlider(v)
     local n = tonumber(v)
     if not n or n ~= n then return nil end
-    n = math.floor(n + 0.5)
+    n = lib.math.round(n)
     if n < 0 then n = 0 elseif n > 100 then n = 100 end
     return n
 end
@@ -867,7 +867,7 @@ end
 local function clampVolume(v)
     local n = tonumber(v)
     if not n or n ~= n then return nil end
-    n = math.floor(n + 0.5)
+    n = lib.math.round(n)
     if n < 0 then n = 0 elseif n > 100 then n = 100 end
     return n
 end
@@ -1723,9 +1723,9 @@ local function sanitizeCustomPalette(v)
         id    = v.id,
         name  = name,
         mode  = v.mode,
-        hue   = math.floor(math.min(math.max(hue, 0), 359) + 0.5),
-        tint  = math.floor(math.min(math.max(tint, 0), 100) + 0.5),
-        depth = math.floor(math.min(math.max(depth, 0), 100) + 0.5),
+        hue   = lib.math.round(lib.math.clamp(hue, 0, 359)),
+        tint  = lib.math.round(lib.math.clamp(tint, 0, 100)),
+        depth = lib.math.round(lib.math.clamp(depth, 0, 100)),
     }
 end
 

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -1230,12 +1230,7 @@ function store.setShell(citizenid, shell, device)
     device = device or 'phone'
     if not citizenid or citizenid == '' then return end
     if not SHELL_IDS[shell] then return end
-    local allowed = allowedShells()
-    local ok = false
-    for i = 1, #allowed do
-        if allowed[i] == shell then ok = true break end
-    end
-    if not ok then return end
+    if not lib.table.contains(allowedShells(), shell) then return end
     MySQL.update.await([[
         INSERT INTO phone_settings (citizenid, device, shell) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE shell = VALUES(shell)

--- a/server/sim/backup.lua
+++ b/server/sim/backup.lua
@@ -276,11 +276,7 @@ function backup.restore(fromId, toId, toNumber, liveFromId)
             run('INSERT IGNORE INTO phone_mail_sessions (citizenid, email) VALUES (?, ?)', { toId, m.email })
 
             local arr = json.decode(m.logged_in_citizens or '[]') or {}
-            local present = false
-            for _, c in ipairs(arr) do
-                if c == toId then present = true break end
-            end
-            if not present then
+            if not lib.table.contains(arr, toId) then
                 arr[#arr + 1] = toId
                 rows = rows + run(
                     'UPDATE phone_mail_accounts SET logged_in_citizens = ? WHERE email = ?',

--- a/server/sim/init.lua
+++ b/server/sim/init.lua
@@ -349,7 +349,7 @@ lib.callback.register('sd-phone:server:sim:get', function(source)
     local profiles = {}
     local restorable = false
     for _, p in ipairs(simStore.listProfiles(realCid)) do
-        local isCloud = p.identity:sub(1, 6) == 'cloud:'
+        local isCloud = lib.string.startsWith(p.identity, 'cloud:')
         local thisPhone = s ~= nil and s.identity == p.deviceIdentity
         local canUse = (isCloud and p.syncedAt ~= nil)
             or (not isCloud and (s == nil or s.identity ~= p.identity))
@@ -424,7 +424,7 @@ end)
 ---@param identity string|nil
 ---@return boolean
 local function isCloudIdentity(identity)
-    return type(identity) == 'string' and identity:sub(1, 6) == 'cloud:'
+    return type(identity) == 'string' and lib.string.startsWith(identity, 'cloud:')
 end
 
 ---@type integer Auto-sync throttle: the enrolled phone re-snapshots at most this often (seconds).

--- a/server/stocks/actions.lua
+++ b/server/stocks/actions.lua
@@ -179,7 +179,7 @@ function actions.buy(src, payload)
         local price = engine.priceOf(symbol)
         if not price or price <= 0 then return { success = false, message = 'No price available' } end
 
-        local fee       = math.floor(amount * (ST.Commission or 0) + 0.5)
+        local fee       = lib.math.round(amount * (ST.Commission or 0))
         local totalCost = amount + fee
 
         local cash = store.ensureWallet(cid, ST.StartingCash)
@@ -247,8 +247,8 @@ function actions.sell(src, payload)
         if fill <= 0 then return { success = false, message = 'No price available' } end
 
         local gross = unitsToSell * fill
-        local fee   = math.floor(gross * (ST.Commission or 0) + 0.5)
-        local net   = math.floor(gross - fee + 0.5)
+        local fee   = lib.math.round(gross * (ST.Commission or 0))
+        local net   = lib.math.round(gross - fee)
 
         local remaining = heldQty - unitsToSell
         if remaining <= 1e-8 then

--- a/server/streaks/actions.lua
+++ b/server/streaks/actions.lua
@@ -157,7 +157,7 @@ function actions.post(src, payload)
     if not cid then return fail('Not signed in') end
 
     local imageUrl = trim(payload.imageUrl)
-    if imageUrl:sub(1, 4) ~= 'http' then return fail('Invalid image') end
+    if not lib.string.startsWith(imageUrl, 'http') then return fail('Invalid image') end
     imageUrl = imageUrl:sub(1, 512)
 
     local caption = trim(payload.caption):sub(1, CFG.MaxCaptionLength)

--- a/server/streaks/actions.lua
+++ b/server/streaks/actions.lua
@@ -36,16 +36,16 @@ local function posInt(v)
 end
 
 ---"$1,500" style for the bank notification line.
+---
+---The amount comes from configs/streaks.lua milestone rewards, so it is server-owner input.
+---lib.math.groupdigits matches on a digit and indexes the capture, meaning an infinity or a NaN
+---raises rather than formatting; util.finite keeps a mistyped reward to a wrong number instead of
+---a failed payout.
 ---@param n number whole-dollar amount
 ---@return string formatted
 local function fmtMoney(n)
-    local s = tostring(math.floor(tonumber(n) or 0))
-    while true do
-        local next_s, count = s:gsub('^(-?%d+)(%d%d%d)', '%1,%2')
-        s = next_s
-        if count == 0 then break end
-    end
-    return '$' .. s
+    local v = tonumber(n)
+    return '$' .. lib.math.groupdigits(util.finite(v) and math.floor(v) or 0, ',')
 end
 
 ---config.Streaks.Milestones (a sparse day -> reward map) sorted ascending into the { day, reward }

--- a/server/util.lua
+++ b/server/util.lua
@@ -596,4 +596,37 @@ AddEventHandler('playerDropped', function()
     for i = 1, #cleanups do pcall(cleanups[i], src, ok and cid or nil) end
 end)
 
+---@type boolean Whether this server's ox_lib carries the triggerClientEvent module.
+---
+---Probed by reading the file, NOT by testing `lib.triggerClientEvent` for nil. ox_lib's loader
+---(`@ox_lib/init.lua`, the `call` metamethod) answers a MISSING module with a stub that forwards to
+---an ox_lib export of the same name, so the field is always truthy and a nil check would pass on
+---every version and then fail at the call with "No such export".
+---
+---sd-phone declares `dependencies { 'ox_lib' }` with no version floor and ships to servers running
+---whatever they already had, and the module carries its own "may be deprecated" note upstream - so
+---the probe guards both directions in time.
+local HAS_BATCHED_PUSH = LoadResourceFile('ox_lib', 'imports/triggerClientEvent/server.lua') ~= nil
+
+---Sends one event to many players. Prefers ox_lib's batched push, which msgpacks the arguments once
+---and reuses the buffer per target instead of re-packing them for each; falls back to a plain loop
+---of TriggerClientEvent, which is what the batched version does internally anyway.
+---
+---Every fan-out in the resource goes through here, so an ox_lib that drops the module is one edit
+---to absorb rather than ten.
+---@param event string client event name
+---@param targets integer[] player server ids; an empty list is a no-op
+---@param ... any event arguments
+function util.pushMany(event, targets, ...)
+    if type(targets) ~= 'table' or not targets[1] then return end
+
+    if HAS_BATCHED_PUSH then
+        return lib.triggerClientEvent(event, targets, ...)
+    end
+
+    for i = 1, #targets do
+        TriggerClientEvent(event, targets[i], ...)
+    end
+end
+
 return util

--- a/server/vibez/actions.lua
+++ b/server/vibez/actions.lua
@@ -110,7 +110,7 @@ end
 ---@param target string profile being (un)followed
 ---@param following boolean new state
 local function pushFollowStatus(follower, target, following)
-    lib.triggerClientEvent('sd-phone:client:vibez:followChanged', sourcesFor(follower),
+    util.pushMany('sd-phone:client:vibez:followChanged', sourcesFor(follower),
         { target = target, following = following })
 end
 
@@ -231,8 +231,8 @@ local function notify(recipient, kind, actor, postId, preview, ctx)
         actorName = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or actor
         thumb     = postId and store.thumbsFor({ postId })[postId] or nil
     end
-    lib.triggerClientEvent('sd-phone:client:vibez:notification', sources, {})
-    lib.triggerClientEvent('sd-phone:client:notify', sources, {
+    util.pushMany('sd-phone:client:vibez:notification', sources, {})
+    util.pushMany('sd-phone:client:notify', sources, {
         app = 'vibez', appId = 'vibez', title = 'Vibez',
         body = ('%s %s'):format(actorName, notifSuffix(kind, preview)), image = thumb,
         time = 'now', quietInApp = true,

--- a/server/vibez/actions.lua
+++ b/server/vibez/actions.lua
@@ -252,7 +252,7 @@ end
 ---@return string|nil url
 local function sanitizeUrl(value)
     local url = trim(value)
-    if url:sub(1, 4) ~= 'http' then return nil end
+    if not lib.string.startsWith(url, 'http') then return nil end
     return url:sub(1, 512)
 end
 

--- a/server/vibez/actions.lua
+++ b/server/vibez/actions.lua
@@ -110,9 +110,8 @@ end
 ---@param target string profile being (un)followed
 ---@param following boolean new state
 local function pushFollowStatus(follower, target, following)
-    for _, dst in ipairs(sourcesFor(follower)) do
-        TriggerClientEvent('sd-phone:client:vibez:followChanged', dst, { target = target, following = following })
-    end
+    lib.triggerClientEvent('sd-phone:client:vibez:followChanged', sourcesFor(follower),
+        { target = target, following = following })
 end
 
 ---UI user card from any row carrying profile columns (author/username, avatar, verified,
@@ -232,16 +231,14 @@ local function notify(recipient, kind, actor, postId, preview, ctx)
         actorName = (actorRow and actorRow.display_name ~= '' and actorRow.display_name) or actor
         thumb     = postId and store.thumbsFor({ postId })[postId] or nil
     end
-    for _, src in ipairs(sources) do
-        TriggerClientEvent('sd-phone:client:vibez:notification', src, {})
-        TriggerClientEvent('sd-phone:client:notify', src, {
-            app = 'vibez', appId = 'vibez', title = 'Vibez',
-            body = ('%s %s'):format(actorName, notifSuffix(kind, preview)), image = thumb,
-            time = 'now', quietInApp = true,
-            link = { ['vibez:tab'] = 'inbox' },
-        })
-        badges.pushApp(src, 'vibez')
-    end
+    lib.triggerClientEvent('sd-phone:client:vibez:notification', sources, {})
+    lib.triggerClientEvent('sd-phone:client:notify', sources, {
+        app = 'vibez', appId = 'vibez', title = 'Vibez',
+        body = ('%s %s'):format(actorName, notifSuffix(kind, preview)), image = thumb,
+        time = 'now', quietInApp = true,
+        link = { ['vibez:tab'] = 'inbox' },
+    })
+    for _, src in ipairs(sources) do badges.pushApp(src, 'vibez') end
 end
 
 ---Refreshes the badge for a user's online sources.

--- a/server/vibez/live.lua
+++ b/server/vibez/live.lua
@@ -194,9 +194,7 @@ end
 ---@param event string event suffix under sd-phone:client:vibez:
 ---@param data table payload
 local function relay(session, event, data)
-    for _, dst in ipairs(participants(session)) do
-        TriggerClientEvent('sd-phone:client:vibez:' .. event, dst, data)
-    end
+    util.pushMany('sd-phone:client:vibez:' .. event, participants(session), data)
 end
 
 ---Push the current (real) viewer count to everyone in the session.

--- a/server/voicememos/init.lua
+++ b/server/voicememos/init.lua
@@ -55,7 +55,7 @@ RegisterNetEvent('sd-phone:server:voice:upload', function(payload)
     payload = type(payload) == 'table' and payload or {}
     local audio = payload.audio
 
-    if type(audio) ~= 'string' or audio:sub(1, 11) ~= 'data:audio/' then
+    if type(audio) ~= 'string' or not lib.string.startsWith(audio, 'data:audio/') then
         TriggerClientEvent('sd-phone:client:voice:uploadFailed', src, 'Bad audio payload')
         return
     end


### PR DESCRIPTION
## What

Applies the same ox_lib pass sd-tablet just took (#2 there) to sd-phone's client. Behaviour-preserving except where noted.

## Swaps

| Was | Now | Sites |
| --- | --- | --- |
| `PlayerPedId()` | `cache.ped` | 49 |
| `GetPlayerServerId(PlayerId())` | `cache.serverId` | 1 |
| `PlayerId()` | `cache.playerId` | 3 |
| `IsPedInAnyVehicle(ped, false)` | `cache.vehicle` | 3 |
| `RequestModel` + `HasModelLoaded` poll | `lib.requestModel` | 4 |
| `RequestAnimDict` + poll | `lib.requestAnimDict` | 2 |
| paired `RegisterCommand` / `RegisterKeyMapping` | `lib.addKeybind` | 4 |
| ~35 `DisableControlAction` per frame | `lib.disableControls` | 2 loops |

Every `lib.request*` call is wrapped in `pcall`: they raise on timeout rather than returning nil, so an unwrapped one turns a cosmetic pose failure into a script error that kills the thread.

## Two real fixes fall out

**Orphaned hand prop on respawn.** A respawn or ped-model change hands the player a new ped while the phone prop stays welded to the old one, which the game does not necessarily delete. The clip re-applied itself on the existing watchdog; the prop never would, because nothing reads that handle again. `lib.onCache('ped')` now drops and re-welds it, with no new poll.

**Leaked anim dicts.** `client/pose.lua` requested a dict per clip and never released one, leaking one per clip for the session. The dict now goes back as soon as the task has it.

## Control suppression

`client/main.lua` ran two per-frame threads, one holding the pause control and one issuing ~28 `DisableControlAction` calls every frame regardless of state. They are now one thread over four data-defined groups, added and removed only when the state changes and re-asserted in a single `lib.disableControls()` call. `client/apps/camera.lua` adds its nine viewfinder keys once on entry and drops them on exit, but still calls `lib.disableControls()` per frame because `IsDisabledControlJustPressed` only reads a control disabled that frame.

Add/Remove are refcounted, so `setControlGroup` guards on current state: an unbalanced pair would leave a control disabled for the rest of the session.

## Debug output

The three config-gated debug helpers now print through `lib.print`. `config.Debug` still prints (at info, so it needs no further setup), and `setr ox:printlevel:sd-phone debug` reaches the same output live without editing a config and restarting.

## Deliberately not adopted

- **`lib.locale`** - `locales/*.json` here is the 200KB-per-language FRONTEND catalog, not a Lua one. Pointing `lib.locale()` at it would flatten the whole thing into the Lua dict. Doing this properly needs a separate `locales_path`, which is its own change.
- **The ~90 remaining colour-coded `print` calls** across 42 server files. `lib.print` prepends its own `[sd-phone]` and level tag, so converting them restyles every operator-facing console line and makes the existing `[sd-phone:module]` prefixes redundant. Worth doing, but as a deliberate formatting decision rather than folded in here.
- **`GetVehiclePedIsIn(ped, false)`** left as-is at the sites that want the entity: it answers `0` where `cache.vehicle` answers `false`, and several call sites compare against `0`.
- **`lib.playAnim`** in `pose.lua` - it loads, plays and releases in one call, which forfeits the "did the player close the phone during the load" re-check between them. `lib.requestAnimDict` plus an explicit `RemoveAnimDict` keeps that check and still releases.

## Testing

- `luac -p` passes on all 19 changed files
- Declaration ordering verified for the new constructs (`startInputThread` before its call site, `TogglePhone`/`enterLookMode`/`exitLookMode` before `lib.addKeybind`, `CTRL_*` before `CONTROLS_VIEWFINDER`)
- ox_lib 3.39.0 confirmed to export every module used

Not exercised in-game. The pose, keybind and control-suppression paths all want a server start to confirm.