### PR TITLE
Fixes navigation and close handling for custom / third-party app ifra…

### DIFF
--- a/web/src/shell/CustomAppFrame.tsx
+++ b/web/src/shell/CustomAppFrame.tsx
@@ -103,7 +103,7 @@ const SWATCHES = [
     '#5856D6', '#AF52DE', '#FF2D55', '#A2845E', '#8E8E93', '#1C1C1E', '#FFFFFF',
 ];
 
-export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }) {
+export function CustomAppFrame({ appId, onClose }: { appId: string; onClose: () => void }) {
     const def = useCustomAppsStore(s => s.apps.find(a => a.id === appId));
     const { theme, airplaneMode, hour24, brightness } = useTheme('theme', 'airplaneMode', 'hour24', 'brightness');
     const active = useDeckActive();
@@ -421,11 +421,14 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
         };
     }, [fetchPhone, showComponent, uploadMedia, settleEmoji, settleGif]);
 
-    const setApp = useCallback((target: string | { name?: string; data?: unknown }) => {
+    const setApp = useCallback((target: string | { name?: string; data?: unknown } | null | undefined) => {
         const name = typeof target === 'string' ? target : target?.name;
-        if (!name) return;
+        if (!name || name === 'home' || name === 'null' || name === '') {
+            onClose();
+            return;
+        }
         window.postMessage({ action: 'sd-phone:launchApp', data: { id: name } }, '*');
-    }, []);
+    }, [onClose]);
 
     const onLoad = useCallback(() => {
         const iframe = iframeRef.current;
@@ -466,6 +469,13 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
             win.formatPhoneNumber = (n: string) => formatPhone(n);
             win.setApp            = setApp;
             win.components        = bridge;
+
+            doc.addEventListener('keydown', (e: KeyboardEvent) => {
+                if (e.key === 'Escape') {
+                    onClose();
+                }
+            });
+
             const rootMarkup = doc.getElementById('root')?.innerHTML.length ?? -1;
             frameDebug(`${d.id}: globals set, #root markup ${rootMarkup} chars, injecting ${COMPONENTS_URL}`);
             const script = doc.createElement('script');
@@ -492,7 +502,7 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
             console.warn('[sd-phone] custom-app iframe injection failed (expected outside FiveM)', err);
         }
         setReady(true);
-    }, [theme, bridge, setApp, markSdkReady]);
+    }, [theme, bridge, setApp, markSdkReady, onClose]);
 
     useEffect(() => {
         if (!loadedRef.current) return;
@@ -511,10 +521,11 @@ export function CustomAppFrame({ appId }: { appId: string; onClose: () => void }
             if (!msg || typeof msg.type !== 'string') return;
             if (msg.type === 'sdphoneDebug' && typeof msg.message === 'string') { frameDebug(msg.message); return; }
             if (msg.type === 'sdphoneSdkReady') markSdkReady();
+            if (msg.type === 'sdphoneCloseApp' || msg.type === 'closeApp') onClose();
         }
         window.addEventListener('message', onFrameMessage);
         return () => window.removeEventListener('message', onFrameMessage);
-    }, [markSdkReady]);
+    }, [markSdkReady, onClose]);
 
     useNuiEvent('customApps:message', useCallback((data) => {
         if (!data || (data.id !== appId && data.id !== 'any')) return;


### PR DESCRIPTION

## Summary

Describe what this PR changes.
Fixes navigation and close handling for custom / third-party app iframes in CustomAppFrame:

setApp(null) / Home Navigation: setApp previously ignored falsy/null targets (if (!name) return;), preventing apps from closing or returning to the home screen via setApp(null). It now triggers onClose() when called with null, '', or 'home'.
Escape Key Forwarding: Attaches an Escape keydown listener to the iframe's document so pressing ESC while inside a custom app returns the user to the phone's home screen, matching native built-in app behavior.
onClose Prop Wiring & Message Handling: Destructures onClose in CustomAppFrame and handles sdphoneCloseApp / closeApp postMessage events from child frames.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [x] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [x] Compatibility
- [ ] Other


## Testing

Describe how this was tested.

Opened custom/third-party app iframe on the phone.
Pressed ESC while focused inside the iframe — verified the app closes smoothly and returns to the home screen.
Called window.setApp(null) from inside the child app — verified the app closes and transitions back to the home screen.
Tested normal navigation to another app (window.setApp('settings')) — verified it still switches apps properly.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [x] Tested with latest ox_lib
- [x] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

Does this introduce any breaking changes?
No

If yes, explain.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.