### PR TITLE
fix(widgets): let custom widgets opt into real pointer events

### DIFF
--- a/client/customapps.lua
+++ b/client/customapps.lua
@@ -35,9 +35,10 @@ local FIELD_TYPES = {
 ---@type table<string, string> Fields of one entry in a def's optional `widgets` array, and the Lua
 ---type each must have. `ui` is the page the home screen frames; `id` defaults to a slug of `name`.
 local WIDGET_FIELD_TYPES = {
-    id   = 'string',
-    name = 'string',
-    ui   = 'string',
+    id          = 'string',
+    name        = 'string',
+    ui          = 'string',
+    interactive = 'boolean',
 }
 
 ---@type table<string, true> Sizes a declared widget may claim, matching the home screen's grid.

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -101,6 +101,12 @@ export interface CustomWidgetDef {
     name:  string;
     ui:    string;
     sizes: ('sm' | 'md' | 'lg')[];
+    /**
+     * Opt-in: lets the widget's iframe receive real pointer events (taps, buttons) instead of
+     * being purely decorative. Off by default so existing third-party widgets that never
+     * expected clicks keep behaving exactly as before.
+     */
+    interactive?: boolean;
 }
 
 export interface CustomAppDef {

--- a/web/src/shell/Homescreen.tsx
+++ b/web/src/shell/Homescreen.tsx
@@ -172,6 +172,9 @@ export function Homescreen({ apps, dock, firstPageApps, wallpaper, onLaunchApp, 
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     const appMap   = useMemo(() => new Map(apps.map(a => [a.id, a])), [apps]);
+    // Tile elements keyed by widget uid, so an interactive custom widget's "open" postMessage
+    // (no MouseEvent to read a launch origin from) can still zoom the app open from its own tile.
+    const widgetTileRefs = useRef<Record<string, HTMLElement>>({});
 
     const [dockIds, setDockIds] = useState<string[]>(() => savedLayout?.dock ?? dock);
     const dockApps = useMemo(
@@ -993,6 +996,7 @@ export function Homescreen({ apps, dock, firstPageApps, wallpaper, onLaunchApp, 
                                         } as CSSProperties}
                                     >
                                         <div
+                                            ref={el => { if (el) widgetTileRefs.current[w.uid] = el; }}
                                             className={editing ? 'animate-app-jiggle' : ''}
                                             // --jiggle scales the wobble down for bigger tiles so a
                                             // 4x4 does not swing five times as far as an icon.
@@ -1022,7 +1026,21 @@ export function Homescreen({ apps, dock, firstPageApps, wallpaper, onLaunchApp, 
                                                     const cd = widgetByKind(card.kind);
                                                     if (!cd) return null;
                                                     return cd.render({ size: w.size, width, height, align: card.align ?? 'left', theme: card.theme ?? 'dark', picks: card.picks,
-                                                        onPicks: ids => setWidgets(prev => prev.map(o => (o.uid === w.uid ? patchCard(o, ci, { picks: ids.length ? ids : undefined }) : o))) });
+                                                        onPicks: ids => setWidgets(prev => prev.map(o => (o.uid === w.uid ? patchCard(o, ci, { picks: ids.length ? ids : undefined }) : o))),
+                                                        editing,
+                                                        // Interactive custom widgets are real pointer targets, so their own
+                                                        // clicks/long-presses no longer bubble out of the (cross-origin)
+                                                        // iframe into this tile - they ask for the same behavior explicitly.
+                                                        onOpen: () => {
+                                                            if (editingRef.current) return;
+                                                            const a = appMap.get(cd.appId);
+                                                            if (!a) return;
+                                                            launch(a, launchOriginFrom(widgetTileRefs.current[w.uid] ?? null));
+                                                        },
+                                                        onLongPress: () => {
+                                                            if (!editingRef.current) setEditing(true);
+                                                        },
+                                                    });
                                                 }}
                                             />
                                         </div>

--- a/web/src/shell/widgets/CustomWidgetFrame.tsx
+++ b/web/src/shell/widgets/CustomWidgetFrame.tsx
@@ -38,15 +38,22 @@ function prettyId(kind: string): string {
     return words ? words.charAt(0).toUpperCase() + words.slice(1) : '';
 }
 
-export function CustomWidgetFrame({ kind, size, width, height }: {
+export function CustomWidgetFrame({ kind, size, width, height, editing, onOpen, onLongPress }: {
     kind:   string;
     size:   WidgetSize;
     width:  number;
     height: number;
+    /** Homescreen is in jiggle/rearrange mode: the widget must stay inert so drag-and-drop works. */
+    editing?: boolean;
+    /** Widget asked to be treated like a tap on its tile (opens the owning app). */
+    onOpen?: () => void;
+    /** Widget detected its own long-press gesture and wants to enter homescreen edit mode. */
+    onLongPress?: () => void;
 }) {
     const apps = useCustomApps();
     const { theme } = useTheme('theme');
     const found = useMemo(() => findWidget(apps, kind), [apps, kind]);
+    const interactive = found?.widget.interactive === true;
 
     const frameRef = useRef<HTMLIFrameElement>(null);
     const [ready, setReady] = useState(false);
@@ -73,6 +80,21 @@ export function CustomWidgetFrame({ kind, size, width, height }: {
             size, width, height, theme,
         }, '*');
     }, [ready, found, size, width, height, theme]);
+
+    // Interactive widgets get real pointer events, so tapping their non-button chrome no longer
+    // bubbles out to the homescreen tile (cross-origin iframes never bubble into the parent
+    // document). The widget opts back into that behavior explicitly via postMessage instead.
+    useEffect(() => {
+        if (!interactive) return;
+        function onMessage(e: MessageEvent) {
+            if (e.source !== frameRef.current?.contentWindow) return;
+            const type = (e.data as { type?: string } | null)?.type;
+            if (type === 'sd-phone:widget:open') onOpen?.();
+            else if (type === 'sd-phone:widget:longpress') onLongPress?.();
+        }
+        window.addEventListener('message', onMessage);
+        return () => window.removeEventListener('message', onMessage);
+    }, [interactive, onOpen, onLongPress]);
 
     const radius = size === 'sm' ? 22 : 26;
     const p = palette('dark');
@@ -102,7 +124,7 @@ export function CustomWidgetFrame({ kind, size, width, height }: {
                 sandbox={SANDBOX}
                 referrerPolicy="no-referrer"
                 onLoad={() => setReady(true)}
-                className="pointer-events-none absolute inset-0 border-0 transition-opacity duration-200"
+                className={`absolute inset-0 border-0 transition-opacity duration-200 ${interactive && !editing ? 'pointer-events-auto' : 'pointer-events-none'}`}
                 style={{
                     width,
                     height,

--- a/web/src/shell/widgets/registry.tsx
+++ b/web/src/shell/widgets/registry.tsx
@@ -26,6 +26,12 @@ interface WidgetRender {
     theme:  WidgetTheme;
     picks?: string[];
     onPicks?: (ids: string[]) => void;
+    /** Homescreen is in jiggle/rearrange mode. Only consumed by interactive custom widgets. */
+    editing?: boolean;
+    /** Fired when an interactive custom widget asks to be treated like a tap on its tile. */
+    onOpen?: () => void;
+    /** Fired when an interactive custom widget detects its own long-press gesture. */
+    onLongPress?: () => void;
 }
 
 export interface WidgetDef {
@@ -142,7 +148,8 @@ function thirdPartyDef(app: CustomAppDef, widget: CustomWidgetDef): WidgetDef {
         label:  () => widget.name,
         sizes:  widget.sizes,
         appId:  app.id,
-        render: o => <CustomWidgetFrame kind={kind} size={o.size} width={o.width} height={o.height} />,
+        render: o => <CustomWidgetFrame kind={kind} size={o.size} width={o.width} height={o.height}
+            editing={o.editing} onOpen={o.onOpen} onLongPress={o.onLongPress} />,
     };
 }
 
@@ -167,7 +174,8 @@ function framedDef(kind: string, appId: string): WidgetDef {
         label:  () => t('widgets.thirdParty', 'Widget'),
         sizes:  ['sm', 'md', 'lg'],
         appId,
-        render: o => <CustomWidgetFrame kind={kind} size={o.size} width={o.width} height={o.height} />,
+        render: o => <CustomWidgetFrame kind={kind} size={o.size} width={o.width} height={o.height}
+            editing={o.editing} onOpen={o.onOpen} onLongPress={o.onLongPress} />,
     };
     framed.set(kind, def);
     return def;


### PR DESCRIPTION
Custom widget iframes on the home screen were hard-coded to `pointer-events: none`, so nothing inside them could ever be tapped - they were purely decorative.

Widgets now declare `interactive = true` on the Lua side to receive real pointer events (still suppressed while the home screen is in jiggle/rearrange mode so drag-and-drop keeps working). Since a cross-origin iframe's own clicks never bubble into the parent tile, an interactive widget opts back into "open the owning app" / "enter edit mode" behavior explicitly via `postMessage({type: 'sd-phone:widget:open' | 'sd-phone:widget:longpress'})`.