### PR TITLE
fix(cameras): keep live video runs whole instead of splicing them

### DIFF
--- a/client/apps/bodycam.lua
+++ b/client/apps/bodycam.lua
@@ -167,6 +167,17 @@ if ENABLED then
         if yielded then reportState() end
     end)
 
+    ---Server push: re-anchor now. A terminal has joined, or the run this client was feeding was
+    ---cut, and either way the only thing a terminal can start from is a fresh header. The encoder
+    ---restarts rather than continuing, which is a visible cut for anyone already watching, so the
+    ---server asks for this sparingly rather than on a timer.
+    ---@param payload table { gen }
+    RegisterNetEvent('sd-phone:client:mdt:cameraAnchor', function(payload)
+        if not demand or not demand.on then return end
+        if type(payload) == 'table' and payload.gen ~= nil and payload.gen ~= demand.gen then return end
+        SendNUIMessage({ action = 'sd-phone:mdt:cameraAnchor', data = { gen = demand.gen } })
+    end)
+
     ---React -> Lua: the broadcaster page asking what the server currently wants, for the case
     ---where the demand landed before the page had loaded this app's chunk.
     RegisterNUICallback('sd-phone:mdt:cameraSync', function(_, cb)

--- a/client/apps/mdt.lua
+++ b/client/apps/mdt.lua
@@ -120,9 +120,17 @@ RegisterNetEvent('sd-phone:client:mdt:warrant', function(data)
 end)
 
 ---Server push: one media segment from a unit's camera, addressed to this terminal only.
----@param data table { citizenid, gen, chunk, init, mime? }
+---@param data table { citizenid, gen, seq, chunk, init, mime? }
 RegisterNetEvent('sd-phone:client:mdt:cameraChunk', function(data)
     SendNUIMessage({ action = 'sd-phone:mdt:cameraChunk', data = data })
+end)
+
+---Server push: the cached opening of a run, so a terminal that joined mid-shift has something to
+---start from. Header first, then every chunk since it, in one payload precisely so the parts cannot
+---arrive out of order the way separate latent sends can.
+---@param data table { citizenid, gen, seq, mime?, chunks }
+RegisterNetEvent('sd-phone:client:mdt:cameraPrime', function(data)
+    SendNUIMessage({ action = 'sd-phone:mdt:cameraPrime', data = data })
 end)
 
 ---Server push: a camera this terminal was watching has gone off the air.

--- a/server/mdt/cameras.lua
+++ b/server/mdt/cameras.lua
@@ -137,6 +137,10 @@ local INGEST_WINDOW = 1000
 local MAX_INGEST_CHUNKS = 24
 ---@type integer Minimum gap between one terminal's cached-header replays, in milliseconds.
 local REPLAY_MS = 4000
+---@type integer Minimum gap between two re-anchor requests to the same broadcaster, in
+---milliseconds. Every re-anchor restarts the encoder and shows as a cut to everyone already
+---watching, so several terminals joining at once must cost one restart rather than one each.
+local ANCHOR_GAP_MS = 1500
 ---@type integer Minimum gap between two audit rows for the same officer watching the same camera.
 local AUDIT_GAP_MS = 60000
 ---@type integer Window a terminal's watch calls are counted over, in milliseconds.
@@ -154,6 +158,8 @@ local FEATURE = 'mdt:cam'
 local sessions = {}
 ---@type table<integer, table> The same sessions, keyed by the host's server id.
 local byHostSrc = {}
+---@type table<string, boolean> '<citizenid>:<reason>' pairs already reported by breakRun.
+local brokenSaid = {}
 ---@type table<integer, integer> Vehicle class last reported by an officer's own client.
 local reportedClass = {}
 
@@ -258,8 +264,11 @@ local function ensureSession(me)
         quality      = nil,   -- nil while nobody is watching, else 'preview' | 'full'
         mime         = nil,   -- e.g. 'video/webm;codecs=vp8', from the header chunk
         header       = nil,   -- the stream header a joining terminal is primed with
-        gop          = {},    -- chunks since that header
+        gop          = {},    -- chunks since that header, contiguous or not cached at all
         gopBytes     = 0,
+        run          = 0,     -- which run the header opened; counts up and never repeats
+        seq          = 0,     -- position of the next chunk in that run
+        anchorAt     = 0,     -- GetGameTimer of the last re-anchor asked of the officer's client
         busy         = false, -- the officer's own camera app has the game view
         unsupported  = false, -- the officer's client cannot capture at all
         onRelay      = false, -- the officer's client is publishing over the media relay instead
@@ -285,6 +294,45 @@ local function resetCache(session)
     session.gop      = {}
     session.gopBytes = 0
     session.replayAt = {}
+end
+
+---Drops the cache without touching the mime, for when the run it holds has stopped being one
+---contiguous piece: a chunk went over the size ceiling, the ingest budget refused one, or the
+---window filled and something had to go. What is left after any of those is a header and a tail
+---with a hole between them, and a hole is not a smaller cache, it is an undecodable one. A
+---terminal primed with it faults, rebuilds, is primed with it again and never recovers, so the
+---cache is emptied instead and the next header starts a fresh run.
+---@param session table broadcast session
+---@param cause string stable machine-readable cause, so a configuration that breaks a run on every
+---chunk is reported once rather than on every chunk
+---@param detail string what to tell the console the first time this cause fires
+local function breakRun(session, cause, detail)
+    if not session.header and #session.gop == 0 then return end
+    local key = session.citizenid .. ':' .. cause
+    if not brokenSaid[key] then
+        brokenSaid[key] = true
+        print(('^3[sd-phone:cameras]^0 %s: %s, so a terminal joining now waits for a fresh header rather than being primed with a gap. Lower Bitrate or TimesliceMs in configs/bodycam.lua to keep instant joins.')
+            :format(session.citizenid, detail))
+    end
+    session.header   = nil
+    session.gop      = {}
+    session.gopBytes = 0
+    session.replayAt = {}
+end
+
+---Asks the officer's client to re-anchor now: a fresh header, which is the only thing a terminal
+---with nothing cached can start from. Throttled per session, so a camera several terminals open at
+---once re-anchors once rather than once each, and a terminal re-asserting its watch on a timer
+---cannot drive the encoder into a permanent restart loop.
+---@param session table broadcast session
+---@return boolean asked
+local function requestAnchor(session)
+    if not session.src or not session.quality then return false end
+    local now = GetGameTimer()
+    if now < (session.anchorAt or 0) + ANCHOR_GAP_MS then return false end
+    session.anchorAt = now
+    TriggerClientEvent('sd-phone:client:mdt:cameraAnchor', session.src, { gen = session.gen })
+    return true
 end
 
 ---@param session table broadcast session
@@ -471,32 +519,39 @@ end
 ---into a shift shows a picture without waiting for the next re-anchor. A replay is up to a megabyte
 ---of latent event, so anything but a first attach is spaced by REPLAY_MS rather than served on
 ---demand: the terminal re-asserts its watch on a timer and would otherwise be replayed every tick.
+---An empty cache is not a failure to prime: it means the run it held stopped being contiguous, and
+---the officer's client is asked for a fresh header instead. The numbering the live chunks carry is
+---reproduced here, so the terminal reads the replay and the live feed it runs into as one run.
 ---@param session table broadcast session
 ---@param src integer viewer server id
 ---@param force boolean whether this is a first attach, which is never spaced
 local function replay(session, src, force)
-    if not session.header then return end
+    if not session.header then
+        requestAnchor(session)
+        return
+    end
 
     local now  = GetGameTimer()
     local last = session.replayAt[src]
     if not force and last and now >= last and (now - last) < REPLAY_MS then return end
     session.replayAt[src] = now
 
-    TriggerLatentClientEvent('sd-phone:client:mdt:cameraChunk', src, RELAY_BPS, {
+    -- One event rather than one per chunk. Latent sends are paced across ticks and several in
+    -- flight together finish in whatever order they finish in, so a header and the chunks behind it
+    -- sent separately can arrive scrambled, and the terminal cannot play a run it cannot order. In
+    -- one payload they cannot overtake each other. The header's own number is as many places back
+    -- from the next live one as the cache is long.
+    local chunks = { session.header }
+    for i = 1, #session.gop do chunks[i + 1] = session.gop[i] end
+
+    TriggerLatentClientEvent('sd-phone:client:mdt:cameraPrime', src, RELAY_BPS, {
         citizenid = session.citizenid,
         gen       = session.gen,
-        chunk     = session.header,
-        init      = true,
+        run       = session.run,
+        seq       = session.seq - #session.gop - 1,
         mime      = session.mime,
+        chunks    = chunks,
     })
-    for i = 1, #session.gop do
-        TriggerLatentClientEvent('sd-phone:client:mdt:cameraChunk', src, RELAY_BPS, {
-            citizenid = session.citizenid,
-            gen       = session.gen,
-            chunk     = session.gop[i],
-            init      = false,
-        })
-    end
 end
 
 ---Detaches a terminal from one camera, or from every camera it holds on that officer.
@@ -695,6 +750,11 @@ end)
 ---Broadcaster chunk push (latent net event). Only an officer with a live demand on them may feed
 ---it, the chunk must be a non-empty string under MAX_CHUNK, and a chunk carrying a stale
 ---generation is dropped rather than mixed into the current stream.
+---
+---These chunks are slices of one continuous encoder byte run, not standalone frames, so a chunk
+---that cannot be forwarded is not a dropped frame: it is a hole, and everything after it is
+---undecodable until the next header. Each refusal below therefore ends the run and asks for a new
+---header rather than quietly skipping one chunk and leaving the terminals to fault on the rest.
 ---@param src integer sender server id
 ---@param payload table { gen, chunk, init?, mime? } attacker-controlled
 function cameras.chunk(src, payload)
@@ -704,10 +764,32 @@ function cameras.chunk(src, payload)
     if math.floor(tonumber(payload.gen) or -1) ~= session.gen then return end
 
     local chunk = payload.chunk
-    if type(chunk) ~= 'string' or chunk == '' or #chunk > MAX_CHUNK then return end
-    if not ingestOk(session, #chunk) then return end
+    if type(chunk) ~= 'string' or chunk == '' then return end
 
     local isInit = payload.init == true
+    -- Numbered before the refusals below rather than after them, because a chunk that never
+    -- reaches the terminals has to leave a hole in the numbering: that hole is the only signal a
+    -- terminal gets that its byte run has been cut, and it stops feeding its decoder on the
+    -- strength of it instead of faulting somewhere on the far side.
+    if isInit then
+        session.run = session.run + 1
+        session.seq = 0
+    end
+    local seq = session.seq
+    session.seq = seq + 1
+
+    if #chunk > MAX_CHUNK then
+        breakRun(session, 'oversize_chunk',
+            ('a chunk of %d bytes is over the %d byte ceiling'):format(#chunk, MAX_CHUNK))
+        requestAnchor(session)
+        return
+    end
+    if not ingestOk(session, #chunk) then
+        breakRun(session, 'ingest_budget', 'the broadcaster is pushing bytes faster than the ingest budget allows')
+        requestAnchor(session)
+        return
+    end
+
     if isInit then
         local mime = util.limitedString(payload.mime, 64)
         if mime then session.mime = mime end
@@ -718,15 +800,20 @@ function cameras.chunk(src, payload)
         local gop = session.gop
         gop[#gop + 1] = chunk
         session.gopBytes = session.gopBytes + #chunk
-        while #gop > 0 and (#gop > MAX_GOP or session.gopBytes > MAX_GOP_BYTES) do
-            session.gopBytes = session.gopBytes - #gop[1]
-            table.remove(gop, 1)
+        -- Trimming the front would leave the header attached to a tail it no longer runs into.
+        -- The whole cache goes instead: a joiner is served nothing and re-anchored, which costs a
+        -- keyframe, where a spliced cache costs the terminal its picture until the camera closes.
+        if #gop > MAX_GOP or session.gopBytes > MAX_GOP_BYTES then
+            breakRun(session, 'cache_full',
+                ('a header plus %d chunks does not fit the %d byte replay cache'):format(#gop, MAX_GOP_BYTES))
         end
     end
 
     local data = {
         citizenid = session.citizenid,
         gen       = session.gen,
+        run       = session.run,
+        seq       = seq,
         chunk     = chunk,
         init      = isInit,
         mime      = isInit and session.mime or nil,
@@ -808,8 +895,33 @@ function cameras.vehicle(src, payload)
     reportedClass[src] = (class >= 0 and class <= 22) and class or nil
 end
 
+---Reports a quality profile whose numbers cannot survive the pipeline they feed. Base64 costs a
+---third on top of the encoded bitrate, so a chunk is roughly bitrate/8 * TimesliceMs * 1.37 bytes:
+---past MAX_CHUNK every chunk is refused and the picture never starts, and past MAX_GOP_BYTES the
+---cache cannot hold a run so every terminal that joins costs a re-anchor. Neither is visible from
+---the game, and both were silent before they were printed here.
+---@param name string quality name, as written in configs/bodycam.lua
+---@param profile table the resolved profile
+local function reportProfileFit(name, profile)
+    local chunkBytes = math.floor(profile.bitrate / 8 * (TIMESLICE_MS / 1000) * 1.37)
+    if chunkBytes > MAX_CHUNK then
+        print(('^1[sd-phone:cameras]^0 %s: Bitrate %d over TimesliceMs %d makes chunks of about %d bytes, past the %d byte ceiling. Every chunk will be refused and the picture will never start: lower Bitrate, or lower TimesliceMs.')
+            :format(name, profile.bitrate, TIMESLICE_MS, chunkBytes, MAX_CHUNK))
+        return
+    end
+
+    local runBytes = math.floor(chunkBytes * (KEYFRAME_MS / TIMESLICE_MS))
+    if runBytes > MAX_GOP_BYTES then
+        print(('^3[sd-phone:cameras]^0 %s: Bitrate %d over KeyframeMs %d makes a run of about %d bytes, past the %d byte replay cache. Terminals joining will wait for a fresh header rather than starting instantly: lower Bitrate or KeyframeMs to keep the cache useful.')
+            :format(name, profile.bitrate, KEYFRAME_MS, runBytes, MAX_GOP_BYTES))
+    end
+end
+
 if ENABLED then
     media.registerFeature(FEATURE, { entitle = entitle })
+
+    reportProfileFit('Preview', PROFILES.preview)
+    reportProfileFit('Fullscreen', PROFILES.full)
 
     -- Media and state travel on net events rather than callbacks because a chunk is latent: it is
     -- paced onto the wire instead of blocking the net thread on one big frame. This stays whatever

--- a/server/photogram/live.lua
+++ b/server/photogram/live.lua
@@ -338,9 +338,14 @@ function live.chunk(src, payload)
         if gop then
             gop[#gop + 1] = chunk
             session.genBytes = (session.genBytes or 0) + #chunk
-            while #gop > 0 and (#gop > MAX_GOP or session.genBytes > MAX_GOP_BYTES) do
-                session.genBytes = session.genBytes - #gop[1]
-                table.remove(gop, 1)
+            -- Dropping the front would leave the header joined to a tail it no longer runs into,
+            -- and these chunks are slices of one encoder byte run rather than standalone segments:
+            -- a viewer primed with a header and a gap cannot decode either side of it. The cache
+            -- goes entirely instead, and the next header starts a fresh one.
+            if #gop > MAX_GOP or session.genBytes > MAX_GOP_BYTES then
+                session.header    = nil
+                session.genChunks = {}
+                session.genBytes  = 0
             end
         end
     end

--- a/server/vibez/live.lua
+++ b/server/vibez/live.lua
@@ -329,9 +329,14 @@ function live.chunk(src, payload)
         if gop then
             gop[#gop + 1] = chunk
             session.genBytes = (session.genBytes or 0) + #chunk
-            while #gop > 0 and (#gop > MAX_GOP or session.genBytes > MAX_GOP_BYTES) do
-                session.genBytes = session.genBytes - #gop[1]
-                table.remove(gop, 1)
+            -- Dropping the front would leave the header joined to a tail it no longer runs into,
+            -- and these chunks are slices of one encoder byte run rather than standalone segments:
+            -- a viewer primed with a header and a gap cannot decode either side of it. The cache
+            -- goes entirely instead, and the next header starts a fresh one.
+            if #gop > MAX_GOP or session.genBytes > MAX_GOP_BYTES then
+                session.header    = nil
+                session.genChunks = {}
+                session.genBytes  = 0
             end
         end
     end

--- a/web/src/apps/mdt/CameraFeed.tsx
+++ b/web/src/apps/mdt/CameraFeed.tsx
@@ -17,8 +17,10 @@ import { mdtCameraUnwatch, mdtCameraWatch } from './mdtApi';
 import {
     onCameraChunk,
     onCameraOff,
+    onCameraPrime,
     onCameraTransport,
     type CameraChunkPush,
+    type CameraPrimePush,
     type CameraTransport,
 } from './cameraBus';
 import type { CameraQuality, CameraTile } from './data';
@@ -127,7 +129,7 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
             void attach(true, relayWanted());
         };
 
-        const feed = (from: CameraTransport, bytes: Uint8Array, init: boolean, hint: string, gen: number) => {
+        const feed = (from: CameraTransport, bytes: Uint8Array, init: boolean, hint: string, gen: number, seq: number | null = null, run: number | null = null) => {
             if (!alive || bytes.byteLength === 0) return;
             const video = videoRef.current;
             if (!video) return;
@@ -167,7 +169,7 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
                 player.start();
                 player.setActive(deckRef.current);
             }
-            playerRef.current.append(bytes, init, gen);
+            playerRef.current.append(bytes, init, gen, seq, run);
         };
 
         const join = async (grant: RelayGrant) => {
@@ -213,7 +215,18 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
 
         const offChunk = onCameraChunk(camera.citizenid, (push: CameraChunkPush) => {
             if (!push.chunk) return;
-            feed('event', base64ToBytes(push.chunk), push.init === true, push.mime ?? '', push.gen ?? 0);
+            feed('event', base64ToBytes(push.chunk), push.init === true, push.mime ?? '', push.gen ?? 0, typeof push.seq === 'number' ? push.seq : null, typeof push.run === 'number' ? push.run : null);
+        });
+
+        // The cached opening of a run, arriving whole: a header and the chunks behind it, in the
+        // order they were encoded, which is the order they have to be fed in.
+        const offPrime = onCameraPrime(camera.citizenid, (push: CameraPrimePush) => {
+            const chunks = Array.isArray(push.chunks) ? push.chunks : [];
+            const first = typeof push.seq === 'number' ? push.seq : null;
+            for (let i = 0; i < chunks.length; i++) {
+                if (!chunks[i]) continue;
+                feed('event', base64ToBytes(chunks[i]), i === 0, push.mime ?? '', push.gen ?? 0, first === null ? null : first + i, typeof push.run === 'number' ? push.run : null);
+            }
         });
 
         const offEnded = onCameraOff(camera.citizenid, () => {
@@ -241,6 +254,7 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
             alive = false;
             window.clearInterval(keepAlive);
             offChunk();
+            offPrime();
             offEnded();
             offTransport();
             dropRelay();

--- a/web/src/apps/mdt/cameraBus.ts
+++ b/web/src/apps/mdt/cameraBus.ts
@@ -24,9 +24,24 @@ export interface CameraTransportPush {
 export interface CameraChunkPush {
     citizenid: string;
     gen?:      number;
+    run?:      number;
+    seq?:      number;
     chunk?:    string;
     init?:     boolean;
     mime?:     string;
+}
+
+export interface CameraPrimePush {
+    citizenid: string;
+    gen?:      number;
+    run?:      number;
+    seq?:      number;
+    mime?:     string;
+    chunks?:   string[];
+}
+
+export interface CameraAnchorPush {
+    gen?: number;
 }
 
 export interface CameraOffPush {
@@ -40,11 +55,15 @@ const CHUNK_ACTION     = 'sd-phone:mdt:cameraChunk';
 const OFF_ACTION       = 'sd-phone:mdt:cameraOff';
 const DEMAND_ACTION    = 'sd-phone:mdt:cameraDemand';
 const TRANSPORT_ACTION = 'sd-phone:mdt:cameraTransport';
+const ANCHOR_ACTION    = 'sd-phone:mdt:cameraAnchor';
+const PRIME_ACTION     = 'sd-phone:mdt:cameraPrime';
 
 const chunkSubs = new Map<string, Set<Handler<CameraChunkPush>>>();
 const offSubs = new Map<string, Set<Handler<CameraOffPush>>>();
 const transportSubs = new Map<string, Set<Handler<CameraTransportPush>>>();
+const primeSubs = new Map<string, Set<Handler<CameraPrimePush>>>();
 const demandSubs = new Set<Handler<CameraDemand | undefined>>();
+const anchorSubs = new Set<Handler<CameraAnchorPush | undefined>>();
 
 let listening = false;
 
@@ -62,10 +81,13 @@ function ensureListener(): void {
         const msg = event.data as { action?: string; data?: unknown } | undefined;
         if (!msg?.action) return;
         if (msg.action === CHUNK_ACTION) fan(chunkSubs, msg.data as CameraChunkPush | undefined);
+        else if (msg.action === PRIME_ACTION) fan(primeSubs, msg.data as CameraPrimePush | undefined);
         else if (msg.action === OFF_ACTION) fan(offSubs, msg.data as CameraOffPush | undefined);
         else if (msg.action === TRANSPORT_ACTION) fan(transportSubs, msg.data as CameraTransportPush | undefined);
         else if (msg.action === DEMAND_ACTION) {
             for (const handler of Array.from(demandSubs)) handler(msg.data as CameraDemand | undefined);
+        } else if (msg.action === ANCHOR_ACTION) {
+            for (const handler of Array.from(anchorSubs)) handler(msg.data as CameraAnchorPush | undefined);
         }
     });
 }
@@ -85,6 +107,10 @@ export function onCameraChunk(citizenid: string, handler: Handler<CameraChunkPus
     return subscribe(chunkSubs, citizenid, handler);
 }
 
+export function onCameraPrime(citizenid: string, handler: Handler<CameraPrimePush>): () => void {
+    return subscribe(primeSubs, citizenid, handler);
+}
+
 export function onCameraOff(citizenid: string, handler: Handler<CameraOffPush>): () => void {
     return subscribe(offSubs, citizenid, handler);
 }
@@ -97,4 +123,10 @@ export function onCameraDemand(handler: Handler<CameraDemand | undefined>): () =
     ensureListener();
     demandSubs.add(handler);
     return () => { demandSubs.delete(handler); };
+}
+
+export function onCameraAnchor(handler: Handler<CameraAnchorPush | undefined>): () => void {
+    ensureListener();
+    anchorSubs.add(handler);
+    return () => { anchorSubs.delete(handler); };
 }

--- a/web/src/apps/mdt/cameraPublisher.ts
+++ b/web/src/apps/mdt/cameraPublisher.ts
@@ -11,17 +11,21 @@ import {
     relayPublish,
     type RelayStreamHandle,
 } from '@/shared/mediaSocket';
-import { onCameraDemand, type CameraDemand, type CameraEncoder } from './cameraBus';
+import { onCameraAnchor, onCameraDemand, type CameraAnchorPush, type CameraDemand, type CameraEncoder } from './cameraBus';
 import { mediaDebug } from '@/shared/mediaDebug';
 
 const FALLBACK_ASPECT = 16 / 9;
 const CAPTURE_ZOOM = PORTRAIT_CROP.width;
 const ANCHOR_MIN_MS = 1000;
 const ANCHOR_DEFAULT_MS = 20000;
+// Comfortably inside the server's own 600000 byte ceiling on one base64 chunk.
+const MAX_EVENT_CHUNK = 400000;
 
 let targetGen: number | null = null;
 let startToken = 0;
 let teardown: (() => void) | null = null;
+/** Restarts the encoder on the running publish, so the next chunk is a fresh header. */
+let anchorNow: (() => void) | null = null;
 let sampler: ReturnType<typeof setInterval> | null = null;
 let encodedBytes = 0;
 let render: GameRender | null = null;
@@ -65,7 +69,22 @@ interface Encoding {
 function eventSink(gen: number, mime: string): Segment {
     return async (blob, init) => {
         const chunk = await blobToBase64(blob);
-        await fetchNui('sd-phone:mdt:cameraChunk', { gen, chunk, init, mime: init ? mime : undefined });
+
+        // The server refuses a chunk past its ceiling, and on this transport a refused chunk is a
+        // hole rather than a dropped frame: everything after it is undecodable until the next
+        // header. A recorder pushed hard enough will produce one, so the encoded run is cut into
+        // pieces that fit instead. Any cut is legal here because what travels is a byte run, not a
+        // frame, and only the first piece opens it.
+        if (chunk.length <= MAX_EVENT_CHUNK) {
+            await fetchNui('sd-phone:mdt:cameraChunk', { gen, chunk, init, mime: init ? mime : undefined });
+            return;
+        }
+
+        for (let at = 0; at < chunk.length; at += MAX_EVENT_CHUNK) {
+            const piece = chunk.slice(at, at + MAX_EVENT_CHUNK);
+            const opens = init && at === 0;
+            await fetchNui('sd-phone:mdt:cameraChunk', { gen, chunk: piece, init: opens, mime: opens ? mime : undefined });
+        }
     };
 }
 
@@ -281,7 +300,9 @@ async function startPublishing(demand: CameraDemand, token: number): Promise<voi
     }
 
     const live = encoding;
+    anchorNow = () => live.anchor();
     teardown = () => {
+        anchorNow = null;
         live.stop();
         if (handle) {
             try { handle.close(); } catch { /* socket already gone */ }
@@ -306,8 +327,16 @@ function applyDemand(demand: CameraDemand | undefined): void {
     void startPublishing(demand, startToken);
 }
 
+/** The server asking for a fresh header, because a terminal has nothing it can start from. */
+function applyAnchor(push: CameraAnchorPush | undefined): void {
+    if (targetGen === null) return;
+    if (push?.gen !== undefined && push.gen !== targetGen) return;
+    anchorNow?.();
+}
+
 if (isFiveM) {
     onCameraDemand(applyDemand);
+    onCameraAnchor(applyAnchor);
 
     void fetchNui<{ success?: boolean; data?: CameraDemand }>('sd-phone:mdt:cameraSync')
         .then(res => applyDemand(res?.data))

--- a/web/src/shared/liveMedia.ts
+++ b/web/src/shared/liveMedia.ts
@@ -82,6 +82,8 @@ const REBUILD_WINDOW_MS = 30_000;
 const REBUILD_FAIL_COUNT = 3;
 const PROGRESS_STALE_MS = 2_000;
 const NEED_INIT_GAP_MS = 1_000;
+const REORDER_MAX = 3;
+const REORDER_MAX_BYTES = 2_097_152;
 const DEFAULT_TIMESLICE_MS = 400;
 
 type Op = { append: Uint8Array; init: boolean } | { remove: [number, number] };
@@ -106,8 +108,11 @@ export class LiveVideoPlayer {
     private active = true;
 
     private gen: number | null = null;
-    private lastInit: Uint8Array | null = null;
-    private lastInitGen: number | null = null;
+    private nextSeq: number | null = null;
+    private run: number | null = null;
+    private pendingRun: number | null = null;
+    private pending = new Map<number, Uint8Array>();
+    private pendingBytes = 0;
     private sawExplicitInit = false;
     private awaitingInit = false;
 
@@ -150,7 +155,7 @@ export class LiveVideoPlayer {
         this.attach();
     }
 
-    append(bytes: Uint8Array, init = false, gen: number | null = null): void {
+    append(bytes: Uint8Array, init = false, gen: number | null = null, seq: number | null = null, run: number | null = null): void {
         if (this.destroyed || !bytes || bytes.byteLength === 0) return;
         this.lastFrameAt = Date.now();
         if (this.healthState === 'offair') {
@@ -164,28 +169,137 @@ export class LiveVideoPlayer {
                 this.gen = gen;
             } else if (this.gen !== gen) {
                 this.gen = gen;
-                this.lastInit = null;
-                this.lastInitGen = null;
                 this.rebuild('gen_change');
             }
         }
 
+        // A transport that numbers its chunks lets a hole be told apart from a swap. Both look
+        // identical to the decoder - a fault a few hundred milliseconds later with no cause
+        // attached - but they want opposite handling: a swap is put back in order and played, a
+        // hole means every byte after it is undecodable until the next header.
+        const numbered = seq !== null && Number.isFinite(seq);
+
+        // Numbering restarts behind every header, so a number alone cannot say which run a chunk
+        // belongs to: the run before this one had a chunk 10 too, and it may still be in flight.
+        // The run it names is what tells a straggler from the chunk it would be mistaken for.
+        if (numbered && run !== null && Number.isFinite(run)) {
+            if (this.run !== null && run < this.run) return;
+            if (this.run === null || run > this.run) {
+                this.run = run;
+                if (this.pendingRun !== run) {
+                    this.dropPending();
+                    this.pendingRun = run;
+                }
+                if (!init) this.nextSeq = null;
+            }
+        }
+
         if (init) {
-            this.lastInit = bytes;
-            this.lastInitGen = this.gen;
+            if (numbered) {
+                this.nextSeq = seq + 1;
+                this.forgetBefore(this.nextSeq);
+            } else {
+                this.dropPending();
+            }
             this.awaitingInit = false;
-        } else if (this.awaitingInit) {
+            this.enqueue(bytes, true);
+            this.drainPending();
+            return;
+        }
+
+        if (numbered) {
+            if (this.nextSeq === null) {
+                // Nothing to measure against yet: these are the chunks that overtook the header
+                // still on its way. Held rather than dropped, so the picture starts on the header
+                // rather than on whatever arrives after it.
+                this.hold(seq, bytes, false);
+                return;
+            }
+            if (seq < this.nextSeq) return;
+            if (seq > this.nextSeq) {
+                this.hold(seq, bytes, true);
+                return;
+            }
+            this.nextSeq = seq + 1;
+            this.enqueue(bytes, false);
+            this.drainPending();
+            return;
+        }
+
+        // An unnumbered transport can only be taken at its word.
+        if (this.awaitingInit) {
             if (this.sawExplicitInit) {
                 this.needInit('awaiting_init');
                 return;
             }
             this.awaitingInit = false;
         }
+        this.enqueue(bytes, false);
+    }
 
+    /** Keeps one out-of-order chunk while the one before it is still in flight. */
+    private hold(seq: number, bytes: Uint8Array, measured: boolean): void {
+        this.pending.set(seq, bytes);
+        this.pendingBytes += bytes.byteLength;
+        if (this.pending.size <= REORDER_MAX && this.pendingBytes <= REORDER_MAX_BYTES) return;
+
+        if (measured) {
+            // The chunk this run is waiting on should have landed by now, so it was lost rather
+            // than overtaken. Holding longer only delays the header that actually repairs this.
+            this.dropPending();
+            this.nextSeq = null;
+            this.awaitingInit = true;
+            this.needInit('gap');
+            return;
+        }
+
+        // Still no header, so nothing here can be called missing. Keep the window small and keep
+        // asking for the one thing that would make these playable.
+        let oldest = Number.POSITIVE_INFINITY;
+        for (const held of this.pending.keys()) if (held < oldest) oldest = held;
+        const evicted = this.pending.get(oldest);
+        if (evicted) {
+            this.pending.delete(oldest);
+            this.pendingBytes -= evicted.byteLength;
+        }
+        this.needInit('awaiting_init');
+    }
+
+    /** Empties the reorder window. */
+    private dropPending(): void {
+        this.pending.clear();
+        this.pendingBytes = 0;
+    }
+
+    /** Forgets anything held from the run a new header has just replaced. */
+    private forgetBefore(seq: number): void {
+        for (const [held, bytes] of Array.from(this.pending)) {
+            if (held >= seq) continue;
+            this.pending.delete(held);
+            this.pendingBytes -= bytes.byteLength;
+        }
+    }
+
+    /** Queues one byte run for the SourceBuffer and starts it moving. */
+    private enqueue(bytes: Uint8Array, init: boolean): void {
         this.ops.push({ append: bytes, init });
         this.opBytes += bytes.byteLength;
         this.guardQueue();
         this.pump();
+    }
+
+    /** Plays out whatever the reorder window is now holding in an unbroken line. */
+    private drainPending(): void {
+        if (this.nextSeq === null || this.pending.size === 0) return;
+        let next = this.pending.get(this.nextSeq);
+        while (next) {
+            this.pending.delete(this.nextSeq);
+            this.pendingBytes -= next.byteLength;
+            this.nextSeq += 1;
+            this.enqueue(next, false);
+            next = this.pending.get(this.nextSeq);
+        }
+        if (this.pending.size === 0) this.pendingBytes = 0;
     }
 
     setActive(active: boolean): void {
@@ -226,7 +340,6 @@ export class LiveVideoPlayer {
         this.teardown(true);
         this.ops = [];
         this.opBytes = 0;
-        this.lastInit = null;
     }
 
     private attach(): void {
@@ -342,13 +455,13 @@ export class LiveVideoPlayer {
         this.attach();
         this.rebuilding = false;
 
-        const init = this.lastInit;
-        if (init && this.lastInitGen === this.gen) {
-            this.ops.push({ append: init, init: true });
-            this.opBytes += init.byteLength;
-            this.awaitingInit = false;
-            this.pump();
-        }
+        // No init is replayed here, and nothing is appended until a fresh one arrives. These chunks
+        // are slices of one continuous byte run rather than standalone segments, so an init only
+        // describes the run it opened: re-priming with the last one and resuming at the live edge
+        // splices bytes onto a header that does not describe them, the element faults again, and
+        // the rebuild that follows repeats it. That loop is what a viewer sees as a flicker.
+        this.nextSeq = null;
+        this.dropPending();
         this.needInit(reason, true);
     }
 


### PR DESCRIPTION
Watching a bodycam flickered constantly. The debug ring in a live terminal showed the player rebuilding two to three times a second, `media_error` alternating with `sourcebuffer_error`, 57 rebuilds inside the window, health flapping live to failed and back.

The flicker was the symptom of one wrong assumption in three places. What a publisher sends is not a sequence of frames, it is one continuous encoder byte run cut into slices. Dropping any slice makes everything after it undecodable until the next header, and reordering two of them does the same. The pipeline treated slices as independently droppable and the transport as ordered, and neither is true:

- **`MAX_CHUNK`** refused an oversized chunk and forwarded the rest, leaving a hole. Measured on a live server: chunks of 616660, 789100 and 781564 bytes against a 600000 ceiling, so roughly every other chunk died.
- **The ingest budget** dropped chunks mid-run for the same reason.
- **The replay cache** trimmed its window from the front while keeping the header, so a joining terminal was primed with a header, a hole, and a tail. `Bitrate 8000000` over `KeyframeMs 20000` is a 27 MB run against a 1 MB cache, so this was the state of the cache almost always.
- **`TriggerLatentClientEvent` does not preserve order.** A capture from a live terminal read `I0 1 2 3 4 5 6 7 9 I0 10 1 3 2 4`: chunk 8 lost, chunk 10 straggling in behind the next header, and 3 arriving before 2. Latent sends are paced across ticks and several in flight finish in whatever order they finish in.
- **The player replayed its cached init after every fault**, which primed the decoder for bytes that could never follow, so any one hole became a permanent loop. That is the flicker.

## Changes

Server (`server/mdt/cameras.lua`), and the same cache defect in `server/photogram/live.lua` and `server/vibez/live.lua`:

- A cached run is now contiguous from its header or it is not cached at all. Overflow drops the whole cache instead of trimming the front.
- Every chunk carries `run` and `seq`. Numbering is assigned before the refusals, so a chunk that never reaches the terminals leaves a visible hole rather than a silent one, and `run` tells a straggler from the chunk of the same number in the run that replaced it.
- A refusal ends the run and asks the broadcaster to re-anchor, throttled per session, rather than quietly skipping one chunk.
- A terminal joining with nothing cached gets a re-anchor instead of nothing. Measured time to first header went from up to `KeyframeMs` (20 s on this config) to 703-974 ms.
- The prime travels as one event rather than one per chunk, so its parts cannot overtake each other.
- Boot-time sanity: a profile whose chunks cannot fit `MAX_CHUNK`, or whose run cannot fit the cache, says so once with the arithmetic.

Publisher (`web/src/apps/mdt/cameraPublisher.ts`): slices an oversized chunk to fit rather than letting the server refuse it. Any cut is legal in a byte run and only the first piece opens it, so this makes a high-bitrate config work rather than merely warn about it.

Player (`web/src/shared/liveMedia.ts`): never replays a cached init; waits for a real header and drops until one arrives. Holds up to three out-of-order chunks and plays them back in order, treating a swap as a swap and a loss as a loss. Discards stragglers by run.

## Gates

- `npx vitest run`: 700 passed, 53 files. 15 of those are a new `liveMedia` suite that reproduces the loop against a fake MediaSource: the cached-init replay, drop-until-init, reorder repair, the lost-chunk window, and straggler-by-run.
- `lua tests/lua/run.lua`: 1615 passed, 5 failed. The 5 are pre-existing on main (missing `server/battery/*`, `settings_device`, one snapshot default) and unrelated. 20 of the passing assertions are a new suite pinning the cache and numbering invariants.
- `tsc --noEmit` clean, `oxlint` 0 errors, `knip` clean.
- Live on a running server, before and after, same capture site:

| | before | after |
|---|---|---|
| arrival (preview) | `I0 1 2 3 4 5 6 7 9 I0 10 1 3 2 4` | `I0 1 2 … 17`, one run |
| prime | spliced cache over N events | `{run 1, seq 0, chunks 11}`, one event |
| first header | up to 20 s | 703-974 ms |
| chunks over ceiling (full quality) | 616660, 789100, 781564 | none, largest is the 400000 slice |
| runs in a 9 s window (full quality) | 2, broken by refusals | 1 |

Tests are local per repo convention and not in this diff.