### PR TITLE
fix(customapps): route iframe escape through the shell ladder and stop stray closes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -623,6 +623,16 @@ function AppContent() {
     }, []);
 
     const handleSwitcherDismiss  = useCallback(() => setSwitcherClosing(true), []);
+
+    const escapeLadder = useCallback(() => {
+        if (switcherOpen)            { setSwitcherClosing(true); return; }
+        if (currentApp && !isClosing) { handleCloseApp();        return; }
+        void fetchNui('sd-phone:close');
+        setLeaving(true);
+    }, [switcherOpen, currentApp, isClosing, handleCloseApp]);
+
+    useNuiEvent('sd-phone:escape', escapeLadder);
+
     const handleSwitcherReady    = useCallback(() => setSwitcherReady(true), []);
     const handleSwitcherDone     = useCallback(() => {
         if (!switcherClosing) return;
@@ -1250,10 +1260,8 @@ function AppContent() {
             ));
 
             if (e.key === 'Escape') {
-                if (switcherOpen)            { handleSwitcherDismiss(); return; }
-                if (currentApp && !isClosing) { handleCloseApp();        return; }
-                void fetchNui('sd-phone:close');
-                setLeaving(true);
+                escapeLadder();
+                return;
             }
             if ((e.key === 'l' || e.key === 'L') && !locked && !typing) {
                 setLocked(true);
@@ -1266,7 +1274,7 @@ function AppContent() {
         }
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
-    }, [locked, currentApp, isClosing, switcherOpen, handleCloseApp, handleSwitcherDismiss]);
+    }, [locked, escapeLadder]);
 
     useEffect(() => {
         if (!isFiveM) return;

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -260,6 +260,7 @@ export type NuiMessage =
     | { action: 'sd-phone:profileReset' }
     | { action: 'sd-phone:client:characterLoaded' }
     | { action: 'sd-phone:launchApp'; data: { id: string; link?: Record<string, unknown> } }
+    | { action: 'sd-phone:escape' }
     | { action: 'sd-phone:battery'; data: number }
     | { action: 'sd-phone:service'; data: { bars: number; level: number; data: boolean } }
     | { action: 'sd-phone:wifi'; data: WifiState }

--- a/web/src/shell/CustomAppFrame.tsx
+++ b/web/src/shell/CustomAppFrame.tsx
@@ -116,6 +116,7 @@ export function CustomAppFrame({ appId, onClose }: { appId: string; onClose: () 
 
     const sdkReadyRef = useRef(false);
     const outboxRef   = useRef<unknown[]>([]);
+    const typingRef   = useRef(false);
 
     const postToApp = useCallback((message: unknown) => {
         if (!sdkReadyRef.current) {
@@ -297,6 +298,7 @@ export function CustomAppFrame({ appId, onClose }: { appId: string; onClose: () 
                 createCall(data ?? {});
                 return Promise.resolve(null);
             case 'toggleInput':
+                typingRef.current = !!data;
                 void fetchNui('sd-phone:typing', { typing: !!data });
                 return Promise.resolve(null);
             case 'OpenMedia': {
@@ -421,14 +423,33 @@ export function CustomAppFrame({ appId, onClose }: { appId: string; onClose: () 
         };
     }, [fetchPhone, showComponent, uploadMedia, settleEmoji, settleGif]);
 
+    useEffect(() => () => {
+        if (!typingRef.current) return;
+        typingRef.current = false;
+        void fetchNui('sd-phone:typing', { typing: false });
+    }, []);
+
+    const closeFromFrame = useCallback(() => {
+        if (typingRef.current) {
+            typingRef.current = false;
+            void fetchNui('sd-phone:typing', { typing: false });
+        }
+        onClose();
+    }, [onClose]);
+
     const setApp = useCallback((target: string | { name?: string; data?: unknown } | null | undefined) => {
-        const name = typeof target === 'string' ? target : target?.name;
-        if (!name || name === 'home' || name === 'null' || name === '') {
-            onClose();
+        if (target === null || target === undefined) {
+            closeFromFrame();
+            return;
+        }
+        const name = typeof target === 'string' ? target : (typeof target === 'object' ? target.name : undefined);
+        if (typeof name !== 'string' || name === '') return;
+        if (name === 'home') {
+            closeFromFrame();
             return;
         }
         window.postMessage({ action: 'sd-phone:launchApp', data: { id: name } }, '*');
-    }, [onClose]);
+    }, [closeFromFrame]);
 
     const onLoad = useCallback(() => {
         const iframe = iframeRef.current;
@@ -471,9 +492,9 @@ export function CustomAppFrame({ appId, onClose }: { appId: string; onClose: () 
             win.components        = bridge;
 
             doc.addEventListener('keydown', (e: KeyboardEvent) => {
-                if (e.key === 'Escape') {
-                    onClose();
-                }
+                if (e.key !== 'Escape') return;
+                e.preventDefault();
+                window.postMessage({ action: 'sd-phone:escape' }, '*');
             });
 
             const rootMarkup = doc.getElementById('root')?.innerHTML.length ?? -1;
@@ -502,7 +523,7 @@ export function CustomAppFrame({ appId, onClose }: { appId: string; onClose: () 
             console.warn('[sd-phone] custom-app iframe injection failed (expected outside FiveM)', err);
         }
         setReady(true);
-    }, [theme, bridge, setApp, markSdkReady, onClose]);
+    }, [theme, bridge, setApp, markSdkReady]);
 
     useEffect(() => {
         if (!loadedRef.current) return;
@@ -521,11 +542,11 @@ export function CustomAppFrame({ appId, onClose }: { appId: string; onClose: () 
             if (!msg || typeof msg.type !== 'string') return;
             if (msg.type === 'sdphoneDebug' && typeof msg.message === 'string') { frameDebug(msg.message); return; }
             if (msg.type === 'sdphoneSdkReady') markSdkReady();
-            if (msg.type === 'sdphoneCloseApp' || msg.type === 'closeApp') onClose();
+            if (msg.type === 'sdphoneCloseApp') closeFromFrame();
         }
         window.addEventListener('message', onFrameMessage);
         return () => window.removeEventListener('message', onFrameMessage);
-    }, [markSdkReady, onClose]);
+    }, [markSdkReady, closeFromFrame]);
 
     useNuiEvent('customApps:message', useCallback((data) => {
         if (!data || (data.id !== appId && data.id !== 'any')) return;


### PR DESCRIPTION
Follow-up to #203, which fixed a real bug — a hosted app genuinely could not close itself — but did it in a way that broke other things. All four review findings addressed.

## What changed

**1. `setApp` no longer closes on anything it cannot read** (`CustomAppFrame.tsx`)

`if (!name || name === 'home' || name === 'null' || name === '')` meant every unreadable target booted the player home: `onClick={setApp}` passing an event, `{ app: 'notes' }`, a number, any undefined error path. Now only an explicit `null`/`undefined` target or the string `'home'` closes; anything else with no readable name is an inert no-op, as it was before #203. Drops the `'null'` string guess and the `=== ''` branch that was dead after `!name`.

**2. Escape is forwarded, not acted on**

The iframe handler called `onClose()` unconditionally, bypassing the shell's Escape ladder (switcher → app → phone). With a bridge overlay open — `setPopUp`, gallery, emoji, camera — Escape collapsed the whole app and the `popupResolve`/`galleryResolve` promise never settled, orphaning the child's await and its button callback.

The child's Escape now posts `sd-phone:escape` and `App.tsx` runs the same ladder the parent keydown uses. The ladder itself is extracted into one `escapeLadder` callback so both entry points cannot drift.

**3. `closeApp` is no longer accepted**

Only `sdphoneCloseApp`, matching every sibling message (`sdphoneDebug`, `sdphoneSdkReady`). The bare name risked colliding with an app's own internal messaging. It appears nowhere else in the codebase and lb-phone's SDK exposes `CloseApp` as a function rather than a message type, so nothing depends on it.

**4. Keep-input leak fixed, including the pre-existing one**

Closing from inside the iframe destroyed the document without a blur, so the SDK's `toggleInput(false)` never fired and `sd-phone:typing` stayed true — leaving the player unable to move. `toggleInput` now records state in a ref, and an unmount cleanup clears typing on every teardown path. That also fixes the older swipe-to-home leak, which #203 only made routine rather than introducing.

## Gates

- `lint`: exit 0, no errors; the remaining warnings are pre-existing and none are in changed lines
- `knip`: clean
- `test`: 585 passed across 45 files
- `build`: `tsc --noEmit` + vite, clean. `sd-tablet` rebuilt too, since it aliases `@` straight at `sd-phone/web/src` — verified its bundle contains the new event
- New `sd-phone:escape` action added to the `NuiMessage` union in `core/types.ts`

## Not verified at runtime

The dev client is serving a cached `index.html` that survives `refresh` and repeated resource restarts, so the new bundle never loaded in game. The four behaviours below still need an in-game pass after a rejoin:

- Escape inside a custom app with an overlay open closes the overlay, not the app
- `setApp(null)` closes; `setApp(event)` does nothing
- Typing state clears when an app is closed from inside the frame
- An app posting `closeApp` is ignored