### PR TITLE
feat(media): run the relay inside the resource, configured by nobody

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           mkdir -p dist/sd-phone/web
           cp fxmanifest.lua README.md dist/sd-phone/
-          cp -r bridge client server shared configs locales images dist/sd-phone/
+          cp -r bridge client server shared configs locales images media-server dist/sd-phone/
           cp -r web/build dist/sd-phone/web/build
 
       # The staging list above is an allowlist, so a new top-level directory is

--- a/configs/media.lua
+++ b/configs/media.lua
@@ -32,6 +32,19 @@ return {
     -- certificate, so it is something you turn on deliberately rather than half-have.
     Enabled = false,
 
+    -- Whether the relay runs inside this resource. With this on there is no Node to install, no
+    -- second process to keep alive, no signing key to generate and no port to pick: the key is
+    -- minted for each boot and never leaves the process, and the port is whichever one is free.
+    --
+    -- It cannot conjure a certificate, and nothing can. The phone's browser refuses an insecure
+    -- socket to anything but the machine it is running on, so a server with real players still
+    -- needs TLS terminated in front of this and its address in sd_phone_relay_url. Without that,
+    -- this is a development convenience and the features stay on the event path.
+    --
+    -- Turn it off to run media-server/ on its own box instead; then sd_phone_relay_url and
+    -- sd_phone_relay_key are read as before.
+    SelfHost = true,
+
     -- Which features may mint a token. A feature switched off here keeps working, it just keeps
     -- working the old way, over the event bus.
     Features = {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,6 +20,7 @@ client_scripts {
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
     'server/crypto.js',
+    'server/relay.js',
     'bridge/server/init.lua',
     'server/main.lua',
 }

--- a/media-server/README.md
+++ b/media-server/README.md
@@ -9,24 +9,39 @@ base64 encoded (a third more bytes), pushed across the NUI boundary, relayed as 
 reassembled by the viewer. That path is slow and it is expensive for the game server. This relay carries
 raw bytes over one socket per phone and never touches the game thread.
 
+## Two ways to run it
+
+**Inside the resource (the easy one).** With `Media.Enabled = true` and `Media.SelfHost = true` in
+`configs/media.lua`, sd-phone starts this code inside FXServer itself. There is no Node to install,
+no second process to keep alive, no signing key to generate and no port to choose: the key is minted
+for each boot and never leaves the process, and the port is the first free one from 30567. The
+console says which port it took.
+
+**On its own (the scalable one).** Set `Media.SelfHost = false` and run `node index.js` here, on this
+box or another one, then point `sd_phone_relay_url` and `sd_phone_relay_key` at it. This is the right
+shape once the relay is carrying enough traffic to want its own CPU.
+
+Either way you still need TLS in front of it for real players. See TLS below: this is the one part
+nothing can do for you.
+
 ## What this is not
 
-* **It is not a FiveM resource.** It is never listed in `fxmanifest.lua`, it is not a `server_script`,
-  it calls no native and it never uses `exports`. Nothing under `media-server/` matches any glob in the
-  resource manifest, so FiveM will not load a single file from this folder.
 * **It is not an authorization system.** Every permission decision stays in Lua. The relay only checks
   that a request carries a valid, unexpired, unused token signed by your game server, and that the token
   names the stream and the role being asked for. A token is a receipt that the Lua checks already passed.
 * **It is not required.** If you never run it, every feature keeps working exactly as it does today over
-  the existing FiveM event path. sd-phone only uses the relay when `sd_phone_relay_url` and
-  `sd_phone_relay_key` are both set, and it falls back to the event path the moment the relay is
-  unreachable. There is no user visible error when the relay is off.
+  the existing FiveM event path, and MDT bodycams can go straight between two clients over a peer
+  connection with no relay at all. sd-phone falls back to the event path the moment the relay is
+  unreachable, and there is no user visible error when it is off.
+* **It is not a place for permissions, storage or business logic.** It moves bytes between sockets.
 
 ## Requirements
 
-* Node.js 18.17 or newer (Node 20 or 22 LTS recommended).
+* Node.js 16.9 or newer to run standalone. Nothing to install to run it inside FXServer, whose own
+  runtime is what executes it there.
 * No dependencies. There is no `npm install` step; the `node_modules` folder is never created.
-* One TCP port reachable from your players (default 30130), and a hostname with a real TLS certificate.
+* CommonJS, not ESM, because FXServer's V8 has no ESM loader and this has to load in both.
+* One TCP port reachable from your players, and a hostname with a real TLS certificate.
 
 ## Quick start
 
@@ -38,7 +53,7 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 SD_PHONE_RELAY_KEY=<the 64 hex characters from step 1> node index.js
 
 # 3. Confirm it answers.
-curl http://127.0.0.1:30130/health
+curl http://127.0.0.1:30567/health
 # {"ok":true,"streams":0,"sockets":0,"uptimeMs":1234}
 ```
 
@@ -50,7 +65,7 @@ Then put the same key, and the public URL, into your `server.cfg` (see below) an
 | --- | --- | --- |
 | `SD_PHONE_RELAY_KEY` | (required) | 64 lowercase hex characters. Must match the `sd_phone_relay_key` convar exactly. The process refuses to start without it. |
 | `SD_PHONE_RELAY_HOST` | `0.0.0.0` | Bind address. Use `127.0.0.1` when a reverse proxy on the same box is the only thing that should reach it. |
-| `SD_PHONE_RELAY_PORT` | `30130` | Bind port. |
+| `SD_PHONE_RELAY_PORT` | `30567` | Bind port. Deliberately clear of the game port and the HTTP endpoint FiveM opens ten above it, which the old default of 30130 collided with. |
 | `SD_PHONE_RELAY_ORIGIN` | `https://cfx-nui-sd-phone,https://cfx-nui-sd-tablet` | Comma separated list of browser origins allowed to upgrade. `*` disables the check. |
 | `SD_PHONE_RELAY_TLS_CERT` | (empty) | Path to a PEM certificate chain. Leave empty when something else terminates TLS. |
 | `SD_PHONE_RELAY_TLS_KEY` | (empty) | Path to the matching PEM private key. |
@@ -102,7 +117,7 @@ node index.js
 
 ```caddyfile
 media.example.com {
-    reverse_proxy 127.0.0.1:30130
+    reverse_proxy 127.0.0.1:30567
 }
 ```
 
@@ -110,7 +125,7 @@ media.example.com {
 
 ```nginx
 location / {
-    proxy_pass http://127.0.0.1:30130;
+    proxy_pass http://127.0.0.1:30567;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
@@ -144,7 +159,7 @@ WorkingDirectory=/opt/sd-phone-media-server
 ExecStart=/usr/bin/node index.js
 Environment=SD_PHONE_RELAY_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 Environment=SD_PHONE_RELAY_HOST=127.0.0.1
-Environment=SD_PHONE_RELAY_PORT=30130
+Environment=SD_PHONE_RELAY_PORT=30567
 Environment=SD_PHONE_RELAY_TRUST_PROXY=1
 Restart=always
 RestartSec=3
@@ -172,7 +187,7 @@ pm2 save
 
 ```bash
 docker build -t sd-phone-media .
-docker run -d --name sd-phone-media -p 30130:30130 \
+docker run -d --name sd-phone-media -p 30567:30567 \
   -e SD_PHONE_RELAY_KEY=... --restart unless-stopped sd-phone-media
 ```
 

--- a/media-server/index.js
+++ b/media-server/index.js
@@ -1,59 +1,62 @@
 #!/usr/bin/env node
-// sd-phone media relay (SDMR/1). Run with `node index.js`.
-//
-// This process is NOT a FiveM resource. It is never listed in fxmanifest.lua, it calls no native
-// and it never talks to the game server except to answer the optional control endpoint. It carries
-// binary media between phones: a publisher pushes encoded frames, viewers get them fanned out.
+(async () => {
+    // sd-phone media relay (SDMR/1). Run with `node index.js`.
+    //
+    // This process is NOT a FiveM resource. It is never listed in fxmanifest.lua, it calls no native
+    // and it never talks to the game server except to answer the optional control endpoint. It carries
+    // binary media between phones: a publisher pushes encoded frames, viewers get them fanned out.
 
-import { loadConfig } from './src/config.js';
-import { createLogger } from './src/log.js';
-import { createRelay } from './src/relay.js';
+    const { loadConfig } = require('./src/config.js');
+    const { createLogger } = require('./src/log.js');
+    const { createRelay } = require('./src/relay.js');
 
-const config = loadConfig(process.env);
-const log = createLogger(config.logLevel === undefined ? 'info' : config.logLevel);
+    const config = loadConfig(process.env);
+    const log = createLogger(config.logLevel === undefined ? 'info' : config.logLevel);
 
-if (config.errors.length > 0) {
-    for (const message of config.errors) log.error('boot', message);
-    log.error('boot', 'refusing to start. See media-server/README.md for the full environment list.');
-    process.exit(1);
-}
-
-const relay = createRelay(config, log);
-
-await relay.listen();
-
-const scheme = config.tlsCert ? 'wss' : 'ws';
-log.info('boot', 'media relay listening', {
-    url: `${scheme}://${config.host}:${config.port}`,
-    tls: config.tlsCert ? 'built in' : 'none (expects a terminator in front)',
-    origins: config.origins.join(' '),
-    maxSockets: config.maxSockets,
-    logLevel: config.logLevel,
-});
-if (!config.tlsCert) {
-    log.info('boot', 'the phone can only reach a wss:// endpoint, so put this behind TLS unless you are testing on loopback');
-    if (!config.trustProxy) {
-        // Something is terminating TLS in front, so every client arrives wearing the proxy's
-        // address. The per-IP abuse counter would then pool the whole server into one bucket and
-        // ban everybody the moment any single player trips it.
-        log.warn('boot', 'no built-in TLS and SD_PHONE_RELAY_TRUST_PROXY is not set. If a reverse proxy is terminating TLS in front, set it to 1: without it every client arrives wearing the proxy address, and one bad client rate-limits the whole server. Ignore this if nothing is in front (plain ws on loopback).');
+    if (config.errors.length > 0) {
+        for (const message of config.errors) log.error('boot', message);
+        log.error('boot', 'refusing to start. See media-server/README.md for the full environment list.');
+        process.exit(1);
     }
-}
 
-let stopping = false;
-async function stop(signal) {
-    if (stopping) return;
-    stopping = true;
-    log.info('boot', 'shutting down', { signal });
-    await relay.close();
-    process.exit(0);
-}
+    const relay = createRelay(config, log);
 
-process.on('SIGINT', () => { stop('SIGINT'); });
-process.on('SIGTERM', () => { stop('SIGTERM'); });
-process.on('uncaughtException', (err) => {
-    log.error('boot', 'uncaught exception', { error: err.message, stack: err.stack });
-});
-process.on('unhandledRejection', (err) => {
-    log.error('boot', 'unhandled rejection', { error: err instanceof Error ? err.message : String(err) });
-});
+    await relay.listen();
+
+    const scheme = config.tlsCert ? 'wss' : 'ws';
+    log.info('boot', 'media relay listening', {
+        url: `${scheme}://${config.host}:${config.port}`,
+        tls: config.tlsCert ? 'built in' : 'none (expects a terminator in front)',
+        origins: config.origins.join(' '),
+        maxSockets: config.maxSockets,
+        logLevel: config.logLevel,
+    });
+    if (!config.tlsCert) {
+        log.info('boot', 'the phone can only reach a wss:// endpoint, so put this behind TLS unless you are testing on loopback');
+        if (!config.trustProxy) {
+            // Something is terminating TLS in front, so every client arrives wearing the proxy's
+            // address. The per-IP abuse counter would then pool the whole server into one bucket and
+            // ban everybody the moment any single player trips it.
+            log.warn('boot', 'no built-in TLS and SD_PHONE_RELAY_TRUST_PROXY is not set. If a reverse proxy is terminating TLS in front, set it to 1: without it every client arrives wearing the proxy address, and one bad client rate-limits the whole server. Ignore this if nothing is in front (plain ws on loopback).');
+        }
+    }
+
+    let stopping = false;
+    async function stop(signal) {
+        if (stopping) return;
+        stopping = true;
+        log.info('boot', 'shutting down', { signal });
+        await relay.close();
+        process.exit(0);
+    }
+
+    process.on('SIGINT', () => { stop('SIGINT'); });
+    process.on('SIGTERM', () => { stop('SIGTERM'); });
+    process.on('uncaughtException', (err) => {
+        log.error('boot', 'uncaught exception', { error: err.message, stack: err.stack });
+    });
+    process.on('unhandledRejection', (err) => {
+        log.error('boot', 'unhandled rejection', { error: err instanceof Error ? err.message : String(err) });
+    });
+
+})();

--- a/media-server/package.json
+++ b/media-server/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "description": "SDMR/1 binary media relay for sd-phone (MDT bodycam, Photogram Live, Vibez Live)",
   "license": "SEE LICENSE IN ../LICENSE",
-  "type": "module",
+  "type": "commonjs",
   "main": "index.js",
   "engines": {
-    "node": ">=18.17"
+    "node": ">=16.9"
   },
   "scripts": {
     "start": "node index.js",

--- a/media-server/selftest.js
+++ b/media-server/selftest.js
@@ -1,870 +1,873 @@
 #!/usr/bin/env node
-// End to end self test. Boots a relay on loopback, publishes a synthetic stream and asserts that a
-// viewer receives the init segment followed by media chunks, then walks the parts of SDMR/1 that
-// are easy to get wrong: prime replay, GOP eviction, the generation fence, token replay defence,
-// oversized frames and the publisher-gone path.
-//
-// Run: node selftest.js        Exit code 0 means every check passed.
+(async () => {
+    // End to end self test. Boots a relay on loopback, publishes a synthetic stream and asserts that a
+    // viewer receives the init segment followed by media chunks, then walks the parts of SDMR/1 that
+    // are easy to get wrong: prime replay, GOP eviction, the generation fence, token replay defence,
+    // oversized frames and the publisher-gone path.
+    //
+    // Run: node selftest.js        Exit code 0 means every check passed.
 
-import assert from 'node:assert/strict';
-import crypto from 'node:crypto';
-import http from 'node:http';
+    const assert = require('node:assert/strict');
+    const crypto = require('node:crypto');
+    const http = require('node:http');
 
-import { loadConfig } from './src/config.js';
-import { createLogger } from './src/log.js';
-import { encodeFrame } from './src/frame.js';
-import { KIND, FLAG, SDMR_HEADER_BYTES, SUBPROTOCOL } from './src/protocol.js';
-import { createRelay } from './src/relay.js';
-import { Stream } from './src/stream.js';
-import { mintToken } from './src/token.js';
+    const { loadConfig } = require('./src/config.js');
+    const { createLogger } = require('./src/log.js');
+    const { encodeFrame } = require('./src/frame.js');
+    const { KIND, FLAG, SDMR_HEADER_BYTES, SUBPROTOCOL } = require('./src/protocol.js');
+    const { createRelay } = require('./src/relay.js');
+    const { Stream } = require('./src/stream.js');
+    const { mintToken } = require('./src/token.js');
 
-const KEY_HEX = crypto.randomBytes(32).toString('hex');
-const KEY = Buffer.from(KEY_HEX, 'hex');
-const PORT = 31000 + Math.floor(Math.random() * 2000);
-const ORIGIN = 'https://cfx-nui-sd-phone';
-const STREAM = 'mdt:cam:ABC12345';
+    const KEY_HEX = crypto.randomBytes(32).toString('hex');
+    const KEY = Buffer.from(KEY_HEX, 'hex');
+    const PORT = 31000 + Math.floor(Math.random() * 2000);
+    const ORIGIN = 'https://cfx-nui-sd-phone';
+    const STREAM = 'mdt:cam:ABC12345';
 
-const results = [];
-let failures = 0;
+    const results = [];
+    let failures = 0;
 
-async function check(name, fn) {
-    try {
-        await fn();
-        results.push(`  PASS  ${name}`);
-    } catch (err) {
-        failures += 1;
-        results.push(`  FAIL  ${name}: ${err.message}`);
+    async function check(name, fn) {
+        try {
+            await fn();
+            results.push(`  PASS  ${name}`);
+        } catch (err) {
+            failures += 1;
+            results.push(`  FAIL  ${name}: ${err.message}`);
+        }
     }
-}
 
-function token(role, streamKey, gen, overrides = {}) {
-    const now = Math.floor(Date.now() / 1000);
-    return mintToken(KEY, {
-        v: 1,
-        iss: 'sd-phone',
-        sub: 'ABC12345',
-        src: 12,
-        name: 'Jonas Vance',
-        key: streamKey,
-        role,
-        gen,
-        iat: now,
-        exp: now + 45,
-        jti: crypto.randomBytes(16).toString('hex'),
-        ...overrides,
+    function token(role, streamKey, gen, overrides = {}) {
+        const now = Math.floor(Date.now() / 1000);
+        return mintToken(KEY, {
+            v: 1,
+            iss: 'sd-phone',
+            sub: 'ABC12345',
+            src: 12,
+            name: 'Jonas Vance',
+            key: streamKey,
+            role,
+            gen,
+            iat: now,
+            exp: now + 45,
+            jti: crypto.randomBytes(16).toString('hex'),
+            ...overrides,
+        });
+    }
+
+    // A websocket client just large enough to drive the relay. Client frames are masked, as RFC 6455
+    // requires, and server frames arrive unmasked.
+    class TestClient {
+        constructor(socket) {
+            this.socket = socket;
+            this.buf = Buffer.alloc(0);
+            this.texts = [];
+            this.frames = [];
+            this.closeCode = 0;
+            this.closed = false;
+            socket.on('data', (chunk) => this.onData(chunk));
+            socket.on('close', () => { this.closed = true; });
+            socket.on('error', () => { this.closed = true; });
+        }
+
+        static connect(options = {}) {
+            return new Promise((resolve, reject) => {
+                const req = http.request({
+                    port: PORT,
+                    host: '127.0.0.1',
+                    path: options.path ?? '/ws',
+                    headers: {
+                        Connection: 'Upgrade',
+                        Upgrade: 'websocket',
+                        Origin: options.origin ?? ORIGIN,
+                        'Sec-WebSocket-Key': crypto.randomBytes(16).toString('base64'),
+                        'Sec-WebSocket-Version': '13',
+                        'Sec-WebSocket-Protocol': SUBPROTOCOL,
+                    },
+                });
+                req.on('upgrade', (res, socket) => {
+                    socket.setNoDelay(true);
+                    resolve(new TestClient(socket));
+                });
+                req.on('response', (res) => reject(new Error(`upgrade refused with ${res.statusCode}`)));
+                req.on('error', reject);
+                req.end();
+            });
+        }
+
+        onData(chunk) {
+            this.buf = Buffer.concat([this.buf, chunk]);
+            for (;;) {
+                if (this.buf.length < 2) return;
+                const opcode = this.buf[0] & 0x0f;
+                const short = this.buf[1] & 0x7f;
+                let offset = 2;
+                let length = short;
+                if (short === 126) {
+                    if (this.buf.length < 4) return;
+                    length = this.buf.readUInt16BE(2);
+                    offset = 4;
+                } else if (short === 127) {
+                    if (this.buf.length < 10) return;
+                    length = Number(this.buf.readBigUInt64BE(2));
+                    offset = 10;
+                }
+                if (this.buf.length < offset + length) return;
+                const payload = this.buf.subarray(offset, offset + length);
+                this.buf = this.buf.subarray(offset + length);
+
+                if (opcode === 0x1) this.texts.push(JSON.parse(payload.toString('utf8')));
+                else if (opcode === 0x2) this.frames.push(this.decode(payload));
+                else if (opcode === 0x8) {
+                    this.closeCode = length >= 2 ? payload.readUInt16BE(0) : 1005;
+                    this.closed = true;
+                } else if (opcode === 0x9) this.send(0xa, payload);
+            }
+        }
+
+        decode(buf) {
+            return {
+                kind: buf[2],
+                flags: buf[3],
+                sid: buf.readUInt32BE(4),
+                gen: buf.readUInt32BE(8),
+                seq: buf.readUInt32BE(12),
+                timestampUs: Number(buf.readBigUInt64BE(16)),
+                payload: Buffer.from(buf.subarray(SDMR_HEADER_BYTES)),
+            };
+        }
+
+        send(opcode, payload) {
+            if (this.socket.destroyed) return;
+            const mask = crypto.randomBytes(4);
+            const length = payload.length;
+            let header;
+            if (length < 126) {
+                header = Buffer.allocUnsafe(2);
+                header[1] = 0x80 | length;
+            } else if (length < 65536) {
+                header = Buffer.allocUnsafe(4);
+                header[1] = 0x80 | 126;
+                header.writeUInt16BE(length, 2);
+            } else {
+                header = Buffer.allocUnsafe(10);
+                header[1] = 0x80 | 127;
+                header.writeBigUInt64BE(BigInt(length), 2);
+            }
+            header[0] = 0x80 | opcode;
+            const masked = Buffer.allocUnsafe(length);
+            for (let i = 0; i < length; i += 1) masked[i] = payload[i] ^ mask[i & 3];
+            this.socket.write(Buffer.concat([header, mask, masked]));
+        }
+
+        json(message) {
+            this.send(0x1, Buffer.from(JSON.stringify(message), 'utf8'));
+        }
+
+        // Sends one text message as two websocket fragments, which a browser is free to do.
+        jsonFragmented(message) {
+            const payload = Buffer.from(JSON.stringify(message), 'utf8');
+            const cut = Math.floor(payload.length / 2);
+            this.sendFragment(0x1, payload.subarray(0, cut), false);
+            this.sendFragment(0x0, payload.subarray(cut), true);
+        }
+
+        sendFragment(opcode, payload, fin) {
+            const mask = crypto.randomBytes(4);
+            const length = payload.length;
+            let header;
+            if (length < 126) {
+                header = Buffer.allocUnsafe(2);
+                header[1] = 0x80 | length;
+            } else {
+                header = Buffer.allocUnsafe(4);
+                header[1] = 0x80 | 126;
+                header.writeUInt16BE(length, 2);
+            }
+            header[0] = (fin ? 0x80 : 0x00) | opcode;
+            const masked = Buffer.allocUnsafe(length);
+            for (let i = 0; i < length; i += 1) masked[i] = payload[i] ^ mask[i & 3];
+            this.socket.write(Buffer.concat([header, mask, masked]));
+        }
+
+        media(kind, sid, gen, seq, payload, flags = 0) {
+            this.send(0x2, encodeFrame(kind, flags, sid, gen, seq, seq * 33333, payload));
+        }
+
+        async waitText(predicate, label, timeoutMs = 2500) {
+            const deadline = Date.now() + timeoutMs;
+            for (;;) {
+                const found = this.texts.find(predicate);
+                if (found) return found;
+                if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+                await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+        }
+
+        async waitFrames(count, label, timeoutMs = 2500) {
+            const deadline = Date.now() + timeoutMs;
+            for (;;) {
+                if (this.frames.length >= count) return this.frames;
+                if (Date.now() > deadline) throw new Error(`timed out waiting for ${label} (${this.frames.length}/${count})`);
+                await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+        }
+
+        async waitClosed(timeoutMs = 2500) {
+            const deadline = Date.now() + timeoutMs;
+            for (;;) {
+                if (this.closed) return this.closeCode;
+                if (Date.now() > deadline) throw new Error('timed out waiting for close');
+                await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+        }
+
+        async hello() {
+            this.json({ t: 'hello', v: 1, token: token('session', '', 0), app: 'sd-phone', device: 'phone', build: 'selftest' });
+            return this.waitText((m) => m.t === 'welcome', 'welcome');
+        }
+
+        destroy() {
+            this.socket.destroy();
+        }
+    }
+
+    const idle = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    const config = loadConfig({
+        SD_PHONE_RELAY_KEY: KEY_HEX,
+        SD_PHONE_RELAY_HOST: '127.0.0.1',
+        SD_PHONE_RELAY_PORT: String(PORT),
+        SD_PHONE_RELAY_LOG: process.env.SELFTEST_LOG ?? 'error',
     });
-}
+    assert.equal(config.errors.length, 0, config.errors.join('; '));
 
-// A websocket client just large enough to drive the relay. Client frames are masked, as RFC 6455
-// requires, and server frames arrive unmasked.
-class TestClient {
-    constructor(socket) {
-        this.socket = socket;
-        this.buf = Buffer.alloc(0);
-        this.texts = [];
-        this.frames = [];
-        this.closeCode = 0;
-        this.closed = false;
-        socket.on('data', (chunk) => this.onData(chunk));
-        socket.on('close', () => { this.closed = true; });
-        socket.on('error', () => { this.closed = true; });
-    }
+    const log = createLogger(config.logLevel);
+    const relay = createRelay(config, log);
+    await relay.listen();
 
-    static connect(options = {}) {
-        return new Promise((resolve, reject) => {
+    const INIT_BYTES = Buffer.from('INIT-SEGMENT-BYTES-0123456789', 'utf8');
+    const keyBytes = (n) => Buffer.alloc(400, 0x40 + n);
+    const deltaBytes = (n) => Buffer.alloc(120, 0x60 + n);
+
+    let publisher = null;
+    let viewer = null;
+    let publisherSid = 0;
+    let viewerSid = 0;
+
+    // The backpressure rules are exercised directly against a stream, because a slow socket cannot be
+    // produced on loopback reliably enough to assert on.
+    await check('backpressure drops deltas first and catches a viewer up at the next keyframe', async () => {
+        const stream = new Stream({ log, removeStream() {} }, 'mdt:cam:BACKPRESS');
+        stream.gen = 3;
+        const record = (kind, seq, size) => ({
+            kind,
+            flags: 0,
+            gen: 3,
+            seq,
+            timestampUs: seq * 1000,
+            payload: Buffer.alloc(size, seq),
+            at: Date.now(),
+        });
+        stream.init = record(KIND.INIT, 0, 32);
+
+        let load = 0;
+        const sent = [];
+        const session = {
+            pendingBytes: 0,
+            load: () => load,
+            flush() {},
+            sendJson: (m) => sent.push(m),
+            releaseStream() {},
+        };
+        const viewer = stream.addViewer(session, 5);
+
+        load = 0;
+        viewer.push(record(KIND.DELTA, 1, 100), false);
+        assert.equal(viewer.pending.length, 2, 'the init segment is queued ahead of the first media frame');
+        assert.equal(viewer.pending[0].kind, KIND.INIT);
+
+        load = 2_000_000;
+        viewer.push(record(KIND.DELTA, 2, 100), false);
+        assert.equal(viewer.pending.length, 2, 'past the soft limit a delta is dropped');
+        assert.equal(viewer.pendingDiscontinuity, true);
+
+        viewer.push(record(KIND.KEY, 3, 100), false);
+        assert.equal(viewer.pending.length, 1, 'a keyframe supersedes everything still pending');
+        assert.equal(viewer.pending[0].kind, KIND.KEY);
+        assert.ok(viewer.pending[0].parts[0][3] & FLAG.DISCONTINUITY, 'the catch up frame is flagged as a discontinuity');
+        assert.equal(viewer.pendingDiscontinuity, false);
+
+        load = 5_000_000;
+        viewer.push(record(KIND.KEY, 4, 100), false);
+        assert.equal(viewer.pending.length, 1, 'past the hard limit even a keyframe is dropped');
+        assert.ok(viewer.starvingSince > 0);
+
+        viewer.starvingSince = Date.now() - 6_000;
+        viewer.push(record(KIND.KEY, 5, 100), false);
+        assert.equal(stream.viewerCount, 0, 'a viewer starving for more than five seconds is detached');
+        assert.ok(sent.some((m) => m.t === 'error' && m.code === 'too_slow'), 'the viewer is told why');
+        assert.ok(sent.some((m) => m.t === 'stream' && m.reason === 'too_slow'));
+        assert.equal(session.pendingBytes, 0, 'its queued bytes are handed back');
+    });
+
+    await check('health endpoint answers before anyone connects', async () => {
+        const body = await new Promise((resolve, reject) => {
+            http.get({ port: PORT, host: '127.0.0.1', path: '/health' }, (res) => {
+                let text = '';
+                res.on('data', (c) => { text += c; });
+                res.on('end', () => resolve({ status: res.statusCode, json: JSON.parse(text) }));
+            }).on('error', reject);
+        });
+        assert.equal(body.status, 200);
+        assert.equal(body.json.ok, true);
+        assert.equal(body.json.streams, 0);
+    });
+
+    await check('publisher completes hello and publish', async () => {
+        publisher = await TestClient.connect();
+        const welcome = await publisher.hello();
+        assert.equal(welcome.sub, 'ABC12345');
+        assert.equal(welcome.limits.maxStreams, 12);
+
+        publisher.json({
+            t: 'publish',
+            token: token('publish', STREAM, 7),
+            key: STREAM,
+            gen: 7,
+            mode: 'video',
+            wire: 'chunks',
+            codec: 'vp8',
+            mime: '',
+            width: 1600,
+            height: 900,
+            fps: 30,
+            bitrate: 8000000,
+        });
+        const ready = await publisher.waitText((m) => m.t === 'ready', 'ready');
+        assert.equal(ready.key, STREAM);
+        assert.equal(ready.gen, 7);
+        assert.equal(ready.viewers, 0);
+        publisherSid = ready.sid;
+
+        const idleState = await publisher.waitText((m) => m.t === 'stream' && m.state === 'idle', 'idle state');
+        assert.equal(idleState.reason, 'no_viewers');
+    });
+
+    await check('viewer joins an unprimed stream and is told it is priming', async () => {
+        viewer = await TestClient.connect();
+        await viewer.hello();
+        viewer.json({ t: 'join', token: token('watch', STREAM, 7), key: STREAM });
+        const joined = await viewer.waitText((m) => m.t === 'joined', 'joined');
+        assert.equal(joined.key, STREAM);
+        assert.equal(joined.gen, 7);
+        assert.equal(joined.live, true);
+        assert.equal(joined.wire, 'chunks');
+        assert.equal(joined.codec, 'vp8');
+        viewerSid = joined.sid;
+
+        const priming = await viewer.waitText((m) => m.t === 'stream' && m.state === 'priming', 'priming state');
+        assert.equal(priming.reason, 'stale_prime');
+    });
+
+    await check('publisher is asked for a keyframe when a viewer joins', async () => {
+        const request = await publisher.waitText((m) => m.t === 'keyframe', 'keyframe request');
+        assert.equal(request.sid, publisherSid);
+        assert.equal(request.reason, 'viewer_join');
+    });
+
+    await check('viewer receives the init segment followed by chunks', async () => {
+        publisher.media(KIND.INIT, publisherSid, 7, 0, INIT_BYTES);
+        publisher.media(KIND.KEY, publisherSid, 7, 1, keyBytes(1));
+        publisher.media(KIND.DELTA, publisherSid, 7, 2, deltaBytes(2));
+        publisher.media(KIND.DELTA, publisherSid, 7, 3, deltaBytes(3));
+
+        const frames = await viewer.waitFrames(4, 'init plus three chunks');
+        assert.equal(frames[0].kind, KIND.INIT, 'first frame must be the init segment');
+        assert.deepEqual(frames[0].payload, INIT_BYTES, 'init payload must arrive byte for byte');
+        assert.equal(frames[0].sid, viewerSid, 'frames are rewritten to the viewer own stream handle');
+        assert.equal(frames[0].gen, 7);
+        assert.equal(frames[0].flags & FLAG.REPLAY, 0, 'a live init is not a replay');
+
+        assert.equal(frames[1].kind, KIND.KEY);
+        assert.deepEqual(frames[1].payload, keyBytes(1));
+        assert.equal(frames[2].kind, KIND.DELTA);
+        assert.equal(frames[3].kind, KIND.DELTA);
+        assert.deepEqual(frames[3].payload, deltaBytes(3));
+        assert.equal(frames[3].seq, 3, 'the publisher sequence number is preserved for gap detection');
+        assert.equal(frames[3].timestampUs, 3 * 33333, 'the presentation timestamp is preserved');
+    });
+
+    await check('a frame carrying the wrong generation is discarded', async () => {
+        const before = viewer.frames.length;
+        publisher.media(KIND.KEY, publisherSid, 6, 4, keyBytes(9));
+        publisher.media(KIND.DELTA, publisherSid, 7, 5, deltaBytes(5));
+        await viewer.waitFrames(before + 1, 'the in-generation frame');
+        await idle(120);
+        assert.equal(viewer.frames.length, before + 1, 'only the in-generation frame is relayed');
+        assert.equal(viewer.frames[before].kind, KIND.DELTA);
+    });
+
+    await check('a late viewer is primed with the init segment and whole GOPs', async () => {
+        const late = await TestClient.connect();
+        await late.hello();
+        late.json({ t: 'join', token: token('watch', STREAM, 7), key: STREAM });
+        await late.waitText((m) => m.t === 'joined', 'joined');
+
+        const frames = await late.waitFrames(4, 'replayed prime cache');
+        assert.equal(frames[0].kind, KIND.INIT);
+        assert.deepEqual(frames[0].payload, INIT_BYTES);
+        assert.ok(frames[0].flags & FLAG.REPLAY, 'a primed init is flagged as a replay');
+        assert.equal(frames[1].kind, KIND.KEY, 'a replay starts at a keyframe, never mid GOP');
+        assert.ok(frames.slice(1).every((f) => (f.flags & FLAG.REPLAY) !== 0), 'every primed frame is flagged');
+
+        const live = await late.waitText((m) => m.t === 'stream' && m.state === 'live', 'live state');
+        assert.equal(live.reason, 'publisher_attached');
+        late.destroy();
+    });
+
+    await check('the prime cache keeps at most two whole GOPs', async () => {
+        for (let n = 0; n < 3; n += 1) {
+            publisher.media(KIND.KEY, publisherSid, 7, 10 + n * 2, keyBytes(20 + n));
+            publisher.media(KIND.DELTA, publisherSid, 7, 11 + n * 2, deltaBytes(20 + n));
+        }
+        await idle(120);
+
+        const late = await TestClient.connect();
+        await late.hello();
+        late.json({ t: 'join', token: token('watch', STREAM, 7), key: STREAM });
+        await late.waitText((m) => m.t === 'joined', 'joined');
+        await late.waitText((m) => m.t === 'stream', 'stream state');
+        await idle(80);
+
+        const keys = late.frames.filter((f) => f.kind === KIND.KEY);
+        assert.equal(keys.length, 2, 'the two newest GOPs are kept and the oldest is evicted whole');
+        assert.deepEqual(keys[0].payload, keyBytes(21), 'the oldest surviving GOP is the second one sent');
+        assert.equal(late.frames[0].kind, KIND.INIT, 'the init segment is never evicted');
+        late.destroy();
+    });
+
+    await check('viewer count changes reach the publisher', async () => {
+        const message = await publisher.waitText((m) => m.t === 'viewers' && m.viewers >= 1, 'viewers message');
+        assert.equal(message.sid, publisherSid);
+    });
+
+    await check('an unknown control type is refused without killing the socket', async () => {
+        viewer.json({ t: 'nonsense' });
+        const error = await viewer.waitText((m) => m.t === 'error' && m.code === 'unknown_type', 'unknown_type error');
+        assert.equal(error.fatal, false);
+        assert.equal(viewer.closed, false);
+    });
+
+    await check('a viewer keyframe request reaches the publisher', async () => {
+        await idle(1050);
+        viewer.json({ t: 'keyframe', sid: viewerSid });
+        const request = await publisher.waitText((m) => m.t === 'keyframe' && m.reason === 'viewer_request', 'viewer_request');
+        assert.equal(request.sid, publisherSid);
+    });
+
+    await check('ping is answered with the timestamp echoed back', async () => {
+        viewer.json({ t: 'ping', ts: 1755600012345 });
+        const pong = await viewer.waitText((m) => m.t === 'pong', 'pong');
+        assert.equal(pong.ts, 1755600012345);
+        assert.ok(pong.serverTimeMs > 0);
+    });
+
+    await check('a replayed token is refused and the socket is closed 4401', async () => {
+        const reused = token('watch', STREAM, 7);
+        const first = await TestClient.connect();
+        await first.hello();
+        first.json({ t: 'join', token: reused, key: STREAM });
+        await first.waitText((m) => m.t === 'joined', 'joined');
+
+        const second = await TestClient.connect();
+        await second.hello();
+        second.json({ t: 'join', token: reused, key: STREAM });
+        const error = await second.waitText((m) => m.t === 'error' && m.code === 'token_replayed', 'token_replayed');
+        assert.equal(error.fatal, true);
+        assert.equal(await second.waitClosed(), 4401);
+        first.destroy();
+    });
+
+    await check('a token signed with the wrong key is refused 4401', async () => {
+        const client = await TestClient.connect();
+        const bad = mintToken(crypto.randomBytes(32), {
+            v: 1,
+            iss: 'sd-phone',
+            sub: 'ABC12345',
+            src: 12,
+            name: 'Jonas Vance',
+            key: '',
+            role: 'session',
+            gen: 0,
+            iat: Math.floor(Date.now() / 1000),
+            exp: Math.floor(Date.now() / 1000) + 45,
+            jti: crypto.randomBytes(16).toString('hex'),
+        });
+        client.json({ t: 'hello', v: 1, token: bad, app: 'sd-phone', device: 'phone', build: 'selftest' });
+        const error = await client.waitText((m) => m.t === 'error', 'auth error');
+        assert.equal(error.code, 'token_bad_signature');
+        assert.equal(await client.waitClosed(), 4401);
+    });
+
+    await check('a watch token cannot be used to publish', async () => {
+        const client = await TestClient.connect();
+        await client.hello();
+        client.json({
+            t: 'publish',
+            token: token('watch', STREAM, 9),
+            key: STREAM,
+            gen: 9,
+            mode: 'video',
+            wire: 'chunks',
+            codec: 'vp8',
+            mime: '',
+            width: 320,
+            height: 180,
+            fps: 4,
+            bitrate: 120000,
+        });
+        const error = await client.waitText((m) => m.t === 'error' && m.code === 'token_scope', 'token_scope');
+        assert.equal(error.fatal, true);
+        assert.equal(await client.waitClosed(), 4403);
+    });
+
+    await check('a second publisher at the same generation is refused, the first keeps the stream', async () => {
+        const client = await TestClient.connect();
+        await client.hello();
+        client.json({
+            t: 'publish',
+            token: token('publish', STREAM, 7),
+            key: STREAM,
+            gen: 7,
+            mode: 'video',
+            wire: 'chunks',
+            codec: 'vp8',
+            mime: '',
+            width: 1600,
+            height: 900,
+            fps: 30,
+            bitrate: 8000000,
+        });
+        const error = await client.waitText((m) => m.t === 'error' && m.code === 'stream_busy', 'stream_busy');
+        assert.equal(error.fatal, false);
+        assert.equal(client.closed, false);
+        client.destroy();
+
+        publisher.media(KIND.DELTA, publisherSid, 7, 99, deltaBytes(7));
+        await viewer.waitText((m) => m.t === 'joined' || m.t === 'welcome', 'session still usable');
+        assert.equal(viewer.closed, false, 'the original publisher and its viewers are untouched');
+    });
+
+    await check('a fragmented control message is reassembled', async () => {
+        const client = await TestClient.connect();
+        client.jsonFragmented({
+            t: 'hello',
+            v: 1,
+            token: token('session', '', 0),
+            app: 'sd-phone',
+            device: 'tablet',
+            build: 'selftest',
+        });
+        const welcome = await client.waitText((m) => m.t === 'welcome', 'welcome');
+        assert.equal(welcome.sub, 'ABC12345');
+        client.destroy();
+    });
+
+    await check('a publisher at a higher generation supersedes the one holding the key', async () => {
+        const key = 'vibez:live:selftest02';
+        const first = await TestClient.connect();
+        await first.hello();
+        first.json({
+            t: 'publish',
+            token: token('publish', key, 1),
+            key,
+            gen: 1,
+            mode: 'video',
+            wire: 'mse',
+            codec: '',
+            mime: 'video/webm;codecs=vp8',
+            width: 640,
+            height: 360,
+            fps: 24,
+            bitrate: 800000,
+        });
+        const ready = await first.waitText((m) => m.t === 'ready', 'ready');
+        first.media(KIND.INIT, ready.sid, 1, 0, INIT_BYTES);
+
+        const watcher = await TestClient.connect();
+        await watcher.hello();
+        watcher.json({ t: 'join', token: token('watch', key, 1), key });
+        await watcher.waitText((m) => m.t === 'joined', 'joined');
+
+        const second = await TestClient.connect();
+        await second.hello();
+        second.json({
+            t: 'publish',
+            token: token('publish', key, 2),
+            key,
+            gen: 2,
+            mode: 'video',
+            wire: 'mse',
+            codec: '',
+            mime: 'video/webm;codecs=vp8',
+            width: 640,
+            height: 360,
+            fps: 24,
+            bitrate: 800000,
+        });
+        await second.waitText((m) => m.t === 'ready' && m.gen === 2, 'ready at the new generation');
+
+        const bye = await first.waitText((m) => m.t === 'bye', 'bye');
+        assert.equal(bye.reason, 'superseded');
+        assert.equal(await first.waitClosed(), 4409);
+
+        const reset = await watcher.waitText((m) => m.t === 'stream' && m.state === 'reset', 'reset state');
+        assert.equal(reset.gen, 2);
+        assert.equal(reset.reason, 'gen_change');
+        second.destroy();
+        watcher.destroy();
+    });
+
+    await check('the same socket can re-publish at a new generation without being evicted', async () => {
+        const key = 'photogram:live:selftest03';
+        const host = await TestClient.connect();
+        await host.hello();
+        const publish = (gen) => host.json({
+            t: 'publish',
+            token: token('publish', key, gen),
+            key,
+            gen,
+            mode: 'video',
+            wire: 'chunks',
+            codec: 'vp8',
+            mime: '',
+            width: 640,
+            height: 360,
+            fps: 24,
+            bitrate: 800000,
+        });
+
+        publish(3);
+        const first = await host.waitText((m) => m.t === 'ready', 'first ready');
+        host.media(KIND.INIT, first.sid, 3, 0, INIT_BYTES);
+
+        const watcher = await TestClient.connect();
+        await watcher.hello();
+        watcher.json({ t: 'join', token: token('watch', key, 3), key });
+        await watcher.waitText((m) => m.t === 'joined', 'joined');
+
+        publish(4);
+        const second = await host.waitText((m) => m.t === 'ready' && m.gen === 4, 'second ready');
+        assert.ok(second.sid > first.sid);
+        assert.equal(host.closed, false, 'the publisher keeps its socket');
+
+        const reset = await watcher.waitText((m) => m.t === 'stream' && m.state === 'reset', 'reset state');
+        assert.equal(reset.gen, 4);
+
+        host.media(KIND.INIT, second.sid, 4, 0, INIT_BYTES);
+        host.media(KIND.KEY, second.sid, 4, 1, keyBytes(4));
+        await watcher.waitFrames(3, 'media at the new generation');
+        const after = watcher.frames.slice(1);
+        assert.ok(after.every((f) => f.gen === 4), 'only the new generation is relayed after a reset');
+        host.destroy();
+        watcher.destroy();
+    });
+
+    await check('a socket is held to twelve streams', async () => {
+        const client = await TestClient.connect();
+        await client.hello();
+        for (let n = 0; n < 12; n += 1) {
+            const key = `mdt:cam:CAP${String(n).padStart(5, '0')}`;
+            client.json({ t: 'join', token: token('watch', key, 0), key });
+        }
+        await client.waitText((m) => m.t === 'joined' && m.key === 'mdt:cam:CAP00011', 'the twelfth join');
+
+        const key = 'mdt:cam:CAP00012';
+        client.json({ t: 'join', token: token('watch', key, 0), key });
+        const error = await client.waitText((m) => m.t === 'error' && m.code === 'too_many_streams', 'too_many_streams');
+        assert.equal(error.fatal, false);
+        assert.equal(client.closed, false);
+        client.destroy();
+    });
+
+    await check('a binary message over 1 MiB closes the socket 4413', async () => {
+        const client = await TestClient.connect();
+        await client.hello();
+        client.send(0x2, Buffer.alloc(1_048_577, 1));
+        const error = await client.waitText((m) => m.t === 'error' && m.code === 'frame_too_large', 'frame_too_large');
+        assert.equal(error.fatal, true);
+        assert.equal(await client.waitClosed(), 4413);
+    });
+
+    await check('a media frame with a bad magic byte closes the socket 4400', async () => {
+        const client = await TestClient.connect();
+        await client.hello();
+        const bogus = Buffer.alloc(40, 0);
+        bogus[0] = 0x11;
+        client.send(0x2, bogus);
+        const error = await client.waitText((m) => m.t === 'error' && m.code === 'bad_message', 'bad_message');
+        assert.equal(error.fatal, true);
+        assert.equal(await client.waitClosed(), 4400);
+    });
+
+    await check('a client that never says hello is closed 4408', async () => {
+        const client = await TestClient.connect();
+        client.json({ t: 'ping', ts: 1 });
+        const error = await client.waitText((m) => m.t === 'error' && m.code === 'no_hello', 'no_hello');
+        assert.equal(error.fatal, true);
+        assert.equal(await client.waitClosed(), 4400);
+    });
+
+    await check('unpublish idles the viewers rather than ending them', async () => {
+        publisher.json({ t: 'unpublish', sid: publisherSid });
+        const idle = await viewer.waitText((m) => m.t === 'stream' && m.state === 'idle', 'idle state');
+        assert.equal(idle.reason, 'unpublished');
+        assert.equal(idle.key, STREAM);
+    });
+
+    await check('a publisher can resume inside the linger window without the viewer rejoining', async () => {
+        const before = viewer.texts.length;
+        publisher.json({
+            t: 'publish',
+            token: token('publish', STREAM, 7),
+            key: STREAM,
+            gen: 7,
+            mode: 'video',
+            wire: 'chunks',
+            codec: 'vp8',
+            mime: '',
+            width: 1600,
+            height: 900,
+            fps: 30,
+            bitrate: 8000000,
+        });
+        const ready = await publisher.waitText((m) => m.t === 'ready' && m.sid !== publisherSid, 'second ready');
+        assert.ok(ready.sid > publisherSid, 'a stream handle is never reused on a socket');
+        publisherSid = ready.sid;
+
+        const live = await viewer.waitText(
+            (m, i) => i >= before && m.t === 'stream' && m.state === 'live',
+            'live state after resume'
+        );
+        assert.equal(live.reason, 'publisher_attached');
+
+        const count = viewer.frames.length;
+        publisher.media(KIND.KEY, publisherSid, 7, 200, keyBytes(30));
+        await viewer.waitFrames(count + 1, 'a frame after the resume');
+        assert.equal(viewer.frames[count].kind, KIND.KEY);
+    });
+
+    await check('the image mode prime cache holds only the newest still frame', async () => {
+        const stills = 'photogram:live:selftest01';
+        const host = await TestClient.connect();
+        await host.hello();
+        host.json({
+            t: 'publish',
+            token: token('publish', stills, 1),
+            key: stills,
+            gen: 1,
+            mode: 'image',
+            wire: 'chunks',
+            codec: '',
+            mime: '',
+            width: 640,
+            height: 360,
+            fps: 1,
+            bitrate: 200000,
+        });
+        const ready = await host.waitText((m) => m.t === 'ready', 'ready');
+        host.media(KIND.JPEG, ready.sid, 1, 0, Buffer.alloc(64, 0xa1));
+        host.media(KIND.JPEG, ready.sid, 1, 1, Buffer.alloc(64, 0xa2));
+        await idle(80);
+
+        const watcher = await TestClient.connect();
+        await watcher.hello();
+        watcher.json({ t: 'join', token: token('watch', stills, 1), key: stills });
+        await watcher.waitText((m) => m.t === 'joined', 'joined');
+        const frames = await watcher.waitFrames(1, 'the cached still');
+        await idle(80);
+        assert.equal(watcher.frames.length, 1, 'only the newest still is cached');
+        assert.equal(frames[0].kind, KIND.JPEG);
+        assert.equal(frames[0].payload[0], 0xa2);
+        host.destroy();
+        watcher.destroy();
+    });
+
+    await check('the control channel reports stats and revokes a stream', async () => {
+        const body = JSON.stringify({ op: 'stats' });
+        const ts = Date.now();
+        const sig = crypto.createHmac('sha256', KEY).update(`${ts}.${body}`).digest('hex');
+        const stats = await new Promise((resolve, reject) => {
             const req = http.request({
                 port: PORT,
                 host: '127.0.0.1',
-                path: options.path ?? '/ws',
-                headers: {
-                    Connection: 'Upgrade',
-                    Upgrade: 'websocket',
-                    Origin: options.origin ?? ORIGIN,
-                    'Sec-WebSocket-Key': crypto.randomBytes(16).toString('base64'),
-                    'Sec-WebSocket-Version': '13',
-                    'Sec-WebSocket-Protocol': SUBPROTOCOL,
-                },
+                path: '/control',
+                method: 'POST',
+                headers: { 'content-type': 'application/json', 'x-sdmr-ts': String(ts), 'x-sdmr-sig': sig },
+            }, (res) => {
+                let text = '';
+                res.on('data', (c) => { text += c; });
+                res.on('end', () => resolve({ status: res.statusCode, json: JSON.parse(text) }));
             });
-            req.on('upgrade', (res, socket) => {
-                socket.setNoDelay(true);
-                resolve(new TestClient(socket));
-            });
-            req.on('response', (res) => reject(new Error(`upgrade refused with ${res.statusCode}`)));
             req.on('error', reject);
-            req.end();
+            req.end(body);
         });
-    }
-
-    onData(chunk) {
-        this.buf = Buffer.concat([this.buf, chunk]);
-        for (;;) {
-            if (this.buf.length < 2) return;
-            const opcode = this.buf[0] & 0x0f;
-            const short = this.buf[1] & 0x7f;
-            let offset = 2;
-            let length = short;
-            if (short === 126) {
-                if (this.buf.length < 4) return;
-                length = this.buf.readUInt16BE(2);
-                offset = 4;
-            } else if (short === 127) {
-                if (this.buf.length < 10) return;
-                length = Number(this.buf.readBigUInt64BE(2));
-                offset = 10;
-            }
-            if (this.buf.length < offset + length) return;
-            const payload = this.buf.subarray(offset, offset + length);
-            this.buf = this.buf.subarray(offset + length);
-
-            if (opcode === 0x1) this.texts.push(JSON.parse(payload.toString('utf8')));
-            else if (opcode === 0x2) this.frames.push(this.decode(payload));
-            else if (opcode === 0x8) {
-                this.closeCode = length >= 2 ? payload.readUInt16BE(0) : 1005;
-                this.closed = true;
-            } else if (opcode === 0x9) this.send(0xa, payload);
-        }
-    }
-
-    decode(buf) {
-        return {
-            kind: buf[2],
-            flags: buf[3],
-            sid: buf.readUInt32BE(4),
-            gen: buf.readUInt32BE(8),
-            seq: buf.readUInt32BE(12),
-            timestampUs: Number(buf.readBigUInt64BE(16)),
-            payload: Buffer.from(buf.subarray(SDMR_HEADER_BYTES)),
-        };
-    }
-
-    send(opcode, payload) {
-        if (this.socket.destroyed) return;
-        const mask = crypto.randomBytes(4);
-        const length = payload.length;
-        let header;
-        if (length < 126) {
-            header = Buffer.allocUnsafe(2);
-            header[1] = 0x80 | length;
-        } else if (length < 65536) {
-            header = Buffer.allocUnsafe(4);
-            header[1] = 0x80 | 126;
-            header.writeUInt16BE(length, 2);
-        } else {
-            header = Buffer.allocUnsafe(10);
-            header[1] = 0x80 | 127;
-            header.writeBigUInt64BE(BigInt(length), 2);
-        }
-        header[0] = 0x80 | opcode;
-        const masked = Buffer.allocUnsafe(length);
-        for (let i = 0; i < length; i += 1) masked[i] = payload[i] ^ mask[i & 3];
-        this.socket.write(Buffer.concat([header, mask, masked]));
-    }
-
-    json(message) {
-        this.send(0x1, Buffer.from(JSON.stringify(message), 'utf8'));
-    }
-
-    // Sends one text message as two websocket fragments, which a browser is free to do.
-    jsonFragmented(message) {
-        const payload = Buffer.from(JSON.stringify(message), 'utf8');
-        const cut = Math.floor(payload.length / 2);
-        this.sendFragment(0x1, payload.subarray(0, cut), false);
-        this.sendFragment(0x0, payload.subarray(cut), true);
-    }
-
-    sendFragment(opcode, payload, fin) {
-        const mask = crypto.randomBytes(4);
-        const length = payload.length;
-        let header;
-        if (length < 126) {
-            header = Buffer.allocUnsafe(2);
-            header[1] = 0x80 | length;
-        } else {
-            header = Buffer.allocUnsafe(4);
-            header[1] = 0x80 | 126;
-            header.writeUInt16BE(length, 2);
-        }
-        header[0] = (fin ? 0x80 : 0x00) | opcode;
-        const masked = Buffer.allocUnsafe(length);
-        for (let i = 0; i < length; i += 1) masked[i] = payload[i] ^ mask[i & 3];
-        this.socket.write(Buffer.concat([header, mask, masked]));
-    }
-
-    media(kind, sid, gen, seq, payload, flags = 0) {
-        this.send(0x2, encodeFrame(kind, flags, sid, gen, seq, seq * 33333, payload));
-    }
-
-    async waitText(predicate, label, timeoutMs = 2500) {
-        const deadline = Date.now() + timeoutMs;
-        for (;;) {
-            const found = this.texts.find(predicate);
-            if (found) return found;
-            if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
-            await new Promise((resolve) => setTimeout(resolve, 10));
-        }
-    }
-
-    async waitFrames(count, label, timeoutMs = 2500) {
-        const deadline = Date.now() + timeoutMs;
-        for (;;) {
-            if (this.frames.length >= count) return this.frames;
-            if (Date.now() > deadline) throw new Error(`timed out waiting for ${label} (${this.frames.length}/${count})`);
-            await new Promise((resolve) => setTimeout(resolve, 10));
-        }
-    }
-
-    async waitClosed(timeoutMs = 2500) {
-        const deadline = Date.now() + timeoutMs;
-        for (;;) {
-            if (this.closed) return this.closeCode;
-            if (Date.now() > deadline) throw new Error('timed out waiting for close');
-            await new Promise((resolve) => setTimeout(resolve, 10));
-        }
-    }
-
-    async hello() {
-        this.json({ t: 'hello', v: 1, token: token('session', '', 0), app: 'sd-phone', device: 'phone', build: 'selftest' });
-        return this.waitText((m) => m.t === 'welcome', 'welcome');
-    }
-
-    destroy() {
-        this.socket.destroy();
-    }
-}
-
-const idle = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const config = loadConfig({
-    SD_PHONE_RELAY_KEY: KEY_HEX,
-    SD_PHONE_RELAY_HOST: '127.0.0.1',
-    SD_PHONE_RELAY_PORT: String(PORT),
-    SD_PHONE_RELAY_LOG: process.env.SELFTEST_LOG ?? 'error',
-});
-assert.equal(config.errors.length, 0, config.errors.join('; '));
-
-const log = createLogger(config.logLevel);
-const relay = createRelay(config, log);
-await relay.listen();
-
-const INIT_BYTES = Buffer.from('INIT-SEGMENT-BYTES-0123456789', 'utf8');
-const keyBytes = (n) => Buffer.alloc(400, 0x40 + n);
-const deltaBytes = (n) => Buffer.alloc(120, 0x60 + n);
-
-let publisher = null;
-let viewer = null;
-let publisherSid = 0;
-let viewerSid = 0;
-
-// The backpressure rules are exercised directly against a stream, because a slow socket cannot be
-// produced on loopback reliably enough to assert on.
-await check('backpressure drops deltas first and catches a viewer up at the next keyframe', async () => {
-    const stream = new Stream({ log, removeStream() {} }, 'mdt:cam:BACKPRESS');
-    stream.gen = 3;
-    const record = (kind, seq, size) => ({
-        kind,
-        flags: 0,
-        gen: 3,
-        seq,
-        timestampUs: seq * 1000,
-        payload: Buffer.alloc(size, seq),
-        at: Date.now(),
-    });
-    stream.init = record(KIND.INIT, 0, 32);
-
-    let load = 0;
-    const sent = [];
-    const session = {
-        pendingBytes: 0,
-        load: () => load,
-        flush() {},
-        sendJson: (m) => sent.push(m),
-        releaseStream() {},
-    };
-    const viewer = stream.addViewer(session, 5);
-
-    load = 0;
-    viewer.push(record(KIND.DELTA, 1, 100), false);
-    assert.equal(viewer.pending.length, 2, 'the init segment is queued ahead of the first media frame');
-    assert.equal(viewer.pending[0].kind, KIND.INIT);
-
-    load = 2_000_000;
-    viewer.push(record(KIND.DELTA, 2, 100), false);
-    assert.equal(viewer.pending.length, 2, 'past the soft limit a delta is dropped');
-    assert.equal(viewer.pendingDiscontinuity, true);
-
-    viewer.push(record(KIND.KEY, 3, 100), false);
-    assert.equal(viewer.pending.length, 1, 'a keyframe supersedes everything still pending');
-    assert.equal(viewer.pending[0].kind, KIND.KEY);
-    assert.ok(viewer.pending[0].parts[0][3] & FLAG.DISCONTINUITY, 'the catch up frame is flagged as a discontinuity');
-    assert.equal(viewer.pendingDiscontinuity, false);
-
-    load = 5_000_000;
-    viewer.push(record(KIND.KEY, 4, 100), false);
-    assert.equal(viewer.pending.length, 1, 'past the hard limit even a keyframe is dropped');
-    assert.ok(viewer.starvingSince > 0);
-
-    viewer.starvingSince = Date.now() - 6_000;
-    viewer.push(record(KIND.KEY, 5, 100), false);
-    assert.equal(stream.viewerCount, 0, 'a viewer starving for more than five seconds is detached');
-    assert.ok(sent.some((m) => m.t === 'error' && m.code === 'too_slow'), 'the viewer is told why');
-    assert.ok(sent.some((m) => m.t === 'stream' && m.reason === 'too_slow'));
-    assert.equal(session.pendingBytes, 0, 'its queued bytes are handed back');
-});
-
-await check('health endpoint answers before anyone connects', async () => {
-    const body = await new Promise((resolve, reject) => {
-        http.get({ port: PORT, host: '127.0.0.1', path: '/health' }, (res) => {
-            let text = '';
-            res.on('data', (c) => { text += c; });
-            res.on('end', () => resolve({ status: res.statusCode, json: JSON.parse(text) }));
-        }).on('error', reject);
-    });
-    assert.equal(body.status, 200);
-    assert.equal(body.json.ok, true);
-    assert.equal(body.json.streams, 0);
-});
-
-await check('publisher completes hello and publish', async () => {
-    publisher = await TestClient.connect();
-    const welcome = await publisher.hello();
-    assert.equal(welcome.sub, 'ABC12345');
-    assert.equal(welcome.limits.maxStreams, 12);
-
-    publisher.json({
-        t: 'publish',
-        token: token('publish', STREAM, 7),
-        key: STREAM,
-        gen: 7,
-        mode: 'video',
-        wire: 'chunks',
-        codec: 'vp8',
-        mime: '',
-        width: 1600,
-        height: 900,
-        fps: 30,
-        bitrate: 8000000,
-    });
-    const ready = await publisher.waitText((m) => m.t === 'ready', 'ready');
-    assert.equal(ready.key, STREAM);
-    assert.equal(ready.gen, 7);
-    assert.equal(ready.viewers, 0);
-    publisherSid = ready.sid;
-
-    const idleState = await publisher.waitText((m) => m.t === 'stream' && m.state === 'idle', 'idle state');
-    assert.equal(idleState.reason, 'no_viewers');
-});
-
-await check('viewer joins an unprimed stream and is told it is priming', async () => {
-    viewer = await TestClient.connect();
-    await viewer.hello();
-    viewer.json({ t: 'join', token: token('watch', STREAM, 7), key: STREAM });
-    const joined = await viewer.waitText((m) => m.t === 'joined', 'joined');
-    assert.equal(joined.key, STREAM);
-    assert.equal(joined.gen, 7);
-    assert.equal(joined.live, true);
-    assert.equal(joined.wire, 'chunks');
-    assert.equal(joined.codec, 'vp8');
-    viewerSid = joined.sid;
-
-    const priming = await viewer.waitText((m) => m.t === 'stream' && m.state === 'priming', 'priming state');
-    assert.equal(priming.reason, 'stale_prime');
-});
-
-await check('publisher is asked for a keyframe when a viewer joins', async () => {
-    const request = await publisher.waitText((m) => m.t === 'keyframe', 'keyframe request');
-    assert.equal(request.sid, publisherSid);
-    assert.equal(request.reason, 'viewer_join');
-});
-
-await check('viewer receives the init segment followed by chunks', async () => {
-    publisher.media(KIND.INIT, publisherSid, 7, 0, INIT_BYTES);
-    publisher.media(KIND.KEY, publisherSid, 7, 1, keyBytes(1));
-    publisher.media(KIND.DELTA, publisherSid, 7, 2, deltaBytes(2));
-    publisher.media(KIND.DELTA, publisherSid, 7, 3, deltaBytes(3));
-
-    const frames = await viewer.waitFrames(4, 'init plus three chunks');
-    assert.equal(frames[0].kind, KIND.INIT, 'first frame must be the init segment');
-    assert.deepEqual(frames[0].payload, INIT_BYTES, 'init payload must arrive byte for byte');
-    assert.equal(frames[0].sid, viewerSid, 'frames are rewritten to the viewer own stream handle');
-    assert.equal(frames[0].gen, 7);
-    assert.equal(frames[0].flags & FLAG.REPLAY, 0, 'a live init is not a replay');
-
-    assert.equal(frames[1].kind, KIND.KEY);
-    assert.deepEqual(frames[1].payload, keyBytes(1));
-    assert.equal(frames[2].kind, KIND.DELTA);
-    assert.equal(frames[3].kind, KIND.DELTA);
-    assert.deepEqual(frames[3].payload, deltaBytes(3));
-    assert.equal(frames[3].seq, 3, 'the publisher sequence number is preserved for gap detection');
-    assert.equal(frames[3].timestampUs, 3 * 33333, 'the presentation timestamp is preserved');
-});
-
-await check('a frame carrying the wrong generation is discarded', async () => {
-    const before = viewer.frames.length;
-    publisher.media(KIND.KEY, publisherSid, 6, 4, keyBytes(9));
-    publisher.media(KIND.DELTA, publisherSid, 7, 5, deltaBytes(5));
-    await viewer.waitFrames(before + 1, 'the in-generation frame');
-    await idle(120);
-    assert.equal(viewer.frames.length, before + 1, 'only the in-generation frame is relayed');
-    assert.equal(viewer.frames[before].kind, KIND.DELTA);
-});
-
-await check('a late viewer is primed with the init segment and whole GOPs', async () => {
-    const late = await TestClient.connect();
-    await late.hello();
-    late.json({ t: 'join', token: token('watch', STREAM, 7), key: STREAM });
-    await late.waitText((m) => m.t === 'joined', 'joined');
-
-    const frames = await late.waitFrames(4, 'replayed prime cache');
-    assert.equal(frames[0].kind, KIND.INIT);
-    assert.deepEqual(frames[0].payload, INIT_BYTES);
-    assert.ok(frames[0].flags & FLAG.REPLAY, 'a primed init is flagged as a replay');
-    assert.equal(frames[1].kind, KIND.KEY, 'a replay starts at a keyframe, never mid GOP');
-    assert.ok(frames.slice(1).every((f) => (f.flags & FLAG.REPLAY) !== 0), 'every primed frame is flagged');
-
-    const live = await late.waitText((m) => m.t === 'stream' && m.state === 'live', 'live state');
-    assert.equal(live.reason, 'publisher_attached');
-    late.destroy();
-});
-
-await check('the prime cache keeps at most two whole GOPs', async () => {
-    for (let n = 0; n < 3; n += 1) {
-        publisher.media(KIND.KEY, publisherSid, 7, 10 + n * 2, keyBytes(20 + n));
-        publisher.media(KIND.DELTA, publisherSid, 7, 11 + n * 2, deltaBytes(20 + n));
-    }
-    await idle(120);
-
-    const late = await TestClient.connect();
-    await late.hello();
-    late.json({ t: 'join', token: token('watch', STREAM, 7), key: STREAM });
-    await late.waitText((m) => m.t === 'joined', 'joined');
-    await late.waitText((m) => m.t === 'stream', 'stream state');
-    await idle(80);
-
-    const keys = late.frames.filter((f) => f.kind === KIND.KEY);
-    assert.equal(keys.length, 2, 'the two newest GOPs are kept and the oldest is evicted whole');
-    assert.deepEqual(keys[0].payload, keyBytes(21), 'the oldest surviving GOP is the second one sent');
-    assert.equal(late.frames[0].kind, KIND.INIT, 'the init segment is never evicted');
-    late.destroy();
-});
-
-await check('viewer count changes reach the publisher', async () => {
-    const message = await publisher.waitText((m) => m.t === 'viewers' && m.viewers >= 1, 'viewers message');
-    assert.equal(message.sid, publisherSid);
-});
-
-await check('an unknown control type is refused without killing the socket', async () => {
-    viewer.json({ t: 'nonsense' });
-    const error = await viewer.waitText((m) => m.t === 'error' && m.code === 'unknown_type', 'unknown_type error');
-    assert.equal(error.fatal, false);
-    assert.equal(viewer.closed, false);
-});
-
-await check('a viewer keyframe request reaches the publisher', async () => {
-    await idle(1050);
-    viewer.json({ t: 'keyframe', sid: viewerSid });
-    const request = await publisher.waitText((m) => m.t === 'keyframe' && m.reason === 'viewer_request', 'viewer_request');
-    assert.equal(request.sid, publisherSid);
-});
-
-await check('ping is answered with the timestamp echoed back', async () => {
-    viewer.json({ t: 'ping', ts: 1755600012345 });
-    const pong = await viewer.waitText((m) => m.t === 'pong', 'pong');
-    assert.equal(pong.ts, 1755600012345);
-    assert.ok(pong.serverTimeMs > 0);
-});
-
-await check('a replayed token is refused and the socket is closed 4401', async () => {
-    const reused = token('watch', STREAM, 7);
-    const first = await TestClient.connect();
-    await first.hello();
-    first.json({ t: 'join', token: reused, key: STREAM });
-    await first.waitText((m) => m.t === 'joined', 'joined');
-
-    const second = await TestClient.connect();
-    await second.hello();
-    second.json({ t: 'join', token: reused, key: STREAM });
-    const error = await second.waitText((m) => m.t === 'error' && m.code === 'token_replayed', 'token_replayed');
-    assert.equal(error.fatal, true);
-    assert.equal(await second.waitClosed(), 4401);
-    first.destroy();
-});
-
-await check('a token signed with the wrong key is refused 4401', async () => {
-    const client = await TestClient.connect();
-    const bad = mintToken(crypto.randomBytes(32), {
-        v: 1,
-        iss: 'sd-phone',
-        sub: 'ABC12345',
-        src: 12,
-        name: 'Jonas Vance',
-        key: '',
-        role: 'session',
-        gen: 0,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 45,
-        jti: crypto.randomBytes(16).toString('hex'),
-    });
-    client.json({ t: 'hello', v: 1, token: bad, app: 'sd-phone', device: 'phone', build: 'selftest' });
-    const error = await client.waitText((m) => m.t === 'error', 'auth error');
-    assert.equal(error.code, 'token_bad_signature');
-    assert.equal(await client.waitClosed(), 4401);
-});
-
-await check('a watch token cannot be used to publish', async () => {
-    const client = await TestClient.connect();
-    await client.hello();
-    client.json({
-        t: 'publish',
-        token: token('watch', STREAM, 9),
-        key: STREAM,
-        gen: 9,
-        mode: 'video',
-        wire: 'chunks',
-        codec: 'vp8',
-        mime: '',
-        width: 320,
-        height: 180,
-        fps: 4,
-        bitrate: 120000,
-    });
-    const error = await client.waitText((m) => m.t === 'error' && m.code === 'token_scope', 'token_scope');
-    assert.equal(error.fatal, true);
-    assert.equal(await client.waitClosed(), 4403);
-});
-
-await check('a second publisher at the same generation is refused, the first keeps the stream', async () => {
-    const client = await TestClient.connect();
-    await client.hello();
-    client.json({
-        t: 'publish',
-        token: token('publish', STREAM, 7),
-        key: STREAM,
-        gen: 7,
-        mode: 'video',
-        wire: 'chunks',
-        codec: 'vp8',
-        mime: '',
-        width: 1600,
-        height: 900,
-        fps: 30,
-        bitrate: 8000000,
-    });
-    const error = await client.waitText((m) => m.t === 'error' && m.code === 'stream_busy', 'stream_busy');
-    assert.equal(error.fatal, false);
-    assert.equal(client.closed, false);
-    client.destroy();
-
-    publisher.media(KIND.DELTA, publisherSid, 7, 99, deltaBytes(7));
-    await viewer.waitText((m) => m.t === 'joined' || m.t === 'welcome', 'session still usable');
-    assert.equal(viewer.closed, false, 'the original publisher and its viewers are untouched');
-});
-
-await check('a fragmented control message is reassembled', async () => {
-    const client = await TestClient.connect();
-    client.jsonFragmented({
-        t: 'hello',
-        v: 1,
-        token: token('session', '', 0),
-        app: 'sd-phone',
-        device: 'tablet',
-        build: 'selftest',
-    });
-    const welcome = await client.waitText((m) => m.t === 'welcome', 'welcome');
-    assert.equal(welcome.sub, 'ABC12345');
-    client.destroy();
-});
-
-await check('a publisher at a higher generation supersedes the one holding the key', async () => {
-    const key = 'vibez:live:selftest02';
-    const first = await TestClient.connect();
-    await first.hello();
-    first.json({
-        t: 'publish',
-        token: token('publish', key, 1),
-        key,
-        gen: 1,
-        mode: 'video',
-        wire: 'mse',
-        codec: '',
-        mime: 'video/webm;codecs=vp8',
-        width: 640,
-        height: 360,
-        fps: 24,
-        bitrate: 800000,
-    });
-    const ready = await first.waitText((m) => m.t === 'ready', 'ready');
-    first.media(KIND.INIT, ready.sid, 1, 0, INIT_BYTES);
-
-    const watcher = await TestClient.connect();
-    await watcher.hello();
-    watcher.json({ t: 'join', token: token('watch', key, 1), key });
-    await watcher.waitText((m) => m.t === 'joined', 'joined');
-
-    const second = await TestClient.connect();
-    await second.hello();
-    second.json({
-        t: 'publish',
-        token: token('publish', key, 2),
-        key,
-        gen: 2,
-        mode: 'video',
-        wire: 'mse',
-        codec: '',
-        mime: 'video/webm;codecs=vp8',
-        width: 640,
-        height: 360,
-        fps: 24,
-        bitrate: 800000,
-    });
-    await second.waitText((m) => m.t === 'ready' && m.gen === 2, 'ready at the new generation');
-
-    const bye = await first.waitText((m) => m.t === 'bye', 'bye');
-    assert.equal(bye.reason, 'superseded');
-    assert.equal(await first.waitClosed(), 4409);
-
-    const reset = await watcher.waitText((m) => m.t === 'stream' && m.state === 'reset', 'reset state');
-    assert.equal(reset.gen, 2);
-    assert.equal(reset.reason, 'gen_change');
-    second.destroy();
-    watcher.destroy();
-});
-
-await check('the same socket can re-publish at a new generation without being evicted', async () => {
-    const key = 'photogram:live:selftest03';
-    const host = await TestClient.connect();
-    await host.hello();
-    const publish = (gen) => host.json({
-        t: 'publish',
-        token: token('publish', key, gen),
-        key,
-        gen,
-        mode: 'video',
-        wire: 'chunks',
-        codec: 'vp8',
-        mime: '',
-        width: 640,
-        height: 360,
-        fps: 24,
-        bitrate: 800000,
-    });
-
-    publish(3);
-    const first = await host.waitText((m) => m.t === 'ready', 'first ready');
-    host.media(KIND.INIT, first.sid, 3, 0, INIT_BYTES);
-
-    const watcher = await TestClient.connect();
-    await watcher.hello();
-    watcher.json({ t: 'join', token: token('watch', key, 3), key });
-    await watcher.waitText((m) => m.t === 'joined', 'joined');
-
-    publish(4);
-    const second = await host.waitText((m) => m.t === 'ready' && m.gen === 4, 'second ready');
-    assert.ok(second.sid > first.sid);
-    assert.equal(host.closed, false, 'the publisher keeps its socket');
-
-    const reset = await watcher.waitText((m) => m.t === 'stream' && m.state === 'reset', 'reset state');
-    assert.equal(reset.gen, 4);
-
-    host.media(KIND.INIT, second.sid, 4, 0, INIT_BYTES);
-    host.media(KIND.KEY, second.sid, 4, 1, keyBytes(4));
-    await watcher.waitFrames(3, 'media at the new generation');
-    const after = watcher.frames.slice(1);
-    assert.ok(after.every((f) => f.gen === 4), 'only the new generation is relayed after a reset');
-    host.destroy();
-    watcher.destroy();
-});
-
-await check('a socket is held to twelve streams', async () => {
-    const client = await TestClient.connect();
-    await client.hello();
-    for (let n = 0; n < 12; n += 1) {
-        const key = `mdt:cam:CAP${String(n).padStart(5, '0')}`;
-        client.json({ t: 'join', token: token('watch', key, 0), key });
-    }
-    await client.waitText((m) => m.t === 'joined' && m.key === 'mdt:cam:CAP00011', 'the twelfth join');
-
-    const key = 'mdt:cam:CAP00012';
-    client.json({ t: 'join', token: token('watch', key, 0), key });
-    const error = await client.waitText((m) => m.t === 'error' && m.code === 'too_many_streams', 'too_many_streams');
-    assert.equal(error.fatal, false);
-    assert.equal(client.closed, false);
-    client.destroy();
-});
-
-await check('a binary message over 1 MiB closes the socket 4413', async () => {
-    const client = await TestClient.connect();
-    await client.hello();
-    client.send(0x2, Buffer.alloc(1_048_577, 1));
-    const error = await client.waitText((m) => m.t === 'error' && m.code === 'frame_too_large', 'frame_too_large');
-    assert.equal(error.fatal, true);
-    assert.equal(await client.waitClosed(), 4413);
-});
-
-await check('a media frame with a bad magic byte closes the socket 4400', async () => {
-    const client = await TestClient.connect();
-    await client.hello();
-    const bogus = Buffer.alloc(40, 0);
-    bogus[0] = 0x11;
-    client.send(0x2, bogus);
-    const error = await client.waitText((m) => m.t === 'error' && m.code === 'bad_message', 'bad_message');
-    assert.equal(error.fatal, true);
-    assert.equal(await client.waitClosed(), 4400);
-});
-
-await check('a client that never says hello is closed 4408', async () => {
-    const client = await TestClient.connect();
-    client.json({ t: 'ping', ts: 1 });
-    const error = await client.waitText((m) => m.t === 'error' && m.code === 'no_hello', 'no_hello');
-    assert.equal(error.fatal, true);
-    assert.equal(await client.waitClosed(), 4400);
-});
-
-await check('unpublish idles the viewers rather than ending them', async () => {
-    publisher.json({ t: 'unpublish', sid: publisherSid });
-    const idle = await viewer.waitText((m) => m.t === 'stream' && m.state === 'idle', 'idle state');
-    assert.equal(idle.reason, 'unpublished');
-    assert.equal(idle.key, STREAM);
-});
-
-await check('a publisher can resume inside the linger window without the viewer rejoining', async () => {
-    const before = viewer.texts.length;
-    publisher.json({
-        t: 'publish',
-        token: token('publish', STREAM, 7),
-        key: STREAM,
-        gen: 7,
-        mode: 'video',
-        wire: 'chunks',
-        codec: 'vp8',
-        mime: '',
-        width: 1600,
-        height: 900,
-        fps: 30,
-        bitrate: 8000000,
-    });
-    const ready = await publisher.waitText((m) => m.t === 'ready' && m.sid !== publisherSid, 'second ready');
-    assert.ok(ready.sid > publisherSid, 'a stream handle is never reused on a socket');
-    publisherSid = ready.sid;
-
-    const live = await viewer.waitText(
-        (m, i) => i >= before && m.t === 'stream' && m.state === 'live',
-        'live state after resume'
-    );
-    assert.equal(live.reason, 'publisher_attached');
-
-    const count = viewer.frames.length;
-    publisher.media(KIND.KEY, publisherSid, 7, 200, keyBytes(30));
-    await viewer.waitFrames(count + 1, 'a frame after the resume');
-    assert.equal(viewer.frames[count].kind, KIND.KEY);
-});
-
-await check('the image mode prime cache holds only the newest still frame', async () => {
-    const stills = 'photogram:live:selftest01';
-    const host = await TestClient.connect();
-    await host.hello();
-    host.json({
-        t: 'publish',
-        token: token('publish', stills, 1),
-        key: stills,
-        gen: 1,
-        mode: 'image',
-        wire: 'chunks',
-        codec: '',
-        mime: '',
-        width: 640,
-        height: 360,
-        fps: 1,
-        bitrate: 200000,
-    });
-    const ready = await host.waitText((m) => m.t === 'ready', 'ready');
-    host.media(KIND.JPEG, ready.sid, 1, 0, Buffer.alloc(64, 0xa1));
-    host.media(KIND.JPEG, ready.sid, 1, 1, Buffer.alloc(64, 0xa2));
-    await idle(80);
-
-    const watcher = await TestClient.connect();
-    await watcher.hello();
-    watcher.json({ t: 'join', token: token('watch', stills, 1), key: stills });
-    await watcher.waitText((m) => m.t === 'joined', 'joined');
-    const frames = await watcher.waitFrames(1, 'the cached still');
-    await idle(80);
-    assert.equal(watcher.frames.length, 1, 'only the newest still is cached');
-    assert.equal(frames[0].kind, KIND.JPEG);
-    assert.equal(frames[0].payload[0], 0xa2);
-    host.destroy();
-    watcher.destroy();
-});
-
-await check('the control channel reports stats and revokes a stream', async () => {
-    const body = JSON.stringify({ op: 'stats' });
-    const ts = Date.now();
-    const sig = crypto.createHmac('sha256', KEY).update(`${ts}.${body}`).digest('hex');
-    const stats = await new Promise((resolve, reject) => {
-        const req = http.request({
-            port: PORT,
-            host: '127.0.0.1',
-            path: '/control',
-            method: 'POST',
-            headers: { 'content-type': 'application/json', 'x-sdmr-ts': String(ts), 'x-sdmr-sig': sig },
-        }, (res) => {
-            let text = '';
-            res.on('data', (c) => { text += c; });
-            res.on('end', () => resolve({ status: res.statusCode, json: JSON.parse(text) }));
+        assert.equal(stats.status, 200);
+        assert.ok(stats.json.streams >= 1);
+        assert.ok(stats.json.streamList.some((s) => s.key === STREAM && s.hasInit === true));
+
+        const badTs = Date.now() - 60_000;
+        const refused = await new Promise((resolve, reject) => {
+            const req = http.request({
+                port: PORT,
+                host: '127.0.0.1',
+                path: '/control',
+                method: 'POST',
+                headers: { 'content-type': 'application/json', 'x-sdmr-ts': String(badTs), 'x-sdmr-sig': sig },
+            }, (res) => {
+                res.resume();
+                res.on('end', () => resolve(res.statusCode));
+            });
+            req.on('error', reject);
+            req.end(body);
         });
-        req.on('error', reject);
-        req.end(body);
-    });
-    assert.equal(stats.status, 200);
-    assert.ok(stats.json.streams >= 1);
-    assert.ok(stats.json.streamList.some((s) => s.key === STREAM && s.hasInit === true));
+        assert.equal(refused, 401, 'a stale control call is refused');
 
-    const badTs = Date.now() - 60_000;
-    const refused = await new Promise((resolve, reject) => {
-        const req = http.request({
-            port: PORT,
-            host: '127.0.0.1',
-            path: '/control',
-            method: 'POST',
-            headers: { 'content-type': 'application/json', 'x-sdmr-ts': String(badTs), 'x-sdmr-sig': sig },
-        }, (res) => {
-            res.resume();
-            res.on('end', () => resolve(res.statusCode));
+        const revokeBody = JSON.stringify({ op: 'revoke', key: STREAM, reason: 'offduty' });
+        const rts = Date.now();
+        const rsig = crypto.createHmac('sha256', KEY).update(`${rts}.${revokeBody}`).digest('hex');
+        await new Promise((resolve, reject) => {
+            const req = http.request({
+                port: PORT,
+                host: '127.0.0.1',
+                path: '/control',
+                method: 'POST',
+                headers: { 'content-type': 'application/json', 'x-sdmr-ts': String(rts), 'x-sdmr-sig': rsig },
+            }, (res) => {
+                res.resume();
+                res.on('end', resolve);
+            });
+            req.on('error', reject);
+            req.end(revokeBody);
         });
-        req.on('error', reject);
-        req.end(body);
-    });
-    assert.equal(refused, 401, 'a stale control call is refused');
 
-    const revokeBody = JSON.stringify({ op: 'revoke', key: STREAM, reason: 'offduty' });
-    const rts = Date.now();
-    const rsig = crypto.createHmac('sha256', KEY).update(`${rts}.${revokeBody}`).digest('hex');
-    await new Promise((resolve, reject) => {
-        const req = http.request({
-            port: PORT,
-            host: '127.0.0.1',
-            path: '/control',
-            method: 'POST',
-            headers: { 'content-type': 'application/json', 'x-sdmr-ts': String(rts), 'x-sdmr-sig': rsig },
-        }, (res) => {
-            res.resume();
-            res.on('end', resolve);
-        });
-        req.on('error', reject);
-        req.end(revokeBody);
+        const ended = await viewer.waitText(
+            (m) => m.t === 'stream' && m.state === 'ended' && m.reason === 'revoked',
+            'revoked state'
+        );
+        assert.equal(ended.key, STREAM);
     });
 
-    const ended = await viewer.waitText(
-        (m) => m.t === 'stream' && m.state === 'ended' && m.reason === 'revoked',
-        'revoked state'
-    );
-    assert.equal(ended.key, STREAM);
-});
+    publisher?.destroy();
+    viewer?.destroy();
+    await relay.close();
 
-publisher?.destroy();
-viewer?.destroy();
-await relay.close();
+    process.stdout.write(`\nsd-phone media relay self test\n${results.join('\n')}\n`);
+    process.stdout.write(failures === 0
+        ? `\n${results.length} checks passed.\n`
+        : `\n${failures} of ${results.length} checks FAILED.\n`);
+    process.exit(failures === 0 ? 0 : 1);
 
-process.stdout.write(`\nsd-phone media relay self test\n${results.join('\n')}\n`);
-process.stdout.write(failures === 0
-    ? `\n${results.length} checks passed.\n`
-    : `\n${failures} of ${results.length} checks FAILED.\n`);
-process.exit(failures === 0 ? 0 : 1);
+})();

--- a/media-server/src/config.js
+++ b/media-server/src/config.js
@@ -9,7 +9,7 @@ function intEnv(raw, fallback, min, max) {
     return Math.min(max, Math.max(min, n));
 }
 
-export function loadConfig(env = process.env) {
+function loadConfig(env = process.env) {
     const errors = [];
 
     const keyHex = String(env.SD_PHONE_RELAY_KEY ?? '').trim();
@@ -40,7 +40,7 @@ export function loadConfig(env = process.env) {
         keyHex,
         key: HEX64.test(keyHex) ? Buffer.from(keyHex, 'hex') : Buffer.alloc(0),
         host: String(env.SD_PHONE_RELAY_HOST ?? '0.0.0.0').trim() || '0.0.0.0',
-        port: intEnv(env.SD_PHONE_RELAY_PORT, 30130, 1, 65535),
+        port: intEnv(env.SD_PHONE_RELAY_PORT, 30567, 1, 65535),
         origins,
         anyOrigin: origins.includes('*'),
         tlsCert,
@@ -53,3 +53,7 @@ export function loadConfig(env = process.env) {
         logLevel,
     };
 }
+
+module.exports = {
+    loadConfig,
+};

--- a/media-server/src/frame.js
+++ b/media-server/src/frame.js
@@ -2,16 +2,16 @@
 // helpers used here are the BE variants for that reason and no little endian read exists in this
 // file by design.
 
-import { FLAG_MASK, KIND, MAGIC, SDMR_HEADER_BYTES, VERSION } from './protocol.js';
+const { FLAG_MASK, KIND, MAGIC, SDMR_HEADER_BYTES, VERSION } = require('./protocol.js');
 
 const KIND_OK = new Set([KIND.INIT, KIND.KEY, KIND.DELTA, KIND.JPEG]);
 
-export function isSelfContained(kind) {
+function isSelfContained(kind) {
     return kind === KIND.INIT || kind === KIND.KEY || kind === KIND.JPEG;
 }
 
 // Returns { ok: true, header } or { ok: false, reason } so the caller can pick the close code.
-export function decodeFrame(buf) {
+function decodeFrame(buf) {
     if (!Buffer.isBuffer(buf) || buf.length < SDMR_HEADER_BYTES) return { ok: false, reason: 'short' };
     if (buf[0] !== MAGIC) return { ok: false, reason: 'magic' };
     if (buf[1] !== VERSION) return { ok: false, reason: 'version' };
@@ -32,7 +32,7 @@ export function decodeFrame(buf) {
     };
 }
 
-export function encodeHeader(kind, flags, sid, gen, seq, timestampUs) {
+function encodeHeader(kind, flags, sid, gen, seq, timestampUs) {
     const head = Buffer.allocUnsafe(SDMR_HEADER_BYTES);
     head[0] = MAGIC;
     head[1] = VERSION;
@@ -46,7 +46,14 @@ export function encodeHeader(kind, flags, sid, gen, seq, timestampUs) {
     return head;
 }
 
-export function encodeFrame(kind, flags, sid, gen, seq, timestampUs, payload) {
+function encodeFrame(kind, flags, sid, gen, seq, timestampUs, payload) {
     const body = payload ?? Buffer.alloc(0);
     return Buffer.concat([encodeHeader(kind, flags, sid, gen, seq, timestampUs), body], SDMR_HEADER_BYTES + body.length);
 }
+
+module.exports = {
+    isSelfContained,
+    decodeFrame,
+    encodeHeader,
+    encodeFrame,
+};

--- a/media-server/src/hub.js
+++ b/media-server/src/hub.js
@@ -1,20 +1,13 @@
 // The process-wide registry: every socket, every stream, the replay defence and the per IP abuse
 // counter (clause 3.12), plus the two housekeeping sweeps clause 1.9 requires.
 
-import { JtiStore } from './jti.js';
-import {
-    AUTH_BAN_MS,
-    AUTH_FAIL_MAX,
-    AUTH_FAIL_WINDOW_MS,
-    CLOSE,
-    RELAY_PING_MS,
-    SOCKET_IDLE_MS,
-} from './protocol.js';
-import { Stream } from './stream.js';
+const { JtiStore } = require('./jti.js');
+const { AUTH_BAN_MS, AUTH_FAIL_MAX, AUTH_FAIL_WINDOW_MS, CLOSE, RELAY_PING_MS, SOCKET_IDLE_MS } = require('./protocol.js');
+const { Stream } = require('./stream.js');
 
 const SWEEP_MS = 2_500;
 
-export class Hub {
+class Hub {
     constructor(config, log) {
         this.config = config;
         this.log = log;
@@ -143,3 +136,7 @@ export class Hub {
         for (const stream of [...this.streams.values()]) stream.destroy('shutdown');
     }
 }
+
+module.exports = {
+    Hub,
+};

--- a/media-server/src/jti.js
+++ b/media-server/src/jti.js
@@ -1,9 +1,9 @@
 // Clause 3.10: replay defence. Entries are never evicted to make room, because evicting reopens
 // the replay window; at the cap the relay refuses new tokens instead.
 
-import { CLOCK_SKEW_S, JTI_MAX, JTI_SWEEP_MS } from './protocol.js';
+const { CLOCK_SKEW_S, JTI_MAX, JTI_SWEEP_MS } = require('./protocol.js');
 
-export class JtiStore {
+class JtiStore {
     constructor() {
         this.seen = new Map();
         this.timer = setInterval(() => this.sweep(), JTI_SWEEP_MS);
@@ -37,3 +37,7 @@ export class JtiStore {
         this.seen.clear();
     }
 }
+
+module.exports = {
+    JtiStore,
+};

--- a/media-server/src/log.js
+++ b/media-server/src/log.js
@@ -19,7 +19,7 @@ function render(fields) {
     return parts.length ? ` ${parts.join(' ')}` : '';
 }
 
-export function createLogger(level = 'info') {
+function createLogger(level = 'info') {
     const threshold = LEVELS[level] ?? LEVELS.info;
 
     function emit(kind, scope, message, fields) {
@@ -38,3 +38,7 @@ export function createLogger(level = 'info') {
         debug: (scope, message, fields) => emit('debug', scope, message, fields),
     };
 }
+
+module.exports = {
+    createLogger,
+};

--- a/media-server/src/protocol.js
+++ b/media-server/src/protocol.js
@@ -1,62 +1,62 @@
 // SDMR/1 wire constants. Clause numbers refer to the sd-phone Media Relay Protocol Specification.
 
-export const PROTOCOL_NAME = 'SDMR';
-export const WIRE_VERSION = 1;
-export const SUBPROTOCOL = 'sdphone-media-v1';
+const PROTOCOL_NAME = 'SDMR';
+const WIRE_VERSION = 1;
+const SUBPROTOCOL = 'sdphone-media-v1';
 
 // Clause 2: binary media frame layout.
-export const SDMR_HEADER_BYTES = 24;
-export const MAGIC = 0xa7;
-export const VERSION = 0x01;
+const SDMR_HEADER_BYTES = 24;
+const MAGIC = 0xa7;
+const VERSION = 0x01;
 
-export const KIND = { INIT: 0x01, KEY: 0x02, DELTA: 0x03, JPEG: 0x04 };
-export const KIND_NAME = { 1: 'INIT', 2: 'KEY', 3: 'DELTA', 4: 'JPEG' };
+const KIND = { INIT: 0x01, KEY: 0x02, DELTA: 0x03, JPEG: 0x04 };
+const KIND_NAME = { 1: 'INIT', 2: 'KEY', 3: 'DELTA', 4: 'JPEG' };
 
-export const FLAG = { REPLAY: 0x01, DISCONTINUITY: 0x02, LAST: 0x04 };
-export const FLAG_MASK = FLAG.REPLAY | FLAG.DISCONTINUITY | FLAG.LAST;
+const FLAG = { REPLAY: 0x01, DISCONTINUITY: 0x02, LAST: 0x04 };
+const FLAG_MASK = FLAG.REPLAY | FLAG.DISCONTINUITY | FLAG.LAST;
 
 // Clause 13: constant reference.
-export const MAX_MESSAGE_BYTES = 1_048_576;
-export const MAX_CONTROL_BYTES = 8_192;
-export const MAX_TOKEN_CHARS = 1_024;
-export const MAX_STREAMS_PER_SOCKET = 12;
-export const MAX_STREAMS_GLOBAL = 256;
+const MAX_MESSAGE_BYTES = 1_048_576;
+const MAX_CONTROL_BYTES = 8_192;
+const MAX_TOKEN_CHARS = 1_024;
+const MAX_STREAMS_PER_SOCKET = 12;
+const MAX_STREAMS_GLOBAL = 256;
 
-export const HELLO_TIMEOUT_MS = 5_000;
-export const RELAY_PING_MS = 15_000;
-export const SOCKET_IDLE_MS = 30_000;
+const HELLO_TIMEOUT_MS = 5_000;
+const RELAY_PING_MS = 15_000;
+const SOCKET_IDLE_MS = 30_000;
 
-export const CLOCK_SKEW_S = 5;
-export const TOKEN_TTL_S_MAX = 120;
-export const JTI_SWEEP_MS = 10_000;
-export const JTI_MAX = 100_000;
-export const AUTH_FAIL_MAX = 20;
-export const AUTH_FAIL_WINDOW_MS = 60_000;
-export const AUTH_BAN_MS = 300_000;
+const CLOCK_SKEW_S = 5;
+const TOKEN_TTL_S_MAX = 120;
+const JTI_SWEEP_MS = 10_000;
+const JTI_MAX = 100_000;
+const AUTH_FAIL_MAX = 20;
+const AUTH_FAIL_WINDOW_MS = 60_000;
+const AUTH_BAN_MS = 300_000;
 
-export const PRIME_MAX_GOPS = 2;
-export const PRIME_MAX_FRAMES = 300;
-export const PRIME_MAX_BYTES = 8_388_608;
-export const PRIME_MAX_AGE_MS = 30_000;
-export const LINGER_MS = 10_000;
+const PRIME_MAX_GOPS = 2;
+const PRIME_MAX_FRAMES = 300;
+const PRIME_MAX_BYTES = 8_388_608;
+const PRIME_MAX_AGE_MS = 30_000;
+const LINGER_MS = 10_000;
 
-export const SOFT_LIMIT = 1_048_576;
-export const HARD_LIMIT = 4_194_304;
-export const CONTROL_HEADROOM = 1_048_576;
-export const SLOW_VIEWER_MS = 5_000;
-export const INGEST_WINDOW_MS = 1_000;
-export const INGEST_MAX_BYTES_CEIL = 4_194_304;
-export const INGEST_OVER_WINDOWS_MAX = 3;
-export const INGEST_ERROR_MS = 2_000;
+const SOFT_LIMIT = 1_048_576;
+const HARD_LIMIT = 4_194_304;
+const CONTROL_HEADROOM = 1_048_576;
+const SLOW_VIEWER_MS = 5_000;
+const INGEST_WINDOW_MS = 1_000;
+const INGEST_MAX_BYTES_CEIL = 4_194_304;
+const INGEST_OVER_WINDOWS_MAX = 3;
+const INGEST_ERROR_MS = 2_000;
 
-export const KEYFRAME_REQUEST_MS = 1_000;
-export const VIEWERS_COALESCE_MS = 500;
-export const DROP_REPORT_MS = 2_000;
+const KEYFRAME_REQUEST_MS = 1_000;
+const VIEWERS_COALESCE_MS = 500;
+const DROP_REPORT_MS = 2_000;
 
-export const CONTROL_SKEW_MS = 30_000;
+const CONTROL_SKEW_MS = 30_000;
 
 // Clause 4.19: close codes.
-export const CLOSE = {
+const CLOSE = {
     NORMAL: 1000,
     GOING_AWAY: 1001,
     PROTOCOL: 4400,
@@ -70,7 +70,56 @@ export const CLOSE = {
 };
 
 // Clause 5.1: stream key grammar.
-export const STREAM_KEY_RE = /^(mdt|photogram|vibez):(cam|live):[A-Za-z0-9_-]{1,64}$/;
+const STREAM_KEY_RE = /^(mdt|photogram|vibez):(cam|live):[A-Za-z0-9_-]{1,64}$/;
 
-export const MODES = new Set(['video', 'image']);
-export const WIRES = new Set(['chunks', 'mse']);
+const MODES = new Set(['video', 'image']);
+const WIRES = new Set(['chunks', 'mse']);
+
+module.exports = {
+    PROTOCOL_NAME,
+    WIRE_VERSION,
+    SUBPROTOCOL,
+    SDMR_HEADER_BYTES,
+    MAGIC,
+    VERSION,
+    KIND,
+    KIND_NAME,
+    FLAG,
+    FLAG_MASK,
+    MAX_MESSAGE_BYTES,
+    MAX_CONTROL_BYTES,
+    MAX_TOKEN_CHARS,
+    MAX_STREAMS_PER_SOCKET,
+    MAX_STREAMS_GLOBAL,
+    HELLO_TIMEOUT_MS,
+    RELAY_PING_MS,
+    SOCKET_IDLE_MS,
+    CLOCK_SKEW_S,
+    TOKEN_TTL_S_MAX,
+    JTI_SWEEP_MS,
+    JTI_MAX,
+    AUTH_FAIL_MAX,
+    AUTH_FAIL_WINDOW_MS,
+    AUTH_BAN_MS,
+    PRIME_MAX_GOPS,
+    PRIME_MAX_FRAMES,
+    PRIME_MAX_BYTES,
+    PRIME_MAX_AGE_MS,
+    LINGER_MS,
+    SOFT_LIMIT,
+    HARD_LIMIT,
+    CONTROL_HEADROOM,
+    SLOW_VIEWER_MS,
+    INGEST_WINDOW_MS,
+    INGEST_MAX_BYTES_CEIL,
+    INGEST_OVER_WINDOWS_MAX,
+    INGEST_ERROR_MS,
+    KEYFRAME_REQUEST_MS,
+    VIEWERS_COALESCE_MS,
+    DROP_REPORT_MS,
+    CONTROL_SKEW_MS,
+    CLOSE,
+    STREAM_KEY_RE,
+    MODES,
+    WIRES,
+};

--- a/media-server/src/relay.js
+++ b/media-server/src/relay.js
@@ -2,21 +2,15 @@
 // control channel (clause 3.13). Nothing in this file knows what a bodycam is; the relay only ever
 // sees stream keys and tokens.
 
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import http from 'node:http';
-import https from 'node:https';
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
 
-import { Hub } from './hub.js';
-import {
-    CONTROL_SKEW_MS,
-    MAX_CONTROL_BYTES,
-    MAX_MESSAGE_BYTES,
-    STREAM_KEY_RE,
-    SUBPROTOCOL,
-} from './protocol.js';
-import { Session } from './session.js';
-import { WsConnection, acceptUpgrade, offersSubprotocol, rejectUpgrade } from './ws.js';
+const { Hub } = require('./hub.js');
+const { CONTROL_SKEW_MS, MAX_CONTROL_BYTES, MAX_MESSAGE_BYTES, STREAM_KEY_RE, SUBPROTOCOL } = require('./protocol.js');
+const { Session } = require('./session.js');
+const { WsConnection, acceptUpgrade, offersSubprotocol, rejectUpgrade } = require('./ws.js');
 
 const CONTROL_BODY_MAX = 16_384;
 
@@ -59,7 +53,7 @@ function signatureOk(key, ts, rawBody, provided) {
     return got.length === want.length && crypto.timingSafeEqual(got, want);
 }
 
-export function createRelay(config, log) {
+function createRelay(config, log) {
     const hub = new Hub(config, log);
 
     async function onControl(req, res) {
@@ -203,3 +197,7 @@ export function createRelay(config, log) {
         },
     };
 }
+
+module.exports = {
+    createRelay,
+};

--- a/media-server/src/session.js
+++ b/media-server/src/session.js
@@ -1,26 +1,11 @@
 // Clause 1 (transport), clause 3.11 (auth failure handling) and clause 4 (control messages). One
 // Session wraps one websocket: every stream a client publishes or watches multiplexes over it.
 
-import crypto from 'node:crypto';
+const crypto = require('node:crypto');
 
-import { decodeFrame } from './frame.js';
-import {
-    CLOSE,
-    CONTROL_HEADROOM,
-    HARD_LIMIT,
-    HELLO_TIMEOUT_MS,
-    MAX_MESSAGE_BYTES,
-    MAX_STREAMS_GLOBAL,
-    MAX_STREAMS_PER_SOCKET,
-    SDMR_HEADER_BYTES,
-    SOCKET_IDLE_MS,
-    SOFT_LIMIT,
-    STREAM_KEY_RE,
-    MODES,
-    WIRES,
-    WIRE_VERSION,
-} from './protocol.js';
-import { verifyToken } from './token.js';
+const { decodeFrame } = require('./frame.js');
+const { CLOSE, CONTROL_HEADROOM, HARD_LIMIT, HELLO_TIMEOUT_MS, MAX_MESSAGE_BYTES, MAX_STREAMS_GLOBAL, MAX_STREAMS_PER_SOCKET, SDMR_HEADER_BYTES, SOCKET_IDLE_MS, SOFT_LIMIT, STREAM_KEY_RE, MODES, WIRES, WIRE_VERSION } = require('./protocol.js');
+const { verifyToken } = require('./token.js');
 
 // Clause 3.11: how each verification failure is answered.
 const AUTH_FAILURE = {
@@ -43,7 +28,7 @@ function integer(value, min, max, fallback) {
     return Math.min(max, Math.max(min, Math.floor(value)));
 }
 
-export class Session {
+class Session {
     constructor(hub, ws, info) {
         this.hub = hub;
         this.log = hub.log;
@@ -486,3 +471,7 @@ export class Session {
         };
     }
 }
+
+module.exports = {
+    Session,
+};

--- a/media-server/src/stream.js
+++ b/media-server/src/stream.js
@@ -2,27 +2,8 @@
 // disappearance). One Stream instance exists per stream key for as long as anyone is attached to
 // it plus the linger window.
 
-import { encodeHeader, isSelfContained } from './frame.js';
-import {
-    CLOSE,
-    DROP_REPORT_MS,
-    FLAG,
-    HARD_LIMIT,
-    INGEST_ERROR_MS,
-    INGEST_MAX_BYTES_CEIL,
-    INGEST_OVER_WINDOWS_MAX,
-    INGEST_WINDOW_MS,
-    KEYFRAME_REQUEST_MS,
-    KIND,
-    LINGER_MS,
-    PRIME_MAX_AGE_MS,
-    PRIME_MAX_BYTES,
-    PRIME_MAX_FRAMES,
-    PRIME_MAX_GOPS,
-    SLOW_VIEWER_MS,
-    SOFT_LIMIT,
-    VIEWERS_COALESCE_MS,
-} from './protocol.js';
+const { encodeHeader, isSelfContained } = require('./frame.js');
+const { CLOSE, DROP_REPORT_MS, FLAG, HARD_LIMIT, INGEST_ERROR_MS, INGEST_MAX_BYTES_CEIL, INGEST_OVER_WINDOWS_MAX, INGEST_WINDOW_MS, KEYFRAME_REQUEST_MS, KIND, LINGER_MS, PRIME_MAX_AGE_MS, PRIME_MAX_BYTES, PRIME_MAX_FRAMES, PRIME_MAX_GOPS, SLOW_VIEWER_MS, SOFT_LIMIT, VIEWERS_COALESCE_MS } = require('./protocol.js');
 
 const DEFAULT_DESC = {
     mode: 'video',
@@ -158,7 +139,7 @@ class Viewer {
     }
 }
 
-export class Stream {
+class Stream {
     constructor(hub, key) {
         this.hub = hub;
         this.log = hub.log;
@@ -564,3 +545,7 @@ export class Stream {
         };
     }
 }
+
+module.exports = {
+    Stream,
+};

--- a/media-server/src/token.js
+++ b/media-server/src/token.js
@@ -3,9 +3,9 @@
 // shared HMAC key. The step order in verifyToken() is normative (clause 3.9) and no claim is
 // inspected before the signature has been checked.
 
-import crypto from 'node:crypto';
+const crypto = require('node:crypto');
 
-import { CLOCK_SKEW_S, MAX_TOKEN_CHARS, TOKEN_TTL_S_MAX } from './protocol.js';
+const { CLOCK_SKEW_S, MAX_TOKEN_CHARS, TOKEN_TTL_S_MAX } = require('./protocol.js');
 
 const PREFIX = 'sdmr1';
 const B64URL_RE = /^[A-Za-z0-9_-]+$/;
@@ -29,7 +29,7 @@ function signingInput(payloadPart) {
 
 // Mints a token. FiveM does this through server/crypto.js in production; this exists so the relay
 // can be exercised by selftest.js and by an owner debugging a deployment.
-export function mintToken(key, payload) {
+function mintToken(key, payload) {
     const json = JSON.stringify(payload);
     const part = b64url(Buffer.from(json, 'utf8'));
     const mac = crypto.createHmac('sha256', key).update(signingInput(part)).digest();
@@ -61,7 +61,7 @@ function fieldsValid(payload) {
 
 // opts: { key: Buffer, role, streamKey, sub, jtiStore, now (unix seconds) }
 // Returns { ok: true, payload } or { ok: false, code } with a code from clause 4.16.
-export function verifyToken(token, opts) {
+function verifyToken(token, opts) {
     if (typeof token !== 'string' || token.length === 0 || token.length > MAX_TOKEN_CHARS) {
         return { ok: false, code: 'token_malformed' };
     }
@@ -111,3 +111,8 @@ export function verifyToken(token, opts) {
     if (opts.jtiStore) opts.jtiStore.remember(payload.jti, payload.exp);
     return { ok: true, payload };
 }
+
+module.exports = {
+    mintToken,
+    verifyToken,
+};

--- a/media-server/src/ws.js
+++ b/media-server/src/ws.js
@@ -4,23 +4,23 @@
 // text frames, binary frames, ping, pong, close and fragmentation. No extensions are negotiated,
 // which is deliberate (the payloads are already compressed media).
 
-import crypto from 'node:crypto';
-import { EventEmitter } from 'node:events';
+const crypto = require('node:crypto');
+const { EventEmitter } = require('node:events');
 
 const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
-export const OPCODE = { CONT: 0x0, TEXT: 0x1, BINARY: 0x2, CLOSE: 0x8, PING: 0x9, PONG: 0xa };
+const OPCODE = { CONT: 0x0, TEXT: 0x1, BINARY: 0x2, CLOSE: 0x8, PING: 0x9, PONG: 0xa };
 
 const WS_PROTOCOL_ERROR = 1002;
 const COMPACT_AT = 1 << 16;
 const CLOSE_LINGER_MS = 3000;
 
-export function computeAccept(key) {
+function computeAccept(key) {
     return crypto.createHash('sha1').update(`${key}${GUID}`).digest('base64');
 }
 
 // Writes the 101 response. Returns false when the request is not a usable websocket upgrade.
-export function acceptUpgrade(req, socket, { subprotocol } = {}) {
+function acceptUpgrade(req, socket, { subprotocol } = {}) {
     const key = req.headers['sec-websocket-key'];
     const version = String(req.headers['sec-websocket-version'] ?? '');
     if (typeof key !== 'string' || key === '' || version !== '13') return false;
@@ -36,13 +36,13 @@ export function acceptUpgrade(req, socket, { subprotocol } = {}) {
     return true;
 }
 
-export function offersSubprotocol(req, name) {
+function offersSubprotocol(req, name) {
     const raw = req.headers['sec-websocket-protocol'];
     if (typeof raw !== 'string') return false;
     return raw.split(',').some((part) => part.trim() === name);
 }
 
-export function rejectUpgrade(socket, status, text) {
+function rejectUpgrade(socket, status, text) {
     try {
         const body = `${text}\n`;
         socket.write(
@@ -55,7 +55,7 @@ export function rejectUpgrade(socket, status, text) {
     socket.destroy();
 }
 
-export class WsConnection extends EventEmitter {
+class WsConnection extends EventEmitter {
     constructor(socket, { maxBinaryBytes, maxTextBytes }) {
         super();
         this.socket = socket;
@@ -306,4 +306,12 @@ export class WsConnection extends EventEmitter {
     }
 }
 
-export { WS_PROTOCOL_ERROR };
+module.exports = {
+    WS_PROTOCOL_ERROR,
+    OPCODE,
+    computeAccept,
+    acceptUpgrade,
+    offersSubprotocol,
+    rejectUpgrade,
+    WsConnection,
+};

--- a/server/media/init.lua
+++ b/server/media/init.lua
@@ -70,6 +70,19 @@ local UNKNOWN_STREAM = 'That stream does not exist'
 ---@type string Refusal answered when the feature that owns a stream would not have it watched.
 local REFUSED = 'You cannot watch that stream'
 
+---@type boolean Whether the relay may run inside this resource (configs/media.lua SelfHost).
+local SELF_HOST = CFG.SelfHost ~= false
+---@type integer Milliseconds to wait for the in-process relay to report which port it took.
+local HOST_START_MS = 3000
+
+---@type string Signing key minted for the relay running inside this resource, empty when there is
+---not one. It exists for this boot only and is never written anywhere.
+local hostedKey = ''
+---@type integer Port that relay took, 0 when nothing is hosted here.
+local hostedPort = 0
+---@type boolean Whether that relay is terminating TLS itself.
+local hostedTls = false
+
 ---@type boolean|nil Cached gate result; nil until the first resolve.
 local ready
 ---@type string Relay endpoint served to the browser, empty until the gate resolves.
@@ -131,6 +144,68 @@ local function probeClaims()
     }
 end
 
+---Starts the relay inside this resource and waits for it to say which port it took. Everything a
+---standalone relay needs configuring by hand is decided here instead: the signing key is minted for
+---this boot and never leaves the process, and the port is whatever is free, because a server owner
+---should not have to know that the relay's own default lands on the HTTP endpoint FiveM opens ten
+---above the game port.
+---
+---This does not conjure a certificate, and nothing can: the phone's browser refuses a ws:// socket
+---to anything but loopback, so a server serving real players still needs TLS terminated in front of
+---this and its address in the URL convar. What it removes is the Node install, the second process,
+---the key and the port.
+---@return boolean hosted
+local function startHost()
+    if not crypto.available() then return false end
+
+    local key = crypto.randomHex(32)
+    if type(key) ~= 'string' or #key ~= 64 then return false end
+
+    local answered, result = false, nil
+    local cookie = AddEventHandler('sd-phone:media:relayHosted', function(payload)
+        answered, result = true, payload
+    end)
+
+    local okCall = pcall(function()
+        exports[GetCurrentResourceName()]:sdRelayHost({
+            keyHex     = key,
+            port       = math.floor(tonumber(GetConvar('sd_phone_relay_port', '')) or 0),
+            logLevel   = GetConvar('sd_phone_relay_log', 'warn'),
+            tlsCert    = GetConvar('sd_phone_relay_tls_cert', ''),
+            tlsKey     = GetConvar('sd_phone_relay_tls_key', ''),
+            trustProxy = GetConvar('sd_phone_relay_url', '') ~= '',
+        })
+    end)
+
+    if okCall then
+        local waited = 0
+        while not answered and waited < HOST_START_MS do
+            Wait(50)
+            waited = waited + 50
+        end
+    end
+    RemoveEventHandler(cookie)
+
+    if not okCall then
+        print('^3[sd-phone:media]^0 the relay could not be started in this resource: the Node runtime did not answer. Run media-server/ separately, or set Media.SelfHost = false to silence this.')
+        return false
+    end
+    if not answered then
+        print('^3[sd-phone:media]^0 the relay did not report back in time; live video stays on the event path.')
+        return false
+    end
+    if type(result) ~= 'table' or result.ok ~= true then
+        local why = type(result) == 'table' and (result.detail or result.reason) or 'unknown'
+        print(('^3[sd-phone:media]^0 the relay could not start: %s'):format(tostring(why)))
+        return false
+    end
+
+    hostedKey  = key
+    hostedPort = math.floor(tonumber(result.port) or 0)
+    hostedTls  = result.tls == true
+    return hostedPort > 0
+end
+
 local function resolve()
     if ready ~= nil then return ready end
     ready = false
@@ -138,6 +213,38 @@ local function resolve()
 
     local url = GetConvar(URL_CONVAR, '')
     local key = GetConvar(KEY_CONVAR, '')
+
+    -- A relay running inside this resource signs with a key nobody had to generate and listens on
+    -- a port nobody had to pick, so both are taken from it rather than from the convars. An owner
+    -- who put TLS in front still sets the URL convar, and that address wins: it is the one their
+    -- players can actually reach.
+    if hostedPort > 0 then
+        key = hostedKey
+
+        -- A loopback URL naming a different port than the one we are listening on cannot be right:
+        -- there is no second relay on this machine, and what is usually there instead is FiveM's
+        -- own HTTP endpoint, which answers the browser's handshake with a redirect. Correcting it
+        -- silently would hide a setting the owner still has wrong somewhere else, so it is said.
+        local convarPort = tonumber(url:match('^wss?://127%.0%.0%.1:(%d+)') or url:match('^wss?://localhost:(%d+)'))
+        if convarPort and convarPort ~= hostedPort then
+            print(('^3[sd-phone:media]^0 %s points at loopback port %d, but the relay in this resource is on %d. Using the one that exists; clear the convar, or set it to the address your players reach.')
+                :format(URL_CONVAR, convarPort, hostedPort))
+            url = ''
+        end
+
+        -- With nothing configured, the relay is listening but has no address a player could use:
+        -- loopback reaches the player's own machine, not this one. Handing that out would cost
+        -- every player a connection that cannot succeed, so it is only advertised when somebody
+        -- deliberately says this is a local test.
+        if url == '' then
+            if GetConvarInt('sd_phone_relay_loopback', 0) == 1 then
+                url = ('%s://127.0.0.1:%d'):format(hostedTls and 'wss' or 'ws', hostedPort)
+            else
+                print(('^3[sd-phone:media]^0 the relay is up on port %d, but no address is set for it. Put TLS in front and `set %s "wss://your.host/ws"`, or `set sd_phone_relay_loopback 1` to test it on this machine. Live video stays on the event path until then.')
+                    :format(hostedPort, URL_CONVAR))
+            end
+        end
+    end
 
     local reason
     if url == '' then
@@ -396,6 +503,7 @@ if ENABLED then
     -- that has to be a live export by then rather than a file the runtime is still reading.
     CreateThread(function()
         Wait(0)
+        if SELF_HOST then startHost() end
         if resolve() then
             print(('^2[sd-phone:media]^0 relay ready at %s ^2·^0 %ds tokens'):format(endpointUrl, ttlSeconds))
         end

--- a/server/relay.js
+++ b/server/relay.js
@@ -1,0 +1,135 @@
+// Runs the media relay inside this resource, so a server that wants one does not have to install
+// Node, keep a second process alive, mint a signing key or match a port. The relay itself is
+// unchanged: this file starts the same code media-server/index.js starts, with a configuration
+// built here instead of read from the environment.
+//
+// It is opt-in and it is not the only way to run one. A large server can still run media-server/
+// on its own box and point sd_phone_relay_url at it; that path is untouched.
+
+const relayNet = require('node:net');
+
+// Loaded on first use rather than at parse time. A require that throws up here takes the whole
+// file with it, exports and all, and the failure then looks like the runtime never answered
+// instead of like the relay core not loading.
+let relayCoreCache = null;
+function relayCore() {
+    if (relayCoreCache) return relayCoreCache;
+    relayCoreCache = {
+        loadConfig: require('./media-server/src/config.js').loadConfig,
+        createLogger: require('./media-server/src/log.js').createLogger,
+        createRelay: require('./media-server/src/relay.js').createRelay,
+    };
+    return relayCoreCache;
+}
+
+// FiveM's JS runtime injects `exports` as the registration function; plain CommonJS binds it to
+// the module's exports object instead. Resolving both keeps the file loadable off-server.
+const relayRegister = typeof exports === 'function' ? exports : global.exports;
+
+const RELAY_RESOURCE = GetCurrentResourceName();
+
+// Well clear of the game port and the HTTP endpoint FiveM opens ten above it, which is what the
+// relay's own default of 30130 collides with on a stock server.
+const RELAY_PORT_BASE = 30567;
+const RELAY_PORT_TRIES = 16;
+
+let relayInstance = null;
+let relayRunning = 0;
+
+/** Whether anything already holds a port on this machine. */
+function relayPortFree(port) {
+    return new Promise(resolve => {
+        const probe = relayNet.createServer();
+        probe.once('error', () => resolve(false));
+        probe.once('listening', () => probe.close(() => resolve(true)));
+        probe.listen(port, '0.0.0.0');
+    });
+}
+
+/**
+ * The first free port at or after the base, skipping any the caller says are spoken for. A server
+ * owner should not have to know that FiveM holds two ports and that one of them is where the
+ * relay's documented default lands.
+ */
+async function relayPickPort(from, avoid) {
+    const taken = new Set((avoid || []).map(Number).filter(Number.isFinite));
+    for (let i = 0; i < RELAY_PORT_TRIES; i++) {
+        const port = from + i;
+        if (taken.has(port)) continue;
+        if (await relayPortFree(port)) return port;
+    }
+    return 0;
+}
+
+/**
+ * Starts the relay and reports back over an event rather than a return value, because binding a
+ * port is asynchronous and the Lua side has nothing to do until it is bound.
+ *
+ * @param {object} opts { keyHex, port, origins, logLevel, tlsCert, tlsKey }
+ */
+async function relayStart(opts) {
+    if (relayInstance) return;
+
+    const wanted = Number(opts && opts.port) || 0;
+    const port = wanted > 0 ? ((await relayPortFree(wanted)) ? wanted : 0) : await relayPickPort(RELAY_PORT_BASE, opts && opts.avoid);
+    if (!port) {
+        emit('sd-phone:media:relayHosted', { ok: false, reason: wanted > 0 ? 'port_taken' : 'no_free_port', port: wanted });
+        return;
+    }
+
+    let loadConfig, createLogger, createRelay;
+    try {
+        ({ loadConfig, createLogger, createRelay } = relayCore());
+    } catch (err) {
+        emit('sd-phone:media:relayHosted', { ok: false, reason: 'core', detail: err && err.message });
+        return;
+    }
+
+    const config = loadConfig({
+        SD_PHONE_RELAY_KEY:      String((opts && opts.keyHex) || ''),
+        SD_PHONE_RELAY_PORT:     String(port),
+        SD_PHONE_RELAY_HOST:     '0.0.0.0',
+        SD_PHONE_RELAY_ORIGIN:   String((opts && opts.origins) || 'https://cfx-nui-sd-phone,https://cfx-nui-sd-tablet'),
+        SD_PHONE_RELAY_LOG:      String((opts && opts.logLevel) || 'warn'),
+        SD_PHONE_RELAY_TLS_CERT: String((opts && opts.tlsCert) || ''),
+        SD_PHONE_RELAY_TLS_KEY:  String((opts && opts.tlsKey) || ''),
+        // TLS is terminated in front of an in-process relay or not at all, and either way the
+        // address a client arrives with is the one to count against.
+        SD_PHONE_RELAY_TRUST_PROXY: (opts && opts.trustProxy) ? '1' : '',
+    });
+
+    if (config.errors.length > 0) {
+        emit('sd-phone:media:relayHosted', { ok: false, reason: 'config', detail: config.errors[0] });
+        return;
+    }
+
+    const log = createLogger(config.logLevel === undefined ? 'warn' : config.logLevel);
+    const started = createRelay(config, log);
+    try {
+        await started.listen();
+    } catch (err) {
+        emit('sd-phone:media:relayHosted', { ok: false, reason: 'listen', detail: err && err.message });
+        return;
+    }
+
+    relayInstance = started;
+    relayRunning = port;
+    emit('sd-phone:media:relayHosted', { ok: true, port, tls: config.tlsCert !== '' });
+}
+
+async function relayStop() {
+    const open = relayInstance;
+    relayInstance = null;
+    relayRunning = 0;
+    if (!open) return;
+    try {
+        await open.close();
+    } catch { /* already down */ }
+}
+
+relayRegister('sdRelayHost', (opts) => { void relayStart(opts || {}); return true; });
+relayRegister('sdRelayPort', () => relayRunning);
+
+on('onResourceStop', (name) => {
+    if (name === RELAY_RESOURCE) void relayStop();
+});


### PR DESCRIPTION
Stacked on #221, which is stacked on #220. Nothing here depends on either, so this can be retargeted straight at `main` whenever suits.

Running the media relay used to mean: install Node, generate a key with openssl, run and supervise a second process, pick a port, and copy the key into `server.cfg`. Six steps before anything works, and the reported failure that started this was one of them going wrong: `sd_phone_relay_url` pointed at 30130, which is the relay's own documented default and also the HTTP endpoint FiveM opens ten above the game port, so the browser's handshake was answered by FXServer with a redirect and reported as `handshake_failed 1006`.

## What this does

`Media.SelfHost = true` runs the relay inside FXServer. No Node install, no second process, no key, no port. The key is minted per boot and never leaves the process; the port is the first free one from 30567.

- `server/relay.js` starts the same code `media-server/index.js` starts, with a config built in Lua instead of read from the environment, and stops with the resource.
- `server/media/init.lua` mints the key, waits for the port, and resolves the endpoint from it. Two things it now says out loud rather than failing quietly:
  - a loopback URL naming a different port than the one we are listening on gets corrected, with the reason;
  - hosting with no URL set does **not** advertise loopback to players, because loopback is their machine, not the server's. It says what to set instead. Without this every player on a real server would burn a connection that cannot succeed.
- `media-server/` is now CommonJS. FXServer's V8 has no ESM loader (`import()` there fails with "Invalid host defined options"), and this code has to load in both. The standalone entry point is unchanged in behaviour.
- The default port moves 30130 → 30567, off the collision.
- The release zip now ships `media-server/`.

## What it still cannot do

Give you a certificate. The phone's browser refuses `ws://` to anything but loopback and rejects self-signed `wss://`, both verified in this CEF build, so a server with real players needs TLS terminated in front of this and its address in `sd_phone_relay_url`. What is removed is everything else.

## Gates

- `node media-server/selftest.js`: **28 checks passed**, before and after the ESM to CommonJS conversion. That suite boots a relay, publishes a synthetic stream and walks prime replay, GOP eviction, the generation fence, token replay defence, oversized frames and the publisher-gone path.
- `lua tests/lua/run.lua` 1615 passed / 5 pre-existing failures. `vitest` 700 passed.
- Live on a running server, with nothing configured but `Media.Enabled`:

```
[sd-phone:media] sd_phone_relay_url points at loopback port 30130, but the relay in this
                 resource is on 30567. Using the one that exists.
[sd-phone:media] relay ready at ws://127.0.0.1:30567 · 45s tokens
```

```
DEBUG [socket] upgraded ip=127.0.0.1 origin=https://cfx-nui-sd-phone sockets=1
```

and a client authenticating with a token the game server minted, which is the one thing the relay's own selftest cannot cover, since it signs with a key it generated itself:

```json
{"t":"welcome","v":1,"sub":"C3106S6K","session":"75e9f459d4707c09",
 "limits":{"maxStreams":12,"maxMessageBytes":1048576,"pingMs":10000,"idleMs":30000}}
```

Not verified live: a full camera stream over the hosted relay end to end. The NUI page on my test client became unusable for automation late in the session, so the media path over this relay is covered by the selftest and the handshake above rather than by watching a picture arrive.