### PR TITLE
fix(payphone): survive a missing or late-starting target resource

### DIFF
--- a/bridge/client/target.lua
+++ b/bridge/client/target.lua
@@ -16,10 +16,58 @@ local function detect()
     return nil
 end
 
----@type string|nil Detection result; nil aborts the module load below.
+---@type string|nil Active backend, or nil while none is started. Deliberately not an error: this
+---module is required for its side effects at client start, so raising here killed the rest of
+---bridge/client/init.lua and left every later `require 'bridge.client.target'` holding whatever
+---sentinel ox_lib caches for a module that failed to load. The symptom was a crash in payphone.lua
+---indexing a boolean, several files away from the actual cause.
 local active = detect()
+
+---@type string|nil Active target resource name, exposed so callers can branch per-backend; nil
+---until one is running.
+target.system = active
+
+---@type fun()[] Callbacks waiting for a backend to appear; drained once one does.
+local pending = {}
+
+---@type table<string, boolean> Methods that have already reported a missing backend.
+local warned = {}
+
+---Reports the missing backend once per method, so a call in a loop is one console line.
+---@param method string bridge method that was called
+local function warnMissing(method)
+    if warned[method] then return end
+    warned[method] = true
+    print(('^3[sd-phone]^0 target.%s ignored: no target resource is running (ox_target, qb-target or qtarget).')
+        :format(method))
+end
+
+---Runs `cb` as soon as a backend is available: right now when one is already started, otherwise
+---the moment a supported resource starts. Registration that would otherwise run at load time
+---belongs here, because a server is free to start sd-phone before its target resource.
+---@param cb fun()
+function target.onReady(cb)
+    if type(cb) ~= 'function' then return end
+    if active then return cb() end
+    pending[#pending + 1] = cb
+end
+
 if not active then
-    error('No target resource found. Install ox_target, qb-target, or qtarget.')
+    print('^3[sd-phone]^0 no target resource is running (ox_target, qb-target or qtarget). Payphone booths and any other target interactions stay off until one starts.')
+
+    AddEventHandler('onClientResourceStart', function(resource)
+        if active then return end
+        for i = 1, #SUPPORTED do
+            if resource == SUPPORTED[i] then
+                active = resource
+                target.system = resource
+                print(('^2[sd-phone]^0 target resource %s started; registering interactions now.'):format(resource))
+                for j = 1, #pending do pending[j]() end
+                pending = {}
+                return
+            end
+        end
+    end)
 end
 
 ---Translate ox_target option entries to the qb-target/qtarget shape. A pass-through when
@@ -292,7 +340,19 @@ function target.removeGlobalPlayer(label)
     return true
 end
 
----@type string Active target resource name, exposed so callers can branch per-backend.
-target.system = active
+-- Every method above reaches for exports[active], so each one is wrapped in a single guard that
+-- turns a call made with no backend into a no-op plus one console line. onReady is the exception:
+-- waiting for a backend is exactly what it is for.
+for name, fn in pairs(target) do
+    if type(fn) == 'function' and name ~= 'onReady' then
+        target[name] = function(...)
+            if not active then
+                warnMissing(name)
+                return false
+            end
+            return fn(...)
+        end
+    end
+end
 
 return target

--- a/client/payphone.lua
+++ b/client/payphone.lua
@@ -503,7 +503,9 @@ RegisterNetEvent('sd-phone:client:payphone:ringStop', function(data)
     end
 end)
 
-if cfg.Enabled then
+---Registers the two booth options on the payphone prop models: Use Payphone when the booth is
+---idle, Answer Phone while it rings.
+local function registerBooths()
     target.addModel(cfg.Models or {}, {
         {
             name     = 'sd-phone:payphone',
@@ -537,6 +539,13 @@ if cfg.Enabled then
             end,
         },
     })
+end
+
+-- Booths are the only way into the payphone UI, so registration waits for a target backend
+-- instead of assuming one is already up: a server is free to start this resource before its
+-- target resource, and without a target resource at all the phone itself is unaffected.
+if cfg.Enabled then
+    target.onReady(registerBooths)
 end
 
 ---Public export: opens the payphone dial UI at the player's position (no booth prop needed),


### PR DESCRIPTION
Reported on 0.9.8, an ESX server:

```
SCRIPT ERROR: @sd-phone/client/payphone.lua:507: attempt to index a boolean value (local 'target')
```

That line is `target.addModel(...)`, and `target` is `require 'bridge.client.target'`. The require did not fail there, it failed earlier. `bridge/client/target.lua` called `error('No target resource found...')` at load when none of ox_target / qb-target / qtarget was started, and that module is required for its side effects on line 5 of `bridge/client/init.lua`. The raise killed that chunk (so `bridge.client.inventory` and `bridge.client.dispatch` on lines 6 and 9 never loaded either) and left ox_lib's module cache holding the sentinel it writes before running a module. The later `require` in payphone.lua handed that sentinel back, so the reporter saw a crash two files away from the cause with the real message nowhere near it.

Payphone booths are the only consumer of the target bridge, so a server with no target script lost considerably more than payphones.

## Changes

- `bridge/client/target.lua` no longer raises. With no backend it loads, names the problem once at boot, and every method is wrapped in a guard that makes the call a no-op returning `false` plus one console line per method. Nothing downstream is killed and nothing indexes a nil export.
- Added `target.onReady(cb)`: runs immediately when a backend is up, otherwise when a supported resource starts. This also covers the load-order case, where a server ensures sd-phone before its target resource. The bridge adopts the first supported resource to start and drains the queue.
- `client/payphone.lua` registers its two booth options through `target.onReady` instead of at load.

## Gates

- `lua tests/lua/run.lua`: 1595 passed, 5 failed. The 5 are pre-existing on main (missing `server/battery/*` files, `settings_device`, one snapshot default) and unrelated.
- New local suite `target_bridge_test` (22 assertions, gitignored per repo convention): ox_target and qb-target detection still translate calls to the right backend method, a missing backend loads and answers `false` with exactly one warning per method, the boot line names the problem, and a backend starting later adopts, drains `onReady` and then reaches the export, with a second backend start not re-running anything.
- Live on the dev server, reproducing the reporter's setup: stopped ox_target, restarted sd-phone, and `exports['sd-phone']:isPayphoneOpen()` answers from the client. That export is registered after line 507, so before this change it did not exist. Payphone.lua now loads to the end with no target resource present. Restarted ox_target and sd-phone afterwards and the console is clean.

Worth noting for support: the phone itself never needed a target resource. Only booths do.