### PR TITLE
fix(mdt): show a vehicle name instead of the properties blob, and stop passive wheel warnings

### DIFF
--- a/bridge/server/records.lua
+++ b/bridge/server/records.lua
@@ -18,8 +18,10 @@ local VEHICLES = framework.name == 'esx'
     and { table = 'owned_vehicles',  idCol = 'owner' }
     or  { table = 'player_vehicles', idCol = 'citizenid' }
 
----@type string[] Columns a model name may live in, in preference order.
-local MODEL_COLS = { 'vehicle', 'model', 'vehicle_name', 'name' }
+---@type string[] Columns a model name may live in, in preference order. `vehicle` is last on
+---purpose: qb/QBox keep a plain name there, but ESX keeps the whole properties blob under the same
+---name, so a fork carrying a real model column should win over it.
+local MODEL_COLS = { 'model', 'vehicle_name', 'name', 'vehicle' }
 
 ---@type integer Characters below which a term is not a filter at all, so the caller is browsing and
 ---the list comes back unfiltered rather than empty.
@@ -276,14 +278,20 @@ function records.searchCitizens(term, page, pageSize)
     return out, tonumber(total) or 0
 end
 
----Builds the normalised vehicle shape from an ownership row.
+---Builds the normalised vehicle shape from an ownership row. The model is the chosen column when it
+---holds a plain name, else the saved-properties model key, else the row's stored hash - ESX keeps the
+---whole properties blob under `vehicle`, so a value opening with a brace is a row rather than a name
+---and printing it verbatim puts the entire blob in the MDT. Same rule as garages.lua's modelOf.
 ---@param row table raw ownership row
 ---@param modelCol string|nil column carrying the model name
 ---@return table vehicle
 local function vehicleOf(row, modelCol)
     local props = decode(row.vehicle)
     local model = modelCol and str(row[modelCol]) or ''
-    if model == '' then model = str(props.model) end
+
+    if model:sub(1, 1) == '{' then model = '' end
+    if model == '' then model = str(props.model or props.modelName) end
+    if model == '' then model = str(row.hash) end
 
     local garage = str(row.garage) ~= '' and str(row.garage) or str(row.parking)
     local state  = row.state

--- a/web/src/apps/maps/MapView.tsx
+++ b/web/src/apps/maps/MapView.tsx
@@ -167,13 +167,23 @@ export const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
     }, [clampPan, tx, ty, vw, vh, minScale, side]);
 
     const lastWheelStep = useRef(0);
-    function onWheel(e: React.WheelEvent) {
+
+    const wheelRef = useRef<(e: WheelEvent) => void>(() => {});
+    wheelRef.current = (e: WheelEvent) => {
         e.preventDefault();
         const now = performance.now();
         if (now - lastWheelStep.current < 160) return;
         lastWheelStep.current = now;
         zoomAround(e.clientX, e.clientY, stepScale(e.deltaY < 0 ? 1 : -1));
-    }
+    };
+
+    useEffect(() => {
+        const el = viewportRef.current;
+        if (!el) return;
+        const onWheel = (e: WheelEvent) => wheelRef.current(e);
+        el.addEventListener('wheel', onWheel, { passive: false });
+        return () => el.removeEventListener('wheel', onWheel);
+    }, []);
     function buttonZoom(dir: 1 | -1) {
         const vp = viewportRef.current;
         if (!vp) return;
@@ -385,7 +395,6 @@ export const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
             ref={viewportRef}
             className="relative h-full w-full touch-none overflow-hidden"
             style={{ background: style.bg, transition: 'background 400ms ease', cursor: dragging ? 'grabbing' : placing ? 'crosshair' : 'grab' }}
-            onWheel={onWheel}
             onPointerDown={onPointerDown}
             onPointerMove={onPointerMove}
             onPointerUp={onPointerUp}

--- a/web/src/shell/AppSwitcher.tsx
+++ b/web/src/shell/AppSwitcher.tsx
@@ -88,18 +88,26 @@ export function AppSwitcher({
         return () => clearTimeout(t);
     }, []);
 
-    function onWheel(e: React.WheelEvent) {
-        e.preventDefault();
-        const now = Date.now();
-        if (now - lastWheelRef.current < 280) return;
-        lastWheelRef.current = now;
+    const rootRef = useRef<HTMLDivElement>(null);
 
-        if (e.deltaY < 0) {
-            setFocusedIdx(f => Math.min(f + 1, recents.length - 1));
-        } else if (e.deltaY > 0) {
-            setFocusedIdx(f => Math.max(f - 1, 0));
+    useEffect(() => {
+        const el = rootRef.current;
+        if (!el) return;
+        function onWheel(e: WheelEvent) {
+            e.preventDefault();
+            const now = Date.now();
+            if (now - lastWheelRef.current < 280) return;
+            lastWheelRef.current = now;
+
+            if (e.deltaY < 0) {
+                setFocusedIdx(f => Math.min(f + 1, recents.length - 1));
+            } else if (e.deltaY > 0) {
+                setFocusedIdx(f => Math.max(f - 1, 0));
+            }
         }
-    }
+        el.addEventListener('wheel', onWheel, { passive: false });
+        return () => el.removeEventListener('wheel', onWheel);
+    }, [recents.length]);
 
     function onPointerDown(e: React.PointerEvent) {
         startXRef.current     = e.clientX;
@@ -161,6 +169,7 @@ export function AppSwitcher({
 
     return (
         <div
+            ref={rootRef}
             data-switcher-ignore="1"
             className="absolute inset-0 z-30"
             style={{
@@ -174,7 +183,6 @@ export function AppSwitcher({
                 if (closing) onDone();
                 else onReady();
             }}
-            onWheel={onWheel}
             onClick={e => {
                 if (!suppressMount.current && !suppressClick.current) onDismiss();
                 e.stopPropagation();


### PR DESCRIPTION
Two reported issues, both reproduced from the code.

## 1. MDT vehicle records print the whole properties blob

`bridge/server/records.lua` looked for a model name in `MODEL_COLS`, which had `vehicle` **first**. On qb/QBox that column holds a plain name (`dominator3`) so it reads correctly, but on ESX the same column holds the entire saved-properties JSON — so the MDT rendered the whole row where the model should be. The existing fallback never fired, because the value was not empty, just wrong.

`bridge/server/garages.lua:116` already had the right rule for exactly this — *"the `vehicle` column when it holds a plain name, else the saved-properties model key, else the row's stored hash"* — the MDT path simply never got it.

- `vehicleOf` now rejects a value that opens with `{`, then falls through to `props.model` / `props.modelName`, then `row.hash`
- `MODEL_COLS` reordered to `model`, `vehicle_name`, `name`, `vehicle` so an ESX fork with a real model column wins over the blob. Safe on QBox: `player_vehicles` carries none of the first three, so it still resolves `vehicle`

Reproduces only on ESX and forks; a QBox server sees no change.

## 2. `Unable to preventDefault inside passive event listener invocation`

React attaches `wheel` to the root container as a **passive** listener, so `e.preventDefault()` inside a JSX `onWheel` is ignored and logs that warning on every scroll. Two handlers were doing it:

- `web/src/apps/maps/MapView.tsx` — map zoom
- `web/src/shell/AppSwitcher.tsx` — switcher scroll

Both now attach a native `wheel` listener with `{ passive: false }`, which is what `web/src/ui/DrumWheel.tsx:66` already does. MapView routes through a handler ref so the listener subscribes once instead of re-binding on every zoom/pan state change.

The warning names the sd-tablet bundle because the tablet shares `sd-phone/web/src` wholesale; both bundles are rebuilt.

## Gates

- `lint`: 0 errors
- `test`: 585 passed across 45 files
- `build`: clean, and `sd-tablet` rebuilt as well
- `lua_check`: `records.lua` compiles

## Not verified at runtime

Neither fix was exercised in game. The vehicle one needs an ESX server to show the original symptom at all, and the wheel warning needs a scroll on the rebuilt bundle.