### PR TITLE
perf(shell): cheaper compositing on the hottest shell paths

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1257,7 +1257,8 @@ function AppContent() {
     useEffect(() => {
         if (!view || preloadArmed.current) return;
         preloadArmed.current = true;
-        const t = window.setTimeout(preloadAllApps, 1500);
+        const ids = view.apps.filter(a => a.base || installedApps.has(a.id)).map(a => a.id);
+        const t = window.setTimeout(() => preloadAllApps(ids), 1500);
         return () => window.clearTimeout(t);
     }, [view]);
 

--- a/web/src/apps/appstore/AppStore.tsx
+++ b/web/src/apps/appstore/AppStore.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { Lock } from 'lucide-react';
 
 import { useSessionState } from '@/hooks/useSessionState';
-import { useDownloads } from '@/stores/downloadStore';
+import { useShallow } from 'zustand/react/shallow';
+import { useDownloadProgress, useDownloadStore } from '@/stores/downloadStore';
 import { useHasData } from '@/stores/serviceStore';
 import { useWifiConnected, useWifiNetworks } from '@/stores/wifiStore';
 import { AlertDialog } from '@/ui/AlertDialog';
@@ -70,6 +71,11 @@ function getDescriptions(): Record<string, string> {
     };
 }
 
+function DownloadRing({ id, queued }: { id: string; queued: boolean }) {
+    const progress = useDownloadProgress(id);
+    return <CircularProgress progress={queued ? 0 : (progress ?? 0)} size={32} stroke={2.5} />;
+}
+
 export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpenApp }: {
     onClose:   () => void;
     apps:      AppDef[];
@@ -77,7 +83,11 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
     onInstall: (id: string) => void;
     onOpenApp: (id: string) => void;
 }) {
-    const downloading = useDownloads();
+    const downloadStatus = useDownloadStore(useShallow(s => {
+        const out: Record<string, 'queued' | 'active'> = {};
+        for (const [id, p] of Object.entries(s.downloads)) out[id] = p < 0 ? 'queued' : 'active';
+        return out;
+    }));
     const hasData = useHasData();
     const wifiConnected = useWifiConnected();
     const wifiNetworks = useWifiNetworks();
@@ -103,6 +113,7 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
     const [q, setQ] = useSessionState('appstore:search', '');
     const [filter, setFilter] = useSessionState<'all' | 'notInstalled'>('appstore:filter', 'all');
     const [selectedId, setSelectedId] = useSessionState<string | null>('appstore:selected', null);
+    const selectedProgress = useDownloadProgress(selectedId ?? '');
     const selected = apps.find(a => a.id === selectedId) ?? null;
     const query = q.trim().toLowerCase();
     const descriptions = getDescriptions();
@@ -142,9 +153,9 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
                     <div className="overflow-hidden rounded-[10px] bg-surface">
                         {list.map((a, i) => {
                             const isInstalled = !!a.base || installed.has(a.id);
-                            const dl = downloading[a.id];
-                            const isDownloading = dl !== undefined;
-                            const isQueued = isDownloading && dl < 0;
+                            const status = downloadStatus[a.id];
+                            const isDownloading = status !== undefined;
+                            const isQueued = status === 'queued';
                             const locked = !isInstalled && lockedNetwork(a) !== null;
                             return (
                                 <div key={a.id} className={`flex items-center gap-3.5 py-2.5 pl-3.5 ${i < list.length - 1 ? 'border-b border-black/10 dark:border-white/10' : ''}`}>
@@ -161,7 +172,7 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
                                         </button>
                                         {isDownloading ? (
                                             <div className={`relative flex shrink-0 items-center justify-center text-ios-blue ${isQueued ? 'animate-pulse' : ''}`} style={{ width: 40, height: 40 }} aria-label={isQueued ? t('appstore.waitingToDownload', 'Waiting to download') : t('appstore.downloading', 'Downloading')}>
-                                                <CircularProgress progress={isQueued ? 0 : dl} size={32} stroke={2.5} />
+                                                <DownloadRing id={a.id} queued={isQueued} />
                                                 <div className="absolute h-[8px] w-[8px] rounded-[1.5px] bg-ios-blue" />
                                             </div>
                                         ) : (
@@ -188,7 +199,7 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
                     app={selected}
                     desc={descOf(selected.id)}
                     installed={!!selected.base || installed.has(selected.id)}
-                    downloadProgress={downloading[selected.id]}
+                    downloadProgress={selectedProgress}
                     onBack={() => setSelectedId(null)}
                     onInstall={installGuarded}
                     canDownload={hasData && lockedNetwork(selected) === null}

--- a/web/src/apps/groups/Groups.tsx
+++ b/web/src/apps/groups/Groups.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useDidEnter } from '@/hooks/useDidEnter';
 import { NavContext } from '@/hooks/useIosPush';
@@ -77,7 +77,7 @@ export function Groups({ onClose }: { onClose: () => void }) {
     }, []));
 
 
-    function handleWillBack() { setReturning(true); }
+    const navValue = useMemo(() => ({ onWillBack: () => setReturning(true) }), []);
     function handleBack()     { setDetail(null); setReturning(false); }
 
     // No-arg: the ref flips true right after mount, so the first navigation
@@ -174,7 +174,7 @@ export function Groups({ onClose }: { onClose: () => void }) {
             </div>
 
             {detail && (
-                <NavContext.Provider value={{ onWillBack: handleWillBack }}>
+                <NavContext.Provider value={navValue}>
                     <GroupDetail
                         group={detail}
                         isActive={state.activeGroupId === detail.id}

--- a/web/src/apps/mdt/Mdt.tsx
+++ b/web/src/apps/mdt/Mdt.tsx
@@ -5,7 +5,7 @@ import { device } from '@device';
 import { t } from '@/i18n';
 import { EmptyState } from '@/ui/EmptyState';
 import { MenuRootProvider } from '@/ui/menuRoot';
-import { NavContext } from '@/hooks/useIosPush';
+import { NavContext, NOOP_NAV } from '@/hooks/useIosPush';
 import type { DepartmentType, MdtSection } from './data';
 import { AffairsPane } from './AffairsPane';
 import { CamerasPane } from './CamerasPane';
@@ -141,7 +141,7 @@ function Terminal({ devDomain }: { devDomain?: DepartmentType }) {
     const session = useMdtSessionState(devDomain);
     return (
         <MdtSessionProvider value={session}>
-            <NavContext.Provider value={{ onWillBack: () => {} }}>
+            <NavContext.Provider value={NOOP_NAV}>
                 {device.id === 'phone' ? <MdtPhone renderPane={pane} /> : <MdtTerminal />}
             </NavContext.Provider>
         </MdtSessionProvider>

--- a/web/src/apps/racing/Racing.tsx
+++ b/web/src/apps/racing/Racing.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties } from 're
 import { Flag } from 'lucide-react';
 
 import { device } from '@device';
-import { NavContext } from '@/hooks/useIosPush';
+import { NavContext, NOOP_NAV } from '@/hooks/useIosPush';
 import { MenuRootProvider } from '@/ui/menuRoot';
 import { surfaceBackdrop } from '@/ui/surfaces';
 import type { RacingSection } from './data';
@@ -93,7 +93,7 @@ export function Racing({ onClose: _onClose }: { onClose: () => void }) {
     const session = useRacingSessionState();
     return (
         <RacingSessionProvider value={session}>
-            <NavContext.Provider value={{ onWillBack: () => {} }}>
+            <NavContext.Provider value={NOOP_NAV}>
                 {device.id === 'phone' ? <RacingPhone pane={pane} /> : <RacingTerminal />}
             </NavContext.Provider>
         </RacingSessionProvider>

--- a/web/src/apps/weazelnews/ManageDashboard.tsx
+++ b/web/src/apps/weazelnews/ManageDashboard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { ChevronLeft, Newspaper, Pencil, Plus, Radio, Trash2 } from 'lucide-react';
 
 import { t } from '@/i18n';
-import { NavContext, useIosPush } from '@/hooks/useIosPush';
+import { NavContext, NOOP_NAV, useIosPush } from '@/hooks/useIosPush';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { EmptyState } from '@/ui/EmptyState';
 import { EditArticle } from './EditArticle';
@@ -151,7 +151,7 @@ export function ManageDashboard({ articles, ticker, dark, animateIn = true, onRe
             </div>
 
             {editing && (
-                <NavContext.Provider value={{ onWillBack: () => {} }}>
+                <NavContext.Provider value={NOOP_NAV}>
                     <EditArticle
                         initial={editing === 'new' ? null : editing}
                         dark={dark}
@@ -162,7 +162,7 @@ export function ManageDashboard({ articles, ticker, dark, animateIn = true, onRe
             )}
 
             {breaking && (
-                <NavContext.Provider value={{ onWillBack: () => {} }}>
+                <NavContext.Provider value={NOOP_NAV}>
                     <EditBreaking
                         initial={ticker}
                         dark={dark}

--- a/web/src/apps/weazelnews/WeazelNews.tsx
+++ b/web/src/apps/weazelnews/WeazelNews.tsx
@@ -4,7 +4,7 @@ import { Eye, Newspaper, Settings2 } from 'lucide-react';
 import { t } from '@/i18n';
 import { EmptyState } from '@/ui/EmptyState';
 import { useDidEnter } from '@/hooks/useDidEnter';
-import { NavContext } from '@/hooks/useIosPush';
+import { NavContext, NOOP_NAV } from '@/hooks/useIosPush';
 import { useSessionState } from '@/hooks/useSessionState';
 import { useTheme } from '@/stores/themeStore';
 import { Article } from './Article';
@@ -210,7 +210,7 @@ export function WeazelNews({ onClose: _onClose }: { onClose: () => void }) {
             </div>
 
             {open && (
-                <NavContext.Provider value={{ onWillBack: () => {} }}>
+                <NavContext.Provider value={NOOP_NAV}>
                     <Article article={open} onBack={() => setOpenId(null)} animateIn={animateNav} />
                 </NavContext.Provider>
             )}

--- a/web/src/hooks/useIosPush.ts
+++ b/web/src/hooks/useIosPush.ts
@@ -5,6 +5,8 @@ export const NavContext = createContext<{ onWillBack: () => void }>({
     onWillBack: () => {},
 });
 
+export const NOOP_NAV = { onWillBack: () => {} };
+
 export function useIosPush(onBack: () => void, animateIn = true) {
     const { onWillBack } = useContext(NavContext);
     const [leaving, setLeaving] = useState(false);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -402,8 +402,7 @@ html, body, #root {
 .animate-pin-shake { animation: pin-shake 0.5s ease; }
 @keyframes faceid-dim-in  { from { opacity: 0; } to { opacity: 1; } }
 .animate-faceid-dim-in    { animation: faceid-dim-in 0.24s ease forwards; }
-@keyframes faceid-blur-in { from { -webkit-backdrop-filter: blur(0px); backdrop-filter: blur(0px); } to { -webkit-backdrop-filter: blur(5px); backdrop-filter: blur(5px); } }
-.animate-faceid-blur-in   { animation: faceid-blur-in 0.34s ease forwards; }
+.faceid-frost             { -webkit-backdrop-filter: blur(5px); backdrop-filter: blur(5px); }
 @keyframes faceid-in      { 0% { opacity: 0; transform: scale(0.82); } 60% { opacity: 1; } 100% { opacity: 1; transform: scale(1); } }
 .animate-faceid-in        { animation: faceid-in 0.42s cubic-bezier(0.22,1,0.36,1) forwards; }
 @keyframes faceid-scanline { 0% { transform: translateY(2px); } 50% { transform: translateY(72px); } 100% { transform: translateY(2px); } }

--- a/web/src/shell/AppDeck.tsx
+++ b/web/src/shell/AppDeck.tsx
@@ -129,7 +129,7 @@ const AppHost = memo(function AppHost({ id, ctx, active, openKey, origin, expand
         <div
             data-app-screen="1"
             className={phase === 'rest' ? 'absolute inset-0' : 'absolute inset-0 app-anim-flatten'}
-            style={{ transformOrigin: `${ox} ${oy}`, animation, willChange: 'transform' }}
+            style={{ transformOrigin: `${ox} ${oy}`, animation, willChange: phase === 'rest' ? undefined : 'transform' }}
             onAnimationEnd={e => {
                 if (e.target !== e.currentTarget) return;
                 if (phase === 'close') onCloseDone();

--- a/web/src/shell/AppSwitcher.tsx
+++ b/web/src/shell/AppSwitcher.tsx
@@ -236,13 +236,12 @@ export function AppSwitcher({
                                 transform:       `translateX(${tx}px) translateY(${ty}px) scale(${cScale})`,
                                 transformOrigin: '50% 0%',
                                 opacity:         cardOpacity,
-                                filter:          `brightness(${cBright})`,
                                 transition: isEjecting
                                     ? 'transform 0.26s ease-in, opacity 0.26s ease-in'
                                     : snapping
-                                        ? 'transform 0.42s cubic-bezier(0.22,1,0.36,1), filter 0.4s ease'
+                                        ? 'transform 0.42s cubic-bezier(0.22,1,0.36,1)'
                                         : 'none',
-                                willChange: 'transform, opacity, filter',
+                                willChange: 'transform, opacity',
                             }}
                         >
                             <div
@@ -315,6 +314,11 @@ export function AppSwitcher({
                                 </div>
 
                                 <CardStage appId={appId} />
+
+                                <div
+                                    className="pointer-events-none absolute inset-0 z-[1] bg-black"
+                                    style={{ opacity: 1 - cBright, transition: snapping ? 'opacity 0.4s ease' : 'none' }}
+                                />
 
                                 {/* Transparent tap target sits ABOVE the live view (which is
                                     inert / pointer-events:none while parented into the card). */}

--- a/web/src/shell/ControlCenter.tsx
+++ b/web/src/shell/ControlCenter.tsx
@@ -23,6 +23,12 @@ export function ControlCenter({ open, onClose, onOpenApp, onWifi }: {
     const music = useMusic();
 
     const [flash, setFlash]       = useState(false);
+    const [frosted, setFrosted]   = useState(open);
+    useEffect(() => {
+        if (open) { setFrosted(true); return; }
+        const id = window.setTimeout(() => setFrosted(false), 420);
+        return () => window.clearTimeout(id);
+    }, [open]);
     const [rotation, setRotation] = useState(false);
     const [focus, setFocus]       = useState(false);
     const [lowPower, setLowPower] = useState(false);
@@ -55,14 +61,12 @@ export function ControlCenter({ open, onClose, onOpenApp, onWifi }: {
     const EASE = 'cubic-bezier(0.32,0.72,0,1)';
     return (
         <div className={'absolute inset-0 z-[700] ' + (open ? '' : 'pointer-events-none')}>
-            <div
-                className="absolute inset-0"
-                style={{
-                    backdropFilter: open ? 'blur(30px)' : 'blur(0px)',
-                    WebkitBackdropFilter: open ? 'blur(30px)' : 'blur(0px)',
-                    transition: `backdrop-filter 420ms ${EASE}, -webkit-backdrop-filter 420ms ${EASE}`,
-                }}
-            />
+            {frosted && (
+                <div
+                    className="absolute inset-0"
+                    style={{ backdropFilter: 'blur(30px)', WebkitBackdropFilter: 'blur(30px)' }}
+                />
+            )}
             <div
                 className="absolute inset-0 bg-black/45"
                 style={{ opacity: open ? 1 : 0, transition: `opacity 420ms ${EASE}` }}

--- a/web/src/shell/Lockscreen.tsx
+++ b/web/src/shell/Lockscreen.tsx
@@ -234,7 +234,7 @@ function FaceScan({ exiting, onSuccess }: { exiting: boolean; onSuccess: () => v
     return (
         <div className="absolute inset-0 z-[80] flex flex-col items-center justify-center">
             <div className="absolute inset-0 bg-black/40 animate-faceid-dim-in" />
-            {!exiting && <div className="absolute inset-0 animate-faceid-blur-in" />}
+            {!exiting && <div className="absolute inset-0 faceid-frost" />}
 
             <div className="relative z-10 flex flex-col items-center animate-faceid-in">
                 <div className="relative flex h-[150px] w-[150px] items-center justify-center">
@@ -448,6 +448,7 @@ export function LockNotifCard({ item, onOpen, onDismiss }: { item: NotificationI
     const [dx, setDx] = useState(0);
     const [exiting, setExiting] = useState(false);
     const hidePreview = useStreamerHidden('previews');
+    const { blurLock: frostedWallpaper } = useTheme('blurLock');
     const start    = useRef({ x: 0, y: 0 });
     const zoom     = useRef(1);
     const dragging = useRef(false);
@@ -498,7 +499,8 @@ export function LockNotifCard({ item, onOpen, onDismiss }: { item: NotificationI
             onPointerCancel={onUp}
             style={{ touchAction: 'pan-y', ...dragStyle }}
             className={[
-                'flex w-full animate-notif-drop touch-pan-y select-none items-start gap-3 rounded-[27px] bg-white/55 px-[18px] py-4 text-left shadow-[0_6px_24px_rgba(0,0,0,0.16)] backdrop-blur-2xl backdrop-saturate-150',
+                'flex w-full animate-notif-drop touch-pan-y select-none items-start gap-3 rounded-[27px] px-[18px] py-4 text-left shadow-[0_6px_24px_rgba(0,0,0,0.16)]',
+                frostedWallpaper ? 'bg-white/70' : 'bg-white/55 backdrop-blur-2xl backdrop-saturate-150',
                 item.emergency ? 'ring-[1.5px] ring-inset ring-[#FF3B30]/75' : 'ring-1 ring-black/[0.04]',
             ].join(' ')}
         >

--- a/web/src/shell/PushLayer.tsx
+++ b/web/src/shell/PushLayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 
 import { NavContext } from '@/hooks/useIosPush';
@@ -21,6 +21,7 @@ export function PushLayer({
     children,
 }: PushLayerProps) {
     const [returning, setReturning] = useState(false);
+    const navValue = useMemo(() => ({ onWillBack: () => setReturning(true) }), []);
     const hasSub = sub !== null && sub !== undefined && sub !== false;
 
     useEffect(() => {
@@ -43,7 +44,7 @@ export function PushLayer({
                 {children}
                 <div className="pointer-events-none absolute inset-0 bg-black" style={dimStyle} />
             </div>
-            <NavContext.Provider value={{ onWillBack: () => setReturning(true) }}>
+            <NavContext.Provider value={navValue}>
                 {sub}
             </NavContext.Provider>
         </div>

--- a/web/src/shell/appRegistry.tsx
+++ b/web/src/shell/appRegistry.tsx
@@ -183,8 +183,9 @@ export function setPreloadPaused(paused: boolean): void {
     if (!paused) preloadResume?.();
 }
 
-export function preloadAllApps(): void {
-    const queue = APP_IDS.slice();
+export function preloadAllApps(ids?: readonly string[]): void {
+    const wanted = ids ? new Set(ids) : null;
+    const queue = wanted ? APP_IDS.filter(id => wanted.has(id)) : APP_IDS.slice();
     const schedule = () => {
         if (preloadPaused || preloadBusy) return;
         if (typeof window.requestIdleCallback === 'function') window.requestIdleCallback(() => pump(), { timeout: 200 });

--- a/web/src/stores/downloadStore.ts
+++ b/web/src/stores/downloadStore.ts
@@ -23,7 +23,3 @@ export function useDownloadProgress(id: string): number | undefined {
 export function useDownloadingIds(): string[] {
     return useDownloadStore(useShallow(s => Object.keys(s.downloads)));
 }
-
-export function useDownloads(): Record<string, number> {
-    return useDownloadStore(s => s.downloads);
-}


### PR DESCRIPTION
## Summary

Shell-level rendering costs found in the performance audit, all on paths that run on every open or unlock.

- **Control Center** no longer animates the backdrop blur radius. The frosted layer mounts at full strength while open (and for the 420ms close), and only the plain dim layer and the panel animate. Keeps the earlier CEF lesson intact: the blur layer is never opacity-faded and has no opacity-animated ancestor.
- **Face ID unlock** used a keyframe that ramped a 5px backdrop blur on every unlock; it is now a static frost class under the existing dim fade.
- **App switcher** cards dropped `filter: brightness()` and `filter` from `will-change`; dimming is a black overlay with animated opacity inside each card, so live app trees are no longer re-rasterised through a filter layer.
- **App deck** only sets `will-change: transform` while an open/close animation is running, so retained apps stop holding a promoted full-screen layer at rest.
- **Preload** after first open now warms only base and installed apps instead of all 49 chunks.
- **Nav context values** are memoised in PushLayer and the five apps that recreated them per render, so drilled-in pages stop re-rendering on every parent update.
- **App Store** subscribes per row to download progress instead of the whole downloads record at 20 updates a second during an install.
- **Lock screen notifications** use a flat translucent fill when the wallpaper itself is already blurred, instead of stacking a backdrop blur on a blurred ancestor.

Retention cap left at 10 on purpose: an earlier fix matched it to the switcher's recents so cards never fall back to a grey icon.

## Gates

- [x] `npm run build` (tsc + vite)
- [x] `npm run lint` (0 errors)
- [x] `npm run knip`
- [x] `npm run i18n:check`
- [x] local test suite (649 passed)

Not merged; awaiting review and an in-game eyeball of the Control Center open.