### PR TITLE
feat(cameras): a bodycam item officers switch on and off

### DIFF
--- a/configs/bodycam.lua
+++ b/configs/bodycam.lua
@@ -89,6 +89,32 @@ return {
     -- encoded video itself, so leave headroom over the bitrates above.
     RelayBytesPerSec = 2048 * 1024,
 
+    -- Whether an officer has to be carrying a bodycam item, and have switched it on, before their
+    -- camera exists at all. With this on, using the item toggles the camera and says so, and a unit
+    -- with theirs off does not appear in the Cameras section: an officer nobody can see is the
+    -- point of a switch.
+    --
+    -- Turning this off gives every eligible officer a camera that is always on, which is what this
+    -- did before the item existed.
+    RequireItem = true,
+
+    -- The item that switches a bodycam on and off. It has to exist in your inventory's item list
+    -- before an officer can be given one.
+    --
+    -- On ox_inventory an item reaches a resource through an export it names itself, so the entry
+    -- has to point back at the one the phone registers ('body_cam' becomes 'sd-phone.useBody_cam'),
+    -- and consume 0 so pressing the switch does not eat the camera:
+    --   ['body_cam'] = { label = 'Bodycam', weight = 200, stack = false, close = true,
+    --                    consume = 0, server = { export = 'sd-phone.useBody_cam' } },
+    --
+    -- qb, qbx, esx and qs register usable items by name, so those need nothing beyond the item.
+    Item = 'body_cam',
+
+    -- Whether a camera switched on stays on across a disconnect. Off means an officer comes back on
+    -- shift with it off, which is the safer default: nobody is broadcasting without having chosen
+    -- to since they last logged in.
+    RememberItemState = false,
+
     -- Terminals allowed on one officer's camera at once (0 = unlimited).
     MaxViewers = 6,
 

--- a/server/mdt/cameras.lua
+++ b/server/mdt/cameras.lua
@@ -10,6 +10,10 @@ local store  = require 'server.mdt.store'
 ---@type table Player bridge (bridge.server.player): the citizenid -> source lookup a watch resolves
 ---its host with, rather than walking every connected player on every keep-alive.
 local player = require 'bridge.server.player'
+---@type table Inventory bridge (bridge.server.inventory): the item check and the usable-item registrar.
+local inventory = require 'bridge.server.inventory'
+---@type table Notify bridge (bridge.server.notify): the toast an officer sees when they switch it.
+local notify = require 'bridge.server.notify'
 ---@type table Media relay (server.media.init): the token mint and the relay's control channel. It
 ---decides nothing; every token this file asks for is signed only after the checks below have run.
 local media  = require 'server.media.init'
@@ -25,6 +29,13 @@ local ENABLED = CFG.Enabled == true
 local REQUIRE_DUTY = CFG.RequireDuty ~= false
 ---@type boolean Whether a broadcasting officer is put into first person while watched.
 local FIRST_PERSON = CFG.FirstPerson ~= false
+
+---@type boolean Whether an officer needs a bodycam item, switched on, to have a camera at all.
+local REQUIRE_ITEM = CFG.RequireItem ~= false
+---@type string The item that switches it.
+local ITEM = type(CFG.Item) == 'string' and CFG.Item ~= '' and CFG.Item or 'body_cam'
+---@type boolean Whether a camera left on survives the officer disconnecting.
+local REMEMBER_ITEM = CFG.RememberItemState == true
 
 ---@type table<string, boolean> Framework jobs that carry a bodycam. An empty config list means
 ---every police department, which is what a server that has not customised the list expects.
@@ -179,6 +190,13 @@ local FEATURE = 'mdt:cam'
 local sessions = {}
 ---@type table<integer, table> The same sessions, keyed by the host's server id.
 local byHostSrc = {}
+---@type table<string, boolean> Officers with a bodycam switched on, keyed by citizenid. Nothing is
+---persisted: a camera is on because somebody switched it on this session.
+local wearing = {}
+---@type table<integer, string> Server id -> citizenid for those, so a disconnect can clear one
+---without asking the framework about a player who has already gone.
+local wearingSrc = {}
+
 ---@type table<string, boolean> '<citizenid>:<reason>' pairs already reported by breakRun.
 local brokenSaid = {}
 ---@type table<integer, integer> Vehicle class last reported by an officer's own client.
@@ -239,8 +257,13 @@ local function cameraOfficer(src)
     if access.domain(me) ~= 'leo' then return nil end
     if JOBS_LISTED and not JOBS[me.job] then return nil end
     if REQUIRE_DUTY and me.duty == false then return nil end
+    -- A camera nobody switched on is not a camera. Checked here rather than at the tile, so an
+    -- officer with theirs off is absent from the section entirely and every route below refuses
+    -- them for the same reason.
+    if REQUIRE_ITEM and not wearing[me.citizenid] then return nil end
     return me
 end
+
 
 ---The police vehicle an officer is sitting in, when it carries a dashcam. The model is read from
 ---the vehicle itself; the class can only be read on a client, so it arrives from the officer's own
@@ -538,6 +561,62 @@ local function dropSession(session, reason)
     if byHostSrc[session.src] == session then byHostSrc[session.src] = nil end
 end
 
+---Turns an officer's camera on or off and tells them which it now is. The item is what the officer
+---holds; this is the state the department can see, and the two are checked against each other on
+---every use, so a camera cannot be left on by dropping the item that switches it.
+---@param src integer officer's server id
+---@param on boolean|nil desired state, nil to flip
+---@return boolean|nil state nil when this player has no business having one
+local function setWearing(src, on)
+    local me = access.identity(src)
+    if not me or access.domain(me) ~= 'leo' then return nil end
+    if JOBS_LISTED and not JOBS[me.job] then return nil end
+
+    local cid = me.citizenid
+    local want = on
+    if want == nil then want = not wearing[cid] end
+
+    if want and not inventory.has(src, ITEM, 1) then
+        notify.to(src, ('You are not carrying a %s.'):format(inventory.label(ITEM) or ITEM), 'error')
+        return false
+    end
+
+    wearing[cid] = want or nil
+    wearingSrc[src] = want and cid or nil
+
+    if not want then
+        -- Everything watching it stops now rather than at the next sweep: the officer switched it
+        -- off, and a terminal still showing their view a few seconds later is the one thing this
+        -- switch exists to prevent.
+        local session = sessions[cid]
+        if session then
+            stopBroadcast(session)
+            dropSession(session, 'switched off')
+        end
+    end
+
+    notify.to(src, want and 'Bodycam on' or 'Bodycam off', want and 'success' or 'info')
+    return want
+end
+
+---@type integer Milliseconds between possession re-checks for one officer. A terminal re-asserts
+---its watch every few seconds and searching an inventory is not free, so the answer is reused.
+local ITEM_CHECK_MS = 5000
+
+---Whether an officer still holds the item their camera is switched on by. Losing it switches the
+---camera off the same way using it would, because the alternative is a camera that stays on the air
+---because nobody thought to press the switch on the way out of it.
+---@param src integer officer's server id
+---@param cid string officer's citizenid
+---@return boolean holding
+local function stillHolding(src, cid)
+    if not REQUIRE_ITEM or not wearing[cid] then return true end
+    if not util.cooldown(cid, 'mdt:cameras:item', ITEM_CHECK_MS) then return true end
+    if inventory.has(src, ITEM, 1) then return true end
+    setWearing(src, false)
+    return false
+end
+
 ---The public status of one camera. A terminal renders a distinct card for each of these, so a
 ---camera that cannot be established says so rather than showing a dead tile.
 ---@param session table|nil broadcast session, nil when nobody has ever watched this officer
@@ -744,6 +823,7 @@ cameras.watch = access.gated('cameras.view', function(src, payload, me)
 
     local host = cameraOfficer(hostSrc)
     if not host or host.citizenid ~= cid then return util.fail('That unit is no longer on the air') end
+    if not stillHolding(hostSrc, cid) then return util.fail('That unit is no longer on the air') end
     if kind == 'dashcam' and not dashVehicle(hostSrc) then return util.fail('That unit is not in a marked vehicle') end
 
     local session = ensureSession(host)
@@ -1100,10 +1180,44 @@ if ENABLED then
     ---it, and a watched one loses them as a terminal.
     util.onCleanup(function(src)
         reportedClass[src] = nil
+        local heldBy = wearingSrc[src]
+        wearingSrc[src] = nil
+        if heldBy and not REMEMBER_ITEM then wearing[heldBy] = nil end
+
         local hosted = byHostSrc[src]
         if hosted then dropSession(hosted, 'offline') end
         detachEverywhere(src)
     end)
+
+    if REQUIRE_ITEM then
+        -- The item is the switch. Using it again turns the camera off, and the officer is told
+        -- which way it went rather than being left to open the terminal and check.
+        local okItem = pcall(inventory.registerUsable, ITEM, function(src)
+            setWearing(src, nil)
+        end)
+        if not okItem then
+            print(('^1[sd-phone:cameras]^0 could not register %q as a usable item, so nobody can switch a bodycam on. Add the item to your inventory, or set RequireItem = false in configs/bodycam.lua.')
+                :format(ITEM))
+        end
+
+        ---Public export: exports['sd-phone']:setBodycam(source, on). Switches an officer's camera
+        ---for them, for a duty script or a locker that should turn one on without the item being
+        ---used by hand. Answers the state it settled on, nil when that player may not have one.
+        ---@param source number officer's server id
+        ---@param on boolean|nil desired state, nil to flip
+        ---@return boolean|nil state
+        exports('setBodycam', function(source, on)
+            if type(source) ~= 'number' then return nil end
+            return setWearing(source, on)
+        end)
+
+        ---Public export: exports['sd-phone']:isBodycamOn(citizenid).
+        ---@param citizenid string
+        ---@return boolean on
+        exports('isBodycamOn', function(citizenid)
+            return type(citizenid) == 'string' and wearing[citizenid] == true
+        end)
+    end
 end
 
 ---Whether the Cameras section is switched on at all, for the routes above it.


### PR DESCRIPTION
An officer's camera was on whenever they were on duty, whether they knew it or not. Now it is a thing they carry and a thing they switch: using the item turns the camera on, using it again turns it off, and a unit with theirs off is absent from the Cameras section entirely rather than sitting there as a dead tile.

## Config

```lua
RequireItem = true,          -- on by default
Item = 'body_cam',
RememberItemState = false,   -- a camera does not survive its officer logging out
```

`RequireItem = false` restores exactly the old behaviour: every eligible officer has a camera, always on, nothing to carry.

Note for existing servers: with this on and no such item in the inventory, nobody has a camera until the item is added. The config block spells out the ox_inventory entry, which has to point back at the export the phone registers and set `consume = 0` so the switch is not eaten by pressing it. qb, qbx, esx and qs need nothing beyond the item existing.

## What the rules actually are

- **Carrying is not the same as switching on.** An officer holding one still has no camera until they use it.
- **Switching off stops what is already watching**, immediately, rather than at the next sweep. A terminal still showing a view seconds after the officer switched it off is the thing a switch exists to prevent.
- **Losing the item switches the camera off**, checked when a terminal tries to watch and throttled to once every five seconds per officer, because searching an inventory is not free and terminals re-assert their watch every few seconds. A camera cannot outlive the thing that turns it off.
- **A disconnect never leaves one on the air**, whether or not anybody was watching at the time, which is why the state is keyed by player id as well as citizenid.
- Two exports for duty scripts and lockers: `setBodycam(source, on)` and `isBodycamOn(citizenid)`.

## Gates

- `lua tests/lua/run.lua`: 1633 passed, 5 failed. The 5 are pre-existing on main and unrelated. 18 of the passing assertions are a new local suite pinning the rules above, including both config states.
- `vitest` 709 passed, `oxlint` 0 errors.
- Live on a running server, driving the real item through ox_inventory:

| step | result |
|---|---|
| carrying, not switched on | `cameras: []` |
| use the item | tile appears, `status: ready`, toast `{type: success, description: "Bodycam on"}` |
| use it again | `cameras: []`, toast `{type: info, description: "Bodycam off"}` |
| item removed while on | next watch refused with "That unit is no longer on the air", officer told `Bodycam off` |
| after four uses | item count still 1, so the switch is not consumed |