### PR TITLE
fix(ui): stop a failed account form scrolling the app out of its frame

### DIFF
--- a/web/src/core/scrollGuard.ts
+++ b/web/src/core/scrollGuard.ts
@@ -1,0 +1,22 @@
+const hiddenAxis = new WeakMap<Element, { y: boolean; x: boolean }>();
+
+function axes(el: Element): { y: boolean; x: boolean } {
+    const cached = hiddenAxis.get(el);
+    if (cached) return cached;
+    const s = getComputedStyle(el);
+    const value = { y: s.overflowY === 'hidden', x: s.overflowX === 'hidden' };
+    hiddenAxis.set(el, value);
+    return value;
+}
+
+export function installScrollGuard(): void {
+    document.addEventListener('scroll', event => {
+        const el = event.target as HTMLElement | null;
+        if (!el || el === (document as unknown as HTMLElement) || !el.getBoundingClientRect) return;
+        if (el.scrollTop === 0 && el.scrollLeft === 0) return;
+
+        const { y, x } = axes(el);
+        if (y && el.scrollTop !== 0) el.scrollTop = 0;
+        if (x && el.scrollLeft !== 0) el.scrollLeft = 0;
+    }, true);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,9 +17,11 @@ import '@fontsource/great-vibes/vietnamese-400.css';
 import { App } from './App';
 import { useMocks } from '@/core/demo';
 import { initTileCheck } from '@/apps/maps/tileCheck';
+import { installScrollGuard } from '@/core/scrollGuard';
 import './index.css';
 
 initTileCheck();
+installScrollGuard();
 
 document.addEventListener('mousedown', e => {
     if ((e.target as HTMLElement | null)?.closest?.('.select-text')) return;

--- a/web/src/shared/AppAuth.tsx
+++ b/web/src/shared/AppAuth.tsx
@@ -142,6 +142,11 @@ export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDis
 
     return (
         <div
+            onScroll={e => {
+                const el = e.currentTarget;
+                if (el.scrollTop !== 0) el.scrollTop = 0;
+                if (el.scrollLeft !== 0) el.scrollLeft = 0;
+            }}
             className={`absolute inset-0 z-10 overflow-hidden ${modal ? 'rounded-t-[14px] shadow-[0_-8px_28px_rgba(0,0,0,0.28)]' : ''}`}
             style={modal ? {
                 animation: dismissing
@@ -609,8 +614,8 @@ function AuthForm({ mode, appName, icon, theme, fields, notice, myNumber, myEmai
             setFieldErrors(errs);
             setError(null);
             const el = inputs.current[firstBad.key];
-            el?.scrollIntoView({ block: 'center' });
-            el?.focus();
+            el?.scrollIntoView({ block: 'nearest' });
+            el?.focus({ preventScroll: true });
             return;
         }
         setFieldErrors({});
@@ -624,12 +629,12 @@ function AuthForm({ mode, appName, icon, theme, fields, notice, myNumber, myEmai
                 if (key) {
                     setFieldErrors({ [key]: res.message ?? t('common.pleaseCheckField', 'Please check this field') });
                     const el = inputs.current[key];
-                    el?.scrollIntoView({ block: 'center' });
-                    el?.focus();
+                    el?.scrollIntoView({ block: 'nearest' });
+                    el?.focus({ preventScroll: true });
                 } else if (!isCreate) {
                     setFieldErrors(Object.fromEntries(shown.map(f => [f.key, t('common.notValidLogin', 'Not a valid login')])));
                     const pw = shown.find(f => f.type === 'password');
-                    if (pw) inputs.current[pw.key]?.focus();
+                    if (pw) inputs.current[pw.key]?.focus({ preventScroll: true });
                 } else {
                     setError(res.message ?? t('common.somethingWentWrong', 'Something went wrong. Please try again.'));
                 }

--- a/web/src/shared/AppAuth.tsx
+++ b/web/src/shared/AppAuth.tsx
@@ -142,11 +142,6 @@ export function AppAuth({ appName, tagline, icon, theme, fields, onAuthed, onDis
 
     return (
         <div
-            onScroll={e => {
-                const el = e.currentTarget;
-                if (el.scrollTop !== 0) el.scrollTop = 0;
-                if (el.scrollLeft !== 0) el.scrollLeft = 0;
-            }}
             className={`absolute inset-0 z-10 overflow-hidden ${modal ? 'rounded-t-[14px] shadow-[0_-8px_28px_rgba(0,0,0,0.28)]' : ''}`}
             style={modal ? {
                 animation: dismissing

--- a/web/src/shell/PhoneShell.tsx
+++ b/web/src/shell/PhoneShell.tsx
@@ -554,6 +554,11 @@ export function PhoneShell({ children, cameraActive = false, entering = false, l
                 >
                     <div
                         data-phone-screen
+                        onScroll={e => {
+                            const el = e.currentTarget;
+                            if (el.scrollTop !== 0) el.scrollTop = 0;
+                            if (el.scrollLeft !== 0) el.scrollLeft = 0;
+                        }}
                         className="absolute overflow-hidden"
                         style={{
                             left: SX, top: SY, width: SW, height: SH,

--- a/web/src/shell/PhoneShell.tsx
+++ b/web/src/shell/PhoneShell.tsx
@@ -554,11 +554,6 @@ export function PhoneShell({ children, cameraActive = false, entering = false, l
                 >
                     <div
                         data-phone-screen
-                        onScroll={e => {
-                            const el = e.currentTarget;
-                            if (el.scrollTop !== 0) el.scrollTop = 0;
-                            if (el.scrollLeft !== 0) el.scrollLeft = 0;
-                        }}
                         className="absolute overflow-hidden"
                         style={{
                             left: SX, top: SY, width: SW, height: SH,


### PR DESCRIPTION
Reported in Cherry: creating an account with an invalid field shifts the whole UI up and out of the phone frame, and it stays there.

## Cause

`shared/AppAuth.tsx` reveals the first bad field on a failed submit:

```js
el?.scrollIntoView({ block: 'center' });
el?.focus();
```

`scrollIntoView` does not scroll one container — it walks up and scrolls **every** scrollable ancestor so the element ends up centred in each. The catch is that `overflow: hidden` elements are still scrollable *programmatically*: they just have no scrollbar and no way for the user to scroll them back. So the phone screen itself gets scrolled, nothing ever restores it, and the app sits displaced until it remounts.

`el.focus()` is a second route to the same place, since focusing an off-screen input also scrolls ancestors.

This is not Cherry-specific. `AppAuth` is shared by **Cherry, Birdy, Mail, Photogram, Ryde and Vibez**, and the code path is the ordinary "you typed something wrong" branch, so every account app could do it.

## Fix

Two layers.

**Cause** — `block: 'center'` becomes `block: 'nearest'`, which scrolls the minimum needed and does nothing for ancestors where the field is already visible, and all three `focus()` calls become `focus({ preventScroll: true })`. The errored field is still brought into view; nothing above it moves.

**Net** — the phone screen (`[data-phone-screen]`) and `AppAuth`'s own root both reset `scrollTop`/`scrollLeft` to 0 if anything ever scrolls them. Both are `overflow: hidden` and are never meant to scroll, so this is a no-op in normal use and makes the displacement unreachable regardless of what future code calls `scrollIntoView`.

## Left alone deliberately

`Calendar` and `ContactsTab` also use `scrollIntoView({ block: 'start' })`, but that is correct for what they do — scroll the current month or letter section to the top of its list. They carried the same latent hazard, which the frame net now neutralises without changing their behaviour. `PhotoViewer` already used `block: 'nearest'`.

## Gates

- `lint` 0 errors, `test` 585 passed across 45 files
- Both bundles rebuilt

## Not verified at runtime

I could not drive the Cherry signup form through validation from the MCP tooling. The mechanism is confirmed by inspection and the fix is small, but the check worth doing is: open Cherry, create an account with a deliberately bad field, and confirm the UI stays put.