### PR TITLE
feat(admin): make the live map pan, zoom and switch tile styles

### DIFF
--- a/web/src/admin/pages/MapPage.tsx
+++ b/web/src/admin/pages/MapPage.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useState } from 'react';
-import { RefreshCw, Users } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Maximize, Minus, Plus, RefreshCw, Users } from 'lucide-react';
 
-import { projectPct, tileUrl } from '@/apps/maps/data';
+import type { MapStyleId } from '@/apps/maps/data';
+import { getMapStyles, loadStyleId, projectPct, saveStyleId } from '@/apps/maps/data';
 import { adminLivePositions } from '../adminApi';
 import type { AdminLivePlayer } from '../types';
 import { Btn, Card, CenterNote, Spinner } from '../ui';
+import { TileCanvas } from './map/TileCanvas';
+import { MAX_ZOOM, MIN_ZOOM, useMapViewport } from './map/useMapViewport';
 
-const ZOOM = 3;
-const SIDE = 2 ** ZOOM;
 const POLL_MS = 5000;
 
 export function MapPage({ onOpenPlayer }: { onOpenPlayer: (cid: string) => void }) {
@@ -15,6 +17,11 @@ export function MapPage({ onOpenPlayer }: { onOpenPlayer: (cid: string) => void 
     const [loading, setLoading] = useState(true);
     const [live, setLive] = useState(true);
     const [hover, setHover] = useState<AdminLivePlayer | null>(null);
+    const [styleId, setStyleId] = useState<MapStyleId>(() => loadStyleId());
+
+    const styles = useMemo(() => getMapStyles(), []);
+    const style = styles.find(s => s.id === styleId) ?? styles[0]!;
+    const vp = useMapViewport();
 
     useEffect(() => {
         let alive = true;
@@ -31,58 +38,70 @@ export function MapPage({ onOpenPlayer }: { onOpenPlayer: (cid: string) => void 
         return () => { alive = false; window.clearInterval(id); };
     }, [live]);
 
-    const tiles: React.ReactNode[] = [];
-    for (let y = 0; y < SIDE; y++) {
-        for (let x = 0; x < SIDE; x++) {
-            tiles.push(
-                <img
-                    key={`${x}-${y}`}
-                    src={tileUrl('satellite', ZOOM, x, y)}
-                    alt=""
-                    draggable={false}
-                    className="h-full w-full object-cover"
-                />,
-            );
-        }
+    function pickStyle(id: MapStyleId) {
+        setStyleId(id);
+        saveStyleId(id);
     }
 
+    const hoverWorld = hover ? projectPct(hover.x, hover.y) : null;
+    const hoverAt = hoverWorld ? vp.toScreen(hoverWorld.left, hoverWorld.top) : null;
+
     return (
-        <div className="space-y-4">
-            <div className="flex items-center justify-between gap-3">
+        <div className="flex h-full min-h-0 flex-col gap-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex items-center gap-2 text-[13px] text-zinc-400">
                     <Users size={14} className="text-zinc-500" />
                     <span className="font-semibold text-zinc-200 tabular-nums">{players.length}</span>
                     online
                     {live && <span className="text-[11.5px] text-zinc-600">· refreshing every {POLL_MS / 1000}s</span>}
                 </div>
-                <Btn onClick={() => setLive(v => !v)}>
-                    <RefreshCw size={13} className={live ? 'animate-spin' : undefined} />
-                    {live ? 'Pause' : 'Resume'}
-                </Btn>
+
+                <div className="flex items-center gap-2">
+                    <div className="flex overflow-hidden rounded-lg ring-1 ring-white/10">
+                        {styles.map(s => (
+                            <button
+                                key={s.id}
+                                type="button"
+                                onClick={() => pickStyle(s.id)}
+                                className={`px-2.5 py-1.5 text-[12px] font-medium transition-colors ${s.id === styleId ? 'bg-white/15 text-zinc-100' : 'bg-transparent text-zinc-500 hover:bg-white/5 hover:text-zinc-300'}`}
+                            >
+                                {s.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    <Btn onClick={() => setLive(v => !v)}>
+                        <RefreshCw size={13} className={live ? 'animate-spin' : undefined} />
+                        {live ? 'Pause' : 'Resume'}
+                    </Btn>
+                </div>
             </div>
 
-            <Card className="p-3">
-                <div className="relative w-full overflow-hidden rounded-lg bg-[#0b1418]" style={{ aspectRatio: '1 / 1' }}>
-                    <div
-                        className="absolute inset-0 grid"
-                        style={{ gridTemplateColumns: `repeat(${SIDE}, 1fr)`, gridTemplateRows: `repeat(${SIDE}, 1fr)` }}
-                    >
-                        {tiles}
-                    </div>
+            <Card className="flex min-h-0 flex-1 p-3">
+                <div
+                    ref={vp.ref}
+                    onPointerDown={vp.surface.onPointerDown}
+                    onWheel={vp.surface.onWheel}
+                    className={`relative mx-auto h-full max-w-full touch-none overflow-hidden rounded-lg ${vp.panning ? 'cursor-grabbing' : 'cursor-grab'}`}
+                    style={{ aspectRatio: '1 / 1', background: style.bg }}
+                >
+                    <TileCanvas style={style} view={vp.view} width={vp.width} />
 
                     {loading && (
                         <div className="absolute inset-0 flex items-center justify-center bg-black/40"><Spinner /></div>
                     )}
 
                     {players.map(p => {
-                        const at = projectPct(p.x, p.y);
+                        const world = projectPct(p.x, p.y);
+                        const at = vp.toScreen(world.left, world.top);
+                        if (at.left < -4 || at.left > 104 || at.top < -4 || at.top > 104) return null;
                         return (
                             <button
                                 key={p.source}
                                 type="button"
                                 onClick={() => onOpenPlayer(p.cid)}
-                                onMouseEnter={() => setHover(p)}
-                                onMouseLeave={() => setHover(null)}
+                                onPointerEnter={() => setHover(p)}
+                                onPointerLeave={() => setHover(null)}
                                 className="absolute -ml-[6px] -mt-[6px] h-3 w-3 rounded-full ring-2 ring-black/60 transition-transform hover:scale-150"
                                 style={{ left: `${at.left}%`, top: `${at.top}%`, background: '#6db4ff' }}
                                 aria-label={p.name}
@@ -90,19 +109,56 @@ export function MapPage({ onOpenPlayer }: { onOpenPlayer: (cid: string) => void 
                         );
                     })}
 
-                    {hover && (
+                    {hover && hoverAt && (
                         <div
                             className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-[150%] whitespace-nowrap rounded-md bg-black/85 px-2 py-1 text-[11.5px] text-zinc-100 ring-1 ring-white/10"
-                            style={{ left: `${projectPct(hover.x, hover.y).left}%`, top: `${projectPct(hover.x, hover.y).top}%` }}
+                            style={{ left: `${hoverAt.left}%`, top: `${hoverAt.top}%` }}
                         >
                             <span className="font-semibold">{hover.name}</span>
                             <span className="ml-1.5 tabular-nums text-zinc-500">{hover.x}, {hover.y}</span>
                         </div>
                     )}
+
+                    <div className="absolute right-2.5 top-2.5 z-10 flex flex-col overflow-hidden rounded-lg bg-black/70 ring-1 ring-white/10">
+                        <ZoomBtn label="Zoom in" disabled={vp.view.zoom >= MAX_ZOOM} onClick={() => vp.zoomBy(1.6)}>
+                            <Plus size={14} />
+                        </ZoomBtn>
+                        <ZoomBtn label="Zoom out" disabled={vp.view.zoom <= MIN_ZOOM} onClick={() => vp.zoomBy(1 / 1.6)}>
+                            <Minus size={14} />
+                        </ZoomBtn>
+                        <ZoomBtn label="Reset view" disabled={vp.atHome} onClick={vp.home}>
+                            <Maximize size={13} />
+                        </ZoomBtn>
+                    </div>
+
+                    <div className="pointer-events-none absolute bottom-2.5 left-2.5 z-10 rounded-md bg-black/70 px-2 py-1 text-[11px] tabular-nums text-zinc-400 ring-1 ring-white/10">
+                        {vp.view.zoom.toFixed(1)}x
+                    </div>
                 </div>
             </Card>
 
             {!loading && players.length === 0 && <CenterNote>Nobody is online right now.</CenterNote>}
         </div>
+    );
+}
+
+function ZoomBtn({ children, label, onClick, disabled }: {
+    children:  ReactNode;
+    label:     string;
+    onClick:   () => void;
+    disabled?: boolean;
+}) {
+    return (
+        <button
+            type="button"
+            title={label}
+            aria-label={label}
+            disabled={disabled}
+            onPointerDown={e => e.stopPropagation()}
+            onClick={onClick}
+            className="flex h-7 w-7 items-center justify-center text-zinc-300 transition-colors hover:bg-white/10 hover:text-white disabled:pointer-events-none disabled:text-zinc-600"
+        >
+            {children}
+        </button>
     );
 }

--- a/web/src/admin/pages/map/TileCanvas.tsx
+++ b/web/src/admin/pages/map/TileCanvas.tsx
@@ -1,0 +1,112 @@
+import { memo, useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+import type { MapStyle } from '@/apps/maps/data';
+import { styleMaxZoom, tileUrl } from '@/apps/maps/data';
+import type { Viewport } from './useMapViewport';
+
+const BACKDROP_Z = 2;
+const TARGET_PX = 160;
+const MIN_DETAIL_Z = 3;
+const MAX_RETRIES = 1;
+
+const missing = new Set<string>();
+
+export function tileZoomFor(style: MapStyle, width: number, zoom: number): number {
+    if (!width) return BACKDROP_Z;
+    const ideal = Math.round(Math.log2((width * zoom) / TARGET_PX));
+    return Math.max(MIN_DETAIL_Z, Math.min(styleMaxZoom(style.tiles), ideal));
+}
+
+function layer(style: MapStyle, z: number, width: number, view: Viewport, cull: boolean): ReactNode[] {
+    const n = 2 ** z;
+    const ts = width / n;
+    const seam = 0.7 / view.zoom;
+
+    let lo = 0;
+    let hi = n - 1;
+    let loY = 0;
+    let hiY = n - 1;
+
+    if (cull) {
+        const reach = 0.5 / view.zoom;
+        const pin = (v: number) => Math.max(0, Math.min(n - 1, v));
+        lo  = pin(Math.floor((view.x + 0.5 - reach) * n) - 1);
+        hi  = pin(Math.floor((view.x + 0.5 + reach) * n) + 1);
+        loY = pin(Math.floor((view.y + 0.5 - reach) * n) - 1);
+        hiY = pin(Math.floor((view.y + 0.5 + reach) * n) + 1);
+    }
+
+    const out: ReactNode[] = [];
+    for (let j = loY; j <= hiY; j++) {
+        for (let i = lo; i <= hi; i++) {
+            const id = `${style.tiles}/${z}/${i}/${j}`;
+            if (missing.has(id)) continue;
+            out.push(
+                <img
+                    key={`${z}-${i}-${j}`}
+                    src={tileUrl(style.tiles, z, i, j)}
+                    alt=""
+                    draggable={false}
+                    decoding="async"
+                    onLoad={e => {
+                        const img = e.currentTarget;
+                        img.style.visibility = '';
+                        img.style.opacity = '1';
+                    }}
+                    onError={e => {
+                        const img = e.currentTarget;
+                        img.style.visibility = 'hidden';
+                        img.style.opacity = '0';
+                        const tries = Number(img.dataset.retry ?? '0');
+                        if (tries >= MAX_RETRIES) {
+                            missing.add(id);
+                            return;
+                        }
+                        img.dataset.retry = String(tries + 1);
+                        const base = img.src.replace(/&r=\d+$/, '');
+                        window.setTimeout(() => { img.src = `${base}&r=${tries + 1}`; }, 700 * (tries + 1));
+                    }}
+                    className="absolute select-none opacity-0 transition-opacity duration-200"
+                    style={{ left: i * ts, top: j * ts, width: ts + seam, height: ts + seam, filter: style.filter }}
+                />,
+            );
+        }
+    }
+    return out;
+}
+
+export const TileCanvas = memo(function TileCanvas({ style, view, width }: {
+    style: MapStyle;
+    view:  Viewport;
+    width: number;
+}) {
+    const z = tileZoomFor(style, width, view.zoom);
+
+    const backdrop = useMemo(
+        () => (width ? layer(style, BACKDROP_Z, width, view, false) : []),
+        [style, width, view],
+    );
+
+    const detail = useMemo(
+        () => (width && z > BACKDROP_Z ? layer(style, z, width, view, true) : []),
+        [style, width, z, view],
+    );
+
+    if (!width) return null;
+
+    return (
+        <div
+            className="absolute left-0 top-0 will-change-transform"
+            style={{
+                width,
+                height: width,
+                transformOrigin: 'center',
+                transform: `scale(${view.zoom}) translate(${-view.x * width}px, ${-view.y * width}px)`,
+            }}
+        >
+            {backdrop}
+            {detail}
+        </div>
+    );
+});

--- a/web/src/admin/pages/map/useMapViewport.ts
+++ b/web/src/admin/pages/map/useMapViewport.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+export interface Viewport {
+    zoom: number;
+    x:    number;
+    y:    number;
+}
+
+export const MIN_ZOOM = 1;
+export const MAX_ZOOM = 16;
+
+const HOME: Viewport = { zoom: 1, x: 0, y: 0 };
+
+function clamp(n: number, lo: number, hi: number): number {
+    return Math.min(hi, Math.max(lo, n));
+}
+
+function settle(next: Viewport): Viewport {
+    const zoom = clamp(next.zoom, MIN_ZOOM, MAX_ZOOM);
+    const span = (1 - 1 / zoom) / 2;
+    return { zoom, x: clamp(next.x, -span, span), y: clamp(next.y, -span, span) };
+}
+
+export interface MapViewport {
+    view:     Viewport;
+    ref:      React.RefObject<HTMLDivElement | null>;
+    width:    number;
+    panning:  boolean;
+    atHome:   boolean;
+    zoomBy:   (factor: number) => void;
+    home:     () => void;
+    focus:    (leftPct: number, topPct: number, zoom?: number) => void;
+    toScreen: (leftPct: number, topPct: number) => { left: number; top: number };
+    surface:  {
+        onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+        onWheel:       (e: React.WheelEvent<HTMLDivElement>) => void;
+    };
+}
+
+export function useMapViewport(): MapViewport {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const [width, setWidth] = useState(0);
+    const [view, setView] = useState<Viewport>(HOME);
+    const [panning, setPanning] = useState(false);
+
+    const live = useRef(view);
+    live.current = view;
+
+    useLayoutEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        const ro = new ResizeObserver(() => setWidth(el.clientWidth));
+        ro.observe(el);
+        setWidth(el.clientWidth);
+        return () => ro.disconnect();
+    }, []);
+
+    const zoomAt = useCallback((factor: number, ox: number, oy: number) => {
+        setView(prev => {
+            const zoom = clamp(prev.zoom * factor, MIN_ZOOM, MAX_ZOOM);
+            if (zoom === prev.zoom) return prev;
+            const shift = 1 / prev.zoom - 1 / zoom;
+            return settle({ zoom, x: prev.x + (ox - 0.5) * shift, y: prev.y + (oy - 0.5) * shift });
+        });
+    }, []);
+
+    const zoomBy = useCallback((factor: number) => zoomAt(factor, 0.5, 0.5), [zoomAt]);
+
+    const home = useCallback(() => setView(HOME), []);
+
+    const focus = useCallback((leftPct: number, topPct: number, zoom = 6) => {
+        setView(settle({ zoom, x: leftPct / 100 - 0.5, y: topPct / 100 - 0.5 }));
+    }, []);
+
+    const onWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+        const el = ref.current;
+        if (!el) return;
+        const box = el.getBoundingClientRect();
+        zoomAt(
+            e.deltaY < 0 ? 1.3 : 1 / 1.3,
+            (e.clientX - box.left) / box.width,
+            (e.clientY - box.top) / box.height,
+        );
+    }, [zoomAt]);
+
+    const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+        const el = ref.current;
+        if (!el || e.button !== 0) return;
+
+        const originX = e.clientX;
+        const originY = e.clientY;
+        const start = live.current;
+        let dragged = false;
+
+        el.setPointerCapture(e.pointerId);
+
+        const move = (ev: PointerEvent) => {
+            const dx = ev.clientX - originX;
+            const dy = ev.clientY - originY;
+            if (!dragged && Math.hypot(dx, dy) > 4) {
+                dragged = true;
+                setPanning(true);
+            }
+            if (!dragged) return;
+            setView(settle({
+                zoom: start.zoom,
+                x: start.x - dx / (el.clientWidth * start.zoom),
+                y: start.y - dy / (el.clientHeight * start.zoom),
+            }));
+        };
+
+        const up = (ev: PointerEvent) => {
+            el.removeEventListener('pointermove', move);
+            el.removeEventListener('pointerup', up);
+            el.removeEventListener('pointercancel', up);
+            try { el.releasePointerCapture(ev.pointerId); } catch { /* released already */ }
+            setPanning(false);
+            if (dragged) {
+                const swallow = (c: MouseEvent) => { c.stopPropagation(); c.preventDefault(); };
+                el.addEventListener('click', swallow, { capture: true, once: true });
+                window.setTimeout(() => el.removeEventListener('click', swallow, true), 0);
+            }
+        };
+
+        el.addEventListener('pointermove', move);
+        el.addEventListener('pointerup', up);
+        el.addEventListener('pointercancel', up);
+    }, []);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        const block = (e: WheelEvent) => e.preventDefault();
+        el.addEventListener('wheel', block, { passive: false });
+        return () => el.removeEventListener('wheel', block);
+    }, []);
+
+    const toScreen = useCallback((leftPct: number, topPct: number) => ({
+        left: ((leftPct / 100 - view.x - 0.5) * view.zoom + 0.5) * 100,
+        top:  ((topPct / 100 - view.y - 0.5) * view.zoom + 0.5) * 100,
+    }), [view]);
+
+    return {
+        view, ref, width, panning,
+        atHome: view.zoom === 1 && view.x === 0 && view.y === 0,
+        zoomBy, home, focus, toScreen,
+        surface: { onPointerDown, onWheel },
+    };
+}


### PR DESCRIPTION
The admin panel's live map painted a fixed 8x8 grid of `satellite` tiles at a hardcoded zoom 3, stretched to a square with `object-cover`. No pan, no zoom, no style switch.

It now uses the same CDN tile plumbing the Maps app does, so an admin can actually read the map.

## What changed

- **Pan and zoom.** Drag to pan, scroll to zoom under the cursor, or use the +/-/reset controls. Zoom runs 1x to 16x with the current level shown bottom-left. Panning is clamped so the world always covers the frame.
- **Style switch.** Satellite/Atlas segmented control, persisted through the Maps app's own `loadStyleId`/`saveStyleId`, so the choice matches what the admin sees on the phone.
- **Tile level follows zoom.** `tileZoomFor` picks the CDN level from the on-screen world size and clamps to each style's `maxZoom` (satellite 6, atlas 5). A level-2 backdrop stays underneath so panning never exposes bare background, and the detail layer is culled to the visible window.
- **Fits the panel.** The map is a centred square sized off the panel's flex height instead of the full card width, so it no longer overflows the scroll area.
- Players, the hover tooltip and click-through-to-player are unchanged, as is the 5s polling and Pause/Resume.

## Missing edge tiles

The satellite set has no z3 tiles for the all-ocean edge columns (`satellite/3/0/*` and `satellite/3/7/*` are 404; atlas has them). Those 16 images painted broken-image glyphs down the left and right edges of the map.

Failed tiles are now hidden outright rather than left to the class's `opacity-0`, retries drop from 2 to 1, and a module-level `missing` set records a tile that stayed 404 so re-renders skip it. Verified in game: 16 failures on first paint, 0 visible; after a re-render 48 z3 tiles are requested instead of 64 and nothing fails.

## Gates

- `tsc --noEmit` clean
- `oxlint src` 0 errors (23 pre-existing `exhaustive-deps` warnings, none in the new files)
- `vitest` 709/709 across 54 files
- `knip` clean
- Both `sd-phone` and `sd-tablet` bundles rebuilt

Verified in game across satellite and atlas at 1x and 6.6x: zoom survives a style switch, culling holds, no failed tiles.