### PR TITLE
Add Secret App feature

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -167,6 +167,7 @@ require 'client.apps.sim'
 require 'client.admin'
 require 'client.payphone'
 require 'client.celltowerblips'
+require 'client.secretapps'
 
 ---@type table Phone visibility state: open/locked flags + cosmetic battery percentage.
 local phoneState = {

--- a/client/secretapps.lua
+++ b/client/secretapps.lua
@@ -1,0 +1,79 @@
+---@type table Secret app catalog root (configs/secret_apps.lua).
+local config = require 'configs.secret_apps'
+---@type table Custom third-party app registry (client.customapps): add/remove/message + lifecycle.
+local customApps = require 'client.customapps'
+
+---@type string This resource, passed to customApps.add as the owning resource.
+local RESOURCE = GetCurrentResourceName()
+
+---@type table<string, table> Secret app id -> def, built once from configs/secret_apps.lua.
+local BY_ID = {}
+for _, app in ipairs(config.Apps or {}) do
+    if type(app.id) == 'string' and app.id ~= '' then BY_ID[app.id] = app end
+end
+
+---Registers one secret app as a custom app on this client only. `defaultApp` marks it already
+---installed (see web/src/App.tsx's `a.base ||` check), so it appears on the home screen the
+---moment it's registered - no separate App Store "Get" step.
+---@param app table secret app def from configs/secret_apps.lua
+local function register(app)
+    if customApps.has(app.id) then return end
+    local appResource = app.resource or (app.ui and app.ui:match('^([^/]+)/')) or app.id
+    customApps.add({
+        identifier  = app.id,
+        name        = app.label or app.id,
+        description = app.description,
+        icon        = app.icon,
+        ui          = app.ui,
+        defaultApp  = true,
+    }, appResource)
+end
+
+local function loadSecretApps()
+    local ok, ids = pcall(lib.callback.await, 'sd-phone:server:secretapps:list', false)
+    if not ok or type(ids) ~= 'table' then return end
+    for _, id in ipairs(ids) do
+        local app = BY_ID[id]
+        if app then register(app) end
+    end
+end
+
+-- Fetch unlocked apps on thread start (if resource restarted while already in-game)
+CreateThread(function()
+    Wait(500)
+    loadSecretApps()
+end)
+
+-- Fetch unlocked apps whenever a player character loads / relogs
+RegisterNetEvent('qbx_core:client:playerLoaded', function()
+    Wait(500)
+    loadSecretApps()
+end)
+
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+    Wait(500)
+    loadSecretApps()
+end)
+
+-- Live unlock: server/secretapps/init.lua fires this the moment the item is used, so the app
+-- shows up without a relog.
+RegisterNetEvent('sd-phone:client:secretapps:unlocked', function(app)
+    if type(app) ~= 'table' or type(app.id) ~= 'string' then return end
+    register(BY_ID[app.id] or app)
+end)
+
+---Unregisters one secret app from custom apps on this client.
+---@param appId string secret app id
+local function unregister(appId)
+    if not customApps.has(appId) then return end
+    local app = BY_ID[appId]
+    local appResource = app and (app.resource or (app.ui and app.ui:match('^([^/]+)/')) or app.id) or appId
+    customApps.remove(appId, appResource)
+end
+
+-- Live removal: server fires this when a secret app is removed/uninstalled.
+RegisterNetEvent('sd-phone:client:secretapps:removed', function(appId)
+    if type(appId) ~= 'string' or appId == '' then return end
+    unregister(appId)
+end)
+

--- a/configs/apps.lua
+++ b/configs/apps.lua
@@ -107,3 +107,8 @@ return {
         -- { id = 'darkchat', label = 'Dark Chat', icon = 'darkchat', route = '/darkchat', accent = '#1c1c1e', base = false, enabled = true, wifi = 'mazebank' },
     },
 }
+
+-- Want an app that never shows here or in the App Store, and only reaches a phone when a player
+-- uses a specific inventory item? That's a `secretapp`, not an entry in the table above - define
+-- it in configs/secret_apps.lua with a `secretapp = '<item id>'` field instead. See that file's
+-- header for the full field list, and server/secretapps/init.lua for how the item hooks in.

--- a/configs/secret_apps.lua
+++ b/configs/secret_apps.lua
@@ -1,0 +1,21 @@
+-- Secret apps: unlocked by using an item, never by the App Store or the home screen grid.
+-- See the `secretapp` note at the bottom of configs/apps.lua for how this differs from a normal
+-- app entry, and server/secretapps/init.lua + client/secretapps.lua for how it's wired up.
+--
+-- Fields:
+--   Core (all secret apps):
+--     id          = '<slug>'   unique app id (letters/numbers/_-, matches a normal app id)
+--     label       = '<name>'   display name shown once unlocked
+--     secretapp   = '<item>'   inventory item id that unlocks this app when used
+--     description = '<text>'   optional, shown on the app's tile/detail view
+--
+--   External / Third-Party Resource only (NOT needed if app is built directly into sd-phone):
+--     resource    = '<name>'   owning resource name (handles lifecycle & cleanup when resource stops)
+--     ui          = '<path>'   iframe URL/path served by the external resource (e.g. 'my_resource/ui/dist/index.html')
+--     icon        = '<url>'    custom tile icon (e.g. 'https://cfx-nui-my_resource/ui/dist/icon.webp')
+--
+-- The inventory item itself still has to exist and point back here - see the item snippet in
+-- server/secretapps/init.lua's header comment.
+return {
+    Apps = {},
+}

--- a/server/main.lua
+++ b/server/main.lua
@@ -43,6 +43,7 @@ require 'server.services.init'
 require 'server.voicememos.init'
 require 'server.music.init'
 require 'server.share.init'
+require 'server.secretapps.init'
 require 'server.devseed'
 -- Optional local-only helpers; absent on every install but a developer's, so a missing file is
 -- expected rather than an error.

--- a/server/secretapps/init.lua
+++ b/server/secretapps/init.lua
@@ -1,0 +1,195 @@
+-- Wires configs/secret_apps.lua's `secretapp` entries to an ox_inventory item: using the item
+-- unlocks the matching app onto that character's phone permanently (server/secretapps/store.lua),
+-- and client/secretapps.lua registers it as a custom app on that player's phone alone, so nobody
+-- else's App Store or home screen ever lists it.
+--
+-- The item itself lives in ox_inventory's own data/items.lua and isn't touched here. Point it at
+-- this export:
+--   ['custom_usb_1'] = {
+--       label   = 'USB Tool',
+--       weight  = 100,
+--       stack   = false,
+--       close   = true,
+--       consume = 1,
+--       server  = { export = 'sd-phone.useSecretAppItem' },
+--   },
+
+---@type table Boot reporter (server.boot): one console summary instead of per-module prints.
+local boot   = require 'server.boot'
+---@type table Secret app catalog root (configs/secret_apps.lua).
+local config = require 'configs.secret_apps'
+---@type table Player bridge (bridge.server.player): citizenid lookups from a server id.
+local player = require 'bridge.server.player'
+---@type table Notify bridge (bridge.server.notify): server -> client toasts.
+local notify = require 'bridge.server.notify'
+---@type table Secret app persistence layer (server.secretapps.store): unlock CRUD.
+local store  = require 'server.secretapps.store'
+
+-- Schema bootstrap.
+CreateThread(function()
+    local success, err = pcall(store.ensureSchema)
+    if not success then
+        boot.schemaFailed('secretapps', err)
+        return
+    end
+    boot.schemaReady()
+end)
+
+-- item id -> app def, built once from configs/secret_apps.lua. A malformed or duplicate entry is
+-- skipped rather than erroring the whole catalog.
+---@type table<string, table> ox_inventory item id -> app def.
+local BY_ITEM = {}
+---@type table<string, table> secret app id -> app def.
+local BY_ID   = {}
+for _, app in ipairs(config.Apps or {}) do
+    if type(app.id) == 'string' and app.id ~= '' then
+        BY_ID[app.id] = app
+        if type(app.secretapp) == 'string' and app.secretapp ~= '' then
+            if BY_ITEM[app.secretapp] then
+                print(('^1[sd-phone]^0 secret app item %s is claimed by more than one app; keeping the first'):format(app.secretapp))
+            else
+                BY_ITEM[app.secretapp] = app
+            end
+        end
+    end
+end
+
+---Finds a secret app definition by app id, secretapp item name, or loose matching.
+---@param query string
+---@return table|nil
+local function findApp(query)
+    if type(query) ~= 'string' or query == '' then return nil end
+    if BY_ID[query] then return BY_ID[query] end
+    if BY_ITEM[query] then return BY_ITEM[query] end
+    for _, app in ipairs(config.Apps or {}) do
+        if app.id:lower() == query:lower() or (app.secretapp and app.secretapp:lower() == query:lower()) then
+            return app
+        end
+    end
+    return nil
+end
+
+---The caller's already-unlocked secret app ids. Read-only.
+---@param source number player server id
+---@return string[] ids
+lib.callback.register('sd-phone:server:secretapps:list', function(source)
+    local cid = player.getIdentifier(source)
+    if not cid then return {} end
+    return store.list(cid)
+end)
+
+---Removes/uninstalls a secret app from a player's phone.
+---@param target number|string player server ID
+---@param appQuery string secret app ID or item name
+---@return boolean success, string? message
+local function removeSecretApp(target, appQuery)
+    local targetSrc = tonumber(target)
+    if not targetSrc or targetSrc <= 0 then
+        return false, 'Invalid player ID'
+    end
+
+    local cid = player.getIdentifier(targetSrc)
+    if not cid then
+        return false, 'Player not found or offline'
+    end
+
+    local app = findApp(appQuery)
+    local appId = app and app.id or appQuery
+
+    if not store.has(cid, appId) then
+        return false, ('App %s is not installed for this player'):format(app and app.label or appId)
+    end
+
+    store.remove(cid, appId)
+    TriggerClientEvent('sd-phone:client:secretapps:removed', targetSrc, appId)
+    notify.to(targetSrc, ('%s uninstalled'):format(app and app.label or appId), 'inform')
+    return true, ('Uninstalled %s for player %s'):format(app and app.label or appId, targetSrc)
+end
+
+exports('removeSecretApp', removeSecretApp)
+exports('uninstallSecretApp', removeSecretApp)
+
+---ox_inventory calls this export for every event on a `secretapp` item (see the header comment
+---for the item's `server.export` field). Only the actual use fires an unlock; a re-use once
+---already unlocked is a no-op notice rather than a second write.
+---@param event string ox_inventory usable-item event name
+---@param item table|nil the used item's static definition (item.name is the item id)
+---@param inv table|nil inventory the item was used from; `.id` is the player's server id
+exports('useSecretAppItem', function(event, item, inv)
+    if event ~= 'usingItem' then return end
+    if type(inv) ~= 'table' or type(inv.id) ~= 'number' then return end
+
+    local itemName = item and item.name
+    local app = type(itemName) == 'string' and BY_ITEM[itemName] or nil
+    if not app then return end
+
+    local source = inv.id
+    local cid = player.getIdentifier(source)
+    if not cid then return end
+
+    if store.has(cid, app.id) then
+        notify.to(source, ('%s is already installed'):format(app.label or app.id), 'error')
+        TriggerClientEvent('sd-phone:client:secretapps:unlocked', source, app)
+        return
+    end
+
+    store.unlock(cid, app.id)
+    notify.to(source, ('%s unlocked'):format(app.label or app.id), 'success')
+    TriggerClientEvent('sd-phone:client:secretapps:unlocked', source, app)
+end)
+
+---/uninstallsecretapp <app> [target] - uninstalls a secret app from a player's phone.
+lib.addCommand('uninstallsecretapp', {
+    help = 'Uninstall a secret app from your phone (or target player)',
+    params = {
+        { name = 'app',    type = 'string',   help = 'Secret App ID or Item name (e.g. ghm-vehiclehack)' },
+        { name = 'target', type = 'playerId', help = 'Target Player ID (Admin only, defaults to yourself)', optional = true },
+    },
+}, function(source, args)
+    local targetSrc = source
+    if args.target and args.target ~= source then
+        if source ~= 0 and not IsPlayerAceAllowed(tostring(source), 'command.phoneadmin') and not IsPlayerAceAllowed(tostring(source), 'command') then
+            notify.to(source, 'You do not have permission to uninstall apps from other players', 'error')
+            return
+        end
+        targetSrc = args.target
+    end
+
+    if targetSrc == 0 then
+        print('^1[sd-phone]^0 Console must specify a target player ID.')
+        return
+    end
+
+    local ok, msg = removeSecretApp(targetSrc, args.app)
+    if source == 0 then
+        print(('%s[sd-phone]^0 %s'):format(ok and '^2' or '^1', msg or 'Done'))
+    elseif source ~= targetSrc then
+        notify.to(source, msg or 'Done', ok and 'success' or 'error')
+    end
+end)
+
+---/removesecretapp <target> <app> - admin command to remove a secret app from a player.
+lib.addCommand('removesecretapp', {
+    help = 'Admin: remove/uninstall a secret app from a player',
+    restricted = 'group.admin',
+    params = {
+        { name = 'target', type = 'playerId', help = 'Target Player ID' },
+        { name = 'app',    type = 'string',   help = 'Secret App ID or Item name (e.g. ghm-vehiclehack)' },
+    },
+}, function(source, args)
+    local targetSrc = args.target or source
+    if not targetSrc or targetSrc <= 0 then
+        if source == 0 then
+            print('^1[sd-phone]^0 Console must specify a target player ID.')
+        end
+        return
+    end
+
+    local ok, msg = removeSecretApp(targetSrc, args.app)
+    if source == 0 then
+        print(('%s[sd-phone]^0 %s'):format(ok and '^2' or '^1', msg or 'Done'))
+    else
+        notify.to(source, msg or 'Done', ok and 'success' or 'error')
+    end
+end)
+

--- a/server/secretapps/store.lua
+++ b/server/secretapps/store.lua
@@ -1,0 +1,62 @@
+---@type table Store module; the table returned at end of file.
+local store = {}
+
+---Creates the phone_secret_apps table (one row per citizenid + unlocked app id).
+function store.ensureSchema()
+    MySQL.query.await([[
+        CREATE TABLE IF NOT EXISTS phone_secret_apps (
+            citizenid   VARCHAR(64) NOT NULL,
+            app_id      VARCHAR(32) NOT NULL,
+            unlocked_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (citizenid, app_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    ]])
+end
+
+---True if the citizen already unlocked this secret app. Read-only.
+---@param citizenid string framework per-character id
+---@param appId string secret app id
+---@return boolean
+function store.has(citizenid, appId)
+    if not citizenid or citizenid == '' then return false end
+    return MySQL.scalar.await(
+        'SELECT 1 FROM phone_secret_apps WHERE citizenid = ? AND app_id = ?', { citizenid, appId }
+    ) ~= nil
+end
+
+---Unlocks a secret app for a citizen. Idempotent (INSERT IGNORE on the composite key).
+---@param citizenid string framework per-character id
+---@param appId string secret app id
+function store.unlock(citizenid, appId)
+    if not citizenid or citizenid == '' then return end
+    MySQL.query.await(
+        'INSERT IGNORE INTO phone_secret_apps (citizenid, app_id) VALUES (?, ?)', { citizenid, appId }
+    )
+end
+
+---The citizen's unlocked secret app ids. Read-only.
+---@param citizenid string framework per-character id
+---@return string[] ids
+function store.list(citizenid)
+    if not citizenid or citizenid == '' then return {} end
+    local rows = MySQL.query.await(
+        'SELECT app_id FROM phone_secret_apps WHERE citizenid = ?', { citizenid }
+    ) or {}
+    local out = {}
+    for i = 1, #rows do out[i] = rows[i].app_id end
+    return out
+end
+
+---Removes a secret app unlock for a citizen.
+---@param citizenid string framework per-character id
+---@param appId string secret app id
+---@return boolean
+function store.remove(citizenid, appId)
+    if not citizenid or citizenid == '' or not appId or appId == '' then return false end
+    local affected = MySQL.update.await(
+        'DELETE FROM phone_secret_apps WHERE citizenid = ? AND app_id = ?', { citizenid, appId }
+    )
+    return (affected or 0) > 0
+end
+
+return store


### PR DESCRIPTION
This allows certain apps to be install via items using the inventory

## Summary

Describe what this PR changes.
Adds complete support for Secret Apps (item-unlocked apps) with dynamic installation, uninstallation, and persistence:

Item-based Unlocking: Allows players to unlock hidden third-party or custom apps onto their phone via usable items (e.g. USB tools via ox_inventory), bypassing the default App Store.
SQL Persistence: Adds phone_secret_apps table to store per-character unlocks (citizenid, app_id), ensuring apps remain installed across relogs and restarts.
Dynamic Uninstallation & Removal: Adds client and server handlers (sd-phone:client:secretapps:removed, store.remove), exports (removeSecretApp / uninstallSecretApp), and commands (/uninstallsecretapp, /removesecretapp) so secret apps can be revoked or uninstalled live without requiring a reconnect or restart.
Client Auto-Registration: Integrates directly with the customApps module on client spawn/relog to dynamically push secret apps to the NUI.

## Type of Change

- [x] New Feature


## Testing

Describe how this was tested.
Unlocking: Used configured secretapp item in ox_inventory — verified item usage triggers the unlock, sends notification, and the custom app tile immediately appears on the home screen.
Persistence: Relogged and restarted the resource — verified the secret app automatically re-registers and displays upon loading into character.
Uninstallation / Removal: Ran /uninstallsecretapp / /removesecretapp and called exports['sd-phone']:removeSecretApp — verified the app is removed from the database and disappears from the phone screen live.
Re-installation: Used item again after uninstalling — verified it successfully unlocks once more without issues.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [x] Tested with latest ox_lib
- [x] Tested with latest ox_inventory

## Breaking Changes

Does this introduce any breaking changes?
No


---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.