### PR TITLE
feat(photos): server exports for reading a player's gallery

### DIFF
--- a/server/photos/actions.lua
+++ b/server/photos/actions.lua
@@ -72,6 +72,51 @@ function actions.list(source, payload)
     return ok(data)
 end
 
+---Shapes a DB photo row for a third-party reader. `isVideo` is added because kind lives in the
+---URL rather than a column, and time is reported only as `timestamp`, a unix integer: the raw
+---created_at column arrives in whatever shape the SQL driver decided on (oxmysql hands back a
+---millisecond epoch, not the datetime text it was written as), which is not a shape to promise
+---an outside caller.
+---@param row { id: string, url: string, favorite: any, ts: any }
+---@return table
+local function shapeExportPhoto(row)
+    return {
+        id        = row.id,
+        url       = row.url,
+        isVideo   = store.isVideoUrl(row.url),
+        favorite  = isTruthy(row.favorite),
+        timestamp = math.floor(tonumber(row.ts) or 0),
+    }
+end
+
+---A player's photos by owner id, newest first, for other resources. Unpaged on purpose: a picker
+---wants one bounded list, so this is the first page and nothing else, clamped to PAGE_SIZE. Reads
+---nothing the owner cannot already see. Always an array, empty when nothing resolves.
+---@param citizenid string owner's framework per-character id
+---@param opts { limit: number|nil, filter: 'favorites'|'videos'|nil }|nil
+---@return table[] photos
+function actions.listForCid(citizenid, opts)
+    if type(citizenid) ~= 'string' or citizenid == '' then return {} end
+
+    opts = type(opts) == 'table' and opts or {}
+    local filter = (opts.filter == 'favorites' or opts.filter == 'videos') and opts.filter or nil
+
+    local limit = tonumber(opts.limit)
+    limit = (limit and util.finite(limit)) and math.floor(limit) or PAGE_SIZE
+    if limit < 1 then limit = 1 elseif limit > PAGE_SIZE then limit = PAGE_SIZE end
+
+    -- listForCitizen deliberately over-reads by one row to prove a further page exists; that probe
+    -- row is not part of the page and would silently hand the caller limit + 1 photos.
+    local rows = store.listForCitizen(citizenid, nil, limit, filter)
+    rows[limit + 1] = nil
+
+    local out = {}
+    for i = 1, #rows do
+        out[i] = shapeExportPhoto(rows[i])
+    end
+    return out
+end
+
 ---@type integer Longest accepted photo URL in bytes, matching the phone_photos.url VARCHAR(512) column.
 local MAX_URL_BYTES = 512
 

--- a/server/photos/init.lua
+++ b/server/photos/init.lua
@@ -147,6 +147,29 @@ lib.callback.register('sd-phone:server:albums:photos', function(src, payload)
     return actions.listAlbumPhotos(src, payload and payload.albumId or '')
 end)
 
+---Public export: exports['sd-phone']:getPhotos(source, opts). Reads a player's gallery, newest
+---first, for other resources: a vehicle-listing photo picker, an evidence board, a print shop.
+---Read-only, and only ever the caller's own photos. Always an array, empty when nothing resolves.
+---@param source number acting player's server id (the gallery owner resolves from it)
+---@param opts { limit: number|nil, filter: 'favorites'|'videos'|nil }|nil
+---@return { id: string, url: string, isVideo: boolean, favorite: boolean, timestamp: integer }[]
+exports('getPhotos', function(source, opts)
+    if type(source) ~= 'number' then return {} end
+    local cid = player.getIdentifier(source)
+    if not cid then return {} end
+    return actions.listForCid(cid, opts)
+end)
+
+---Public export: exports['sd-phone']:getPhotosByIdentifier(citizenid, opts). The same read keyed
+---by owner id rather than a live source, for offline owners and for callers holding a phone
+---number: resolve it through getIdentifierByNumber first. Read-only.
+---@param citizenid string owner's framework per-character id
+---@param opts { limit: number|nil, filter: 'favorites'|'videos'|nil }|nil
+---@return { id: string, url: string, isVideo: boolean, favorite: boolean, timestamp: integer }[]
+exports('getPhotosByIdentifier', function(citizenid, opts)
+    return actions.listForCid(citizenid, opts)
+end)
+
 ---Public export: exports['sd-phone']:addPhoto(source, url). Saves an already-hosted http(s) URL
 ---into a player's gallery and pushes photos:added; a non-integer source returns { success = false }.
 ---@param source number acting player's server id (the gallery owner resolves from it)

--- a/server/photos/store.lua
+++ b/server/photos/store.lua
@@ -102,6 +102,21 @@ end
 ---@type string Video-URL test, mirroring isVideoUrl() in web/src/core/photosApi.ts.
 local VIDEO_RE <const> = '\\.(mp4|webm|mov|m4v|ogg)([?#]|$)'
 
+---@type table<string, boolean> The same extensions as VIDEO_RE, for the Lua-side twin below.
+local VIDEO_EXT <const> = { mp4 = true, webm = true, mov = true, m4v = true, ogg = true }
+
+---Whether a stored URL points at a video. The table has no is_video column, so kind is read back
+---off the extension; this is the Lua twin of VIDEO_RE, which only MySQL can run, and the two are
+---kept adjacent so a new format lands in both.
+---@param url string|nil stored media URL
+---@return boolean isVideo
+function store.isVideoUrl(url)
+    if type(url) ~= 'string' then return false end
+    local path = url:match('^[^?#]*') or url
+    local ext = path:match('%.([%a%d]+)$')
+    return ext ~= nil and VIDEO_EXT[ext:lower()] == true
+end
+
 ---Splits an opaque "ts:id" cursor. nil/'' means the first page.
 ---@param cursor string|nil
 ---@return integer|nil ts, string|nil id

--- a/web/src/apps/mdt/CctvOverlay.tsx
+++ b/web/src/apps/mdt/CctvOverlay.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { t } from '@/i18n';
 import { useNuiEvent } from '@/hooks/useNuiEvent';
+import { captureThumb } from './cctvThumbs';
 
 export interface CctvActive {
     cameraId: string;
@@ -29,6 +30,14 @@ export function CctvOverlay({ active }: { active: CctvActive }) {
     }, []);
 
     useEffect(() => { setElapsed(0); }, [active.cameraId]);
+
+    useEffect(() => {
+        let alive = true;
+        const timer = window.setTimeout(() => {
+            if (alive) void captureThumb(active.cameraId);
+        }, 1200);
+        return () => { alive = false; window.clearTimeout(timer); };
+    }, [active.cameraId]);
 
     const mins = String(Math.floor(elapsed / 60)).padStart(2, '0');
     const secs = String(elapsed % 60).padStart(2, '0');

--- a/web/src/apps/mdt/CctvPane.tsx
+++ b/web/src/apps/mdt/CctvPane.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
-import { Cctv, ChevronRight, Radio, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Cctv, Radio, X } from 'lucide-react';
 
 import { t } from '@/i18n';
 import { EmptyState } from '@/ui/EmptyState';
@@ -8,6 +8,7 @@ import { useAsyncData } from '@/hooks/useAsyncData';
 import { useSessionState } from '@/hooks/useSessionState';
 import { mdtPanePad, mdtRowMeta, mdtSectionHeader } from './mdtTheme';
 import { cctvClose, cctvList, cctvWatch, type CctvCamera } from './mdtApi';
+import { onThumbs, thumbFor } from './cctvThumbs';
 
 const ART: Record<string, { from: string; to: string; glow: string }> = {
     Bank:            { from: '#12263f', to: '#0a1622', glow: 'rgba(120,180,255,0.30)' },
@@ -17,17 +18,21 @@ const ART: Record<string, { from: string; to: string; glow: string }> = {
     YouTool:         { from: '#0f2620', to: '#081410', glow: 'rgba(110,235,190,0.26)' },
 };
 
-function Thumb({ camera, live }: { camera: CctvCamera; live: boolean }) {
+function Thumb({ camera, live, shot }: { camera: CctvCamera; live: boolean; shot: string | null }) {
     const art = ART[camera.category] ?? { from: '#1b1b1f', to: '#0d0d10', glow: 'rgba(255,255,255,0.2)' };
     return (
         <div
-            className="relative h-[74px] w-[104px] shrink-0 overflow-hidden rounded-[10px]"
+            className="relative aspect-[7/5] w-full overflow-hidden rounded-[10px]"
             style={{ background: `linear-gradient(150deg, ${art.from} 0%, ${art.to} 100%)` }}
         >
-            <div
-                className="absolute inset-0"
-                style={{ background: `radial-gradient(120% 90% at 30% 15%, ${art.glow} 0%, transparent 60%)` }}
-            />
+            {shot
+                ? <img src={shot} alt="" draggable={false} className="absolute inset-0 h-full w-full object-cover" />
+                : (
+                    <div
+                        className="absolute inset-0"
+                        style={{ background: `radial-gradient(120% 90% at 30% 15%, ${art.glow} 0%, transparent 60%)` }}
+                    />
+                )}
             <div
                 className="absolute inset-0 opacity-[0.22]"
                 style={{ backgroundImage: 'repeating-linear-gradient(to bottom, rgba(255,255,255,0.5) 0px, rgba(255,255,255,0.5) 1px, transparent 1px, transparent 3px)' }}
@@ -53,7 +58,7 @@ function Group({ label, cameras, activeId, onPick }: {
     return (
         <div className="mb-5">
             <div className={`mb-2 ${mdtSectionHeader}`}>{label}</div>
-            <div className="flex flex-col gap-1.5">
+            <div className="grid grid-cols-3 gap-2.5">
                 {cameras.map(camera => {
                     const on = camera.id === activeId;
                     return (
@@ -61,25 +66,22 @@ function Group({ label, cameras, activeId, onPick }: {
                             key={camera.id}
                             type="button"
                             onClick={() => onPick(camera)}
-                            className="flex items-center gap-3 rounded-[14px] p-2 text-left transition-colors"
+                            className="flex flex-col gap-1.5 rounded-[14px] p-2 text-left transition-colors"
                             style={{
                                 background: on ? 'rgba(59,130,246,0.16)' : 'rgba(127,127,127,0.08)',
                                 boxShadow: on ? 'inset 0 0 0 1.5px rgba(59,130,246,0.55)' : undefined,
                             }}
                         >
-                            <Thumb camera={camera} live={on} />
-                            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                                <span className="truncate text-[14px] font-semibold">{camera.label}</span>
-                                <span className="truncate text-[11.5px] text-ios-gray">{camera.category}</span>
+                            <Thumb camera={camera} live={on} shot={thumbFor(camera.id)} />
+                            <span className="min-w-0 px-0.5">
+                                <span className="block truncate text-[12.5px] font-semibold leading-tight">{camera.label}</span>
+                                {on && (
+                                    <span className="mt-0.5 flex items-center gap-1 text-[10.5px] font-bold uppercase tracking-wide text-blue-500">
+                                        <Radio className="h-[10px] w-[10px]" strokeWidth={2.8} />
+                                        {t('mdt.cctvViewing', 'Viewing')}
+                                    </span>
+                                )}
                             </span>
-                            {on ? (
-                                <span className="flex shrink-0 items-center gap-1 text-[11px] font-bold uppercase tracking-wide text-blue-500">
-                                    <Radio className="h-[12px] w-[12px]" strokeWidth={2.6} />
-                                    {t('mdt.cctvViewing', 'Viewing')}
-                                </span>
-                            ) : (
-                                <ChevronRight className="h-[15px] w-[15px] shrink-0 text-ios-gray" strokeWidth={2.2} />
-                            )}
                         </button>
                     );
                 })}
@@ -91,6 +93,9 @@ function Group({ label, cameras, activeId, onPick }: {
 export function CctvPane() {
     const [activeId, setActiveId] = useSessionState<string | null>('mdt:cctv:active', null);
     const [busy, setBusy] = useState(false);
+    const [, bumpThumbs] = useState(0);
+
+    useEffect(() => onThumbs(() => bumpThumbs(n => n + 1)), []);
 
     const { data, settled } = useAsyncData(() => cctvList(), []);
     const cameras = useMemo(() => data?.cameras ?? [], [data]);

--- a/web/src/apps/mdt/cctvThumbs.ts
+++ b/web/src/apps/mdt/cctvThumbs.ts
@@ -1,0 +1,90 @@
+import { getGameRender } from '@/render';
+
+const KEY = 'sd-phone:cctv:thumbs';
+const THUMB_W = 224;
+const THUMB_H = 158;
+const SETTLE_MS = 900;
+const MAX_STORED = 60;
+
+type ThumbMap = Record<string, string>;
+
+let cache: ThumbMap | null = null;
+const listeners = new Set<() => void>();
+
+function load(): ThumbMap {
+    if (cache) return cache;
+    try {
+        const raw = window.localStorage.getItem(KEY);
+        cache = raw ? (JSON.parse(raw) as ThumbMap) : {};
+    } catch {
+        cache = {};
+    }
+    return cache;
+}
+
+function persist(map: ThumbMap): void {
+    cache = map;
+    try {
+        window.localStorage.setItem(KEY, JSON.stringify(map));
+    } catch {
+        const keys = Object.keys(map);
+        for (let i = 0; i < Math.ceil(keys.length / 2); i++) delete map[keys[i]];
+        try { window.localStorage.setItem(KEY, JSON.stringify(map)); } catch { /* give up quietly */ }
+    }
+    for (const fn of listeners) fn();
+}
+
+export function thumbFor(cameraId: string): string | null {
+    return load()[cameraId] ?? null;
+}
+
+export function onThumbs(fn: () => void): () => void {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+}
+
+let capturing = false;
+
+export async function captureThumb(cameraId: string): Promise<void> {
+    if (capturing || !cameraId) return;
+    capturing = true;
+
+    let render: Awaited<ReturnType<typeof getGameRender>> | null = null;
+    const source = document.createElement('canvas');
+
+    try {
+        const feed = await getGameRender();
+        if (!feed) return;
+        render = feed;
+        feed.setZoom(1);
+        feed.setTargetFps(10);
+        feed.renderToTarget(source);
+
+        await new Promise(resolve => window.setTimeout(resolve, SETTLE_MS));
+        if (!source.width || !source.height) return;
+
+        const out = document.createElement('canvas');
+        out.width = THUMB_W;
+        out.height = THUMB_H;
+        const ctx = out.getContext('2d');
+        if (!ctx) return;
+
+        const scale = Math.max(THUMB_W / source.width, THUMB_H / source.height);
+        const w = source.width * scale;
+        const h = source.height * scale;
+        ctx.drawImage(source, (THUMB_W - w) / 2, (THUMB_H - h) / 2, w, h);
+
+        const data = out.toDataURL('image/jpeg', 0.55);
+        if (data.length < 128) return;
+
+        const map = { ...load(), [cameraId]: data };
+        const keys = Object.keys(map);
+        if (keys.length > MAX_STORED) delete map[keys[0]];
+        persist(map);
+    } catch {
+        /* a thumbnail is a nicety; never let it break the camera view */
+    } finally {
+        try { render?.stop(); } catch { /* renderer gone */ }
+        capturing = false;
+    }
+}


### PR DESCRIPTION
Photos had `addPhoto` and `uploadMedia` (both writes) and no read. Any third-party script wanting a gallery picker had to run its own SQL against `phone_photos`, which is how jg-usedvehicles' photo gallery broke on a server that switched from lb-phone: its lb adapter selects `link` keyed by `phone_number`, and sd-phone owns that table keyed by `citizenid` with a `url` column, so the query dies on `Unknown column 'link'`. An export shim can intercept a call but never a query, so the compat layer cannot reach this.

## Changes

- `getPhotos(source, opts)` and `getPhotosByIdentifier(citizenid, opts)`, mirroring the `getPlayerDocuments` precedent: always an array, empty when nothing resolves, read-only, owner resolved server-side.
- `opts` is `{ limit, filter = 'favorites'|'videos' }`. One bounded page, clamped to the same PAGE_SIZE of 200 the NUI uses, so nobody pulls a thousand-photo library through an export.
- Entry shape is `{ id, url, isVideo, favorite, timestamp }`. `isVideo` is new: the table has no `is_video` column, so kind is read off the URL extension by `store.isVideoUrl`, the Lua twin of the `VIDEO_RE` the SQL filter uses, kept adjacent to it.
- `created_at` is deliberately not exposed: oxmysql hands that column back as a millisecond epoch rather than the datetime text it was written as, which is a driver detail, not a shape to promise. `timestamp` is unix seconds.

## Gates

- `lua tests/lua/run.lua`: 1573 passed, 5 failed. The 5 are pre-existing on main (missing `server/battery/*` files, `settings_device`, one snapshot default) and unrelated to photos; the count before this change was 1563 passed / same 5 failed.
- New local suite `photos_export_test` (39 assertions, gitignored per repo convention): URL classification, limit clamping including NaN/inf/non-numeric, filter allowlisting, the over-read probe row not leaking into the page, and both export names actually registering.
- Live on the dev server: restarted sd-phone, seeded a photo and a video through `addPhoto`, read both back through `getPhotos` and `getPhotosByIdentifier`, confirmed `isVideo` on a `.webm?sig=` URL, confirmed the `videos` filter, and walked the documented number chain (`getPhoneNumber` to `getIdentifierByNumber` to `getPhotosByIdentifier`). Seed rows deleted afterwards.

## Docs

Published alongside: `exports-server` gains both exports, and lb-phone-compatibility gains a section on scripts that query lb's tables directly, with the column mapping and a drop-in adapter for vehicle-sale photo pickers. VitePress build passes with no dead links.