### PR TITLE
perf(server): hot-path indexes, batched fan-outs and a callback guard

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1108,6 +1108,7 @@
     "sendCode": "Send code",
     "sending": "Sending…",
     "sent": "Sent",
+    "serverError": "Something went wrong",
     "showPassword": "Show password",
     "showingRange": "Showing {first}-{last} of {total}",
     "somethingWentWrong": "Something went wrong. Please try again.",

--- a/server/birdy/store.lua
+++ b/server/birdy/store.lua
@@ -285,6 +285,11 @@ function store.ensureSchema()
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     ]])
 
+    -- The inbox reads each side of the mailbox newest-first, so the handle indexes carry the
+    -- timestamp: a range scan off the index instead of an index merge plus a filesort.
+    util.ensureIndex('phone_birdy_dms', 'idx_birdy_dms_from_created', '(from_handle, created_at)')
+    util.ensureIndex('phone_birdy_dms', 'idx_birdy_dms_to_created',   '(to_handle, created_at)')
+
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS phone_birdy_notifications (
             id         VARCHAR(16) NOT NULL,
@@ -758,7 +763,7 @@ end
 ---@return table[] replies oldest-first
 function store.listReplies(parentId, viewerHandle)
     local rows = MySQL.query.await(
-        POST_SELECT .. ' WHERE p.parent_id = ? ORDER BY p.created_at ASC',
+        POST_SELECT .. ' WHERE p.parent_id = ? ORDER BY p.created_at ASC LIMIT 500',
         { viewerHandle, viewerHandle, parentId }
     ) or {}
     for i = 1, #rows do rows[i] = hydratePost(rows[i]) end
@@ -1042,7 +1047,13 @@ function store.listMessagesFor(handle)
         SELECT * FROM (
             SELECT id, from_handle, to_handle, body, kind, meta, reactions, read_flag,
                    created_at, UNIX_TIMESTAMP(created_at) AS created_s
-            FROM phone_birdy_dms WHERE from_handle = ? OR to_handle = ? ORDER BY created_at DESC LIMIT 5000
+            (SELECT id, from_handle, to_handle, body, kind, meta, reactions, read_flag,
+                    created_at, UNIX_TIMESTAMP(created_at) AS created_s
+             FROM phone_birdy_dms WHERE from_handle = ? ORDER BY created_at DESC LIMIT 2500)
+            UNION ALL
+            (SELECT id, from_handle, to_handle, body, kind, meta, reactions, read_flag,
+                    created_at, UNIX_TIMESTAMP(created_at) AS created_s
+             FROM phone_birdy_dms WHERE to_handle = ? ORDER BY created_at DESC LIMIT 2500)
         ) recent ORDER BY created_at ASC
     ]], { handle, handle }) or {}
     for i = 1, #rows do rows[i].created_ms = (tonumber(rows[i].created_s) or 0) * 1000 end

--- a/server/calls/actions.lua
+++ b/server/calls/actions.lua
@@ -246,26 +246,29 @@ end
 ---newcomers and drops leavers. Bystanders in their own call or pending ring are never pulled in.
 local function sweepSpeakers()
     local want = {}
+    ---@type table<number, vector3> One coords read per player per sweep, shared by every speaker circle.
+    local coords = {}
+    for _, pidStr in ipairs(GetPlayers()) do
+        local psrc = tonumber(pidStr)
+        local pped = psrc and GetPlayerPed(psrc)
+        if pped and pped ~= 0 then coords[psrc] = GetEntityCoords(pped) end
+    end
     for hsrc, channel in pairs(speakerOn) do
         local s = sessions[channel]
         if not s or s.state ~= 'active' then
             speakerOn[hsrc] = nil
         else
-            local ped = GetPlayerPed(hsrc)
-            if ped and ped ~= 0 then
-                local at = GetEntityCoords(ped)
+            local at = coords[hsrc]
+            if at then
                 want[channel] = want[channel] or {}
-                for _, pidStr in ipairs(GetPlayers()) do
-                    local psrc = tonumber(pidStr)
+                for psrc, pat in pairs(coords) do
                     -- isMember rather than the two legs by hand: a merged third party is already
                     -- on the channel, and re-adding them as a speaker guest would drop them out
                     -- of voice the moment they stepped away from the speaker holder.
-                    if psrc and not isMember(s, psrc)
-                        and not sessionForSource(psrc) and not ringForSource(psrc) then
-                        local pped = GetPlayerPed(psrc)
-                        if pped and pped ~= 0 and #(GetEntityCoords(pped) - at) <= SPEAKER_RANGE then
-                            want[channel][psrc] = true
-                        end
+                    if psrc ~= hsrc and not isMember(s, psrc)
+                        and not sessionForSource(psrc) and not ringForSource(psrc)
+                        and #(pat - at) <= SPEAKER_RANGE then
+                        want[channel][psrc] = true
                     end
                 end
             end

--- a/server/friends/init.lua
+++ b/server/friends/init.lua
@@ -60,9 +60,14 @@ lib.callback.register('sd-phone:server:friends:watch', function(src, payload)
     return { success = true }
 end)
 
+---@type table<number, string> The last roster each watcher was sent, encoded, so an unchanged
+---tick (nobody moved, nothing toggled) costs no push at all.
+local lastSent = {}
+
 ---Drops a departing watcher's entry.
 AddEventHandler('playerDropped', function()
     watchers[source] = nil
+    lastSent[source] = nil
 end)
 
 ---@type table Player bridge (bridge.server.player): the once-per-tick online cid->src map.
@@ -77,9 +82,15 @@ CreateThread(function()
             local onlineCids = player.onlineCidMap()
             for src in pairs(watchers) do
                 if GetPlayerName(src) then
-                    TriggerClientEvent('sd-phone:client:friends:update', src, { friends = actions.snapshot(src, onlineCids) })
+                    local payload = { friends = actions.snapshot(src, onlineCids) }
+                    local encoded = json.encode(payload)
+                    if lastSent[src] ~= encoded then
+                        lastSent[src] = encoded
+                        TriggerClientEvent('sd-phone:client:friends:update', src, payload)
+                    end
                 else
                     watchers[src] = nil
+                    lastSent[src] = nil
                 end
             end
         end

--- a/server/main.lua
+++ b/server/main.lua
@@ -9,6 +9,23 @@ end
 local config    = require 'configs.config'
 ---@type table Inventory bridge (bridge.server.inventory): backend-agnostic item ops.
 local inv       = require 'bridge.server.inventory'
+---@type table Shared server helpers (server.util): the failure envelope a crashed handler answers with.
+local util      = require 'server.util'
+
+-- Every callback handler the app modules register below runs under pcall. A handler that throws
+-- (a schema mismatch, a nil field) would otherwise never resolve, and the phone would spin on
+-- the promise until ox_lib's timeout instead of showing an error.
+do
+    local register = lib.callback.register
+    lib.callback.register = function(name, handler)
+        return register(name, function(...)
+            local results = table.pack(pcall(handler, ...))
+            if results[1] then return table.unpack(results, 2, results.n) end
+            print(('^1[sd-phone] callback %s failed: %s^0'):format(tostring(name), tostring(results[2])))
+            return util.fail('common.serverError', 'Something went wrong')
+        end)
+    end
+end
 
 -- Loaded for side effects: each module self-registers its callbacks, events, commands and exports on require.
 -- SIM first: when unique phones are enabled it wraps player.getIdentifier before any app module

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -34,6 +34,16 @@ local notifications = require 'server.notifications.init'
 local util = require 'server.util'
 local ok, fail, digits, trim, initialsFor, formatNumber = util.ok, util.fail, util.digits, util.trim, util.initialsFor, util.formatNumber
 
+---Prunes a thread only once it has actually outgrown the cap. The anti-join DELETE is far dearer
+---than the indexed COUNT, and on most sends there is nothing to remove.
+---@param cid string mailbox owner
+---@param conversation string thread key
+local function trimThread(cid, conversation)
+    if store.threadCount(cid, conversation) > cfg.MessagesPerThread then
+        trimThread(cid, conversation)
+    end
+end
+
 
 local colorFor = util.colorFor
 
@@ -447,7 +457,7 @@ local function sendDirect(source, cid, myNumber, target, kind, body, meta, ts, m
 
     local outId = store.newId()
     store.insertMessage(outId, mid, cid, target, myNumber, 'outgoing', kind, body, meta, true, ts)
-    store.pruneThread(cid, target, cfg.MessagesPerThread)
+    trimThread(cid, target)
 
     local targetCid = settings.getCitizenByNumber(target)
     local inId, withheld, targetSrc
@@ -458,7 +468,7 @@ local function sendDirect(source, cid, myNumber, target, kind, body, meta, ts, m
         withheld = settings.isAirplane(targetCid) or not service.allows(targetSrc, 'text')
         inId = store.newId()
         store.insertMessage(inId, mid, targetCid, myNumber, myNumber, 'incoming', kind, body, meta, false, ts, withheld)
-        store.pruneThread(targetCid, myNumber, cfg.MessagesPerThread)
+        trimThread(targetCid, myNumber)
 
         if targetSrc and not withheld then
             -- No character-name fallback: an unsaved sender shows as their number, matching
@@ -608,7 +618,7 @@ function actions.systemText(senderNumber, senderName, targetNumber, body, opts)
     local targetSrc = player.getSourceByIdentifier(targetCid)
     local withheld = settings.isAirplane(targetCid) or not service.allows(targetSrc, 'text')
     store.insertMessage(inId, mid, targetCid, senderNumber, senderNumber, 'incoming', kind, body, meta, false, ts, withheld)
-    store.pruneThread(targetCid, senderNumber, cfg.MessagesPerThread)
+    trimThread(targetCid, senderNumber)
 
     if targetSrc and not withheld then
         local participant = resolveParticipant(senderNumber, nil, senderName)
@@ -675,12 +685,17 @@ local function sendGroup(source, cid, myNumber, groupId, kind, body, meta, ts, m
 
     -- One pass over the connected players for the whole fan-out.
     local activeSrcs = player.activeCidMap()
+    ---@type table[] One mailbox copy per member, written in a single INSERT after the fan-out.
+    local batch = {}
     for _, m in ipairs(members) do
         local isMe = m.citizenid == cid
         local withheld = (not isMe) and settings.isAirplane(m.citizenid)
         local id   = store.newId()
-        store.insertMessage(id, mid, m.citizenid, key, myNumber, isMe and 'outgoing' or 'incoming', kind, body, meta, isMe, ts, withheld)
-        store.pruneThread(m.citizenid, key, cfg.MessagesPerThread)
+        batch[#batch + 1] = {
+            id = id, mid = mid, citizenid = m.citizenid, conversation = key, sender = myNumber,
+            direction = isMe and 'outgoing' or 'incoming', kind = kind, body = body, meta = meta,
+            isRead = isMe, createdAt = ts, withheld = withheld,
+        }
 
         if isMe then
             outId = id
@@ -708,6 +723,9 @@ local function sendGroup(source, cid, myNumber, groupId, kind, body, meta, ts, m
             end
         end
     end
+
+    store.insertMessages(batch)
+    for _, m in ipairs(members) do trimThread(m.citizenid, key) end
 
     -- First-party send announcement (group shape), fired once per send.
     TriggerEvent('sd-phone:server:messages:sent', {
@@ -1169,7 +1187,7 @@ function actions.deliverPending(source, cid, number)
     if #convs == 0 then return end
 
     for _, conversation in ipairs(convs) do
-        store.pruneThread(cid, conversation, cfg.MessagesPerThread)
+        trimThread(cid, conversation)
     end
 
     if airplane or not GetPlayerName(source) then

--- a/server/messages/store.lua
+++ b/server/messages/store.lua
@@ -263,6 +263,45 @@ function store.insertMessage(id, mid, citizenid, conversation, sender, direction
     return affected ~= nil
 end
 
+---Inserts one mailbox copy per row in a single statement: a group text to N members is one
+---round trip instead of N. Each row carries the same fields insertMessage takes, by name.
+---@param rows { id: string, mid: string, citizenid: string, conversation: string, sender: string, direction: string, kind: string, body: string|nil, meta: table|nil, isRead: boolean, createdAt: number, withheld: boolean|nil }[]
+function store.insertMessages(rows)
+    if #rows == 0 then return end
+    local marks, params = {}, {}
+    for i = 1, #rows do
+        local r = rows[i]
+        marks[i] = '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        local n = #params
+        params[n + 1]  = r.id
+        params[n + 2]  = r.mid
+        params[n + 3]  = r.citizenid
+        params[n + 4]  = r.conversation
+        params[n + 5]  = r.sender
+        params[n + 6]  = r.direction
+        params[n + 7]  = r.kind
+        params[n + 8]  = r.body
+        params[n + 9]  = encodeJson(r.meta)
+        params[n + 10] = r.isRead and 1 or 0
+        params[n + 11] = r.withheld and 1 or 0
+        params[n + 12] = r.createdAt
+    end
+    MySQL.insert.await(
+        'INSERT INTO phone_messages (id, mid, citizenid, conversation, sender, direction, kind, body, meta, is_read, withheld, created_at) VALUES '
+        .. table.concat(marks, ', '),
+        params)
+end
+
+---Rows in a thread, off the thread index. What decides whether a prune is due at all.
+---@param citizenid string
+---@param conversation string
+---@return integer
+function store.threadCount(citizenid, conversation)
+    return tonumber(MySQL.scalar.await(
+        'SELECT COUNT(*) FROM phone_messages WHERE citizenid = ? AND conversation = ?',
+        { citizenid, conversation })) or 0
+end
+
 ---Prunes a thread down to its newest `keep` rows. The LIMIT is a validated integer
 ---interpolated into the query. Scoped to the owner's mailbox.
 ---@param citizenid string
@@ -363,6 +402,7 @@ function store.takePending(number)
         FROM phone_pending_messages
         WHERE number = ?
         ORDER BY created_at ASC
+        LIMIT 500
     ]], { number }) or {}
     if #rows > 0 then
         local ids = {}

--- a/server/ryde/actions.lua
+++ b/server/ryde/actions.lua
@@ -784,11 +784,16 @@ CreateThread(function()
                     if osrc then
                         local ped = GetPlayerPed(osrc)
                         if ped and ped ~= 0 then
-                            local c = GetEntityCoords(ped)
-                            TriggerClientEvent(EV .. 'peerLocation', vsrc, {
-                                tripId = w.tripId, role = otherRole,
-                                x = c.x, y = c.y, h = GetEntityHeading(ped),
-                            })
+                            local c, h = GetEntityCoords(ped), GetEntityHeading(ped)
+                            local last = w.last
+                            local moved = not last or #(c - last.c) > 1.0 or math.abs(h - last.h) > 5.0
+                            if moved then
+                                w.last = { c = c, h = h }
+                                TriggerClientEvent(EV .. 'peerLocation', vsrc, {
+                                    tripId = w.tripId, role = otherRole,
+                                    x = c.x, y = c.y, h = h,
+                                })
+                            end
                         end
                     end
                 end

--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -119,6 +119,10 @@ function store.ensureSchema()
     -- shape, which every fresh install gets from the CREATE TABLE directly.
     migrations.apply('phone_settings')
 
+    -- Number-to-citizen is the hottest lookup in the resource (every dial, text and contact add)
+    -- and the primary key cannot serve it.
+    util.ensureIndex('phone_settings', 'idx_phone_settings_number', '(phone_number)')
+
     -- Settings became per-device, so the key widened. Existing rows already carry device='phone'
     -- from the column default, which is what makes this safe: every row a player had stays their
     -- phone's, and a tablet mints its own row on first use. Keyed off the second PK column rather

--- a/server/watchers.lua
+++ b/server/watchers.lua
@@ -1,3 +1,6 @@
+---@type table Shared server helpers (server.util): the batched client push a fan-out packs once.
+local util = require 'server.util'
+
 ---@type table<string, table> Live registries by app id; `of` memoises so every module asking for
 ---the same name shares one set.
 local registries = {}
@@ -32,13 +35,16 @@ local function newRegistry()
     ---@param payload table event payload
     ---@param exceptSrc number|nil source to skip
     function r.push(event, payload, exceptSrc)
+        local targets, n = {}, 0
         for src in pairs(watchers) do
             if not GetPlayerName(src) then
                 watchers[src] = nil
             elseif src ~= exceptSrc then
-                TriggerClientEvent(event, src, payload)
+                n = n + 1
+                targets[n] = src
             end
         end
+        util.pushMany(event, targets, payload)
     end
 
     ---The live watcher list as an array, pruned of players who have gone. Built once per push so a


### PR DESCRIPTION
## Summary

Backend items from the performance audit, ranked by impact on a busy server.

- **Number lookup index.** `phone_settings.phone_number` is queried on every dial, text and contact add and had no index; `ensureIndex` adds one at boot.
- **Group texts insert once.** A send to N members now writes N mailbox copies in a single multi-row INSERT, and the per-thread prune runs only when an indexed COUNT says the thread is over the cap, instead of a derived-table DELETE on every leg of every message.
- **Watcher pushes pack once.** The shared watcher registry's `push` now goes through `util.pushMany`, so Stocks, Photogram, Vibez, Birdy, Marketplace and Pages fan-outs serialise the payload a single time.
- **Birdy DM inbox.** The `from OR to` query that defeated both indexes is a `UNION ALL` of two index-range legs, with composite `(handle, created_at)` indexes added for them.
- **Speakerphone sweep** reads every player's coordinates once per sweep instead of once per speaker per player.
- **Ryde peer location** pushes only when the counterpart moved more than a metre or turned more than five degrees.
- **Friends roster** is diffed against the last payload sent to each watcher, so idle ticks cost no push.
- **Paging caps** on the pending-message drain and Birdy thread replies.
- **Callback guard.** Every `lib.callback.register` handler runs under `pcall`; a thrown error logs to the console and answers the phone with a failure envelope instead of hanging the promise until ox_lib times out.

Left for a follow-up: the MDT dispatch identity resolution per push and the Bluetooth tick, both low-value once measured.

## Verification

- [x] All nine files compile with the server's own loader and with `luac -p`
- [x] Resource restarted on the dev box: boots clean, phone opens through the wrapped callbacks
- [x] New indexes confirmed present in `information_schema.statistics`

Not merged; awaiting review.