### PR TITLE
feat(cameras): watch a bodycam straight from the officer's client

### DIFF
--- a/client/apps/bodycam.lua
+++ b/client/apps/bodycam.lua
@@ -51,11 +51,12 @@ local unsupported = false
 local function demandPayload()
     if not demand then return { on = false } end
     return {
-        on       = demand.on == true and not yielded,
-        gen      = demand.gen,
-        quality  = demand.quality,
-        enc      = demand.enc,
-        streamId = demand.streamId,
+        on        = demand.on == true and not yielded,
+        gen       = demand.gen,
+        citizenid = demand.citizenid,
+        quality   = demand.quality,
+        enc       = demand.enc,
+        streamId  = demand.streamId,
     }
 end
 
@@ -151,9 +152,10 @@ if ENABLED then
         end
 
         demand = {
-            on       = true,
-            gen      = payload.gen,
-            quality  = payload.quality,
+            on        = true,
+            gen       = payload.gen,
+            citizenid = type(payload.citizenid) == 'string' and payload.citizenid or nil,
+            quality   = payload.quality,
             enc      = type(payload.enc) == 'table' and payload.enc or nil,
             streamId = type(payload.streamId) == 'string' and payload.streamId or nil,
         }
@@ -176,6 +178,34 @@ if ENABLED then
         if not demand or not demand.on then return end
         if type(payload) == 'table' and payload.gen ~= nil and payload.gen ~= demand.gen then return end
         SendNUIMessage({ action = 'sd-phone:mdt:cameraAnchor', data = { gen = demand.gen } })
+    end)
+
+    ---Server push: which terminals hold a peer connection to this camera, and whether anything
+    ---still needs the encoded chunks. A camera watched only over peer connections stops encoding:
+    ---the page keeps the capture running to feed the peers and stops producing segments nobody is
+    ---waiting for.
+    ---@param payload table { gen, viewers, encode }
+    RegisterNetEvent('sd-phone:client:mdt:cameraPeers', function(payload)
+        if type(payload) ~= 'table' then return end
+        SendNUIMessage({ action = 'sd-phone:mdt:cameraPeers', data = payload })
+    end)
+
+    ---Server push: one WebRTC handshake message from the other end of a peer connection. Opaque
+    ---here; the page is the only thing that reads it.
+    ---@param payload table { citizenid, from, kind, data }
+    RegisterNetEvent('sd-phone:client:mdt:cameraSignal', function(payload)
+        if type(payload) ~= 'table' then return end
+        SendNUIMessage({ action = 'sd-phone:mdt:cameraSignal', data = payload })
+    end)
+
+    ---React -> Lua: one WebRTC handshake message on its way to the other end. A plain event rather
+    ---than a latent one: these are small and their order is the handshake.
+    ---@param payload table { citizenid, to, kind, data }
+    RegisterNUICallback('sd-phone:mdt:cameraSignal', function(payload, cb)
+        if type(payload) == 'table' then
+            TriggerServerEvent('sd-phone:server:mdt:cameraSignal', payload)
+        end
+        cb({ success = true })
     end)
 
     ---React -> Lua: the broadcaster page asking what the server currently wants, for the case

--- a/configs/bodycam.lua
+++ b/configs/bodycam.lua
@@ -92,6 +92,22 @@ return {
     -- Terminals allowed on one officer's camera at once (0 = unlimited).
     MaxViewers = 6,
 
+    -- Whether a terminal may take the picture straight from the officer's client, with this server
+    -- carrying nothing but the handshake that sets it up. It needs no port, no certificate and no
+    -- configuration of its own: the STUN and TURN settings the phone's voice mesh already uses
+    -- (configs/voice.lua) decide whether two clients can reach each other, and a pair that cannot
+    -- falls back to the path below on its own. Neither end sees more than the picture taking a
+    -- moment longer to start.
+    --
+    -- A camera every terminal watches this way stops encoding for the server entirely.
+    PeerToPeer = true,
+
+    -- Direct connections one camera may hand out at once (0 = unlimited). Each one is an upload
+    -- from the broadcasting officer's own connection rather than from the server, so this sits
+    -- below MaxViewers on purpose: terminals past it watch through the server instead, which costs
+    -- the officer nothing.
+    PeerMaxViewers = 3,
+
     -- Seconds a viewer may go quiet before the server drops them and, if they were the last
     -- one, tells the officer's client to stop encoding. The terminal refreshes the grid well
     -- inside this, so it only ever fires for a terminal that died without saying so.

--- a/locales/en.json
+++ b/locales/en.json
@@ -2743,6 +2743,7 @@
     "title": "MDT",
     "total": "Total",
     "transportEvent": "Server",
+    "transportPeer": "Direct",
     "transportRelay": "Relay",
     "type": "Type",
     "typeAll": "All",

--- a/server/mdt/cameras.lua
+++ b/server/mdt/cameras.lua
@@ -106,6 +106,13 @@ local PREVIEWS = not (type(CFG.Preview) == 'table' and CFG.Preview.Enabled == fa
 
 ---@type integer Terminals allowed on one officer's camera at once (0 = unlimited).
 local MAX_VIEWERS = math.max(0, math.floor(tonumber(CFG.MaxViewers) or 6))
+---@type boolean Whether a terminal may take the picture straight from the officer's client over a
+---peer connection, leaving this server carrying nothing but the handshake.
+local PEER_TO_PEER = CFG.PeerToPeer ~= false
+---@type integer Peer connections one camera may hand out at once (0 = unlimited). Each one is an
+---upload from the officer's own connection, so this is deliberately smaller than MAX_VIEWERS;
+---terminals past it watch over the event path instead.
+local PEER_MAX = math.max(0, math.floor(tonumber(CFG.PeerMaxViewers) or 3))
 ---@type integer Per-viewer latent send ceiling, in bytes per second.
 local RELAY_BPS = math.max(64 * 1024, math.floor(tonumber(CFG.RelayBytesPerSec) or 512 * 1024))
 ---@type integer Milliseconds a viewer may go quiet before the server drops them.
@@ -141,6 +148,20 @@ local REPLAY_MS = 4000
 ---milliseconds. Every re-anchor restarts the encoder and shows as a cut to everyone already
 ---watching, so several terminals joining at once must cost one restart rather than one each.
 local ANCHOR_GAP_MS = 1500
+-- Ceilings on the WebRTC handshake this server relays but never reads. Sized like the voice mesh's:
+-- an SDP is a few kilobytes of text, a candidate a couple of hundred bytes, and a negotiation is a
+-- short burst rather than a stream, so anything past these is a client misbehaving.
+---@type integer Byte ceiling on one offer or answer.
+local SDP_BYTES = 32768
+---@type integer Byte ceiling on one ICE candidate.
+local CANDIDATE_BYTES = 2048
+---@type integer Window the handshake budgets are measured over, in milliseconds.
+local SIGNAL_WINDOW = 10000
+---@type integer Candidates one client may relay per window, across every camera it is on.
+local CANDIDATES_PER_WINDOW = 400
+---@type integer Offers and answers one client may relay per window.
+local SDP_PER_WINDOW = 60
+
 ---@type integer Minimum gap between two audit rows for the same officer watching the same camera.
 local AUDIT_GAP_MS = 60000
 ---@type integer Window a terminal's watch calls are counted over, in milliseconds.
@@ -355,6 +376,42 @@ local function wantedQuality(session)
     return want
 end
 
+---Tells the officer's client which terminals hold a peer connection to it, and whether anything
+---still needs the encoder that feeds the event path. A camera watched only over peer connections
+---stops encoding entirely: the picture then travels between the two clients and never crosses this
+---server at all, which is the whole reason the peer path exists.
+---@param session table broadcast session
+local function syncPeers(session)
+    if not PEER_TO_PEER or not session.src then return end
+
+    local peers, encode = {}, false
+    for viewerSrc, viewer in pairs(session.viewers) do
+        if viewer.peer then peers[#peers + 1] = viewerSrc else encode = true end
+    end
+
+    TriggerClientEvent('sd-phone:client:mdt:cameraPeers', session.src, {
+        gen     = session.gen,
+        viewers = peers,
+        encode  = encode or session.quality == nil,
+    })
+end
+
+---Whether one more terminal may hold a peer connection to this camera. A mesh costs the
+---broadcasting officer one upload per viewer, so this is a ceiling on their connection rather than
+---on the server: terminals past it watch over the event path instead, which costs them nothing.
+---@param session table broadcast session
+---@param src integer viewer asking
+---@return boolean allowed
+local function peerRoomFor(session, src)
+    if not PEER_TO_PEER then return false end
+    if PEER_MAX == 0 then return true end
+    local n = 0
+    for viewerSrc, viewer in pairs(session.viewers) do
+        if viewer.peer and viewerSrc ~= src then n = n + 1 end
+    end
+    return n < PEER_MAX
+end
+
 ---Tells the officer's client what to encode, or that it may stop. This is the whole of the
 ---"an idle officer costs nothing" rule: the client holds no WebGL context, no encoder and sends no
 ---bytes until a demand arrives, and tears all three down again when one is withdrawn.
@@ -364,6 +421,9 @@ local function pushDemand(session, on)
     TriggerClientEvent('sd-phone:client:mdt:cameraDemand', session.src, {
         on          = on,
         gen         = session.gen,
+        -- The officer's own id, so their page can address the peer handshake for this camera
+        -- without asking who it is.
+        citizenid   = session.citizenid,
         quality     = session.quality,
         enc         = on and PROFILES[session.quality] or nil,
         firstPerson = FIRST_PERSON and session.quality == 'full',
@@ -412,6 +472,10 @@ local function applyDemand(session, now)
             local streamId = streamFor(session.citizenid)
             if streamId then media.setGen(streamId, session.gen) end
             pushDemand(session, true)
+            -- The client tears its publish down and builds a new one on a demand, peers included,
+            -- so the list it should hold has to follow the demand rather than wait for a viewer to
+            -- re-assert one.
+            syncPeers(session)
         end
         return
     end
@@ -577,14 +641,18 @@ local function detach(session, src, id)
     session.replayAt[src] = nil
 end
 
+
 ---Releases a terminal from every camera it holds anywhere.
 ---@param src integer viewer server id
 local function detachEverywhere(src)
     local now = GetGameTimer()
     for _, session in pairs(sessions) do
-        if session.viewers[src] then
+        local viewer = session.viewers[src]
+        if viewer then
+            local held = viewer.peer
             detach(session, src, nil)
             applyDemand(session, now)
+            if held then syncPeers(session) end
         end
     end
 end
@@ -687,7 +755,7 @@ cameras.watch = access.gated('cameras.view', function(src, payload, me)
 
     local fresh = not viewer or not viewer.ids[payload.cameraId]
     if not viewer then
-        viewer = { quality = quality, at = GetGameTimer(), ids = {} }
+        viewer = { quality = quality, at = GetGameTimer(), ids = {}, peer = false }
         session.viewers[src] = viewer
     end
     viewer.at = GetGameTimer()
@@ -695,6 +763,15 @@ cameras.watch = access.gated('cameras.view', function(src, payload, me)
     viewer.quality = quality
     for _, held in pairs(viewer.ids) do
         if held == 'full' then viewer.quality = 'full' end
+    end
+
+    -- The terminal says whether it is holding a peer connection for this camera, and the answer
+    -- says whether it may. Asking every keep-alive rather than once means a terminal whose
+    -- connection dies mid-shift is put back on the event path by the next beat.
+    local wantsPeer = payload.peer == true and peerRoomFor(session, src)
+    if wantsPeer ~= viewer.peer then
+        viewer.peer = wantsPeer
+        syncPeers(session)
     end
 
     applyDemand(session, GetGameTimer())
@@ -729,8 +806,56 @@ cameras.watch = access.gated('cameras.view', function(src, payload, me)
         status   = statusOf(session),
         viewers  = viewerCount(session),
         relay    = grant,
+        -- Whether this terminal may hold a peer connection, and who to. A terminal that asked and
+        -- was refused reads this as "stay on the event path" rather than being left to time out.
+        peer     = viewer.peer,
+        peerHost = viewer.peer and session.src or nil,
     })
 end)
+
+---Relays one WebRTC handshake message between the officer's client and a terminal watching it.
+---Both ends are re-checked against the session on every message: the sender must be the camera's
+---own officer or a terminal attached to it, and the addressee must be the other side of that same
+---pair. Nothing here inspects the payload beyond its shape and size, because it is opaque to the
+---server by design; what it carries is the two clients agreeing how to reach each other.
+---@param src integer sender server id
+---@param payload table { citizenid, to, kind, data } attacker-controlled
+function cameras.signal(src, payload)
+    if not PEER_TO_PEER then return end
+    payload = tbl(payload)
+
+    local session = sessions[util.limitedString(payload.citizenid, 64) or '']
+    if not session then return end
+
+    local to = math.floor(tonumber(payload.to) or 0)
+    if to <= 0 then return end
+
+    -- One of the two has to be the broadcaster and the other a terminal attached to them, in
+    -- either direction. Anything else is a client asking this server to talk to somebody it has
+    -- no relationship with.
+    local fromHost = session.src == src and session.viewers[to] ~= nil
+    local fromView = session.viewers[src] ~= nil and session.src == to
+    if not fromHost and not fromView then return end
+    if fromView and not session.viewers[src].peer then return end
+
+    local kind = payload.kind
+    if kind ~= 'offer' and kind ~= 'answer' and kind ~= 'ice' then return end
+
+    local cid = player.getIdentifier(src)
+    if not cid then return end
+    local budget = kind == 'ice' and CANDIDATES_PER_WINDOW or SDP_PER_WINDOW
+    if not util.rateLimit(cid, 'mdt:cameras:signal:' .. kind, SIGNAL_WINDOW, budget) then return end
+
+    local data = util.smallTable(payload.data, 16, kind == 'ice' and CANDIDATE_BYTES or SDP_BYTES)
+    if not data then return end
+
+    TriggerClientEvent('sd-phone:client:mdt:cameraSignal', to, {
+        citizenid = session.citizenid,
+        from      = src,
+        kind      = kind,
+        data      = data,
+    })
+end
 
 ---Releases the caller from one camera, or from every camera when the payload names none.
 cameras.unwatch = access.gated('cameras.view', function(src, payload)
@@ -738,8 +863,10 @@ cameras.unwatch = access.gated('cameras.view', function(src, payload)
     local session = cid and sessions[cid]
 
     if session then
+        local held = session.viewers[src] and session.viewers[src].peer
         detach(session, src, payload.cameraId)
         applyDemand(session, GetGameTimer())
+        if held then syncPeers(session) end
     elseif payload.cameraId == nil then
         detachEverywhere(src)
     end
@@ -838,6 +965,11 @@ function cameras.state(src, payload)
     session.unsupported = payload.unsupported == true
     if session.busy or session.unsupported then resetCache(session) end
 
+    -- A report means the page has finished building its publish, which is the first moment it can
+    -- act on a peer list. The list was pushed when the terminal asked, which is before this: sent
+    -- once more here so a camera starting up does not miss the terminals already waiting on it.
+    syncPeers(session)
+
     local onRelay = payload.relay == true and not session.busy and not session.unsupported
         and GetGameTimer() >= (session.relayBlocked or 0)
     if onRelay == session.onRelay then return end
@@ -930,6 +1062,9 @@ if ENABLED then
     RegisterNetEvent('sd-phone:server:mdt:cameraChunk', function(payload) cameras.chunk(source, payload) end)
     RegisterNetEvent('sd-phone:server:mdt:cameraState', function(payload) cameras.state(source, payload) end)
     RegisterNetEvent('sd-phone:server:mdt:cameraVehicle', function(payload) cameras.vehicle(source, payload) end)
+    -- The peer handshake: two clients agreeing how to reach each other, with this server carrying
+    -- nothing but the envelopes. Once they connect, the picture never comes through here at all.
+    RegisterNetEvent('sd-phone:server:mdt:cameraSignal', function(payload) cameras.signal(source, payload) end)
 
     -- Idle sweep: drops terminals that stopped answering, retires broadcasts nobody is watching,
     -- and forgets a session whose officer has gone. Everything that stops an officer encoding

--- a/web/src/apps/mdt/CameraFeed.tsx
+++ b/web/src/apps/mdt/CameraFeed.tsx
@@ -14,6 +14,7 @@ import {
     type RelayStreamHandle,
 } from '@/shared/mediaSocket';
 import { mdtCameraUnwatch, mdtCameraWatch } from './mdtApi';
+import { CameraPeerViewer } from './cameraPeer';
 import {
     onCameraChunk,
     onCameraOff,
@@ -31,6 +32,9 @@ const ATTACH_GAP_MS = 2500;
 const SWITCH_IDLE_MS = 1500;
 const SILENT_MS = 15000;
 const TIMESLICE_MS = 400;
+// Whether a terminal asks the officer's client for a direct connection before settling for the
+// picture coming through the game server. The server has the final say; this is only the ask.
+const PEER_FIRST = true;
 const DEFAULT_MIME = 'video/webm';
 
 export function feedNotice(camera: CameraTile, active: boolean, previews: boolean): string | null {
@@ -90,9 +94,11 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
         let relayMime = '';
         let committed: CameraTransport | null = null;
         let offered = true;
+        let peer: CameraPeerViewer | null = null;
+        let peerWanted = PEER_FIRST;
         let attachedAt = 0;
         let framedAt = Date.now();
-        const seen: Record<CameraTransport, number> = { relay: 0, event: 0 };
+        const seen: Record<CameraTransport, number> = { relay: 0, event: 0, peer: 0 };
 
         setHealth('starting');
         setTransport('event');
@@ -197,12 +203,47 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
             handle = opened;
         };
 
+        // The peer path is asked for first and given up on quietly. Nothing about the event path
+        // changes while it is being tried, so a terminal that cannot reach the officer directly
+        // never notices more than that the picture came the longer way round.
+        const dropPeer = (reason: string) => {
+            const open = peer;
+            peer = null;
+            if (!open) return;
+            open.close();
+            peerWanted = false;
+            mediaDebug('camera', 'peerDropped', { id: camera.id, reason });
+            if (committed === 'peer') {
+                committed = null;
+                const video = videoRef.current;
+                if (video) video.srcObject = null;
+                setTransport('event');
+                void attach(true, relayWanted());
+            }
+        };
+
+        const onPeerStream = (stream: MediaStream) => {
+            const video = videoRef.current;
+            if (!alive || !video) return;
+            // The picture is arriving decoded now, so the buffered player and everything feeding it
+            // is redundant: what it holds belongs to a transport this terminal has left.
+            destroy();
+            committed = 'peer';
+            setTransport('peer');
+            setFailure(null);
+            setSilent(false);
+            framedAt = Date.now();
+            video.srcObject = stream;
+            void video.play().catch(() => { /* autoplay is muted, so this only rejects while hidden */ });
+            publish('live');
+        };
+
         const attach = async (reprime: boolean, wantRelay: boolean) => {
             const now = Date.now();
             if (now - attachedAt < ATTACH_GAP_MS) return;
             attachedAt = now;
 
-            const res = await mdtCameraWatch(camera.id, quality, reprime, wantRelay, offered && !handle && !relayAvailable());
+            const res = await mdtCameraWatch(camera.id, quality, reprime, wantRelay, offered && !handle && !relayAvailable(), peerWanted);
             if (!alive) return;
             if (typeof res === 'string') {
                 if (!showingRef.current) setFailure(res || t('mdt.cameraNoFeed', 'No feed from that unit'));
@@ -211,6 +252,19 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
             setFailure(null);
             if (res.mime && !mime) mime = res.mime;
             if (res.relay) void join(res.relay);
+
+            if (res.peer && res.peerHost !== null && !peer) {
+                peer = new CameraPeerViewer({
+                    citizenid: camera.citizenid,
+                    host:      res.peerHost,
+                    onStream:  onPeerStream,
+                    onLost:    reason => dropPeer(reason),
+                });
+            } else if (!res.peer && peer) {
+                // The server took the peer slot back: another terminal wanted it, or the officer
+                // stopped serving them.
+                dropPeer('refused');
+            }
         };
 
         const offChunk = onCameraChunk(camera.citizenid, (push: CameraChunkPush) => {
@@ -253,6 +307,8 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
         return () => {
             alive = false;
             window.clearInterval(keepAlive);
+            peer?.close();
+            peer = null;
             offChunk();
             offPrime();
             offEnded();
@@ -290,7 +346,9 @@ export function CameraFeed({ camera, quality, active, notice, showTransport, onH
                 <span className="pointer-events-none absolute bottom-2 right-2 rounded-[6px] bg-black/70 px-1.5 py-[2px] text-[10.5px] font-bold uppercase tracking-wide text-white/70">
                     {transport === 'relay'
                         ? t('mdt.transportRelay', 'Relay')
-                        : t('mdt.transportEvent', 'Server')}
+                        : transport === 'peer'
+                            ? t('mdt.transportPeer', 'Direct')
+                            : t('mdt.transportEvent', 'Server')}
                 </span>
             )}
 

--- a/web/src/apps/mdt/cameraBus.ts
+++ b/web/src/apps/mdt/cameraBus.ts
@@ -7,14 +7,15 @@ export interface CameraEncoder {
 }
 
 export interface CameraDemand {
-    on:        boolean;
+    on:         boolean;
+    citizenid?: string;
     gen?:      number;
     quality?:  string;
     enc?:      CameraEncoder;
     streamId?: string;
 }
 
-export type CameraTransport = 'relay' | 'event';
+export type CameraTransport = 'relay' | 'event' | 'peer';
 
 export interface CameraTransportPush {
     citizenid: string;
@@ -40,6 +41,19 @@ export interface CameraPrimePush {
     chunks?:   string[];
 }
 
+export interface CameraSignalPush {
+    citizenid: string;
+    from:      number;
+    kind:      'offer' | 'answer' | 'ice';
+    data?:     { sdp?: string } & Record<string, unknown>;
+}
+
+export interface CameraPeersPush {
+    gen?:     number;
+    viewers?: number[];
+    encode?:  boolean;
+}
+
 export interface CameraAnchorPush {
     gen?: number;
 }
@@ -57,11 +71,15 @@ const DEMAND_ACTION    = 'sd-phone:mdt:cameraDemand';
 const TRANSPORT_ACTION = 'sd-phone:mdt:cameraTransport';
 const ANCHOR_ACTION    = 'sd-phone:mdt:cameraAnchor';
 const PRIME_ACTION     = 'sd-phone:mdt:cameraPrime';
+const SIGNAL_ACTION    = 'sd-phone:mdt:cameraSignal';
+const PEERS_ACTION     = 'sd-phone:mdt:cameraPeers';
 
 const chunkSubs = new Map<string, Set<Handler<CameraChunkPush>>>();
 const offSubs = new Map<string, Set<Handler<CameraOffPush>>>();
 const transportSubs = new Map<string, Set<Handler<CameraTransportPush>>>();
 const primeSubs = new Map<string, Set<Handler<CameraPrimePush>>>();
+const signalSubs = new Map<string, Set<Handler<CameraSignalPush>>>();
+const peersSubs = new Set<Handler<CameraPeersPush | undefined>>();
 const demandSubs = new Set<Handler<CameraDemand | undefined>>();
 const anchorSubs = new Set<Handler<CameraAnchorPush | undefined>>();
 
@@ -82,10 +100,13 @@ function ensureListener(): void {
         if (!msg?.action) return;
         if (msg.action === CHUNK_ACTION) fan(chunkSubs, msg.data as CameraChunkPush | undefined);
         else if (msg.action === PRIME_ACTION) fan(primeSubs, msg.data as CameraPrimePush | undefined);
+        else if (msg.action === SIGNAL_ACTION) fan(signalSubs, msg.data as CameraSignalPush | undefined);
         else if (msg.action === OFF_ACTION) fan(offSubs, msg.data as CameraOffPush | undefined);
         else if (msg.action === TRANSPORT_ACTION) fan(transportSubs, msg.data as CameraTransportPush | undefined);
         else if (msg.action === DEMAND_ACTION) {
             for (const handler of Array.from(demandSubs)) handler(msg.data as CameraDemand | undefined);
+        } else if (msg.action === PEERS_ACTION) {
+            for (const handler of Array.from(peersSubs)) handler(msg.data as CameraPeersPush | undefined);
         } else if (msg.action === ANCHOR_ACTION) {
             for (const handler of Array.from(anchorSubs)) handler(msg.data as CameraAnchorPush | undefined);
         }
@@ -105,6 +126,16 @@ function subscribe<T>(subs: Map<string, Set<Handler<T>>>, key: string, handler: 
 
 export function onCameraChunk(citizenid: string, handler: Handler<CameraChunkPush>): () => void {
     return subscribe(chunkSubs, citizenid, handler);
+}
+
+export function onCameraSignal(citizenid: string, handler: Handler<CameraSignalPush>): () => void {
+    return subscribe(signalSubs, citizenid, handler);
+}
+
+export function onCameraPeers(handler: Handler<CameraPeersPush | undefined>): () => void {
+    ensureListener();
+    peersSubs.add(handler);
+    return () => { peersSubs.delete(handler); };
 }
 
 export function onCameraPrime(citizenid: string, handler: Handler<CameraPrimePush>): () => void {

--- a/web/src/apps/mdt/cameraPeer.ts
+++ b/web/src/apps/mdt/cameraPeer.ts
@@ -1,0 +1,297 @@
+import { apiData } from '@/core/api';
+import { fetchNui, isFiveM } from '@/core/nui';
+import { mediaDebug } from '@/shared/mediaDebug';
+import { onCameraSignal, type CameraSignalPush } from './cameraBus';
+
+const FALLBACK: RTCConfiguration = { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] };
+const CONNECT_TIMEOUT_MS = 8000;
+// What a peer connection is allowed when the quality profile does not say. Well above the shipped
+// full-screen profile, because a direct connection costs the server nothing and the officer's
+// uplink is the only budget it spends.
+const FALLBACK_BITRATE = 4_000_000;
+
+let iceCached: RTCConfiguration | null = null;
+
+/**
+ * ICE servers for a camera peer connection. The same set the voice mesh uses: public STUN, plus a
+ * TURN relay when the server has one provisioned, which is what carries the pairs that cannot see
+ * each other directly.
+ */
+async function iceConfig(): Promise<RTCConfiguration> {
+    if (iceCached) return iceCached;
+    if (!isFiveM) return FALLBACK;
+    const res = await apiData<{ iceServers?: RTCIceServer[] }>('sd-phone:voice:ice');
+    iceCached = res?.iceServers?.length ? { iceServers: res.iceServers } : FALLBACK;
+    return iceCached;
+}
+
+function send(citizenid: string, to: number, kind: 'offer' | 'answer' | 'ice', data: unknown): void {
+    void fetchNui('sd-phone:mdt:cameraSignal', { citizenid, to, kind, data });
+}
+
+/**
+ * Tells the encoder where to begin rather than making it discover the link from the floor. A peer
+ * connection opens at a few hundred kilobits and climbs as it learns what the path can carry, which
+ * is right for a call somebody stays on and wrong for a camera somebody opens for twenty seconds:
+ * the whole viewing would be spent ramping. The ceiling is still the ceiling, and congestion
+ * control still owns everything after the first seconds.
+ *
+ * Only the video codecs are touched, and only in the offer this client is about to send as its own
+ * description. A malformed result is caught by setLocalDescription, which drops the connection to
+ * the path that was already working.
+ */
+function withStartBitrate(sdp: string | undefined, maxBitrate: number): string | undefined {
+    if (!sdp) return sdp;
+
+    const startKbps = Math.max(300, Math.min(Math.round(maxBitrate / 1000 / 2), 4000));
+    const maxKbps = Math.max(startKbps, Math.round(maxBitrate / 1000));
+
+    const lines = sdp.split(/\r\n|\n/);
+
+    const video = new Set<number>();
+    let inVideo = false;
+    for (const line of lines) {
+        if (line.startsWith('m=')) inVideo = line.startsWith('m=video');
+        if (!inVideo) continue;
+        const codec = /^a=rtpmap:(\d+) (?:VP8|VP9|H264|AV1)\//.exec(line);
+        if (codec) video.add(Number(codec[1]));
+    }
+    if (!video.size) return sdp;
+
+    // Which of them already carry parameters decides whether this extends a line or adds one, and
+    // a codec must never end up with two.
+    const described = new Set<number>();
+    for (const line of lines) {
+        const fmtp = /^a=fmtp:(\d+) /.exec(line);
+        if (fmtp && video.has(Number(fmtp[1]))) described.add(Number(fmtp[1]));
+    }
+
+    const params = `x-google-start-bitrate=${startKbps};x-google-max-bitrate=${maxKbps}`;
+    const out: string[] = [];
+
+    for (const line of lines) {
+        const fmtp = /^a=fmtp:(\d+) (.*)$/.exec(line);
+        if (fmtp && video.has(Number(fmtp[1]))) {
+            out.push(`a=fmtp:${fmtp[1]} ${fmtp[2]};${params}`);
+            continue;
+        }
+        out.push(line);
+        const rtpmap = /^a=rtpmap:(\d+) (?:VP8|VP9|H264|AV1)\//.exec(line);
+        if (rtpmap && !described.has(Number(rtpmap[1]))) {
+            out.push(`a=fmtp:${rtpmap[1]} ${params}`);
+        }
+    }
+
+    return out.join('\r\n');
+}
+
+/**
+ * The broadcasting side. Holds one connection per watching terminal, all fed from the one capture
+ * the page is already running, and offers to each as it appears. The server names who may hold one;
+ * this only does as it is told, because who may watch a camera is not a decision for a client.
+ */
+export class CameraPeerHost {
+    private peers = new Map<number, RTCPeerConnection>();
+    private off: () => void;
+    private closed = false;
+
+    constructor(private citizenid: string, private stream: MediaStream, private maxBitrate = FALLBACK_BITRATE) {
+        this.off = onCameraSignal(citizenid, sig => void this.handle(sig));
+    }
+
+    /** Opens a connection to every terminal named here, and drops the ones no longer named. */
+    setViewers(srcs: number[]): void {
+        if (this.closed) return;
+        const wanted = new Set(srcs.filter(n => Number.isFinite(n)));
+
+        for (const [src, pc] of Array.from(this.peers)) {
+            if (wanted.has(src)) continue;
+            this.peers.delete(src);
+            try { pc.close(); } catch { /* already gone */ }
+        }
+
+        for (const src of wanted) {
+            if (!this.peers.has(src)) void this.open(src);
+        }
+    }
+
+    private async open(src: number): Promise<void> {
+        const config = await iceConfig();
+        if (this.closed || this.peers.has(src)) return;
+
+        const pc = new RTCPeerConnection(config);
+        this.peers.set(src, pc);
+
+        pc.onicecandidate = e => {
+            if (e.candidate) send(this.citizenid, src, 'ice', e.candidate.toJSON());
+        };
+        pc.onconnectionstatechange = () => {
+            mediaDebug('peer', 'host', { to: src, state: pc.connectionState });
+            if (pc.connectionState === 'failed' || pc.connectionState === 'closed') this.drop(src);
+        };
+
+        for (const track of this.stream.getVideoTracks()) {
+            // Without this the encoder treats the capture as camera video, where softening the
+            // picture to hold a frame rate is the right trade. It is the wrong one here: a sharp
+            // slower picture is what a plate or a face is read from, and this is a game view, so
+            // there is no sensor noise for the usual heuristics to reason about either.
+            track.contentHint = 'detail';
+            pc.addTrack(track, this.stream);
+        }
+        this.tune(pc);
+
+        try {
+            const offer = await pc.createOffer();
+            if (this.closed || this.peers.get(src) !== pc) return;
+            offer.sdp = withStartBitrate(offer.sdp, this.maxBitrate);
+            await pc.setLocalDescription(offer);
+            send(this.citizenid, src, 'offer', { sdp: pc.localDescription?.sdp });
+        } catch {
+            this.drop(src);
+        }
+    }
+
+    /**
+     * What one viewer may cost the officer's own connection, and how the encoder should spend it.
+     * The ceiling is the quality profile's own bitrate, so the two paths are asked for the same
+     * picture rather than the peer one quietly being worse. Everything else here says the same
+     * thing in a different place: when the link cannot carry the full rate, give up frames, not
+     * pixels.
+     */
+    private tune(pc: RTCPeerConnection): void {
+        const sender = pc.getSenders().find(s => s.track?.kind === 'video');
+        if (!sender) return;
+        try {
+            const params = sender.getParameters();
+            params.encodings = params.encodings?.length ? params.encodings : [{}];
+            for (const encoding of params.encodings) {
+                encoding.maxBitrate = this.maxBitrate;
+                encoding.scaleResolutionDownBy = 1;
+            }
+            params.degradationPreference = 'maintain-resolution';
+            void sender.setParameters(params);
+        } catch { /* older CEF rejects some fields; the default encoding still works */ }
+    }
+
+    private drop(src: number): void {
+        const pc = this.peers.get(src);
+        if (!pc) return;
+        this.peers.delete(src);
+        try { pc.close(); } catch { /* already gone */ }
+    }
+
+    private async handle(sig: CameraSignalPush): Promise<void> {
+        const pc = this.peers.get(sig.from);
+        if (!pc) return;
+        try {
+            if (sig.kind === 'answer' && sig.data?.sdp) {
+                await pc.setRemoteDescription({ type: 'answer', sdp: sig.data.sdp });
+            } else if (sig.kind === 'ice' && sig.data) {
+                await pc.addIceCandidate(sig.data as RTCIceCandidateInit);
+            }
+        } catch { /* late or duplicate handshake traffic is not fatal */ }
+    }
+
+    close(): void {
+        if (this.closed) return;
+        this.closed = true;
+        this.off();
+        for (const pc of this.peers.values()) {
+            try { pc.close(); } catch { /* already gone */ }
+        }
+        this.peers.clear();
+    }
+}
+
+export interface CameraPeerViewerOptions {
+    citizenid: string;
+    host:      number;
+    onStream:  (stream: MediaStream) => void;
+    onLost:    (reason: string) => void;
+}
+
+/**
+ * The watching side. Answers the broadcaster's offer and hands up the track when it arrives. It
+ * gives up on a deadline rather than waiting forever, because the caller has a working event path
+ * to fall back to and a terminal showing nothing is worse than one showing a costlier picture.
+ */
+export class CameraPeerViewer {
+    private pc: RTCPeerConnection | null = null;
+    private off: () => void;
+    private timer: ReturnType<typeof setTimeout>;
+    private closed = false;
+    private streaming = false;
+
+    constructor(private opts: CameraPeerViewerOptions) {
+        this.off = onCameraSignal(opts.citizenid, sig => void this.handle(sig));
+        this.timer = setTimeout(() => {
+            if (!this.streaming) this.fail('timeout');
+        }, CONNECT_TIMEOUT_MS);
+    }
+
+    private async ensure(): Promise<RTCPeerConnection | null> {
+        if (this.pc || this.closed) return this.pc;
+        const config = await iceConfig();
+        if (this.closed) return null;
+        if (this.pc) return this.pc;
+
+        const pc = new RTCPeerConnection(config);
+        this.pc = pc;
+        pc.onicecandidate = e => {
+            if (e.candidate) send(this.opts.citizenid, this.opts.host, 'ice', e.candidate.toJSON());
+        };
+        pc.ontrack = e => {
+            const stream = e.streams[0] ?? new MediaStream([e.track]);
+            this.streaming = true;
+            clearTimeout(this.timer);
+            this.opts.onStream(stream);
+        };
+        pc.onconnectionstatechange = () => {
+            mediaDebug('peer', 'viewer', { host: this.opts.host, state: pc.connectionState });
+            if (pc.connectionState === 'failed') this.fail('failed');
+        };
+        return pc;
+    }
+
+    private async handle(sig: CameraSignalPush): Promise<void> {
+        if (this.closed || sig.from !== this.opts.host) return;
+        const pc = await this.ensure();
+        if (!pc) return;
+        try {
+            if (sig.kind === 'offer' && sig.data?.sdp) {
+                await pc.setRemoteDescription({ type: 'offer', sdp: sig.data.sdp });
+                const answer = await pc.createAnswer();
+                await pc.setLocalDescription(answer);
+                send(this.opts.citizenid, this.opts.host, 'answer', { sdp: pc.localDescription?.sdp });
+            } else if (sig.kind === 'ice' && sig.data) {
+                await pc.addIceCandidate(sig.data as RTCIceCandidateInit);
+            }
+        } catch {
+            this.fail('handshake');
+        }
+    }
+
+    private fail(reason: string): void {
+        if (this.closed) return;
+        mediaDebug('peer', 'viewerLost', { host: this.opts.host, reason });
+        this.close();
+        this.opts.onLost(reason);
+    }
+
+    close(): void {
+        if (this.closed) return;
+        this.closed = true;
+        clearTimeout(this.timer);
+        this.off();
+        if (this.pc) {
+            try { this.pc.close(); } catch { /* already gone */ }
+            this.pc = null;
+        }
+    }
+}
+
+/**
+ * SDP rewriting is exactly the kind of string work that should be pinned rather than trusted.
+ * @testseam
+ */
+export const __testing = { withStartBitrate };

--- a/web/src/apps/mdt/cameraPublisher.ts
+++ b/web/src/apps/mdt/cameraPublisher.ts
@@ -11,7 +11,8 @@ import {
     relayPublish,
     type RelayStreamHandle,
 } from '@/shared/mediaSocket';
-import { onCameraAnchor, onCameraDemand, type CameraAnchorPush, type CameraDemand, type CameraEncoder } from './cameraBus';
+import { onCameraAnchor, onCameraDemand, onCameraPeers, type CameraAnchorPush, type CameraDemand, type CameraEncoder, type CameraPeersPush } from './cameraBus';
+import { CameraPeerHost } from './cameraPeer';
 import { mediaDebug } from '@/shared/mediaDebug';
 
 const FALLBACK_ASPECT = 16 / 9;
@@ -26,6 +27,10 @@ let startToken = 0;
 let teardown: (() => void) | null = null;
 /** Restarts the encoder on the running publish, so the next chunk is a fresh header. */
 let anchorNow: (() => void) | null = null;
+/** The peer connections this client is serving, while it is publishing. */
+let peerHost: CameraPeerHost | null = null;
+/** Starts or stops the encoder on the running publish, without disturbing the capture. */
+let encodingSwitch: ((on: boolean) => void) | null = null;
 let sampler: ReturnType<typeof setInterval> | null = null;
 let encodedBytes = 0;
 let render: GameRender | null = null;
@@ -59,6 +64,11 @@ function ensureSurface(): HTMLCanvasElement {
 }
 
 type Segment = (blob: Blob, init: boolean, key: boolean) => Promise<void>;
+
+interface Capture {
+    stream: MediaStream;
+    stop(): void;
+}
 
 interface Encoding {
     stop(): void;
@@ -98,19 +108,23 @@ function relaySink(handle: RelayStreamHandle, onLost: () => void): Segment {
     };
 }
 
-function encode(
-    source: HTMLCanvasElement,
-    enc: CameraEncoder,
-    outW: number,
-    outH: number,
-    mime: string,
-    first: Segment,
-): Encoding | null {
+/**
+ * The capture itself: the game view drawn into an offscreen canvas at the profile's size, as a
+ * MediaStream. This is deliberately separate from the encoder below, because a peer connection
+ * wants the stream and nothing else, and a camera watched only over peer connections runs this
+ * with no encoder attached at all.
+ */
+function capture(source: HTMLCanvasElement, enc: CameraEncoder, outW: number, outH: number): Capture | null {
     const off = document.createElement('canvas');
     off.width = outW;
     off.height = outH;
     const octx = off.getContext('2d');
     if (!octx) return null;
+    // The game view arrives at the player's full screen size and is drawn down to the profile's
+    // width. Chromium's default resampling for that is fast and mushy; this is the one place the
+    // picture loses detail before an encoder has even seen it.
+    octx.imageSmoothingEnabled = true;
+    octx.imageSmoothingQuality = 'high';
 
     const pump = setInterval(() => {
         if (source.width && source.height) octx.drawImage(source, 0, 0, outW, outH);
@@ -124,6 +138,16 @@ function encode(
         return null;
     }
 
+    return {
+        stream,
+        stop() {
+            clearInterval(pump);
+            try { stream.getTracks().forEach(track => track.stop()); } catch { /* tracks gone */ }
+        },
+    };
+}
+
+function encode(stream: MediaStream, enc: CameraEncoder, mime: string, first: Segment): Encoding | null {
     let recorder: MediaRecorder | null = null;
     let stopped = false;
     let sink = first;
@@ -173,12 +197,10 @@ function encode(
         stop() {
             stopped = true;
             clearInterval(beat);
-            clearInterval(pump);
             if (recorder && recorder.state !== 'inactive') {
                 try { recorder.onstop = null; recorder.stop(); } catch { /* already inactive */ }
             }
             recorder = null;
-            try { stream.getTracks().forEach(track => track.stop()); } catch { /* tracks gone */ }
         },
         anchor,
         setSink(next: Segment) {
@@ -291,25 +313,68 @@ async function startPublishing(demand: CameraDemand, token: number): Promise<voi
         return;
     }
 
-    encoding = encode(canvas, enc, outW, outH, mime, handle ? relaySink(handle, downgrade) : eventSink(gen, mime));
-    if (!encoding) {
+    const source = capture(canvas, enc, outW, outH);
+    if (!source) {
         handle?.close();
         stopPublishing();
         reportState('unsupported', false);
         return;
     }
 
-    const live = encoding;
-    anchorNow = () => live.anchor();
+    const sink = () => (handle ? relaySink(handle, downgrade) : eventSink(gen, mime));
+
+    /**
+     * Starts or stops the encoder without touching the capture. A camera every terminal watches
+     * over a peer connection needs no encoder at all: the picture is already going out over those
+     * connections, and encoding a second copy for nobody is the cost this exists to avoid.
+     */
+    const setEncoding = (on: boolean) => {
+        if (on === (encoding !== null)) return;
+        if (!on) {
+            encoding?.stop();
+            encoding = null;
+            anchorNow = null;
+            return;
+        }
+        encoding = encode(source.stream, enc, mime, sink());
+        anchorNow = encoding ? () => encoding?.anchor() : null;
+    };
+
+    setEncoding(true);
+    if (!encoding) {
+        source.stop();
+        handle?.close();
+        stopPublishing();
+        reportState('unsupported', false);
+        return;
+    }
+
+    const host = new CameraPeerHost(demand.citizenid ?? '', source.stream, enc.bitrate);
+    peerHost = host;
+    encodingSwitch = setEncoding;
+
     teardown = () => {
         anchorNow = null;
-        live.stop();
+        encodingSwitch = null;
+        peerHost = null;
+        host.close();
+        encoding?.stop();
+        encoding = null;
+        source.stop();
         if (handle) {
             try { handle.close(); } catch { /* socket already gone */ }
             handle = null;
         }
     };
     reportState('ok', handle !== null);
+}
+
+/** The server naming who holds a peer connection, and whether the encoder is still earning its keep. */
+function applyPeers(push: CameraPeersPush | undefined): void {
+    if (!push) return;
+    if (push.gen !== undefined && targetGen !== null && push.gen !== targetGen) return;
+    peerHost?.setViewers(Array.isArray(push.viewers) ? push.viewers : []);
+    encodingSwitch?.(push.encode !== false);
 }
 
 function applyDemand(demand: CameraDemand | undefined): void {
@@ -337,6 +402,7 @@ function applyAnchor(push: CameraAnchorPush | undefined): void {
 if (isFiveM) {
     onCameraDemand(applyDemand);
     onCameraAnchor(applyAnchor);
+    onCameraPeers(applyPeers);
 
     void fetchNui<{ success?: boolean; data?: CameraDemand }>('sd-phone:mdt:cameraSync')
         .then(res => applyDemand(res?.data))

--- a/web/src/apps/mdt/mdtApi.ts
+++ b/web/src/apps/mdt/mdtApi.ts
@@ -894,19 +894,30 @@ export async function mdtCameras(): Promise<CameraGrid> {
     };
 }
 
+/**
+ * A camera attach, plus what the server decided about a peer connection for it. Kept here rather
+ * than on CameraStream because it describes this terminal's relationship to the camera, not the
+ * camera itself: the same broadcast is peer-served to one terminal and event-served to the next.
+ */
+export interface CameraAttach extends CameraStream {
+    peer:     boolean;
+    peerHost: number | null;
+}
+
 export async function mdtCameraWatch(
     cameraId: string,
     quality: CameraQuality,
     reprime = false,
     relay = false,
     relayFailed = false,
-): Promise<CameraStream | string> {
+    peer = false,
+): Promise<CameraAttach | string> {
     if (!isFiveM) {
         const tile = DEV_CAMERAS.find(c => c.id === cameraId);
         if (!tile) return 'That unit is no longer on the air';
-        return { cameraId, gen: 1, mime: null, status: tile.status, viewers: tile.viewers, relay: null };
+        return { cameraId, gen: 1, mime: null, status: tile.status, viewers: tile.viewers, relay: null, peer: false, peerHost: null };
     }
-    const res = await apiCall<CameraStream>('sd-phone:mdt:cameras:watch', { cameraId, quality, reprime, relay, relayFailed });
+    const res = await apiCall<CameraAttach>('sd-phone:mdt:cameras:watch', { cameraId, quality, reprime, relay, relayFailed, peer });
     if (!res.success || !res.data) return res.message ?? '';
     const grant = res.data.relay ?? null;
     return {
@@ -916,6 +927,8 @@ export async function mdtCameraWatch(
         status:   res.data.status ?? 'ready',
         viewers:  res.data.viewers ?? 0,
         relay:    grant && typeof grant.token === 'string' && typeof grant.url === 'string' ? grant : null,
+        peer:     res.data.peer === true,
+        peerHost: typeof res.data.peerHost === 'number' ? res.data.peerHost : null,
     };
 }
 


### PR DESCRIPTION
Stacked on #220. Base is `fix/live-video-byte-runs`, so read that one first; this will retarget to `main` once it merges.

A bodycam watched through the game server costs roughly the profile bitrate per viewer, encoded, base64'd, and pushed across the event bus. Measured on a live server at the shipped full-quality profile: about 12 Mbit/s of game-server traffic for one terminal. That is the reason the media relay exists, and the relay needs a domain and a certificate, which most servers will never have.

They do not need one. The phone already runs WebRTC for video calls, and a peer connection is exempt from everything that makes the relay hard: peers authenticate each other with DTLS fingerprints, so there is no CA in the path, nothing to provision and no port to open. Verified in this CEF build before building on it: a canvas `captureStream` over an `RTCPeerConnection` connects and decodes.

## What this does

A terminal asks the officer's client for a direct connection. The server decides who may have one, relays the handshake, and then carries nothing at all. A camera every terminal watches this way **stops encoding entirely**.

- `server/mdt/cameras.lua`: viewers carry a peer flag, asked and answered on every keep-alive so a connection that dies puts the terminal back on the event path by the next beat. `PeerMaxViewers` bounds how many connections one officer serves, because a mesh costs their uplink one upload each. `cameras.signal` relays offers, answers and candidates, re-checking on every message that the sender and addressee are the two ends of one real session, with the same size and rate ceilings the voice mesh uses. The payload is opaque here by design.
- `web/src/apps/mdt/cameraPeer.ts`: the two roles. The broadcaster holds one connection per terminal, all fed from the capture already running. The viewer answers, hands up the track, and gives up on a deadline rather than waiting forever.
- `web/src/apps/mdt/cameraPublisher.ts`: the capture is now separate from the encoder, so the encoder can stop while the picture keeps flowing to peers.
- `web/src/apps/mdt/CameraFeed.tsx`: asks for a peer connection first and falls back quietly. The transport chip reads Direct.
- ICE comes from the existing `sd-phone:voice:ice` route, so the STUN and TURN already configured for voice serve this too and there is nothing new to set up.

## Gates

- `tsc --noEmit` clean, `oxlint` 0 errors, `knip` clean, `vitest` 700 passed, `lua tests/lua/run.lua` 1615 passed / 5 pre-existing failures.
- Live on a running server, negotiating through the real signalling relay against the real publisher:

```
offer -> track -> answered
connection: connected, ice: connected
inbound-rtp: framesDecoded 258, bytesReceived 1343851
```

- And the point of the whole thing, same server, same camera:

| | chunks through the server | peers push |
|---|---|---|
| terminal watching direct | **0** in 6 s | `viewers:[7], encode:false` |
| after it drops the direct connection | 16 in 6 s | `viewers:[], encode:true` |

Two things not proven here: two clients behind two different NATs (this was one machine, so ICE had an easy time; the voice mesh already relies on the same STUN and TURN in production), and the viewer-side give-up deadline, which is code-reviewed rather than measured.

Defaults are `PeerToPeer = true` and `PeerMaxViewers = 3`. A server that wants none of it sets the first to false and nothing else changes.