### PR TITLE
fix(maps): anchor scroll zoom to the cursor

### DIFF
--- a/web/src/apps/maps/MapView.tsx
+++ b/web/src/apps/maps/MapView.tsx
@@ -89,6 +89,10 @@ export const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
     const [scale, setScale] = useState(1);
     const [tx, setTx] = useState(0);
     const [ty, setTy] = useState(0);
+    const viewRef = useRef({ scale: 1, tx: 0, ty: 0 });
+    viewRef.current.scale = scale;
+    viewRef.current.tx = tx;
+    viewRef.current.ty = ty;
     const [vw, setVw] = useState(0);
     const [vh, setVh] = useState(0);
     const [dragging, setDragging] = useState(false);
@@ -128,7 +132,7 @@ export const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
     const minScale = side ? Math.min(1, vw / (side * 0.72)) : 1;
 
     const stepScale = (dir: 1 | -1): number => {
-        const lvl = Math.log2(scale);
+        const lvl = Math.log2(viewRef.current.scale);
         if (dir > 0) {
             const up = Math.floor(lvl + 1e-6) + 1;
             return up <= 0 ? 1 : 2 ** Math.min(maxLevelFor(side), up);
@@ -157,14 +161,14 @@ export const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
         const z = ancestorZoom(vp);
         const cx = (clientX / z - rect.left) - vw / 2;
         const cy = (clientY / z - rect.top)  - vh / 2;
-        setScale(prevS => {
-            const s = Math.max(minScale, Math.min(maxScaleFor(side), nextScale));
-            const ratio = s / prevS;
-            setTx(prevTx => clampPan(cx - (cx - prevTx) * ratio, ty, s).x);
-            setTy(prevTy => clampPan(tx, cy - (cy - prevTy) * ratio, s).y);
-            return s;
-        });
-    }, [clampPan, tx, ty, vw, vh, minScale, side]);
+        const view = viewRef.current;
+        const s = Math.max(minScale, Math.min(maxScaleFor(side), nextScale));
+        if (s === view.scale) return;
+        const ratio = s / view.scale;
+        const c = clampPan(cx - (cx - view.tx) * ratio, cy - (cy - view.ty) * ratio, s);
+        viewRef.current = { scale: s, tx: c.x, ty: c.y };
+        setScale(s); setTx(c.x); setTy(c.y);
+    }, [clampPan, vw, vh, minScale, side]);
 
     const lastWheelStep = useRef(0);
 


### PR DESCRIPTION
## Summary

Scroll zoom on the map didn't zoom into the point under the cursor.

`zoomAround` called `setTx`/`setTy` inside the `setScale` updater. React runs
updaters more than once, so the pan offset got applied twice and the map
overshot. Now scale and offsets are computed up front from a ref and set
normally. Pinch and the +/- buttons go through the same function.

`web/src/apps/maps/MapView.tsx`

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Improvement / Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Compatibility
- [ ] Other

## Related Issues

Closes #

## Testing

Scrolled in and out over different parts of the map, near the edges and corners,
checked the point under the cursor stays put. Pinch zoom, the +/- buttons and
placing a marker after zooming all still behave. `tsc --noEmit` and `oxlint` clean.

- [x] Tested locally
- [x] Tested with latest sd-phone
- [ ] Tested with latest ox_lib
- [ ] Tested with latest ox_inventory
- [ ] Multiplayer tested

## Breaking Changes

No. Zoom steps, limits and snapping are unchanged, only the anchor point.

---

## Checklist

- [x] My code follows the existing style of the project.
- [x] I have tested my changes.
- [x] I have updated any necessary documentation.
- [x] I have removed any debug code.
- [x] This PR does not include unrelated changes.
- [x] I have verified this works on the latest version of sd-phone.