### PR TITLE
perf(apps): chat composer isolation and windowed feed video

### DIFF
--- a/web/src/apps/photogram/feed/PostCard.tsx
+++ b/web/src/apps/photogram/feed/PostCard.tsx
@@ -34,6 +34,7 @@ export function PostCard({ post, onLike, onDoubleLike, onSave, onComment, onOpen
     const viewportRef = useRef<HTMLDivElement>(null);
     const vids = useRef<Record<number, HTMLVideoElement | null>>({});
     const [inView, setInView] = useState(false);
+    const [near,   setNear]   = useState(false);
     const [muted,  setMuted]  = useState(true);
     const hasVideo      = post.images.some(isVideoUrl);
     const activeIsVideo = isVideoUrl(post.images[idx] ?? '');
@@ -47,6 +48,17 @@ export function PostCard({ post, onLike, onDoubleLike, onSave, onComment, onOpen
         const obs = new IntersectionObserver(
             entries => { const e = entries[0]; if (e) setInView(e.isIntersecting && e.intersectionRatio >= 0.55); },
             { root: scrollRoot?.current ?? null, threshold: [0, 0.55, 1] },
+        );
+        obs.observe(el);
+        return () => obs.disconnect();
+    }, [hasVideo, scrollRoot]);
+
+    useEffect(() => {
+        const el = viewportRef.current;
+        if (!el || !hasVideo) return;
+        const obs = new IntersectionObserver(
+            entries => { const e = entries[0]; if (e) setNear(e.isIntersecting); },
+            { root: scrollRoot?.current ?? null, rootMargin: '150% 0px', threshold: 0 },
         );
         obs.observe(el);
         return () => obs.disconnect();
@@ -138,7 +150,9 @@ export function PostCard({ post, onLike, onDoubleLike, onSave, onComment, onOpen
                     }}
                 >
                     {post.images.map((src, i) => (
-                        isVideoUrl(src) ? (
+                        isVideoUrl(src) ? (!near ? (
+                            <div key={i} className="h-full w-full shrink-0 bg-black" />
+                        ) : (
                             <video
                                 key={i}
                                 ref={el => { vids.current[i] = el; }}
@@ -149,7 +163,7 @@ export function PostCard({ post, onLike, onDoubleLike, onSave, onComment, onOpen
                                 preload="metadata"
                                 className="h-full w-full shrink-0 object-cover"
                             />
-                        ) : (
+                        )) : (
                             <img key={i} src={src} alt={post.caption} draggable={false} loading="lazy" decoding="async" className="h-full w-full shrink-0 object-cover" />
                         )
                     ))}

--- a/web/src/shared/chat/ChatView.tsx
+++ b/web/src/shared/chat/ChatView.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ArrowUp, ChevronLeft, MapPin, Mic, Phone, UserPlus, Video, X } from 'lucide-react';
+import { ChevronLeft, MapPin, Mic, Phone, UserPlus, Video, X } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 import { device } from '@device';
 import { t } from '@/i18n';
 import { useTheme } from '@/stores/themeStore';
-import { useSessionState } from '@/hooks/useSessionState';
+import { Composer, type ComposerHandle } from './Composer';
 import { fetchNui, isFiveM } from '@/core/nui';
 import { apiData, failText } from '@/core/api';
 import { requestOpenMaps } from '@/shell/deeplink';
@@ -97,7 +97,6 @@ export function ChatView({ conv, totalUnread, contacts, myNumber, onBack, onSend
         return [...conv.messages, ...extra].sort((a, b) => a.ts - b.ts);
     }, [conv.messages, conv.id]);
 
-    const [draft,    setDraft]    = useSessionState(`messages:draft:${conv.id}`, '');
     const [panel,    setPanel]    = useState<Panel>(null);
     const [closing,  setClosing]  = useState(false);
     const [pickerId, setPickerId] = useState<string | null>(null);
@@ -119,6 +118,7 @@ export function ChatView({ conv, totalUnread, contacts, myNumber, onBack, onSend
     const [addingContact, setAddingContact] = useState(false);
     const listRef   = useRef<HTMLDivElement>(null);
     const inputRef  = useRef<HTMLInputElement>(null);
+    const composerRef = useRef<ComposerHandle>(null);
 
     useTapbackDismiss(pickerId, setPickerId);
 
@@ -218,21 +218,15 @@ export function ChatView({ conv, totalUnread, contacts, myNumber, onBack, onSend
         inputRef.current?.focus();
     }
 
-    function sendText() {
-        const text = draft.trim();
+    function sendText(text: string) {
         if (!text && attachments.length === 0) return;
         attachments.forEach(url => send({ kind: 'image', gifUrl: url, body: t('messages.photoPreview', '📷 Photo') }));
         if (text) send({ body: text, kind: 'text' });
-        setDraft('');
         setAttachments([]);
     }
 
     function removeAttachment(idx: number) {
         setAttachments(prev => prev.filter((_, i) => i !== idx));
-    }
-
-    function handleKey(e: React.KeyboardEvent) {
-        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendText(); }
     }
 
     const name = conv.groupName ?? conv.participants[0]?.name ?? t('messages.unknown', 'Unknown');
@@ -253,6 +247,7 @@ export function ChatView({ conv, totalUnread, contacts, myNumber, onBack, onSend
 
     const items = useMemo<RenderItem[]>(() => {
         const out: RenderItem[] = [];
+        const byId = new Map(conv.participants.map(p => [p.id, p]));
         messages.forEach((msg, i) => {
             const prev = messages[i - 1];
             const next = messages[i + 1];
@@ -260,7 +255,7 @@ export function ChatView({ conv, totalUnread, contacts, myNumber, onBack, onSend
                 out.push({ kind: 'separator', ts: msg.ts });
             }
             const isLast  = !next || next.from !== msg.from || next.ts - msg.ts > 60_000;
-            const contact = conv.participants.find(p => p.id === msg.from);
+            const contact = byId.get(msg.from);
             out.push({ kind: 'msg', msg, isLast, contact });
         });
         return out;
@@ -427,7 +422,7 @@ export function ChatView({ conv, totalUnread, contacts, myNumber, onBack, onSend
             <div className="relative shrink-0">
                 {panel === 'emoji' && (
                     <div className="absolute inset-x-0 bottom-full z-20">
-                        <EmojiPanel isDark={isDark} onSelect={e => setDraft(d => d + e)} />
+                        <EmojiPanel isDark={isDark} onSelect={e => composerRef.current?.append(e)} />
                     </div>
                 )}
 
@@ -466,32 +461,15 @@ export function ChatView({ conv, totalUnread, contacts, myNumber, onBack, onSend
                     </div>
                 )}
 
-                <div className="px-3 pb-2 pt-1.5">
-                    <div
-                        className={`flex items-center gap-1 rounded-[22px] bg-base py-[9px] pl-4 dark:bg-surface ${draft.trim() || attachments.length ? 'pr-[5px]' : 'pr-4'}`}
-                        style={{ boxShadow: `inset 0 0 0 var(--hairline-w, 1px) ${composerBdr}` }}
-                    >
-                        <input
-                            ref={inputRef}
-                            type="text"
-                            value={draft}
-                            onChange={e => setDraft(e.target.value)}
-                            onKeyDown={handleKey}
-                            onFocus={() => setPanel(null)}
-                            placeholder={t('messages.textMessagePlaceholder', 'Text Message')}
-                            className="min-w-0 flex-1 bg-transparent py-[5px] text-[18px] text-black dark:text-white placeholder-black/35 dark:placeholder-white/35 outline-none"
-                        />
-                        {(draft.trim() || attachments.length > 0) && (
-                            <button
-                                type="button"
-                                onClick={sendText}
-                                className="flex h-[33px] w-[33px] shrink-0 items-center justify-center rounded-full bg-ios-blue active:opacity-70"
-                            >
-                                <ArrowUp className="h-[19px] w-[19px] text-white" strokeWidth={2.75} />
-                            </button>
-                        )}
-                    </div>
-                </div>
+                <Composer
+                    ref={composerRef}
+                    convId={conv.id}
+                    inputRef={inputRef}
+                    hasAttachments={attachments.length > 0}
+                    borderColor={composerBdr}
+                    onFocus={() => setPanel(null)}
+                    onSendText={sendText}
+                />
 
                 <div
                     className="flex items-center justify-around px-4 pb-11 pt-2.5"

--- a/web/src/shared/chat/Composer.tsx
+++ b/web/src/shared/chat/Composer.tsx
@@ -1,0 +1,64 @@
+import { forwardRef, useImperativeHandle } from 'react';
+import type { KeyboardEvent, RefObject } from 'react';
+import { ArrowUp } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { useSessionState } from '@/hooks/useSessionState';
+
+export interface ComposerHandle {
+    append: (text: string) => void;
+}
+
+export const Composer = forwardRef<ComposerHandle, {
+    convId:         string;
+    inputRef:       RefObject<HTMLInputElement | null>;
+    hasAttachments: boolean;
+    borderColor:    string;
+    onFocus:        () => void;
+    onSendText:     (text: string) => void;
+}>(function Composer({ convId, inputRef, hasAttachments, borderColor, onFocus, onSendText }, ref) {
+    const [draft, setDraft] = useSessionState(`messages:draft:${convId}`, '');
+
+    useImperativeHandle(ref, () => ({ append: s => setDraft(d => d + s) }), [setDraft]);
+
+    const canSend = !!draft.trim() || hasAttachments;
+
+    function submit() {
+        if (!canSend) return;
+        onSendText(draft.trim());
+        setDraft('');
+    }
+
+    function handleKey(e: KeyboardEvent) {
+        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submit(); }
+    }
+
+    return (
+        <div className="px-3 pb-2 pt-1.5">
+            <div
+                className={`flex items-center gap-1 rounded-[22px] bg-base py-[9px] pl-4 dark:bg-surface ${canSend ? 'pr-[5px]' : 'pr-4'}`}
+                style={{ boxShadow: `inset 0 0 0 var(--hairline-w, 1px) ${borderColor}` }}
+            >
+                <input
+                    ref={inputRef}
+                    type="text"
+                    value={draft}
+                    onChange={e => setDraft(e.target.value)}
+                    onKeyDown={handleKey}
+                    onFocus={onFocus}
+                    placeholder={t('messages.textMessagePlaceholder', 'Text Message')}
+                    className="min-w-0 flex-1 bg-transparent py-[5px] text-[18px] text-black dark:text-white placeholder-black/35 dark:placeholder-white/35 outline-none"
+                />
+                {canSend && (
+                    <button
+                        type="button"
+                        onClick={submit}
+                        className="flex h-[33px] w-[33px] shrink-0 items-center justify-center rounded-full bg-ios-blue active:opacity-70"
+                    >
+                        <ArrowUp className="h-[19px] w-[19px] text-white" strokeWidth={2.75} />
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+});


### PR DESCRIPTION
## Summary

Two app-level costs from the performance audit.

- **Shared chat view.** The composer input now owns its draft in a small `Composer` component, so a keystroke re-renders the composer alone instead of rebuilding the whole message list. The emoji panel appends through an imperative handle. Participant lookup per message is a `Map` instead of a linear scan, so long group threads stop doing an O(n·m) walk on every change.
- **Photogram feed.** A post card mounts its `<video>` element only when the card is within about one and a half screens of the viewport, with a black placeholder otherwise, so a long feed no longer keeps a media pipeline alive per post. Autoplay and pause logic is unchanged.

Photo tile thumbnails were on the audit list but need a server-side thumbnail source that the upload pipeline does not produce today, so that item is left as a follow-up.

## Gates

- [x] `npm run build` (tsc + vite)
- [x] `npm run lint` (0 errors)
- [x] `npm run knip`
- [x] `npm run i18n:check`
- [x] local test suite (649 passed)

Not merged; awaiting review and an in-game check of sending a message with text, an attachment, and an emoji.