### PR TITLE
feat(housing): add kartik-properties support

### DIFF
--- a/bridge/server/housing.lua
+++ b/bridge/server/housing.lua
@@ -541,6 +541,27 @@ ADAPTERS['nolag_properties'] = function(source, id)
     return out
 end
 
+ADAPTERS['kartik-properties'] = function(source, id)
+    local ok, raw = pcall(function() return exports['kartik-properties']:GetPlayerHousingData(id) end)
+    if not ok or type(raw) ~= 'table' then return {} end
+    local out = {}
+    for _, p in ipairs(raw) do
+        local coords = asXY(p.coords)
+        local isOwner = (tostring(p.owner) == tostring(id))
+        out[#out + 1] = home{
+            id      = p.houseId,
+            address = s(p.label),
+            type    = isOwner and 'House' or 'Leased',
+            area    = '',
+            value   = 0,
+            status  = isOwner and 'owned' or 'rented',
+            coords  = coords,
+            locked  = p.locked,
+        }
+    end
+    return out
+end
+
 -- Capability map: which detail-view actions each system supports.
 ---@type table<string, { lock: boolean, keyList: boolean, keyManage: boolean }> Per-system action support.
 local CAPS = {
@@ -555,6 +576,7 @@ local CAPS = {
     ['loaf_housing']   = { lock = false, keyList = false, keyManage = false },
     ['LNS_Housing']    = { lock = true,  keyList = true,  keyManage = true  },
     ['nolag_properties'] = { lock = true,  keyList = true,  keyManage = true  },
+    ['kartik-properties'] = { lock = true,  keyList = true,  keyManage = true  },
 }
 
 ---Capability flags for the active system, all-false when none is detected.
@@ -683,6 +705,12 @@ function housing.lock(src, id, want)
             refreshHomes(src)
             return want
         end
+    elseif ACTIVE == 'kartik-properties' then
+        local ok = pcall(function() exports['kartik-properties']:SetPropertyLocked(p, want) end)
+        if ok then
+            refreshHomes(src)
+            return want
+        end
     end
     return nil
 end
@@ -768,6 +796,17 @@ function housing.keyHolders(src, id)
             cids[#cids + 1] = cid
         end
         return resolveCids(cids)
+    elseif ACTIVE == 'kartik-properties' then
+        if not ownsProperty(src, id) then return {} end
+        local ok, house = pcall(function() return exports['kartik-properties']:GetPropertyHousingData(p) end)
+        if not ok or type(house) ~= 'table' or not house.keyholders then return {} end
+        local out = {}
+        for _, kh in ipairs(house.keyholders) do
+            if not kh.isowner then
+                out[#out + 1] = { id = tostring(kh.identifier), name = kh.name or 'Resident' }
+            end
+        end
+        return out
     end
     return {}
 end
@@ -816,6 +855,16 @@ function housing.giveKey(src, id, targetSrc)
             refreshHomes(src, targetSrc)
             return true
         end
+    elseif ACTIVE == 'kartik-properties' then
+        local cid = player.getIdentifier(targetSrc)
+        local ownerCid = player.getIdentifier(src)
+        if not cid then return false end
+        local ok, res = pcall(function() return exports['kartik-properties']:GrantHousingKey(p, cid, ownerCid) end)
+        if ok and res and res.success then
+            refreshHomes(src, targetSrc)
+            return true
+        end
+        return false
     end
     return false
 end
@@ -865,6 +914,14 @@ function housing.removeKey(src, id, holderId)
             refreshHomes(src, holderId)
             return true
         end
+    elseif ACTIVE == 'kartik-properties' then
+        local ownerCid = player.getIdentifier(src)
+        local ok, res = pcall(function() return exports['kartik-properties']:RevokeHousingKey(p, tostring(holderId), ownerCid) end)
+        if ok and res and res.success then
+            refreshHomes(src, holderId)
+            return true
+        end
+        return false
     end
     return false
 end

--- a/configs/housing.lua
+++ b/configs/housing.lua
@@ -13,6 +13,6 @@ return {
     Resources = {
         'qs-housing', 'ps-housing', 'vms_housing', 'rtx_housing',
         'origen_housing', 'bcs_housing', 'loaf_housing', 'tk_housing', 'RxHousing', 'LNS_Housing',
-        'nolag_properties',
+        'nolag_properties', 'kartik-properties',
     },
 }


### PR DESCRIPTION
## Summary

Adds `kartik-properties` as a supported housing system.

- Add adapter using `GetPlayerHousingData` server export
- Add lock toggle via `SetPropertyLocked` export
- Add key holder listing via `GetPropertyHousingData` export
- Add give/remove key via `GrantHousingKey` / `RevokeHousingKey` exports
- Register `kartik-properties` in `CAPS` table and `Resources` list

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [x] Compatibility
- [ ] Other

## Related Issues

N/A

## Testing

Tested property listing, lock toggle, and key management on a local FiveM server.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [x] Tested with latest ox_lib
- [x] Tested with latest ox_inventory
- [x] Multiplayer tested

## Breaking Changes

No breaking changes introduced.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.
