### PR TITLE
feat(bridge): add ND framework (ND_Core) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Unlock it, rearrange the home screen, install apps from the App Store, open the 
 
 ---
 
-**An iOS-themed smartphone for FiveM.** that supports QBOX, QBCORE, ESX and ox_core. 49 server-backed apps, real app accounts, a live game-view camera and online multiplayer games. Ships its own custom phone props: eight phone items in eight colours, each tinting both the on-screen frame and the custom prop model held in hand. A unique phone system as well as sim cards can be enabled!
+**An iOS-themed smartphone for FiveM.** that supports QBOX, QBCORE, ESX, ox_core and ND. 49 server-backed apps, real app accounts, a live game-view camera and online multiplayer games. Ships its own custom phone props: eight phone items in eight colours, each tinting both the on-screen frame and the custom prop model held in hand. A unique phone system as well as sim cards can be enabled!
 
 **A drop-in lb-phone replacement.** Scripts and custom apps written against lb-phone's exports and events keep running unmodified, and a first-boot migration carries your players across rather than resetting them: phone numbers and lock passcodes, contacts, blocked numbers, call history, SMS threads including groups and reactions, photos and albums, notes, phone settings, mail accounts with their inboxes, wallet transaction history, voice memos, Photogram and Birdy accounts with their posts, stories, DMs and followers, and the app logins themselves, so players open the phone already signed in.
 
@@ -24,7 +24,7 @@ If sd-phone is useful to you, please ⭐ the repo. Issues and pull requests are 
 [![Discord](https://img.shields.io/discord/842045164951437383?label=Discord&logo=discord&logoColor=white)](https://discord.gg/FzPehMQaBQ)
 [![Documentation](https://img.shields.io/badge/Docs-docs.samueldev.shop-94DD0C)](https://docs.samueldev.shop/resources/phone/)
 
-![Framework](https://img.shields.io/badge/Framework-QBCore%20%7C%20QBox%20%7C%20ESX%20%7C%20ox__core%20(beta)-3b82f6)
+![Framework](https://img.shields.io/badge/Framework-QBCore%20%7C%20QBox%20%7C%20ESX%20%7C%20ox__core%20(beta)%20%7C%20ND%20(beta)-3b82f6)
 ![Voice](https://img.shields.io/badge/Voice-pma--voice-3b82f6)
 ![Compatibility](https://img.shields.io/badge/lb--phone-drop--in%20compatible-3b82f6)
 
@@ -180,7 +180,7 @@ end)
 
 | Layer | Supported |
 |---|---|
-| Frameworks | QBCore, QBox, ESX, ox_core (auto-detected) |
+| Frameworks | QBCore, QBox, ESX, ox_core, ND (auto-detected) |
 | Inventories | ox_inventory, one_inventory, tgiann-inventory, qb-inventory, qs-inventory(-pro), origen_inventory, codem-inventory, jaksam_inventory, lj-inventory, ps-inventory |
 | Voice | pma-voice |
 | Housing | 9 housing systems for the Homes app |

--- a/bridge/client/job.lua
+++ b/bridge/client/job.lua
@@ -2,6 +2,8 @@
 local framework = require 'bridge.shared.framework'
 ---@type table|nil ox_core helpers (bridge.shared.oxcore); nil on every other framework.
 local oxc       = framework.name == 'ox' and require 'bridge.shared.oxcore' or nil
+---@type table|nil ND_Core helpers (bridge.shared.ndcore); nil on every other framework.
+local ndc       = framework.name == 'nd' and require 'bridge.shared.ndcore' or nil
 
 ---@type table Job module; the table returned at end of file. Client-side job identity, kept live off
 ---the framework's own job-change events so callers never poll.
@@ -32,6 +34,9 @@ local function playerData()
         local ok, data = pcall(function() return exports.ox_core:GetPlayer() end)
         return ok and data or nil
     end
+    if framework.name == 'nd' then
+        return ndc.player()
+    end
     if framework.name == 'esx' then
         if not framework.core then return nil end
         local ok, data = pcall(function() return framework.core.GetPlayerData() end)
@@ -54,6 +59,11 @@ local function readJob(raw)
     if framework.name == 'ox' then
         -- The client player blob carries identity, not groups, so the job is asked for by type.
         return oxc.groupByTypes(nil, oxc.jobTypes)
+    end
+    if framework.name == 'nd' then
+        -- ND's `job` is a bare name string, with the rank on a separate `jobInfo` blob, so the
+        -- whole character is re-read rather than picked apart from the one field passed in.
+        return ndc.jobOf(ndc.player())
     end
     return name, tonumber(raw.grade) or 0
 end
@@ -122,6 +132,16 @@ elseif framework.name == 'ox' then
     end)
     AddEventHandler('ox:playerLoaded', refresh)
     AddEventHandler('ox:playerLogout', function() apply(nil, 0) end)
+elseif framework.name == 'nd' then
+    -- Both events carry the whole character, so the job comes off the payload rather than out of a
+    -- re-read: ND sets its own copy from the same events, and the order between the two is not ours.
+    RegisterNetEvent('ND:characterLoaded', function(character)
+        if type(character) == 'table' then apply(ndc.jobOf(character)) else refresh() end
+    end)
+    RegisterNetEvent('ND:updateCharacter', function(character)
+        if type(character) == 'table' then apply(ndc.jobOf(character)) else refresh() end
+    end)
+    RegisterNetEvent('ND:characterUnloaded', function() apply(nil, 0) end)
 elseif framework.name == 'esx' then
     RegisterNetEvent('esx:setJob', function(raw)
         if type(raw) == 'table' then apply(readJob(raw)) else refresh() end

--- a/bridge/client/notify.lua
+++ b/bridge/client/notify.lua
@@ -47,9 +47,9 @@ local function chooseBackend()
         return function(data) framework.core.Functions.Notify(data.description, data.type or 'info') end
     end
 
-    -- ox_core ships no notify of its own, but it refuses to start without ox_lib, so lib.notify is
-    -- always there to fall back on even when the ox_lib backend above is switched off in config.
-    if framework.name == 'ox' and lib ~= nil then
+    -- Neither ox_core nor ND ships a notify of its own, but both refuse to start without ox_lib, so
+    -- lib.notify is always there even when the ox_lib backend above is switched off in config.
+    if (framework.name == 'ox' or framework.name == 'nd') and lib ~= nil then
         return function(data)
             lib.notify({
                 title       = data.title,

--- a/bridge/server/banking.lua
+++ b/bridge/server/banking.lua
@@ -234,6 +234,15 @@ function banking.addOffline(citizenid, amount)
                 { amount, tonumber(citizenid) })
         end)
         return ok and (tonumber(affected) or 0) > 0
+    elseif framework.name == 'nd' then
+        -- charid is an INT column, so the identifier has to go back to a number: passed as the
+        -- string the phone carries it as, the row never matches and the credit silently vanishes.
+        local ok, affected = pcall(function()
+            return MySQL.update.await(
+                'UPDATE nd_characters SET bank = bank + ? WHERE charid = ?',
+                { amount, tonumber(citizenid) })
+        end)
+        return ok and (tonumber(affected) or 0) > 0
     end
     return false
 end

--- a/bridge/server/gang.lua
+++ b/bridge/server/gang.lua
@@ -1,16 +1,18 @@
----@type table Framework detection (bridge.shared.framework): name ('qb'|'esx') + live core handle.
+---@type table Framework detection (bridge.shared.framework): name ('qb'|'esx'|'ox'|'nd') + live core handle.
 local framework  = require 'bridge.shared.framework'
 ---@type table Player bridge (bridge.server.player): framework-native player object resolution.
 local player_mod = require 'bridge.server.player'
 ---@type table|nil ox_core helpers (bridge.shared.oxcore); nil on every other framework.
 local ox         = framework.name == 'ox' and require 'bridge.shared.oxcore' or nil
+---@type table|nil ND_Core helpers (bridge.shared.ndcore); nil on every other framework.
+local nd         = framework.name == 'nd' and require 'bridge.shared.ndcore' or nil
 
----@type table Gang module; the table returned at end of file. QBCore/QBox gang lookups, and on
----ox_core the groups whose type is listed in configs/framework.lua GangTypes; every helper returns
----its zero/false default on ESX, which has no gangs.
+---@type table Gang module; the table returned at end of file. QBCore/QBox gang lookups, on ox_core
+---the groups typed in configs/framework.lua GangTypes and on ND the groups `nd_groups` does not
+---define as jobs; every helper returns its zero/false default on ESX, which has no gangs.
 local gang = {}
 
----The player's current gang name (QBCore only). Nil when unresolvable or on ESX.
+---The player's current gang name. Nil when unresolvable or on ESX.
 ---@param source number player server id
 ---@return string|nil
 function gang.getName(source)
@@ -18,11 +20,11 @@ function gang.getName(source)
     if not p then return nil end
     if framework.qb then return p.PlayerData.gang and p.PlayerData.gang.name or nil end
     if framework.name == 'ox' then return (ox.groupByTypes(source, ox.gangTypes)) end
+    if framework.name == 'nd' then return (nd.gangOf(p)) end
     return nil
 end
 
----The player's current gang grade level (QBCore only). Returns 0 when the player or grade can't
----be resolved.
+---The player's current gang grade level. Returns 0 when the player or grade can't be resolved.
 ---@param source number player server id
 ---@return integer
 function gang.getGrade(source)
@@ -34,6 +36,10 @@ function gang.getGrade(source)
     if framework.name == 'ox' then
         local _, grade = ox.groupByTypes(source, ox.gangTypes)
         return grade
+    end
+    if framework.name == 'nd' then
+        local _, rank = nd.gangOf(p)
+        return rank
     end
     return 0
 end
@@ -58,6 +64,13 @@ function gang.has(source, gangName, minGrade)
         -- By name, like job.has: holding the group is the question, not whether it is active.
         local grade = ox.call(source, 'getGroup', gangName)
         return type(grade) == 'number' and grade >= minGrade
+    elseif framework.name == 'nd' then
+        -- By name for the same reason, and only for a group ND does NOT define as a job: a gate
+        -- asking about a gang must not unlock for a player who happens to hold a job of that name.
+        if not nd.isJobGroup(gangName) then
+            local rank = nd.rankIn(p, gangName)
+            return rank ~= nil and rank >= minGrade
+        end
     end
     return false
 end

--- a/bridge/server/garages.lua
+++ b/bridge/server/garages.lua
@@ -23,6 +23,8 @@ if framework.name == 'esx' then
     BASE = { table = 'owned_vehicles',  idCol = 'owner' }
 elseif framework.name == 'ox' then
     BASE = { table = 'vehicles',        idCol = 'owner' }
+elseif framework.name == 'nd' then
+    BASE = { table = 'nd_vehicles',     idCol = 'owner' }
 else
     BASE = { table = 'player_vehicles', idCol = 'citizenid' }
 end
@@ -68,6 +70,7 @@ local PROFILES = {
     ['codem-garage']       = { garage = { 'parking', 'garage' },  state = { 'state', 'stored' } },
     ['cd_garage']          = { garage = { 'garage_id', 'garage' },state = { 'in_garage', 'state' } },
     ['esx_garage']         = { garage = { 'parking', 'garage' },  state = { 'stored', 'state' } },
+    ['ND_Core']            = { garage = {},                       state = { 'stored' }, impoundCol = 'impounded' },
 }
 
 ---Resolve which supported garage system is running: an explicit config override wins, else the
@@ -98,12 +101,12 @@ local function pick(row, names)
     return nil
 end
 
----Decode the saved vehicle-properties blob (qb `mods`, esx `vehicle`, some forks
+---Decode the saved vehicle-properties blob (qb `mods`, esx `vehicle`, ND `properties`, some forks
 ---`modifications`): tables pass through, JSON-looking strings are decoded, failures yield nil.
 ---@param row table vehicle DB row
 ---@return table|nil props decoded properties, nil when absent/undecodable
 local function decodeProps(row)
-    for _, col in ipairs({ 'mods', 'vehicle', 'modifications' }) do
+    for _, col in ipairs({ 'mods', 'vehicle', 'properties', 'modifications' }) do
         local raw = row[col]
         if type(raw) == 'string' and (lib.string.startsWith(raw, '{') or lib.string.startsWith(raw, '[')) then
             local ok, decoded = pcall(json.decode, raw)

--- a/bridge/server/housing.lua
+++ b/bridge/server/housing.lua
@@ -106,6 +106,19 @@ local function offlineName(cid)
             local last  = s(r.lastname)
             if first or last then return (first or '') .. ' ' .. (last or '') end
         end
+    elseif framework.name == 'nd' then
+        local ok, rows = pcall(function()
+            return MySQL.query.await(
+                'SELECT firstname, lastname FROM nd_characters WHERE charid = ? LIMIT 1',
+                { tonumber(cid) }
+            )
+        end)
+        if ok and rows and rows[1] then
+            local r = rows[1]
+            local first = s(r.firstname)
+            local last  = s(r.lastname)
+            if first or last then return (first or '') .. ' ' .. (last or '') end
+        end
     else
         local ok, rows = pcall(function()
             return MySQL.query.await(

--- a/bridge/server/job.lua
+++ b/bridge/server/job.lua
@@ -4,6 +4,8 @@ local framework  = require 'bridge.shared.framework'
 local player_mod = require 'bridge.server.player'
 ---@type table|nil ox_core helpers (bridge.shared.oxcore); nil on every other framework.
 local ox         = framework.name == 'ox' and require 'bridge.shared.oxcore' or nil
+---@type table|nil ND_Core helpers (bridge.shared.ndcore); nil on every other framework.
+local nd         = framework.name == 'nd' and require 'bridge.shared.ndcore' or nil
 
 ---@type table Job module; the table returned at end of file. Job identity/permission primitives
 ---for the server bridge.
@@ -19,6 +21,7 @@ function job.getName(source)
     if framework.name == 'esx'  then return p.job and p.job.name or nil end
     if framework.qb then return p.PlayerData.job and p.PlayerData.job.name or nil end
     if framework.name == 'ox' then return (ox.groupByTypes(source, ox.jobTypes)) end
+    if framework.name == 'nd' then return (nd.jobOf(p)) end
     return nil
 end
 
@@ -35,6 +38,10 @@ function job.getGrade(source)
     if framework.name == 'ox' then
         local _, grade = ox.groupByTypes(source, ox.jobTypes)
         return grade
+    end
+    if framework.name == 'nd' then
+        local _, rank = nd.jobOf(p)
+        return rank
     end
     return 0
 end
@@ -65,6 +72,11 @@ function job.has(source, jobName, minGrade)
         -- treat as their active one, and holding it is what the gate is asking about.
         local grade = ox.call(source, 'getGroup', jobName)
         return type(grade) == 'number' and grade >= minGrade
+    elseif framework.name == 'nd' then
+        -- Asked by name rather than off the active job: ND is natively multi-group, and a player
+        -- may hold a job group that is not the one currently marked active.
+        local rank = nd.rankIn(p, jobName)
+        return rank ~= nil and rank >= minGrade
     end
     return false
 end
@@ -106,6 +118,12 @@ function job.isBoss(source, jobName, esxBossGrade)
         local grade = ox.call(source, 'getGroup', jobName)
         local top = ox.topGrade(jobName)
         return type(grade) == 'number' and top > 0 and grade >= top
+    elseif framework.name == 'nd' then
+        -- ND stores a real isBoss flag per rank in `nd_group_ranks`, so unlike ox_core there is
+        -- nothing to approximate: the held rank either carries the flag or it does not.
+        local held = nd.heldGroups(p)[jobName]
+        if not held then return false end
+        return nd.isBossRank(jobName, held.rank, held)
     end
     return false
 end
@@ -128,11 +146,18 @@ function job.set(source, jobName, grade)
         -- silently fire the player instead of hiring them at the bottom rung.
         return ox.call(source, 'setGroup', jobName, grade > 0 and grade or 1) ~= false
     end
+    if framework.name == 'nd' then
+        -- ND ranks are 1-based, so a caller-defaulted 0 would ask for a rank that does not exist;
+        -- setJob without keepGroup drops the previous job group, as every caller here expects.
+        if type(p.setJob) ~= 'function' then return false end
+        local ok, res = pcall(p.setJob, jobName, grade > 0 and grade or 1)
+        return ok and res ~= nil and res ~= false
+    end
     return false
 end
 
----The player's current on-duty state via QBCore/QBox `job.onduty`. Nil on ESX or when the player
----can't be resolved.
+---The player's current on-duty state via QBCore/QBox `job.onduty`. Nil when the player can't be
+---resolved, and on ESX and ND, neither of which has a duty concept to read.
 ---@param source number player server id
 ---@return boolean|nil
 function job.getDuty(source)
@@ -152,11 +177,11 @@ function job.getDuty(source)
 end
 
 ---True when the framework supports a multi-job ("saved jobs") model. QBCore/QBox keep saved jobs
----alongside an active one; ox_core is natively multi-group, so a character simply holds several.
----False on ESX, which has no such model.
+---alongside an active one; ox_core and ND are natively multi-group, so a character simply holds
+---several. False on ESX, which has no such model.
 ---@return boolean
 function job.supportsMultijob()
-    return framework.qb or framework.name == 'ox'
+    return framework.qb or framework.name == 'ox' or framework.name == 'nd'
 end
 
 ---Every job the framework has assigned to this player, not just the active one. On QBox these
@@ -192,6 +217,17 @@ function job.getAll(source)
         return out
     end
 
+    if framework.name == 'nd' then
+        -- Filtered on the group DEFINITION, never the isJob field on the character's own entry:
+        -- that one marks their single ACTIVE job, so it would return exactly one job every time.
+        for name, group in pairs(nd.heldGroups(p)) do
+            if type(name) == 'string' and nd.isJobGroup(name) then
+                out[name] = tonumber(group.rank) or 0
+            end
+        end
+        return out
+    end
+
     local active = job.getName(source)
     if active then out[active] = job.getGrade(source) end
     return out
@@ -218,11 +254,15 @@ function job.getLabel(jobName)
         local def = ox.group(jobName)
         return def and def.label or nil
     end
+    if framework.name == 'nd' then
+        local def = nd.group(jobName)
+        return def and def.label or nil
+    end
     return nil
 end
 
----Drive the player's on-duty state through QBCore/QBox SetJobDuty. A no-op returning false on
----ESX.
+---Drive the player's on-duty state through QBCore/QBox SetJobDuty. A no-op returning false on ESX
+---and ND, neither of which has a duty state to drive.
 ---@param source number player server id
 ---@param onDuty boolean
 ---@return boolean applied true when the framework applied it
@@ -251,6 +291,14 @@ function job.leave(source, jobName)
     if framework.name == 'ox' then
         -- Grade 0 is ox_core's own remove-from-group signal.
         return ox.call(source, 'setGroup', jobName, 0) ~= false
+    end
+    if framework.name == 'nd' then
+        -- ND removes a group by name rather than by writing a sentinel rank, and clears the active
+        -- job pointer itself when the group being dropped is the active one.
+        local p = player_mod.get(source)
+        if not p or type(p.removeGroup) ~= 'function' then return false end
+        local ok, res = pcall(p.removeGroup, jobName)
+        return ok and res ~= nil
     end
     if framework.name ~= 'qbx' then return false end
     local p = player_mod.get(source)

--- a/bridge/server/money.lua
+++ b/bridge/server/money.lua
@@ -6,6 +6,8 @@ local inventoryId = require 'bridge.shared.inventory_id'
 local player_mod  = require 'bridge.server.player'
 ---@type table|nil ox_core helpers (bridge.shared.oxcore); nil on every other framework.
 local ox          = framework.name == 'ox' and require 'bridge.shared.oxcore' or nil
+---@type table|nil ND_Core helpers (bridge.shared.ndcore); nil on every other framework.
+local nd          = framework.name == 'nd' and require 'bridge.shared.ndcore' or nil
 
 ---@type table Money module; the table returned at end of file. Personal money + black-money
 ---operations. Black money is the black_money item on ox_inventory, the markedbills item with
@@ -13,12 +15,12 @@ local ox          = framework.name == 'ox' and require 'bridge.shared.oxcore' or
 local money = {}
 
 ---Normalise caller-passed money type names across frameworks. ESX wants `money` for cash, QBCore
----wants `cash`; both accept `bank` as-is. ox_core is not in here: it has no account named for a
----money type at all, so its paths below branch on the type rather than renaming it.
+---and ND want `cash`; all three accept `bank` as-is. ox_core is not in here: it has no account
+---named for a money type at all, so its paths below branch on the type rather than renaming it.
 ---@param t string
 ---@return string
 local function convertType(t)
-    if t == 'money' and framework.qb  then return 'cash'  end
+    if t == 'money' and (framework.qb or framework.name == 'nd') then return 'cash'  end
     if t == 'cash'  and framework.name == 'esx' then return 'money' end
     return t
 end
@@ -58,6 +60,8 @@ function money.add(source, moneyType, amount, reason)
         end
         local acc = oxAccount(source)
         if acc then ox.accountCall(acc.accountId, 'addBalance', { amount = amount, message = reason }) end
+    elseif framework.name == 'nd' then
+        if type(p.addMoney) == 'function' then p.addMoney(convertType(moneyType), amount, reason) end
     end
 end
 
@@ -87,6 +91,11 @@ function money.remove(source, moneyType, amount, reason)
         -- already pre-check the balance.
         return ox.accountCall(acc.accountId, 'removeBalance',
             { amount = amount, overdraw = false, message = reason }) ~= false
+    elseif framework.name == 'nd' then
+        -- deductMoney returns nil rather than false on a rejected amount, and lets the balance go
+        -- negative, so the caller's own pre-check against money.get is what keeps it in range.
+        if type(p.deductMoney) ~= 'function' then return false end
+        return p.deductMoney(convertType(moneyType), amount, reason) == true
     end
     return false
 end
@@ -109,6 +118,8 @@ function money.get(source, moneyType)
         if oxIsCash(moneyType) then return require('bridge.server.inventory').count(source, 'money') end
         local acc = oxAccount(source)
         return (acc and acc.balance) or 0
+    elseif framework.name == 'nd' then
+        return tonumber(p[convertType(moneyType)]) or 0
     end
     return 0
 end

--- a/bridge/server/player.lua
+++ b/bridge/server/player.lua
@@ -1,7 +1,9 @@
----@type table Framework detection (bridge.shared.framework): name ('qb'|'esx'|'ox') + live core handle.
+---@type table Framework detection (bridge.shared.framework): name ('qb'|'esx'|'ox'|'nd') + live core handle.
 local framework = require 'bridge.shared.framework'
 ---@type table|nil ox_core helpers (bridge.shared.oxcore); nil on every other framework.
 local ox        = framework.name == 'ox' and require 'bridge.shared.oxcore' or nil
+---@type table|nil ND_Core helpers (bridge.shared.ndcore); nil on every other framework.
+local nd        = framework.name == 'nd' and require 'bridge.shared.ndcore' or nil
 
 ---@type table Player module; the table returned at end of file. Player resolution + identity
 ---helpers for the server bridge.
@@ -22,6 +24,9 @@ local function chooseGet()
     end
     if framework.name == 'ox' then
         return function(src) return ox.player(src) end
+    end
+    if framework.name == 'nd' then
+        return function(src) return nd.player(src) end
     end
     return function(src)
         error(('Unsupported framework — cannot resolve player for source %s'):format(src))
@@ -50,6 +55,11 @@ local function chooseIdentifier()
         -- charId, as a string: it is ox_core's character primary key, and the same value ox_core
         -- hands ox_inventory, so the phone and the inventory agree on who owns what.
         return function(p) return p.charId and tostring(p.charId) or nil end
+    end
+    if framework.name == 'nd' then
+        -- charid, as a string: it is ND's character primary key in `nd_characters`, and the value
+        -- `nd_vehicles.owner` is a foreign key onto, so the phone and ND agree on who owns what.
+        return function(p) return p.id and tostring(p.id) or nil end
     end
     return function() return nil end
 end
@@ -121,6 +131,13 @@ elseif framework.name == 'esx' then
 elseif framework.name == 'ox' then
     AddEventHandler('ox:playerLoaded', function(src) player.forget(src) end)
     AddEventHandler('ox:playerLogout', function(src) player.forget(src) end)
+elseif framework.name == 'nd' then
+    -- ND's two lifecycle events disagree on their signature: characterLoaded is handed the
+    -- character, which carries the source, while characterUnloaded is handed the source first.
+    AddEventHandler('ND:characterLoaded', function(character)
+        player.forget(character and character.source)
+    end)
+    AddEventHandler('ND:characterUnloaded', function(src) player.forget(src) end)
 end
 
 ---The player's persistent per-character identifier (citizenid on QBCore/QBox, identifier on ESX).
@@ -157,6 +174,15 @@ function player.getName(source)
         if first or last then return ('%s %s'):format(first or '', last or '') end
         return 'Unknown'
     end
+    if framework.name == 'nd' then
+        -- ND assembles `fullname` itself when the character loads; the parts are the fallback for
+        -- a record built before that ran.
+        if p.fullname and p.fullname ~= '' then return p.fullname end
+        if p.firstname or p.lastname then
+            return ('%s %s'):format(p.firstname or '', p.lastname or '')
+        end
+        return 'Unknown'
+    end
     return 'Unknown'
 end
 
@@ -169,10 +195,11 @@ function player.getJob(source)
     if framework.name == 'esx'  then return p.job and p.job.name or nil end
     if framework.qb then return p.PlayerData.job and p.PlayerData.job.name or nil end
     if framework.name == 'ox' then return (ox.groupByTypes(source, ox.jobTypes)) end
+    if framework.name == 'nd' then return (nd.jobOf(p)) end
     return nil
 end
 
----The player's current gang name. QBCore and ox_core only; always nil on ESX.
+---The player's current gang name. QBCore, ox_core and ND only; always nil on ESX.
 ---@param source number player server id
 ---@return string|nil
 function player.getGang(source)
@@ -180,6 +207,7 @@ function player.getGang(source)
     if not p then return nil end
     if framework.qb then return p.PlayerData.gang and p.PlayerData.gang.name or nil end
     if framework.name == 'ox' then return (ox.groupByTypes(source, ox.gangTypes)) end
+    if framework.name == 'nd' then return (nd.gangOf(p)) end
     return nil
 end
 
@@ -205,6 +233,13 @@ function player.getMetadata(source, key)
         return ok and value or nil
     end
     if framework.name == 'ox' then return ox.call(source, 'get', key) end
+    if framework.name == 'nd' then
+        -- getMetadata is a closure on the character record rather than a method, so it takes the
+        -- key alone; pcall-guarded because a record assembled offline carries no functions at all.
+        if type(p.getMetadata) ~= 'function' then return nil end
+        local ok, value = pcall(p.getMetadata, key)
+        return ok and value or nil
+    end
     return nil
 end
 

--- a/bridge/server/records.lua
+++ b/bridge/server/records.lua
@@ -10,17 +10,20 @@ local garages = require 'bridge.server.garages'
 local records = {}
 
 ---@type { table: string, idCol: string } Framework citizen table: QBCore/QBox key characters by
----citizenid in `players`, ESX by identifier in `users`, ox_core by charId in `characters`.
+---citizenid in `players`, ESX by identifier in `users`, ox_core by charId in `characters`, ND by
+---charid in `nd_characters`.
 ---
----ox_core also HAS a `users` table, but it is the account (one per player, many characters), not
----the character - reaching ESX's branch here would read the wrong rows entirely.
+---ox_core and ND both also HAVE an account table (`users` and `nd_users`), one row per player
+---rather than per character - reaching ESX's branch here would read the wrong rows entirely.
 local PEOPLE
 if framework.name == 'esx' then
-    PEOPLE = { table = 'users',      idCol = 'identifier' }
+    PEOPLE = { table = 'users',         idCol = 'identifier' }
 elseif framework.name == 'ox' then
-    PEOPLE = { table = 'characters', idCol = 'charId' }
+    PEOPLE = { table = 'characters',    idCol = 'charId' }
+elseif framework.name == 'nd' then
+    PEOPLE = { table = 'nd_characters', idCol = 'charid' }
 else
-    PEOPLE = { table = 'players',    idCol = 'citizenid' }
+    PEOPLE = { table = 'players',       idCol = 'citizenid' }
 end
 
 ---@type { table: string, idCol: string } Framework ownership table, picked the same way
@@ -30,6 +33,8 @@ if framework.name == 'esx' then
     VEHICLES = { table = 'owned_vehicles',  idCol = 'owner' }
 elseif framework.name == 'ox' then
     VEHICLES = { table = 'vehicles',        idCol = 'owner' }
+elseif framework.name == 'nd' then
+    VEHICLES = { table = 'nd_vehicles',     idCol = 'owner' }
 else
     VEHICLES = { table = 'player_vehicles', idCol = 'citizenid' }
 end
@@ -179,10 +184,50 @@ local function esxCitizen(row)
     }
 end
 
+---Builds the normalised citizen shape from an ND `nd_characters` row. charid is an INT column, so
+---it is stringified on the way out to match the identifier every caller carries.
+---@param row table
+---@return table citizen
+local function ndCitizen(row)
+    local cid   = tostring(row.charid)
+    local first = str(row.firstname)
+    local last  = str(row.lastname)
+    local name  = str(first .. ' ' .. last)
+    local meta  = decode(row.metadata)
+
+    local activeJob, activeRank = '', 0
+    for groupName, group in pairs(decode(row.groups)) do
+        if type(groupName) == 'string' and type(group) == 'table' and group.isJob then
+            activeJob, activeRank = groupName, tonumber(group.rank) or 0
+            break
+        end
+    end
+
+    return {
+        citizenid   = cid,
+        name        = name ~= '' and name or cid,
+        firstname   = first,
+        lastname    = last,
+        dob         = str(row.dob),
+        sex         = str(row.gender),
+        phone       = str(row.phonenumber),
+        nationality = '',
+        job         = activeJob,
+        jobGrade    = activeRank,
+        licences    = {},
+        fingerprint = str(meta.fingerprint),
+        bloodtype   = str(meta.bloodtype),
+        callsign    = str(meta.callsign),
+    }
+end
+
 ---@type string QBCore/QBox citizen projection.
 local QB_CITIZEN_COLS = 'citizenid, charinfo, metadata, job'
 ---@type string ESX citizen projection.
 local ESX_CITIZEN_COLS = 'identifier, firstname, lastname, dateofbirth, sex, phone_number, job, job_grade'
+---@type string ND citizen projection. `groups` carries the job: ND stores no job column, the active
+---one is the held group flagged isJob.
+local ND_CITIZEN_COLS = 'charid, firstname, lastname, dob, gender, phonenumber, `groups`, metadata'
 
 ---One citizen by their framework identifier, or nil. Read-only.
 ---@param cid string citizenid on QBCore/QBox, identifier on ESX
@@ -194,6 +239,13 @@ function records.getCitizen(cid)
         local row = MySQL.single.await(
             ('SELECT %s FROM players WHERE citizenid = ? LIMIT 1'):format(QB_CITIZEN_COLS), { cid })
         return row and qbCitizen(row) or nil
+    end
+
+    if framework.name == 'nd' then
+        local row = MySQL.single.await(
+            ('SELECT %s FROM nd_characters WHERE charid = ? LIMIT 1'):format(ND_CITIZEN_COLS),
+            { tonumber(cid) })
+        return row and ndCitizen(row) or nil
     end
 
     local have = columnsOf('users')
@@ -222,6 +274,19 @@ function records.namesFor(cids)
             local info = decode(rows[i].charinfo)
             local name = str(str(info.firstname) .. ' ' .. str(info.lastname))
             out[rows[i].citizenid] = name ~= '' and name or rows[i].citizenid
+        end
+        return out
+    end
+
+    if framework.name == 'nd' then
+        local ids = {}
+        for i = 1, #cids do ids[i] = tonumber(cids[i]) end
+        local rows = MySQL.query.await(
+            ('SELECT charid, firstname, lastname FROM nd_characters WHERE charid IN (%s)'):format(inClause), ids) or {}
+        for i = 1, #rows do
+            local cid  = tostring(rows[i].charid)
+            local name = str(str(rows[i].firstname) .. ' ' .. str(rows[i].lastname))
+            out[cid] = name ~= '' and name or cid
         end
         return out
     end
@@ -276,6 +341,24 @@ function records.searchCitizens(term, page, pageSize)
         return out, tonumber(total) or 0
     end
 
+    if framework.name == 'nd' then
+        local where, args = '', {}
+        if not browse then
+            where = 'WHERE charid LIKE ? OR firstname LIKE ? OR lastname LIKE ? OR phonenumber LIKE ?'
+            args  = { like, like, like, like }
+        end
+        local order = citizenOrder('nd_characters', 'charid', 'charid')
+        local total = MySQL.scalar.await(
+            ('SELECT COUNT(*) FROM nd_characters %s'):format(where), args)
+        local rows  = MySQL.query.await(
+            ('SELECT %s FROM nd_characters %s ORDER BY %s LIMIT %d OFFSET %d')
+                :format(ND_CITIZEN_COLS, where, order, limit, offset), args) or {}
+
+        local out = {}
+        for i = 1, #rows do out[i] = ndCitizen(rows[i]) end
+        return out, tonumber(total) or 0
+    end
+
     local where, args = '', {}
     if not browse then
         where = 'WHERE identifier LIKE ? OR firstname LIKE ? OR lastname LIKE ? OR phone_number LIKE ?'
@@ -295,14 +378,15 @@ function records.searchCitizens(term, page, pageSize)
 end
 
 ---Builds the normalised vehicle shape from an ownership row. The model is the chosen column when it
----holds a plain name, else the saved-properties model key, else the row's stored hash - ESX keeps the
----whole properties blob under `vehicle`, so a value opening with a brace is a row rather than a name
----and printing it verbatim puts the entire blob in the MDT. Same rule as garages.lua's modelOf.
+---holds a plain name, else the saved-properties model key (`vehicle` on ESX, `properties` on ND),
+---else the row's stored hash - ESX keeps the whole blob under `vehicle`, so a value opening with a
+---brace is a row rather than a name. Same rule as garages.lua's modelOf.
 ---@param row table raw ownership row
 ---@param modelCol string|nil column carrying the model name
 ---@return table vehicle
 local function vehicleOf(row, modelCol)
     local props = decode(row.vehicle)
+    if next(props) == nil then props = decode(row.properties) end
     local model = modelCol and str(row[modelCol]) or ''
 
     if model:sub(1, 1) == '{' then model = '' end

--- a/bridge/server/society.lua
+++ b/bridge/server/society.lua
@@ -4,6 +4,8 @@ local framework = require 'bridge.shared.framework'
 local job       = require 'bridge.server.job'
 ---@type table|nil ox_core helpers (bridge.shared.oxcore); nil on every other framework.
 local oxc       = framework.name == 'ox' and require 'bridge.shared.oxcore' or nil
+---@type table|nil ND_Core helpers (bridge.shared.ndcore); nil on every other framework.
+local ndc       = framework.name == 'nd' and require 'bridge.shared.ndcore' or nil
 ---@type table Player bridge (bridge.server.player): identifier -> online source resolution.
 local player    = require 'bridge.server.player'
 
@@ -67,6 +69,9 @@ function society.available()
     -- ox_core needs no provider: it creates a shared account per group at setup, so the company
     -- money the other frameworks farm out to qb-banking or esx_addonaccount is built in.
     if framework.name == 'ox' then return true end
+    -- ND has no group account and no management resource of its own, and the providers below are
+    -- all qb/ESX-only, so there is nothing truthful to read: the Services app hides company money.
+    if framework.name == 'nd' then return false end
     return provider() ~= nil
 end
 
@@ -215,6 +220,20 @@ function society.getGrades(jobName)
         return out
     end
 
+    if framework.name == 'nd' then
+        -- ND weights ranks from 1 upward in `nd_group_ranks`, so the weight IS the grade level.
+        local def = ndc.group(jobName)
+        local ranks = def and def.ranksData
+        if type(ranks) == 'table' then
+            for weight, rank in pairs(ranks) do
+                local lvl = tonumber(weight) or 0
+                out[#out + 1] = { level = lvl, label = (type(rank) == 'table' and rank.label) or ('Grade ' .. lvl) }
+            end
+        end
+        table.sort(out, function(a, b) return a.level < b.level end)
+        return out
+    end
+
     if framework.qb then
         local def
         if framework.name == 'qbx' then
@@ -282,6 +301,32 @@ function society.listEmployees(jobName)
                     citizenid = tostring(r.charId),
                     name      = ('%s %s'):format(r.firstName or '', r.lastName or ''),
                     grade     = tonumber(r.grade) or 0,
+                }
+            end
+        end
+        return out
+    end
+
+    if framework.name == 'nd' then
+        -- ND keeps a character's groups as a JSON object keyed by group name rather than in a join
+        -- table, so membership is a path test and the rank is read out of the same blob.
+        local ok, rows = pcall(function()
+            return MySQL.query.await([[
+                SELECT charid, firstname, lastname,
+                       JSON_EXTRACT(`groups`, CONCAT('$."', ?, '".rank')) AS rank
+                FROM nd_characters
+                WHERE JSON_CONTAINS_PATH(`groups`, 'one', CONCAT('$."', ?, '"'))
+                  AND deleted_at IS NULL
+            ]], { jobName, jobName })
+        end)
+        if ok and type(rows) == 'table' then
+            for _, r in ipairs(rows) do
+                local cid  = tostring(r.charid)
+                local name = ('%s %s'):format(r.firstname or '', r.lastname or ''):gsub('^%s+', ''):gsub('%s+$', '')
+                out[#out + 1] = {
+                    citizenid = cid,
+                    name      = name ~= '' and name or cid,
+                    grade     = tonumber(r.rank) or 0,
                 }
             end
         end
@@ -366,6 +411,19 @@ function society.namesByCids(cids)
                 out[r.identifier] = n ~= '' and n or r.identifier
             end
         end
+    elseif framework.name == 'nd' then
+        local ids = {}
+        for i = 1, #cids do ids[i] = tonumber(cids[i]) end
+        local ok, rows = pcall(function()
+            return MySQL.query.await(('SELECT charid, firstname, lastname FROM nd_characters WHERE charid IN (%s)'):format(inClause), ids)
+        end)
+        if ok and type(rows) == 'table' then
+            for _, r in ipairs(rows) do
+                local cid = tostring(r.charid)
+                local n = ('%s %s'):format(r.firstname or '', r.lastname or ''):gsub('^%s+', ''):gsub('%s+$', '')
+                out[cid] = n ~= '' and n or cid
+            end
+        end
     end
 
     return out
@@ -386,17 +444,17 @@ end
 ---Reset an online target to the unemployed job. Returns false when offline. No permission checks
 ---here.
 ---
----`fromJob` is only read on ox_core, which has no unemployed group to move someone into: being
----fired there means the group is REMOVED, so the caller has to say which one. The other
----frameworks ignore it and move the target to `unemployedJob` as before.
+---`fromJob` is only read on ox_core and ND, neither of which has an unemployed group to move
+---someone into: being fired there means the group is REMOVED, so the caller has to say which one.
+---The other frameworks ignore it and move the target to `unemployedJob` as before.
 ---@param targetCid string
 ---@param unemployedJob string
----@param fromJob? string the job being fired from; required on ox_core
+---@param fromJob? string the job being fired from; required on ox_core and ND
 ---@return boolean
 function society.fire(targetCid, unemployedJob, fromJob)
     local src = player.getSourceByIdentifier(targetCid)
     if not src then return false end
-    if framework.name == 'ox' then
+    if framework.name == 'ox' or framework.name == 'nd' then
         if not fromJob then return false end
         return job.leave(src, fromJob) == true
     end

--- a/bridge/shared/framework.lua
+++ b/bridge/shared/framework.lua
@@ -1,16 +1,22 @@
 ---@class FrameworkInfo
----@field name 'qbx'|'qb'|'esx'|'ox' Detected framework identifier.
+---@field name 'qbx'|'qb'|'esx'|'ox'|'nd' Detected framework identifier.
 ---@field qb boolean True for both QBox and QBCore, whose player objects share a shape. False on
----ox_core, which shares nothing with them - never use it as a stand-in for "not ESX".
----@field core any Live core object (QBCore's, or the ESX shared object). Nil on QBox and ox_core,
----neither of which has one: everything they need is a discrete export.
+---ox_core and ND, which share nothing with them - never use it as a stand-in for "not ESX".
+---@field core any Live core object (QBCore's, or the ESX shared object). Nil on QBox, ox_core and
+---ND, none of which has one: everything they need is a discrete export.
 
 ---Detects the running player framework and returns a populated FrameworkInfo, or nil when no
----supported framework is started. QBox is checked first so it is driven through its own exports
----rather than through the qb-core compatibility layer it provides. ox_core is checked before
----qb-core for the same reason, though it ships no compatibility layer to be caught by.
+---supported framework is started. ND is checked first: it ships esx and qb compatibility shims,
+---and while the `provide` lines that would alias them are commented out upstream (they "could
+---interfere with resources checking if the resources are started"), checking ND first keeps this
+---correct if that ever changes. QBox is checked before qb-core so it is driven through its own
+---exports rather than through the qb-core compatibility layer it provides. ox_core is checked
+---before qb-core for the same reason, though it ships no compatibility layer to be caught by.
 ---@return FrameworkInfo|nil
 local function detect()
+    if GetResourceState('ND_Core') == 'started' then
+        return { name = 'nd', qb = false }
+    end
     if GetResourceState('qbx_core') == 'started' then
         return { name = 'qbx', qb = true }
     end
@@ -37,6 +43,7 @@ if not info then
         - ox_core
         - QBCore (qb-core)
         - ESX (es_extended)
+        - ND (ND_Core)
 
         Please ensure your framework is started before this resource.
     ]])
@@ -51,6 +58,18 @@ if info.name == 'ox' then
 ^3Not yet wired: employee and owner NAMES come back blank in the Services roster, the MDT people^0
 ^3search and Homes offline lookups, and jail features stay off. Identity, cash and bank, jobs,^0
 ^3gangs and society balances all work.^0
+^3Please report anything wrong at github.com/Samuels-Development/sd-phone/issues^0
+    ]])
+end
+
+if info.name == 'nd' then
+    print([[
+^3[SD-PHONE] Running on ND_Core.^0
+^3Nothing to configure: ND names its jobs and gangs itself, through the isJob flag on nd_groups.^0
+^3Not wired, because ND_Core has no such concept: COMPANY BALANCES (the Services app keeps its^0
+^3roster, hiring and boss actions but shows no shared account), ON-DUTY state, and jail features.^0
+^3Identity, cash and bank, jobs, gangs, boss grades, the MDT people and vehicle search, Garages,^0
+^3Homes and the admin panel all work.^0
 ^3Please report anything wrong at github.com/Samuels-Development/sd-phone/issues^0
     ]])
 end

--- a/bridge/shared/ndcore.lua
+++ b/bridge/shared/ndcore.lua
@@ -1,0 +1,199 @@
+---@type table ND_Core helpers; the table returned at end of file. Every ND-specific call in the
+---bridge goes through here, so an upstream API change is one file to fix rather than fifteen.
+local nd = {}
+
+---@type boolean Server context. ND's getPlayer is shaped differently on the two sides: the server
+---addresses a player by source, the client only ever means the local player and takes no argument.
+local IS_SERVER = IsDuplicityVersion() == true
+
+---ND's own tables, for the bridges that read character and vehicle rows directly rather than going
+---through an export. `nd_characters` is keyed by charid, and `nd_vehicles.owner` is a foreign key
+---onto it; ND's `nd_users` table is the ACCOUNT (one per player, many characters), which is not the
+---same thing despite filling the role ESX gives its `users`.
+nd.PEOPLE_TABLE = 'nd_characters'
+nd.PEOPLE_ID_COL = 'charid'
+nd.VEHICLE_TABLE = 'nd_vehicles'
+nd.VEHICLE_ID_COL = 'owner'
+
+---@type table<string, table>|nil Client-side memo of the replicated group definitions, dropped
+---whenever ND announces a change.
+local convarGroups = nil
+
+---Whether a value read out of one of ND's TINYINT(1) columns means true. Both shapes reach here:
+---oxmysql deserialises those as a boolean on current builds and as 1/0 on older ones.
+---@param v any
+---@return boolean
+local function isTruthy(v)
+    return v == true or v == 1 or v == '1'
+end
+
+nd.isTruthy = isTruthy
+
+---Raw ND character record. `source` is required on the server and ignored on the client, which can
+---only ever mean the local player. Nil when there is no loaded character.
+---@param source? number player server id (server only)
+---@return table|nil
+function nd.player(source)
+    local ok, p = pcall(function()
+        if IS_SERVER then return exports.ND_Core:getPlayer(source) end
+        return exports.ND_Core:getPlayer()
+    end)
+    return ok and p or nil
+end
+
+---The phone's identifier for a source: ND's charid, as a string. charid is the character primary
+---key in `nd_characters`, and the value `nd_vehicles.owner` is a foreign key onto.
+---@param source number player server id
+---@return string|nil
+function nd.charId(source)
+    local p = nd.player(source)
+    local id = p and p.id
+    return id and tostring(id) or nil
+end
+
+---Every group definition ND publishes to the client, as name -> { label, isJob, ranks }. ND mirrors
+---its group table into the `core:groups` replicated convar, so this needs no export or round trip.
+---@return table<string, table>
+local function replicatedGroups()
+    if convarGroups then return convarGroups end
+    local raw = GetConvar('core:groups', '')
+    if raw == '' then return {} end
+    local ok, decoded = pcall(json.decode, raw)
+    convarGroups = (ok and type(decoded) == 'table') and decoded or {}
+    return convarGroups
+end
+
+if not IS_SERVER then
+    -- ND fires this alongside the convar write, so dropping the memo is enough: the next read
+    -- refills it from the convar rather than trusting the event payload.
+    AddEventHandler('ND:groupsUpdated', function() convarGroups = nil end)
+end
+
+---A group's definition (label, isJob, ranks), or nil when the group is unknown. On the server this
+---is ND's own cache, which carries the per-rank isBoss flags; on the client, the convar copy, which
+---does not.
+---@param groupName string|nil
+---@return table|nil
+function nd.group(groupName)
+    if not groupName or groupName == '' then return nil end
+    if IS_SERVER then
+        local ok, g = pcall(function() return exports.ND_Core:getGroupData(groupName) end)
+        if ok and type(g) == 'table' then return g end
+    end
+    return replicatedGroups()[groupName]
+end
+
+---Whether a group is DEFINED as a job. Read from the definition, never from the copy on a
+---character: that one's `isJob` marks which single group is their ACTIVE job, so a job group added
+---without the flag would read as a gang.
+---@param groupName string|nil
+---@return boolean
+function nd.isJobGroup(groupName)
+    local def = nd.group(groupName)
+    return def ~= nil and isTruthy(def.isJob)
+end
+
+---Every group a character currently holds, as name -> { label, rankName, rank, isJob, isBoss,
+---metadata }. Empty table when the character holds none or is nil.
+---@param p table|nil ND character record
+---@return table<string, table>
+function nd.heldGroups(p)
+    local groups = p and p.groups
+    return type(groups) == 'table' and groups or {}
+end
+
+---The character's active job name and rank. ND keeps exactly one active job - setJob clears the
+---isJob marker off every other group - and surfaces it as `job` plus a `jobInfo` blob.
+---@param p table|nil ND character record
+---@return string|nil name, integer rank
+function nd.jobOf(p)
+    if not p then return nil, 0 end
+    local name = type(p.job) == 'string' and p.job ~= '' and p.job or nil
+    if not name then return nil, 0 end
+    local info = type(p.jobInfo) == 'table' and p.jobInfo or nd.heldGroups(p)[name]
+    return name, tonumber(info and info.rank) or 0
+end
+
+---The character's gang: the first group they hold whose definition is not a job. ND has no gang
+---concept of its own, so where a character holds several non-job groups the winner is arbitrary.
+---@param p table|nil ND character record
+---@return string|nil name, integer rank
+function nd.gangOf(p)
+    for name, group in pairs(nd.heldGroups(p)) do
+        if type(name) == 'string' and not nd.isJobGroup(name) then
+            return name, tonumber(group.rank) or 0
+        end
+    end
+    return nil, 0
+end
+
+---The rank a character holds in `groupName`, or nil when they do not hold it. Distinct from rank 0:
+---ND ranks start at 1, so 0 is not the "not a member" signal ox_core's grade 0 is.
+---@param p table|nil ND character record
+---@param groupName string
+---@return integer|nil
+function nd.rankIn(p, groupName)
+    local group = nd.heldGroups(p)[groupName]
+    if not group then return nil end
+    return tonumber(group.rank) or 0
+end
+
+---Whether a rank is a boss rank of its group, read from ND's own per-rank isBoss flag. Falls back
+---to the character's group entry, which caches the flag, for the client, whose copy omits it.
+---@param groupName string
+---@param rank integer|nil
+---@param heldGroup? table the character's entry for this group, used as the fallback
+---@return boolean
+function nd.isBossRank(groupName, rank, heldGroup)
+    rank = tonumber(rank)
+    if not rank then return false end
+    local def = nd.group(groupName)
+    local rankData = def and type(def.ranksData) == 'table' and def.ranksData[rank]
+    if rankData then return isTruthy(rankData.isBoss) end
+    return heldGroup ~= nil and isTruthy(heldGroup.isBoss)
+end
+
+---The highest rank defined for a group, or 0 when the group is unknown. ND weights ranks from 1
+---upward, as a `ranksData` map on the server and a `ranks` array on the client.
+---@param groupName string
+---@return integer
+function nd.topRank(groupName)
+    local def = nd.group(groupName)
+    if not def then return 0 end
+    local top = 0
+    if type(def.ranksData) == 'table' then
+        for weight in pairs(def.ranksData) do
+            local n = tonumber(weight) or 0
+            if n > top then top = n end
+        end
+    end
+    if top == 0 and type(def.ranks) == 'table' then top = #def.ranks end
+    return top
+end
+
+---A rank's label within a group, or nil when the group or rank is unknown.
+---@param groupName string
+---@param rank integer|nil
+---@return string|nil
+function nd.rankLabel(groupName, rank)
+    rank = tonumber(rank)
+    if not rank then return nil end
+    local def = nd.group(groupName)
+    if not def then return nil end
+    local rankData = type(def.ranksData) == 'table' and def.ranksData[rank]
+    if rankData and rankData.label then return rankData.label end
+    return type(def.ranks) == 'table' and def.ranks[rank] or nil
+end
+
+---Every group definition ND knows about, as name -> definition. Enumerates companies for the
+---Services app rather than answering a question about one player.
+---@return table<string, table>
+function nd.allGroups()
+    if IS_SERVER then
+        local ok, groups = pcall(function() return exports.ND_Core:getAllGroups() end)
+        if ok and type(groups) == 'table' then return groups end
+    end
+    return replicatedGroups()
+end
+
+return nd

--- a/configs/framework.lua
+++ b/configs/framework.lua
@@ -4,8 +4,14 @@
 -- MDT people search and Homes offline lookups, and jail features stay off. Identity, cash and
 -- bank money, jobs, gangs and society balances are all wired.
 --
--- Only ox_core needs anything here: QBCore, QBox and ESX all name
+-- Only ox_core needs anything here: QBCore, QBox, ESX and ND all name
 -- their concepts the same way on every install, so the bridge reads them without asking.
+--
+-- ND in particular needs NOTHING configured. Its `nd_groups` table carries an `isJob` flag per
+-- group, so the phone reads which groups are jobs and which are gangs straight from ND, and
+-- `nd_group_ranks.isBoss` gives it a real boss grade rather than the guess ox_core needs below.
+-- Not wired on ND, because ND_Core has no such concept: company balances (the Services app keeps
+-- its roster, hiring and boss actions, but shows no shared account), on-duty state, and jail.
 --
 -- ox_core has no jobs or gangs. It has GROUPS, and a group's `type` is a free-form string the
 -- server owner picks when creating it (types/index.ts declares it `type?: string`, with no

--- a/configs/garages.lua
+++ b/configs/garages.lua
@@ -15,10 +15,13 @@ return {
 
     -- Resources checked, in priority order, when System = 'auto'. The first
     -- one that's `started` wins. Add custom/renamed resources here.
+    -- ND_Core is last on purpose: on ND it owns the vehicles itself (`nd_vehicles`, with its own
+    -- stored/impounded flags), so it is the fallback once no dedicated garage resource is running.
+    -- ND keeps no garage-NAME column, so vehicles list with their status but without a location.
     Resources = {
         'qs-advancedgarages', 'jg-advancedgarages', 'qbx_garages', 'qb-garages',
         'cd_garage', 'okokGarage', 'codem-garage', 'lunar_garage', 'nc_garage',
-        'op_garages', 'esx_garage',
+        'op_garages', 'esx_garage', 'ND_Core',
     },
 
     -- Default for whether a real photo of each vehicle (matched by spawn name)

--- a/server/admin/store.lua
+++ b/server/admin/store.lua
@@ -94,6 +94,14 @@ function store.namesFor(cids)
             for _, r in ipairs(rows) do
                 out[r.identifier] = ('%s %s'):format(r.firstname or '', r.lastname or '')
             end
+        elseif framework.name == 'nd' then
+            local ids = {}
+            for i = 1, #list do ids[i] = tonumber(list[i]) end
+            local rows = MySQL.query.await(
+                ('SELECT charid, firstname, lastname FROM nd_characters WHERE charid IN (%s)'):format(placeholders), ids) or {}
+            for _, r in ipairs(rows) do
+                out[tostring(r.charid)] = ('%s %s'):format(r.firstname or '', r.lastname or '')
+            end
         end
     end)
     return out
@@ -123,6 +131,13 @@ function store.searchByName(like, limit)
                 LIMIT ?
             ]], { like, limit }) or {}
             for _, r in ipairs(rows) do out[#out + 1] = r.identifier end
+        elseif framework.name == 'nd' then
+            local rows = MySQL.query.await([[
+                SELECT charid FROM nd_characters
+                WHERE CONCAT(firstname, ' ', lastname) LIKE ?
+                LIMIT ?
+            ]], { like, limit }) or {}
+            for _, r in ipairs(rows) do out[#out + 1] = tostring(r.charid) end
         end
     end)
     return out

--- a/server/groups/init.lua
+++ b/server/groups/init.lua
@@ -98,6 +98,10 @@ elseif framework.name == 'esx' then
     AddEventHandler('esx:playerLoaded', function(playerId)
         pushOnline(playerId)
     end)
+elseif framework.name == 'nd' then
+    AddEventHandler('ND:characterLoaded', function(character)
+        pushOnline(character and character.source)
+    end)
 end
 
 ---Uninstalling Groups leaves every membership behind: groups the player leads are disbanded,

--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -201,6 +201,10 @@ function store.loadRoster(frameworkName)
         if frameworkName == 'esx' then
             return MySQL.query.await('SELECT identifier AS citizenid, NULL AS license FROM users') or {}
         end
+        if frameworkName == 'nd' then
+            return MySQL.query.await(
+                'SELECT CAST(charid AS CHAR) AS citizenid, identifier AS license FROM nd_characters') or {}
+        end
         return MySQL.query.await('SELECT citizenid, license FROM players') or {}
     end)
     if not ok or type(rows) ~= 'table' then return { cids = cids, licenseToCids = licenseToCids } end

--- a/server/services/init.lua
+++ b/server/services/init.lua
@@ -45,6 +45,11 @@ elseif framework.name == 'esx' then
     AddEventHandler('esx:playerLoaded', function(playerId)
         if playerId then SetTimeout(1500, function() actions.reconcileJobs(playerId) end) end
     end)
+elseif framework.name == 'nd' then
+    AddEventHandler('ND:characterLoaded', function(character)
+        local src = character and character.source
+        if src then SetTimeout(1500, function() actions.reconcileJobs(src) end) end
+    end)
 end
 
 ---Refreshes a disconnecting player's company rosters.


### PR DESCRIPTION
Adds ND (`ND_Core`) as the fifth supported framework, alongside QBox, QBCore, ESX and ox_core.

## Detection

`ND_Core` is checked **first**. ND ships esx/qb compatibility shims, and while the `provide "es_extended"` / `provide "qb-Core"` lines that would alias them are commented out upstream (they "could interfere with resources checking if the resources are started"), checking ND first keeps detection correct if that ever changes.

## ND needs no configuration

Unlike ox_core, ND needs **nothing** in `configs/framework.lua`:

| Concept | ox_core | ND |
| --- | --- | --- |
| Job vs gang | configured group-type lists | `nd_groups.isJob`, read natively |
| Boss grade | guessed ("top grade is boss") | `nd_group_ranks.isBoss`, a real flag |
| Job label | GlobalState | `core:groups` replicated convar (both sides) |

## What's wired

Identity, cash and bank, jobs, gangs, boss grades, multijob, notify, MDT people **and** vehicle search, Garages, Homes offline names, the admin panel name lookup, and the lb-phone migration roster.

## What isn't, and why

Reported honestly rather than faked — all three are absent from ND_Core itself, and the boot print says so on startup:

- **Company balances** — no group-account concept, and every provider the society bridge knows is qb/ESX-only. Services keeps its roster, hiring and boss actions; the shared account is hidden rather than shown as a zero balance the UI would render as a real, empty account.
- **On-duty state** — no duty flag and no `activeGroup` equivalent. Returns `nil`, the same answer ESX gives, which callers already read as "this server has no duty".
- **Jail** — no ND-aware jail resource exists.

Garages lists ND-owned vehicles with their stored/impounded status, but `nd_vehicles` has no garage-name column, so there's no per-garage grouping or waypoint.

## Two traps worth flagging in review

1. **`records.lua` fall-through.** `getCitizen`/`namesFor` branch on `framework.qb` and then fall through to the ESX `users` query. That is the live reason ox_core names come back blank — on ox_core, `users` is the *account* table, not the character. ND gets an explicit branch **before** that fall-through, so it doesn't inherit the same silent-wrong-table bug.
2. **`charid` is an INT.** ND is the second framework (after ox_core) whose identifier is numeric, and the phone carries identifiers as strings. Every ND SQL path converts with `tonumber()` going in and `tostring()` coming out. Passed as the string the phone holds, an offline bank credit matches no row and silently vanishes.

Also worth a look: a character's group entry carries its **own** `isJob` field marking their *active job*, set by whoever called `addGroup` — not the same as the group's definition. Gang detection reads the definition; the MDT citizen record reads the character flag. Both uses are deliberate.

## Gates

- `luac -p` clean on all 18 changed Lua files
- Full existing suite: **166 passed, 2 failed** — both failures pre-exist on the branch base (verified via `git stash`), unrelated to this change
- New local ND bridge suite: **68 passed, 0 failed**, covering identity, money, jobs, gangs, boss flags, the multijob filter and the society opt-out
- Mutation-tested: swapping `isTruthy(def.isJob)` for `def.isJob == true` fails 8 assertions, including a job group misclassifying as a gang (which would wrongly unlock gang-gated apps). oxmysql returns `TINYINT(1)` as a boolean on current builds and `1/0` on older ones; both shapes are handled.

## Not covered

Inventory needed no work — ND's own README points at **ox_inventory**, already first in the phone's detection list, same as ox_core.

Docs (`index.md`, `installation.md`, `configuration.md`) are edited in the OneDrive VitePress repo but left **uncommitted** there for you to review; they add ox_core alongside ND, since that site had never been updated for ox_core either.
