### PR TITLE
ui: shared spacer and spinner primitives, one status-bar height, red token

### DIFF
--- a/web/src/apps/_classifieds/CreateEntryPage.tsx
+++ b/web/src/apps/_classifieds/CreateEntryPage.tsx
@@ -8,6 +8,7 @@ import { useSessionState, clearSessionState } from '@/hooks/useSessionState';
 import { ContactFields } from './ContactFields';
 import type { ClassifiedDraft, ClassifiedItem } from './types';
 import { t } from '@/i18n';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function CreateEntryPage({ pageTitle = t('classifieds.newPost', 'New Post'), backLabel, bodyPlaceholder = t('classifieds.yourPost', 'Your post'), submitLabel = t('classifieds.post', 'Post'), showPrice = true, initial, draftKey, animateIn = true, onCancel, onCreate }: {
     pageTitle?: string;
@@ -73,7 +74,7 @@ export function CreateEntryPage({ pageTitle = t('classifieds.newPost', 'New Post
                     willChange: 'transform',
                 }}
             >
-                <div className="h-[58px] shrink-0" aria-hidden />
+                <StatusBarSpacer />
 
                 <div className="flex h-11 shrink-0 items-center justify-between px-2">
                     <button type="button" onClick={cancel} className="flex items-center gap-0.5 text-[17px] text-ios-blue active:opacity-60">

--- a/web/src/apps/_classifieds/ListingDetail.tsx
+++ b/web/src/apps/_classifieds/ListingDetail.tsx
@@ -8,6 +8,7 @@ import { Scroller } from '@/ui/Scroller';
 import { MailGlyph, MessageGlyph, PhoneGlyph } from '@/shell/AppGlyphs';
 import { fmtPrice, type ClassifiedItem } from './types';
 import { t } from '@/i18n';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function ListingDetail({ item, backLabel, itemNoun = t('classifieds.post', 'Post'), onBack, onMessage, onCall, onEmail, onEdit, onDelete, animateIn = true }: {
     item:      ClassifiedItem;
@@ -84,7 +85,7 @@ export function ListingDetail({ item, backLabel, itemNoun = t('classifieds.post'
                 willChange: 'transform',
             }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex h-11 shrink-0 items-center px-2">
                 <button type="button" onClick={() => dismiss(onBack)} className="flex items-center gap-0.5 text-[17px] text-ios-blue active:opacity-60">

--- a/web/src/apps/appstore/AppDetail.tsx
+++ b/web/src/apps/appstore/AppDetail.tsx
@@ -117,7 +117,7 @@ export function AppDetail({ app, desc, installed, downloadProgress, onBack, onIn
 
 function InfoRow({ label, value, last }: { label: string; value: string; last?: boolean }) {
     return (
-        <div className={`flex items-center justify-between gap-4 py-3.5 ${last ? '' : 'border-b border-black/10 dark:border-white/10'}`}>
+        <div className={`flex items-center justify-between gap-4 py-3.5 ${last ? '' : 'border-b border-hairline/10'}`}>
             <span className="shrink-0 text-[18px] text-black/55 dark:text-white/55">{label}</span>
             <span className="truncate text-right text-[18px] font-medium text-black dark:text-white">{value}</span>
         </div>

--- a/web/src/apps/appstore/AppDetail.tsx
+++ b/web/src/apps/appstore/AppDetail.tsx
@@ -6,6 +6,7 @@ import { CircularProgress } from '@/ui/CircularProgress';
 import { getCustomApp } from '@/stores/customAppsStore';
 import { t, appLabel } from '@/i18n';
 import type { AppDef } from '@/core/types';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const HEAVY = new Set(['cookie', 'wordle', 'flappy', 'blocks', 'casino', 'climber', 'connectfour', 'photogram', 'vibez', 'cherry', 'birdy', 'camera', 'maps', 'music', 'weazelnews', 'streaks']);
 const LIGHT = new Set(['calculator', 'notes', 'clock', 'weather', 'voicememos', 'settings', 'calendar']);
@@ -52,7 +53,7 @@ export function AppDetail({ app, desc, installed, downloadProgress, onBack, onIn
             }}
             onTransitionEnd={() => { if (!shown) onBack(); }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center px-3 pb-1">
                 <button type="button" onClick={() => setShown(false)} className="flex items-center text-ios-blue active:opacity-60">

--- a/web/src/apps/appstore/AppStore.tsx
+++ b/web/src/apps/appstore/AppStore.tsx
@@ -15,6 +15,7 @@ import { AppDetail } from './AppDetail';
 import { getCustomApp } from '@/stores/customAppsStore';
 import { t, appLabel } from '@/i18n';
 import type { AppDef } from '@/core/types';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 function getDescriptions(): Record<string, string> {
     return {
@@ -129,7 +130,7 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <h1 className="px-5 pb-2 pt-1 text-[32px] font-bold tracking-tight text-black dark:text-white">{t('appstore.title', 'Apps')}</h1>
 

--- a/web/src/apps/appstore/AppStore.tsx
+++ b/web/src/apps/appstore/AppStore.tsx
@@ -159,7 +159,7 @@ export function AppStore({ onClose: _onClose, apps, installed, onInstall, onOpen
                             const isQueued = status === 'queued';
                             const locked = !isInstalled && lockedNetwork(a) !== null;
                             return (
-                                <div key={a.id} className={`flex items-center gap-3.5 py-2.5 pl-3.5 ${i < list.length - 1 ? 'border-b border-black/10 dark:border-white/10' : ''}`}>
+                                <div key={a.id} className={`flex items-center gap-3.5 py-2.5 pl-3.5 ${i < list.length - 1 ? 'border-b border-hairline/10' : ''}`}>
                                     <button type="button" onClick={() => setSelectedId(a.id)} aria-label={t('appstore.appDetails', '{label} details', { label: appLabel(a) })} className="shrink-0 active:opacity-60">
                                         <StoreIcon icon={a.icon} />
                                     </button>

--- a/web/src/apps/banking/AllTransactions.tsx
+++ b/web/src/apps/banking/AllTransactions.tsx
@@ -5,6 +5,7 @@ import { useIosPush } from '@/hooks/useIosPush';
 import { t } from '@/i18n';
 import { groupTx, type BankTx } from './bankingApi';
 import { TxRows, fmtAmount } from './TxRow';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function AllTransactions({ transactions, onBack, onSelectTx }: { transactions: BankTx[]; onBack: () => void; onSelectTx?: (tx: BankTx) => void }) {
     const { goBack, pageStyle } = useIosPush(onBack);
@@ -15,7 +16,7 @@ export function AllTransactions({ transactions, onBack, onSelectTx }: { transact
 
     return (
         <div className="absolute inset-0 z-20 flex flex-col bg-base text-black dark:text-white" style={pageStyle}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="px-2 pb-0.5">
                 <button type="button" onClick={goBack} className="flex items-center gap-0.5 text-ios-blue active:opacity-60">
@@ -34,7 +35,7 @@ export function AllTransactions({ transactions, onBack, onSelectTx }: { transact
                         <div className="flex items-baseline justify-between px-1 pb-2 pt-1">
                             <span className="text-[17px] font-semibold">{day.label}</span>
                             <span className={`text-[17px] font-semibold tabular-nums ${
-                                day.total > 0 ? 'text-[#34c759]' : day.total < 0 ? 'text-[#ff3b30]' : 'text-black/45 dark:text-white/45'
+                                day.total > 0 ? 'text-[#34c759]' : day.total < 0 ? 'text-ios-red' : 'text-black/45 dark:text-white/45'
                             }`}>
                                 {fmtAmount(day.total)}
                             </span>

--- a/web/src/apps/banking/Banking.tsx
+++ b/web/src/apps/banking/Banking.tsx
@@ -22,6 +22,7 @@ import { resolveStyle, type CardStyle } from './bankBrands';
 import { TxRows } from './TxRow';
 import { InvoicesTab } from './InvoicesTab';
 import { TabBar, type TabBarItem } from '@/ui/TabBar';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type BankingTab = 'home' | 'invoices';
 
@@ -101,7 +102,7 @@ export function Banking({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 z-10 flex flex-col bg-base text-black dark:text-white">
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             {tab === 'invoices' ? (
                 <div key="invoices" className="flex min-h-0 flex-1 flex-col animate-swipe-in-left">

--- a/web/src/apps/banking/InvoicesTab.tsx
+++ b/web/src/apps/banking/InvoicesTab.tsx
@@ -118,7 +118,7 @@ export function InvoicesTab({ received, receivedLoading, onRefetchReceived, onPa
                             const card = contactByNumber.get(digits(inv.toNumber));
                             return (
                             <div key={inv.id}>
-                                {i > 0 && <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+                                {i > 0 && <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />}
                                 <div className="flex items-center gap-3.5 px-4 py-4">
                                     {card ? <ContactAvatar contact={card} size={46} /> : <PlaceholderAvatar size={46} />}
                                     <div className="min-w-0 flex-1">

--- a/web/src/apps/banking/NewInvoicePage.tsx
+++ b/web/src/apps/banking/NewInvoicePage.tsx
@@ -10,6 +10,7 @@ import { digits } from '@/lib/format';
 import { formatPhonePartial } from '@/lib/phone';
 import { createPersonalInvoice, type PersonalInvoice } from './bankingApi';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const DRAFT_KEY = 'banking:newInvoice';
 
@@ -71,7 +72,7 @@ export function NewInvoicePage({ onClose, onSent }: {
                     willChange: 'transform',
                 }}
             >
-                <div className="h-[58px] shrink-0" aria-hidden />
+                <StatusBarSpacer />
 
                 <div className="flex h-11 shrink-0 items-center justify-between px-2">
                     <button type="button" onClick={cancel} className="flex items-center gap-0.5 text-[17px] text-ios-blue active:opacity-60">

--- a/web/src/apps/banking/ReceivedInvoices.tsx
+++ b/web/src/apps/banking/ReceivedInvoices.tsx
@@ -60,7 +60,7 @@ export function ReceivedInvoices({ invoices, loading, onRefetch, onPaid, contact
             <div className="overflow-hidden rounded-[16px] bg-surface">
                 {invoices.map((inv, i) => (
                     <div key={inv.id}>
-                        {i > 0 && <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+                        {i > 0 && <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />}
                         <div className="flex items-center gap-3.5 px-4 py-4">
                             {inv.personal ? (
                                 cardOf(inv)

--- a/web/src/apps/banking/SendMoney.tsx
+++ b/web/src/apps/banking/SendMoney.tsx
@@ -11,6 +11,7 @@ import { AlertDialog } from '@/ui/AlertDialog';
 import { formatPhonePartial } from '@/lib/phone';
 import { sendMoney, sendTarget, type BankTx, type SendMode, type SendTarget } from './bankingApi';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const MAX_ID_DIGITS = 5;
 
@@ -66,7 +67,7 @@ export function SendMoney({ balance, allowAnonymous = false, onClose, onSent }: 
             className="absolute inset-0 z-30 flex flex-col bg-base font-sf"
             style={pageStyle}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex h-11 shrink-0 items-center justify-between px-3">
                 <button
@@ -200,7 +201,7 @@ function AmountStage({ balance, target, toLabel, amount, setAmount, anon, setAno
             className="absolute inset-0 z-10 flex flex-col bg-base font-sf"
             style={pageStyle}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex h-11 shrink-0 items-center justify-between px-3">
                 <button

--- a/web/src/apps/banking/TxRow.tsx
+++ b/web/src/apps/banking/TxRow.tsx
@@ -66,7 +66,7 @@ export function TxRows({ items, onSelect }: { items: BankTx[]; onSelect?: (tx: B
                     <div style={ROW_BOX}>
                         <TxRow tx={tx} onSelect={onSelect} hideAmount={hideAmount} />
                     </div>
-                    {i < items.length - 1 && <div className="pointer-events-none h-[0.5px] bg-black/15 dark:bg-white/15" />}
+                    {i < items.length - 1 && <div className="pointer-events-none h-[0.5px] bg-hairline/15" />}
                 </Fragment>
             ))}
         </div>

--- a/web/src/apps/birdy/Birdy.tsx
+++ b/web/src/apps/birdy/Birdy.tsx
@@ -30,6 +30,7 @@ import { Notifications } from './discover/Notifications';
 import { PostDetail } from './feed/PostDetail';
 import { Profile } from './profile/Profile';
 import { Search } from './discover/Search';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type Tab = 'home' | 'search' | 'notifications' | 'messages';
 
@@ -320,7 +321,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
         <Push onClose={() => setOpenPostId(null)} z={postOverProfile ? 30 : 20} animateIn={animateNav}>
             {close => (
                 <div className="flex h-full flex-col">
-                    <div className="h-[54px] shrink-0" aria-hidden />
+                    <StatusBarSpacer />
                     <div className="min-h-0 flex-1">
                         {openPost
                             ? (
@@ -465,7 +466,7 @@ export function Birdy({ onClose }: { onClose: () => void }) {
                     />
                 ) : (
                     <div className="absolute inset-0 z-20 flex flex-col" style={{ background: BG }}>
-                        <div className="h-[58px] shrink-0" aria-hidden />
+                        <StatusBarSpacer />
                         <div className="flex shrink-0 items-center px-2 pb-3">
                             <button type="button" onClick={() => setOpenConvoId(null)} aria-label={t('squawk.back', 'Back')} className="active:opacity-60" style={{ color: BLUE }}>
                                 <ChevronLeft className="h-[38px] w-[38px]" strokeWidth={2.4} />

--- a/web/src/apps/birdy/dms/ChatView.tsx
+++ b/web/src/apps/birdy/dms/ChatView.tsx
@@ -25,6 +25,7 @@ import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { warmPhotos, apiSavePhotoFromUrl } from '@/core/photosApi';
 import { BG, BLUE, CARD, LINE, PILL, type BirdyConversation, type BirdyMessage } from '../data';
 import { Avatar } from '../ui';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type Panel = 'emoji' | 'money' | 'voice' | null;
 
@@ -177,7 +178,7 @@ export function ChatView({ convo, onBack, onSend, onReact, onPayRequest, animate
             }}
             onAnimationEnd={e => { if (e.target === e.currentTarget && closing) onBack(); }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="shrink-0">
                 <div className="flex items-center gap-2 px-2 pb-3">

--- a/web/src/apps/birdy/feed/Composer.tsx
+++ b/web/src/apps/birdy/feed/Composer.tsx
@@ -10,6 +10,7 @@ import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { BG, BLUE, LINE, MAX_POST_LENGTH } from '../data';
 import { Avatar } from '../ui';
 import type { BirdyAuthor } from '../data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const MAX_IMAGES = 3;
 
@@ -78,7 +79,7 @@ export function Composer({ me, onClose, onPost }: {
                 boxShadow: '0 -8px 30px rgba(0,0,0,0.18)',
             }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <header className="flex items-center justify-between px-4 py-2.5">
                 <button type="button" onClick={requestClose} className="text-[16px]" style={{ color: BLUE }}>

--- a/web/src/apps/birdy/profile/EditProfile.tsx
+++ b/web/src/apps/birdy/profile/EditProfile.tsx
@@ -11,6 +11,7 @@ import { ChangePasswordPage } from '@/shared/ChangePasswordPage';
 import { AVATAR_EMPTY, BG, BLUE, CARD, LINE_STRONG, META, TEXT, type BirdyProfile } from '../data';
 import { VerifiedBadge } from '../ui';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const RED = '#ff3b30';
 
@@ -86,7 +87,7 @@ export function EditProfile({ profile, onCancel, onSaved, onSignOut, onSignOutAl
                 willChange: 'transform',
             }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <header className="flex items-center justify-between px-4 py-2.5">
                 <button type="button" onClick={() => dismiss(onCancel)} className="text-[17px]" style={{ color: BLUE }}>{t('squawk.cancel', 'Cancel')}</button>
                 <div className="text-[17px] font-semibold">{t('squawk.editProfile', 'Edit profile')}</div>

--- a/web/src/apps/birdy/profile/FollowList.tsx
+++ b/web/src/apps/birdy/profile/FollowList.tsx
@@ -8,6 +8,7 @@ import { useIosPush } from '@/hooks/useIosPush';
 import { apiFollowList, apiToggleFollow } from '../birdyApi';
 import { BG, BLUE, LINE_STRONG, META, PILL, TEXT, type BirdyFollowUser } from '../data';
 import { Avatar, RichText, VerifiedBadge } from '../ui';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function FollowList({ kind, handle, onBack }: {
     kind:    'followers' | 'following';
@@ -19,7 +20,7 @@ export function FollowList({ kind, handle, onBack }: {
 
     return (
         <div className="absolute inset-0 z-20 flex flex-col" style={{ background: BG, ...pageStyle }}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <header className="flex shrink-0 items-center border-b border-hairline/10 px-2 pb-2.5 pt-2">
                 <button type="button" onClick={goBack} aria-label={t('squawk.back', 'Back')} className="flex h-9 w-9 items-center justify-center text-label active:opacity-60">
                     <ArrowLeft className="h-6 w-6" strokeWidth={2.2} />

--- a/web/src/apps/camera/Camera.tsx
+++ b/web/src/apps/camera/Camera.tsx
@@ -712,7 +712,7 @@ export function Camera({ onClose, onLandscapeChange, onOpenApp, photoOnly = fals
 
                 {recording && (
                     <div className="absolute left-1/2 top-3 z-30 flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-black/55 px-2.5 py-1 backdrop-blur">
-                        <span className="h-2 w-2 rounded-full bg-[#ff3b30] motion-safe:animate-pulse" />
+                        <span className="h-2 w-2 rounded-full bg-ios-red motion-safe:animate-pulse" />
                         <span className="text-[12px] font-semibold tabular-nums text-white">{formatDuration(recSecs)}</span>
                     </div>
                 )}
@@ -899,8 +899,8 @@ export function Camera({ onClose, onLandscapeChange, onOpenApp, photoOnly = fals
                             <span
                                 className={
                                     recording
-                                        ? 'block h-[26px] w-[26px] rounded-[7px] bg-[#ff3b30] transition-all duration-150'
-                                        : 'block h-[61px] w-[61px] rounded-full bg-[#ff3b30] transition-all duration-150 group-active:scale-90'
+                                        ? 'block h-[26px] w-[26px] rounded-[7px] bg-ios-red transition-all duration-150'
+                                        : 'block h-[61px] w-[61px] rounded-full bg-ios-red transition-all duration-150 group-active:scale-90'
                                 }
                             />
                         ) : (

--- a/web/src/apps/cherry/Cherry.tsx
+++ b/web/src/apps/cherry/Cherry.tsx
@@ -28,6 +28,7 @@ import { MatchOverlay, SwipeDeck } from './SwipeDeck';
 import { EditProfile } from './EditProfile';
 import { Matches } from './Matches';
 import { MatchChat } from './MatchChat';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type View = 'deck' | 'profile' | 'matches' | { chatId: string };
 
@@ -322,7 +323,7 @@ export function Cherry({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className={`absolute inset-0 flex flex-col bg-[#e5e5e5] font-sf ${justAuthed ? 'animate-swipe-in-left' : ''}`}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex shrink-0 items-center justify-between px-6 pb-6 pt-3">
                 <button type="button" aria-label={t('cherry.yourProfile', 'Your profile')} onClick={() => setView('profile')}

--- a/web/src/apps/cherry/EditProfile.tsx
+++ b/web/src/apps/cherry/EditProfile.tsx
@@ -10,6 +10,7 @@ import { Toggle } from '@/ui/Toggle';
 import { portalToPhoneScreen } from '@/ui/portal';
 import { cherryBlockedList, cherryUnblock, type BlockedEntry } from './cherryApi';
 import { CHERRY, type Gender, type InterestedIn, type MyProfile } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const MAX_PHOTOS = 6;
 
@@ -306,7 +307,7 @@ function BlockedSheet({ onClose }: { onClose: () => void }) {
                 willChange: 'transform',
             }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="flex shrink-0 items-center justify-between px-5 pb-3 pt-1">
                 <h2 className="text-[26px] font-bold tracking-tight text-black">{t('cherry.blocked', 'Blocked')}</h2>
                 <button

--- a/web/src/apps/cherry/MatchChat.tsx
+++ b/web/src/apps/cherry/MatchChat.tsx
@@ -25,6 +25,7 @@ import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { warmPhotos, apiSavePhotoFromUrl } from '@/core/photosApi';
 import { GenderBadge } from './GenderBadge';
 import { CHERRY, type Match, type MatchPartner, msgPreview } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type Panel = 'emoji' | 'money' | 'voice' | null;
 
@@ -151,7 +152,7 @@ export function MatchChat({ match, onBack, onSend, onReact, onPayRequest, onUnma
                 if (e.target === e.currentTarget && closing) onBack();
             }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="shrink-0">
                 <div className="flex items-center gap-2 px-2 pb-3">

--- a/web/src/apps/clock/Alarms.tsx
+++ b/web/src/apps/clock/Alarms.tsx
@@ -106,7 +106,7 @@ function AlarmCard({ alarm, editing, onToggle, onRemove, onEdit, hour24 }: {
                     type="button"
                     aria-label={t('clock.deleteAlarmAria', 'Delete {time} alarm', { time: `${time.hhmm}${time.ampm ? ' ' + time.ampm : ''}` })}
                     onClick={onRemove}
-                    className="flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full bg-[#ff3b30] active:opacity-70"
+                    className="flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full bg-ios-red active:opacity-70"
                 >
                     <Minus className="h-[19px] w-[19px] text-white" strokeWidth={3} />
                 </button>

--- a/web/src/apps/darkchat/DarkChat.tsx
+++ b/web/src/apps/darkchat/DarkChat.tsx
@@ -14,6 +14,7 @@ import { RoomView } from './RoomView';
 import { CreateRoomSheet } from './CreateRoomSheet';
 import { JoinCodeSheet } from './JoinCodeSheet';
 import { NicknameSheet } from './NicknameSheet';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type SheetKind = 'create' | 'join' | 'nickname' | null;
 
@@ -268,7 +269,7 @@ export function DarkChat({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="dark absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <RoomsList
                 publicRooms={publicRooms}

--- a/web/src/apps/darkchat/RoomView.tsx
+++ b/web/src/apps/darkchat/RoomView.tsx
@@ -16,6 +16,7 @@ import { apiSavePhotoFromUrl } from '@/core/photosApi';
 import { Composer } from './Composer';
 import { RoomSettingsSheet } from './RoomSettingsSheet';
 import { toBubbleMsg, type ChatMessage, type DarkChatDraft, type Room } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function RoomView({ room, nickname, onBack, onSend, onReact, onLeave, onMemberRemoved, onCodeChanged, animateIn = true }: {
     room:     Room;
@@ -85,7 +86,7 @@ export function RoomView({ room, nickname, onBack, onSend, onReact, onLeave, onM
             className="dark absolute inset-0 z-20 flex flex-col bg-base"
             style={{ ...pageStyle, willChange: 'transform' }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <header className="relative flex shrink-0 items-center justify-between border-b border-white/10 px-3 pb-2.5 pt-[15px]">
                 <button type="button" onClick={goBack} aria-label={t('darkchat.back', 'Back')} className="z-10 text-ios-blue active:opacity-60">

--- a/web/src/apps/documents/Browse.tsx
+++ b/web/src/apps/documents/Browse.tsx
@@ -13,6 +13,7 @@ import { SearchBar } from '@/ui/SearchBar';
 import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { FileRow, FolderRow } from './DocRow';
 import { childDocs, childFolders, countChildren, MAX_NAME_LENGTH, type DocFile, type DocFolder, type DocList } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
     list:           DocList;
@@ -56,7 +57,7 @@ function FolderView({ folderId, title, backLabel, list, onBack, onOpenFolder, on
             className="absolute inset-0 z-10 flex flex-col bg-base text-black dark:text-white"
             style={pageStyle}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             {onBack && (
                 <div className="flex items-center justify-between px-2 pt-1">

--- a/web/src/apps/documents/Recents.tsx
+++ b/web/src/apps/documents/Recents.tsx
@@ -7,6 +7,7 @@ import { GroupCard } from '@/ui/ListGroup';
 import { SearchBar } from '@/ui/SearchBar';
 import { FileRow } from './DocRow';
 import { RECENTS_LIMIT, type DocFile, type DocList } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
     list:      DocList;
@@ -26,7 +27,7 @@ export function Recents({ list, onOpenDoc, onMoreDoc }: Props) {
 
     return (
         <div className="absolute inset-0 z-10 flex flex-col bg-base text-black dark:text-white">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="px-4 pt-1">
                 <h1 className="text-[34px] font-bold tracking-tight">{t('documents.recents', 'Recents')}</h1>

--- a/web/src/apps/documents/SignRequestLayer.tsx
+++ b/web/src/apps/documents/SignRequestLayer.tsx
@@ -5,6 +5,7 @@ import { t } from '@/i18n';
 import { respondSignRequestApi } from './documentsApi';
 import { RichBody, SignatureBlock, SignSheet } from './TextEditor';
 import type { DocFile } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export interface SignRequestData {
     requestId: string;
@@ -41,7 +42,7 @@ export function SignRequestLayer({ request, onDone }: {
                 ? 'ios-sheet-down 0.26s cubic-bezier(0.32,0,0.68,1) forwards'
                 : 'ios-sheet-up 0.34s cubic-bezier(0.32,0.72,0,1)' }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="shrink-0 px-5 pb-2 pt-2 text-center">
                 <div className="text-[15px] font-semibold text-ios-gray">

--- a/web/src/apps/documents/TextEditor.tsx
+++ b/web/src/apps/documents/TextEditor.tsx
@@ -10,6 +10,7 @@ import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { apiGetSignature, apiSetSignature, apiSignDoc } from './documentsApi';
 import { SignaturePad, renderTypedSignature, signatureStyles, type SignaturePadHandle } from './SignaturePad';
 import { MAX_TEXT_LENGTH, formatDocDate, type DocFile, type DocSignature } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
     doc:       DocFile;
@@ -111,7 +112,7 @@ export function TextEditor({ doc, backLabel, onBack, onSave, onSigned, animateIn
             className="absolute inset-0 z-30 flex flex-col bg-base text-black dark:text-white"
             style={pageStyle}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center gap-2 px-2 pb-1 pt-3">
                 <button

--- a/web/src/apps/garages/Garages.tsx
+++ b/web/src/apps/garages/Garages.tsx
@@ -14,6 +14,7 @@ import { useSessionState } from '@/hooks/useSessionState';
 import { VEHICLES, type ValetInfo, type Vehicle, type VehicleStatus } from './data';
 import { t } from '@/i18n';
 import { Pill, type PillTone } from '@/ui/Pill';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const ACCENTS = ['#FF3B30', '#0A84FF', '#30B0C7', '#FF9500', '#5E5CE6', '#34C759', '#AF52DE', '#FF2D55'];
 
@@ -86,7 +87,7 @@ export function Garages({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="px-5 pb-2 pt-1">
                 <div className="flex items-center justify-between">
@@ -291,7 +292,7 @@ function VehicleDetail({ v, showImages, valet, onBack, onDelivered, animateIn = 
 
     return (
         <div className="absolute inset-0 z-20 flex flex-col bg-base font-sf" style={pageStyle}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <NavBar backLabel={t('garages.title', 'Garages')} onBack={goBack} />
 

--- a/web/src/apps/groups/GroupsList.tsx
+++ b/web/src/apps/groups/GroupsList.tsx
@@ -8,6 +8,7 @@ import { t } from '@/i18n';
 import { initialsFor } from './data';
 import type { Group, Invite } from './data';
 import { Pill } from '@/ui/Pill';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
     groups:          Group[];
@@ -43,7 +44,7 @@ export function GroupsList({
     return (
         <div className="absolute inset-0 flex flex-col bg-base text-black dark:text-white">
 
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center justify-between px-5 pb-2 pt-0.5">
                 <h1 className="text-[34px] font-bold tracking-tight text-black dark:text-white">{t('groups.groups', 'Groups')}</h1>

--- a/web/src/apps/homes/Homes.tsx
+++ b/web/src/apps/homes/Homes.tsx
@@ -14,6 +14,7 @@ import { NavBar } from '@/ui/NavBar';
 import { HOMES, DEV_CAPS, type Home, type HomesCaps, type KeyHolder } from './data';
 import { t } from '@/i18n';
 import { Pill } from '@/ui/Pill';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const ACCENTS = ['#5E5CE6', '#0A84FF', '#30B0C7', '#FF9500', '#34C759', '#FF3B30', '#AF52DE', '#FF2D55'];
 
@@ -49,7 +50,7 @@ export function Homes({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="px-5 pb-2 pt-1">
                 <h1 className="text-[32px] font-bold tracking-tight text-black dark:text-white">{t('homes.title','Homes')}</h1>
@@ -163,7 +164,7 @@ function HomeDetail({ h, caps, onBack, animateIn = true }: { h: Home; caps: Home
 
     return (
         <div className="absolute inset-0 z-20 flex flex-col bg-base font-sf" style={pageStyle}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <NavBar backLabel={t('homes.backHomes','Homes')} onBack={goBack} />
 

--- a/web/src/apps/id/CardDetail.tsx
+++ b/web/src/apps/id/CardDetail.tsx
@@ -9,6 +9,7 @@ import { IdCard } from './IdCard';
 import { DetailsList } from './DetailsList';
 import { idShare } from './idApi';
 import { cardTitle, formatCountdown, type IdCardData, type ReceivedIdCard } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 function useCountdown(expiresAt: number | undefined): string | null {
     const [left, setLeft] = useState(() => (expiresAt ? expiresAt - Date.now() : 0));
@@ -34,7 +35,7 @@ export function CardDetail({ card, received, sharePortrait = null, onBack }: {
 
     return (
         <div className="absolute inset-0 z-20 flex flex-col bg-base font-sf" style={pageStyle}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <NavBar backLabel={t('id.id', 'ID')} onBack={goBack} title={cardTitle(card)} />
 
             <div className="min-h-0 flex-1 overflow-y-auto no-scrollbar px-5 pb-8 pt-2">

--- a/web/src/apps/id/Id.tsx
+++ b/web/src/apps/id/Id.tsx
@@ -18,6 +18,8 @@ import { IdCard } from './IdCard';
 import { CardDetail } from './CardDetail';
 import { devCapturePortrait, idHeadshot, idList, idSetPortrait } from './idApi';
 import { CARD_RATIO, cardTitle, formatCountdown, type ReceivedIdCard } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
+import { Spinner } from '@/ui/Spinner';
 
 const PEEK   = 74;
 const CARD_W = device.screen.w - 40;
@@ -104,7 +106,7 @@ export function Id({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex shrink-0 items-end justify-between px-5 pb-2 pt-1">
                 <h1 className="text-[34px] font-bold tracking-tight text-black dark:text-white">{t('id.id', 'ID')}</h1>
@@ -122,7 +124,7 @@ export function Id({ onClose: _onClose }: { onClose: () => void }) {
             <div className="min-h-0 flex-1 overflow-y-auto no-scrollbar px-5 pb-8">
                 {pending ? (
                     <div className="flex h-full items-center justify-center">
-                        <span className="h-7 w-7 animate-spin rounded-full border-[3px] border-black/15 border-t-black/50 dark:border-white/15 dark:border-t-white/60" />
+                        <Spinner />
                     </div>
                 ) : cards.length === 0 ? (
                     <EmptyState center icon={IdCardGlyph} title={t('id.noCards', 'No Cards')} subtitle={t('id.noCardsSub', 'Your identity documents will appear here.')} />

--- a/web/src/apps/mail/Attachments.tsx
+++ b/web/src/apps/mail/Attachments.tsx
@@ -65,7 +65,7 @@ export function AttachmentStrip({ attachments, max, onRemove }: {
                 {others.map(({ a, i }, idx) => (
                     <div key={i}>
                         {(idx > 0 || photos.length > 0) && (
-                            <div className="bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />
+                            <div className="bg-hairline/10" style={{ height: '0.5px' }} />
                         )}
                         <div className="flex items-center gap-3 px-4 py-3">
                             {a.kind === 'audio' ? (
@@ -220,7 +220,7 @@ export function MemoPickerSheet({ excludeUrls, max, onPickMany, onClose }: {
                                 <span className="shrink-0 text-[15px] text-ios-gray">{fmtDuration(m.duration)}</span>
                                 <SelectCircle selected={selected.has(m.id)} />
                             </button>
-                            {i < candidates.length - 1 && <div className="bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+                            {i < candidates.length - 1 && <div className="bg-hairline/10" style={{ height: '0.5px' }} />}
                         </div>
                     ))}
                 </div>
@@ -285,7 +285,7 @@ export function NotePickerSheet({ max, onPickMany, onClose }: {
                                 </div>
                                 <SelectCircle selected={selected.has(n.id)} />
                             </button>
-                            {i < notes.length - 1 && <div className="bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+                            {i < notes.length - 1 && <div className="bg-hairline/10" style={{ height: '0.5px' }} />}
                         </div>
                     ))}
                 </div>
@@ -349,7 +349,7 @@ export function DocPickerSheet({ excludeIds, max, onPickMany, onClose }: {
                                 </div>
                                 <SelectCircle selected={selected.has(d.id)} />
                             </button>
-                            {i < candidates.length - 1 && <div className="bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+                            {i < candidates.length - 1 && <div className="bg-hairline/10" style={{ height: '0.5px' }} />}
                         </div>
                     ))}
                 </div>

--- a/web/src/apps/mail/Attachments.tsx
+++ b/web/src/apps/mail/Attachments.tsx
@@ -14,6 +14,7 @@ import { RichBody, SignatureBlock } from '@/apps/documents/TextEditor';
 import type { DocFile } from '@/apps/documents/data';
 import { attachmentSaveStates, saveAttachment, type MailAttachment } from './data';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type DocAttachment = Extract<MailAttachment, { kind: 'document' }>;
 
@@ -371,7 +372,7 @@ function DocAttachmentSheet({ att, onClose }: { att: DocAttachment; onClose: () 
                 ? 'ios-sheet-down 0.26s cubic-bezier(0.32,0,0.68,1) forwards'
                 : 'ios-sheet-up 0.34s cubic-bezier(0.32,0.72,0,1)' }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="relative flex h-11 shrink-0 items-center px-4">
                 <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
                     <span className="max-w-[60%] truncate text-[15px] font-semibold">{att.name}</span>
@@ -412,7 +413,7 @@ function NoteSheet({ title, body, onClose }: { title: string; body: string; onCl
                 ? 'ios-sheet-down 0.26s cubic-bezier(0.32,0,0.68,1) forwards'
                 : 'ios-sheet-up 0.34s cubic-bezier(0.32,0.72,0,1)' }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="relative flex h-11 shrink-0 items-center px-4">
                 <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
                     <span className="max-w-[60%] truncate text-[15px] font-semibold">{title || t('mail.note', 'Note')}</span>

--- a/web/src/apps/mail/MailDetail.tsx
+++ b/web/src/apps/mail/MailDetail.tsx
@@ -7,6 +7,7 @@ import { useIosPush } from '@/hooks/useIosPush';
 import { AttachmentsView } from './Attachments';
 import { avatarColor, formatFullDate, formatMailTime, initials } from './data';
 import type { Folder, MailMessage } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
     msg:        MailMessage;
@@ -42,7 +43,7 @@ export function MailDetail({ msg, backLabel, prevId, nextId, onBack, onOpenSibli
             className="absolute inset-0 z-30 flex flex-col bg-base text-black dark:text-white"
             style={pageStyle}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center px-2 pb-1">
                 <button

--- a/web/src/apps/mail/MailList.tsx
+++ b/web/src/apps/mail/MailList.tsx
@@ -8,6 +8,7 @@ import { AlertDialog } from '@/ui/AlertDialog';
 import { SearchBar } from '@/ui/SearchBar';
 import { getFolders, formatMailTime, inFolder, previewBody } from './data';
 import type { Folder, MailMessage } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
     folder:    Folder;
@@ -87,7 +88,7 @@ export function MailList({ folder, accountId, accountName, messages, onBack, onO
             className="absolute inset-0 z-20 flex flex-col bg-base text-black dark:text-white"
             style={pageStyle}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center px-2 pb-0.5">
                 <button

--- a/web/src/apps/mail/MailboxList.tsx
+++ b/web/src/apps/mail/MailboxList.tsx
@@ -10,6 +10,7 @@ import { ancestorZoom, trackFractionY } from '@/lib/zoom';
 import { t } from '@/i18n';
 import { getFolderLabels, shortEmail, unreadCount } from './data';
 import type { Folder, MailAccount, MailMessage } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
     accounts:         MailAccount[];
@@ -119,7 +120,7 @@ export function MailboxList({
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base text-black dark:text-white">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center justify-between px-5 pb-0.5">
                 <button
@@ -326,7 +327,7 @@ export function MailboxList({
                     <button
                         type="button"
                         onClick={() => setConfirmDeleteAcc(true)}
-                        className="mt-3 w-full rounded-[10px] bg-[#ff3b30] py-4 text-center text-[18px] font-semibold text-white active:opacity-80"
+                        className="mt-3 w-full rounded-[10px] bg-ios-red py-4 text-center text-[18px] font-semibold text-white active:opacity-80"
                     >
                         {t('mail.deleteAccount', 'Delete Account')}
                     </button>

--- a/web/src/apps/mail/SavedEmails.tsx
+++ b/web/src/apps/mail/SavedEmails.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from '@/ui/EmptyState';
 import { PromptDialog } from '@/ui/PromptDialog';
 import { Sheet } from '@/ui/Sheet';
 import { isEmailish } from './mailSuggest';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 /** Compose's quick picker: tap an address to append it to the To field. */
 export function SavedEmailsSheet({ emails, onPick, onClose }: {
@@ -86,7 +87,7 @@ export function SavedEmailsPage({ emails, onAdd, onRemove, onBack }: {
             className="absolute inset-0 z-20 flex flex-col bg-base text-black dark:text-white"
             style={pageStyle}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center px-2 pb-0.5">
                 <button
@@ -129,7 +130,7 @@ export function SavedEmailsPage({ emails, onAdd, onRemove, onBack }: {
                                         type="button"
                                         onClick={() => setConfirmRemove(email)}
                                         aria-label={t('mail.removeSavedEmail', 'Remove saved email')}
-                                        className="shrink-0 text-[#ff3b30] active:opacity-60"
+                                        className="shrink-0 text-ios-red active:opacity-60"
                                     >
                                         <Trash2 className="h-[20px] w-[20px]" strokeWidth={2} />
                                     </button>

--- a/web/src/apps/maps/MapView.tsx
+++ b/web/src/apps/maps/MapView.tsx
@@ -454,7 +454,7 @@ export const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
             >
                 <div className="flex flex-col overflow-hidden rounded-[10px] bg-elevated/90 shadow-md ring-1 ring-black/5 dark:bg-elevated/90 dark:ring-white/10">
                     <CtrlBtn onClick={() => buttonZoom(1)} label={t('maps.zoomIn', 'Zoom in')}><Plus className="h-[18px] w-[18px]" /></CtrlBtn>
-                    <div className="h-px w-full bg-black/10 dark:bg-white/10" />
+                    <div className="h-px w-full bg-hairline/10" />
                     <CtrlBtn onClick={() => buttonZoom(-1)} label={t('maps.zoomOut', 'Zoom out')}><Minus className="h-[18px] w-[18px]" /></CtrlBtn>
                 </div>
                 <button

--- a/web/src/apps/maps/Maps.tsx
+++ b/web/src/apps/maps/Maps.tsx
@@ -491,7 +491,7 @@ export function Maps({ onClose }: { onClose: () => void }) {
                                             <Navigation className="h-[18px] w-[18px]" strokeWidth={2.2} />
                                         </button>
                                         {i < companyMatches.length - 1 && (
-                                            <div className="absolute bottom-0 left-0 right-0 h-px bg-black/[0.07] dark:bg-white/[0.08]" />
+                                            <div className="absolute bottom-0 left-0 right-0 h-px bg-hairline/[0.08]" />
                                         )}
                                     </div>
                                 ))}
@@ -543,7 +543,7 @@ export function Maps({ onClose }: { onClose: () => void }) {
                                             <Trash2 className="h-[18px] w-[18px]" strokeWidth={2.2} />
                                         </button>
                                         {i < shown.length - 1 && (
-                                            <div className="absolute bottom-0 left-0 right-0 h-px bg-black/[0.07] dark:bg-white/[0.08]" />
+                                            <div className="absolute bottom-0 left-0 right-0 h-px bg-hairline/[0.08]" />
                                         )}
                                     </div>
                                 );

--- a/web/src/apps/maps/PeoplePanel.tsx
+++ b/web/src/apps/maps/PeoplePanel.tsx
@@ -265,7 +265,7 @@ export function PeoplePanel({ friends, selectedId, showAvatars, onFocus, onToggl
                                         <Trash2 className="h-[18px] w-[18px]" strokeWidth={2.2} />
                                     </button>
                                     {i < friends.length - 1 && (
-                                        <div className="absolute bottom-0 left-0 right-0 h-px bg-black/[0.07] dark:bg-white/[0.08]" />
+                                        <div className="absolute bottom-0 left-0 right-0 h-px bg-hairline/[0.08]" />
                                     )}
                                 </div>
                             );
@@ -364,7 +364,7 @@ export function ContactsPanel({ existing, onPick, onCancel }: {
                                         ? <Check className="h-[20px] w-[20px] shrink-0 text-ios-green" strokeWidth={2.6} />
                                         : <UserPlus className="h-[20px] w-[20px] shrink-0 text-ios-blue" strokeWidth={2.3} />}
                                     {i < shown.length - 1 && (
-                                        <div className="absolute bottom-0 left-0 right-0 h-px bg-black/[0.07] dark:bg-white/[0.08]" />
+                                        <div className="absolute bottom-0 left-0 right-0 h-px bg-hairline/[0.08]" />
                                     )}
                                 </button>
                             );

--- a/web/src/apps/maps/SheetList.tsx
+++ b/web/src/apps/maps/SheetList.tsx
@@ -32,7 +32,7 @@ export function SheetRow({ rowRef, asButton = false, selected = false, disabled 
         </span>
     );
     const hairline = divider && (
-        <div className="absolute bottom-0 left-0 right-0 h-px bg-black/[0.07] dark:bg-white/[0.08]" />
+        <div className="absolute bottom-0 left-0 right-0 h-px bg-hairline/[0.08]" />
     );
     if (asButton) {
         return (

--- a/web/src/apps/marketplace/Marketplace.tsx
+++ b/web/src/apps/marketplace/Marketplace.tsx
@@ -14,6 +14,7 @@ import { ListingDetail } from '@/apps/_classifieds/ListingDetail';
 import { useClassifiedsFeed } from '@/apps/_classifieds/useClassifiedsFeed';
 import { useContactActions } from '@/apps/_classifieds/useContactActions';
 import { MarketplaceTabBar, type MarketTab } from './MarketplaceTabBar';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function Marketplace({ onClose: _onClose }: { onClose: () => void }) {
     const [tab,      setTab]      = useSessionState<MarketTab>('marketplace:tab', 'home');
@@ -89,7 +90,7 @@ export function Marketplace({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex flex-1 flex-col overflow-hidden">
                 <div key={tab} className="flex min-h-0 flex-1 flex-col animate-swipe-in-left">

--- a/web/src/apps/messages/ConversationList.tsx
+++ b/web/src/apps/messages/ConversationList.tsx
@@ -13,6 +13,7 @@ import { SearchBar } from '@/ui/SearchBar';
 import { AlertDialog } from '@/ui/AlertDialog';
 import { PromptDialog } from '@/ui/PromptDialog';
 import { t } from '@/i18n';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface ConversationListProps {
     conversations: Conversation[];
@@ -90,7 +91,7 @@ export function ConversationList({ conversations, onOpen, onCompose, onMarkRead,
 
     return (
         <div className="flex flex-1 flex-col bg-base overflow-hidden">
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center justify-between px-5 pb-0.5">
                 <button type="button" onClick={toggleEditing} className="text-[17px] text-ios-blue active:opacity-60">

--- a/web/src/apps/messages/NewMessage.tsx
+++ b/web/src/apps/messages/NewMessage.tsx
@@ -93,7 +93,7 @@ export function NewMessage({ contacts, myNumber, onCancel, onSend }: NewMessageP
             <div className="shrink-0 px-4 pb-2 pt-1 text-center">
                 <span className="text-[19px] font-semibold">{t('messages.newMessage', 'New Message')}</span>
             </div>
-            <div className="h-[0.5px] bg-black/10 dark:bg-white/10" />
+            <div className="h-[0.5px] bg-hairline/10" />
 
             <div className="shrink-0 px-4 py-2.5">
                 <div className="flex flex-wrap items-center gap-1.5">
@@ -120,7 +120,7 @@ export function NewMessage({ contacts, myNumber, onCancel, onSend }: NewMessageP
                     />
                 </div>
             </div>
-            <div className="h-[0.5px] bg-black/10 dark:bg-white/10" />
+            <div className="h-[0.5px] bg-hairline/10" />
 
             <div className="min-h-0 flex-1 overflow-y-auto no-scrollbar px-2 pt-2">
                 {showSuggestions && (

--- a/web/src/apps/music/Music.tsx
+++ b/web/src/apps/music/Music.tsx
@@ -591,7 +591,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 }
 
 function Divider() {
-    return <div className="pointer-events-none absolute bottom-0 left-[6%] right-[6%] h-[0.5px] bg-black/15 dark:bg-white/15" />;
+    return <div className="pointer-events-none absolute bottom-0 left-[6%] right-[6%] h-[0.5px] bg-hairline/15" />;
 }
 
 function CategoryRow({ icon: Icon, label, onPress, divider }: { icon: LucideIcon; label: string; onPress: () => void; divider?: boolean }) {

--- a/web/src/apps/notes/NoteEditor.tsx
+++ b/web/src/apps/notes/NoteEditor.tsx
@@ -16,6 +16,7 @@ import { formatLastEdited, joinTitle, splitTitle, shareNote } from "./data";
 import type { Note } from "./data";
 import { SketchCanvas } from "./SketchCanvas";
 import { t } from "@/i18n";
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
   note: Note;
@@ -121,7 +122,7 @@ export function NoteEditor({
       className="absolute inset-0 z-20 flex flex-col bg-base text-black dark:text-white"
       style={pageStyle}
     >
-      <div className="h-[58px] shrink-0" aria-hidden />
+      <StatusBarSpacer />
 
       <div className="flex items-center gap-2 px-2 pb-0.5 pt-4">
         <button

--- a/web/src/apps/notes/NotesList.tsx
+++ b/web/src/apps/notes/NotesList.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '@/ui/EmptyState';
 import { formatRelativeDate, noteTitle, notePreview, noteHasContent } from './data';
 import type { Note } from './data';
 import { t } from '@/i18n';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface Props {
     notes:     Note[];
@@ -31,7 +32,7 @@ export function NotesList({ notes, onOpen, onCompose }: Props) {
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base text-black dark:text-white">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center justify-between px-5 pb-1 pt-1">
                 <h1 className="text-[34px] font-bold tracking-tight">{t('notes.appTitle', 'Notes')}</h1>

--- a/web/src/apps/notes/NotesList.tsx
+++ b/web/src/apps/notes/NotesList.tsx
@@ -70,7 +70,7 @@ export function NotesList({ notes, onOpen, onCompose }: Props) {
                                     </div>
                                 </button>
                                 {i < sorted.length - 1 && (
-                                    <div className="pointer-events-none mx-[6%] h-[0.4px] bg-black/15 dark:bg-white/15" />
+                                    <div className="pointer-events-none mx-[6%] h-[0.4px] bg-hairline/15" />
                                 )}
                             </div>
                         ))}

--- a/web/src/apps/notes/SketchCanvas.tsx
+++ b/web/src/apps/notes/SketchCanvas.tsx
@@ -225,7 +225,7 @@ export function SketchCanvas({ initial, onSave, onCancel }: Props) {
                         <Eraser className="h-[16px] w-[16px]" strokeWidth={2} />
                     </ToolBtn>
 
-                    <div className="mx-1 h-5 w-[1px] bg-black/15 dark:bg-white/15" />
+                    <div className="mx-1 h-5 w-[1px] bg-hairline/15" />
 
                     {WIDTHS.map(w => (
                         <button

--- a/web/src/apps/pages/Pages.tsx
+++ b/web/src/apps/pages/Pages.tsx
@@ -14,6 +14,7 @@ import { ListingDetail } from '@/apps/_classifieds/ListingDetail';
 import { useClassifiedsFeed } from '@/apps/_classifieds/useClassifiedsFeed';
 import { useContactActions } from '@/apps/_classifieds/useContactActions';
 import { PagesTabBar, type PagesTab } from './PagesTabBar';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function Pages({ onClose: _onClose }: { onClose: () => void }) {
     const [tab,      setTab]      = useSessionState<PagesTab>('pages:tab', 'browse');
@@ -88,7 +89,7 @@ export function Pages({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex flex-1 flex-col overflow-hidden">
                 <div key={tab} className="flex min-h-0 flex-1 flex-col animate-swipe-in-left">

--- a/web/src/apps/passwords/Passwords.tsx
+++ b/web/src/apps/passwords/Passwords.tsx
@@ -13,6 +13,7 @@ import { SearchBar } from '@/ui/SearchBar';
 import { accountsDeletePassword, accountsListPasswords, type VaultEntry } from '@/core/accountsApi';
 import { SlideOver } from '@/ui/SlideOver';
 import { t } from '@/i18n';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const APP_LABELS: Record<string, string> = {
     photogram: 'Photogram', cherry: 'Cherry', vibez: 'Clout', birdy: 'Squawk', mail: 'Mail',
@@ -54,7 +55,7 @@ export function Passwords({ onClose }: { onClose: () => void }) {
     return (
         <div className="absolute inset-0 z-10 overflow-hidden bg-base font-sf text-black dark:text-white">
             <div className="flex h-full flex-col">
-                <div className="h-[54px] shrink-0" aria-hidden />
+                <StatusBarSpacer />
 
                 <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-10">
                     <h1 className="pt-3 text-[32px] font-extrabold tracking-tight">{t('passwords.title', 'Passwords')}</h1>
@@ -113,7 +114,7 @@ function Detail({ entry, onBack, onDelete }: { entry: VaultEntry; onBack: () => 
 
     return (
         <div className="flex h-full flex-col bg-base text-black dark:text-white">
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <header className="flex items-center px-3 py-2">
                 <button type="button" onClick={onBack} className="flex items-center text-ios-blue active:opacity-60">
                     <ChevronLeft className="h-[28px] w-[28px]" strokeWidth={2.4} />

--- a/web/src/apps/passwords/Passwords.tsx
+++ b/web/src/apps/passwords/Passwords.tsx
@@ -72,7 +72,7 @@ export function Passwords({ onClose }: { onClose: () => void }) {
                                     key={e.id}
                                     type="button"
                                     onClick={() => setOpenId(e.id)}
-                                    className={`flex w-full items-center gap-4 px-4 py-[18px] text-left active:bg-black/5 dark:active:bg-white/5 ${i === shown.length - 1 ? '' : 'border-b-[0.5px] border-black/10 dark:border-white/10'}`}
+                                    className={`flex w-full items-center gap-4 px-4 py-[18px] text-left active:bg-black/5 dark:active:bg-white/5 ${i === shown.length - 1 ? '' : 'border-b-[0.5px] border-hairline/10'}`}
                                 >
                                     <span className="h-[56px] w-[56px] shrink-0 overflow-hidden rounded-[13px] [&>svg]:block [&>svg]:h-full [&>svg]:w-full" style={{ boxShadow: '0 2px 6px rgba(0,0,0,0.14)' }}>
                                         <AppIconSVG icon={e.app} />
@@ -192,7 +192,7 @@ function CopyButton({ value, label }: { value: string; label: string }) {
 
 function Row({ label, value, last, copyable = true }: { label: string; value: string; last?: boolean; copyable?: boolean }) {
     return (
-        <div className={`flex items-center px-4 py-3.5 ${last ? '' : 'border-b-[0.5px] border-black/10 dark:border-white/10'}`}>
+        <div className={`flex items-center px-4 py-3.5 ${last ? '' : 'border-b-[0.5px] border-hairline/10'}`}>
             <div className="min-w-0 flex-1">
                 <div className="text-[14px] text-black/80 dark:text-white/80">{label}</div>
                 <div className="truncate pt-0.5 text-[18px]">{value}</div>

--- a/web/src/apps/phone/Phone.tsx
+++ b/web/src/apps/phone/Phone.tsx
@@ -19,6 +19,7 @@ import { dialCall } from './callsApi';
 import { useContacts, useContactsStore, saveNewContact } from '@/stores/contactsStore';
 import { t } from '@/i18n';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface CallTarget { number: string; name?: string; video?: boolean }
 
@@ -100,7 +101,7 @@ export function Phone({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[61px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex flex-1 flex-col overflow-hidden">
                 {/* No key={tab} and no permanent animation class. key= remounted the whole

--- a/web/src/apps/phone/contacts/AddContact.tsx
+++ b/web/src/apps/phone/contacts/AddContact.tsx
@@ -123,5 +123,5 @@ function Field({ placeholder, value, onChange, inputMode }: {
 }
 
 function Divider() {
-    return <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />;
+    return <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />;
 }

--- a/web/src/apps/phone/contacts/ContactDetail.tsx
+++ b/web/src/apps/phone/contacts/ContactDetail.tsx
@@ -279,5 +279,5 @@ function ActionRow({ label, tone = 'blue', onClick }: { label: string; tone?: 'b
 }
 
 function Divider() {
-    return <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />;
+    return <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />;
 }

--- a/web/src/apps/phone/contacts/ContactsTab.tsx
+++ b/web/src/apps/phone/contacts/ContactsTab.tsx
@@ -184,7 +184,7 @@ function ContactRow({ contact, divider, onOpen }: { contact: Contact; divider: b
                 </div>
             </button>
             {divider && (
-                <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />
+                <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />
             )}
         </>
     );

--- a/web/src/apps/phone/contacts/EditContact.tsx
+++ b/web/src/apps/phone/contacts/EditContact.tsx
@@ -139,5 +139,5 @@ function Field({ placeholder, value, onChange, inputMode, tint, readOnly }: {
 }
 
 function Divider() {
-    return <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />;
+    return <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />;
 }

--- a/web/src/apps/phone/contacts/FavoritesTab.tsx
+++ b/web/src/apps/phone/contacts/FavoritesTab.tsx
@@ -86,7 +86,7 @@ function FavoriteRow({ contact, editing, onRemove, onInfo, onCall }: {
                     type="button"
                     aria-label={t('phone.removeFromFavoritesAria','Remove {name} from favorites',{ name: contact.name })}
                     onClick={() => onRemove(contact.id)}
-                    className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full bg-[#ff3b30] active:opacity-70"
+                    className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full bg-ios-red active:opacity-70"
                 >
                     <Minus className="h-[18px] w-[18px] text-white" strokeWidth={3} />
                 </button>

--- a/web/src/apps/phone/contacts/FavoritesTab.tsx
+++ b/web/src/apps/phone/contacts/FavoritesTab.tsx
@@ -47,7 +47,7 @@ export function FavoritesTab({ favorites, onRemoveFavorite, onRequestCall, onUpd
                                         onCall={() => onRequestCall({ number: c.phone, name: c.name })}
                                     />
                                     {i < favorites.length - 1 && (
-                                        <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />
+                                        <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />
                                     )}
                                 </div>
                             ))}

--- a/web/src/apps/phone/recents/RecentsTab.tsx
+++ b/web/src/apps/phone/recents/RecentsTab.tsx
@@ -70,7 +70,7 @@ export function RecentsTab({ recents, onAddContact, onRequestCall, onUpdateConta
                                     <div key={entry.id}>
                                         <CallRow entry={entry} onBody={requestCall} onInfo={openProfile} />
                                         {i < list.length - 1 && (
-                                            <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />
+                                            <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />
                                         )}
                                     </div>
                                 ))}

--- a/web/src/apps/phone/recordings/RecordingsTab.tsx
+++ b/web/src/apps/phone/recordings/RecordingsTab.tsx
@@ -75,7 +75,7 @@ export function RecordingsTab() {
                             {items.map((rec, i) => (
                                 <div key={rec.id}>
                                     {i > 0 && (
-                                        <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />
+                                        <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />
                                     )}
                                     <Row
                                         rec={rec}

--- a/web/src/apps/photogram/Photogram.tsx
+++ b/web/src/apps/photogram/Photogram.tsx
@@ -40,6 +40,7 @@ import { EditProfile } from './profile/EditProfile';
 import { LiveStream } from './live/LiveStream';
 import { LiveViewer } from './live/LiveViewer';
 import { AlertDialog } from '@/ui/AlertDialog';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
     const { authed, setAuthed, authChecked, justAuthed, setJustAuthed, myNumber, myEmails, savedLogin, savedAccounts, refreshAccounts } = useAppAuth('photogram',
@@ -323,7 +324,7 @@ export function Photogram({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className={`absolute inset-0 flex flex-col bg-[#f2f2f2] font-sf ${justAuthed ? 'animate-swipe-in-left' : ''}`}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                 <TabPane key={tab} animate={animateNav}>

--- a/web/src/apps/photogram/create/CreateSheet.tsx
+++ b/web/src/apps/photogram/create/CreateSheet.tsx
@@ -7,6 +7,7 @@ import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { IG } from '../data';
 import { MediaThumb } from './Media';
 import { apiCurrentZone } from '../photogramApi';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function CreateSheet({ onClose, onPost, animateIn = true }: {
     onClose: () => void;
@@ -51,7 +52,7 @@ export function CreateSheet({ onClose, onPost, animateIn = true }: {
                 willChange: 'transform',
             }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <header className="relative flex items-center justify-between px-4 pb-2">
                 <button type="button" onClick={() => dismiss(onClose)} className="text-[17px] text-black active:opacity-50">{t('photogram.cancel', 'Cancel')}</button>
                 <span className="pointer-events-none absolute left-1/2 -translate-x-1/2 text-[18px] font-semibold text-black">{t('photogram.newPost', 'New post')}</span>

--- a/web/src/apps/photogram/dms/ChatView.tsx
+++ b/web/src/apps/photogram/dms/ChatView.tsx
@@ -19,6 +19,7 @@ import { warmPhotos, apiSavePhotoFromUrl } from '@/core/photosApi';
 import { IG, type DM, type DMsg, type SharedPost } from '../data';
 import { MediaThumb } from '../create/Media';
 import { avatarFor } from '../photogramApi';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type Panel = 'emoji' | 'voice' | null;
 
@@ -132,7 +133,7 @@ export function ChatView({ convo, onBack, onSend, onReact, onOpenPost, animateIn
 
     return (
         <div className="absolute inset-0 z-20 flex flex-col overflow-hidden" style={{ background: SURFACE, ...pageStyle }}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="shrink-0">
                 <div className="flex items-center gap-2 px-2 pb-3">

--- a/web/src/apps/photogram/dms/DirectMessages.tsx
+++ b/web/src/apps/photogram/dms/DirectMessages.tsx
@@ -12,6 +12,7 @@ import { ChatView } from './ChatView';
 import { IG, nowTime, type DM, type DMsg, type User } from '../data';
 import { apiDmList, apiDmReact, apiDmSend, apiDmThread, apiSearch, type Conversation, type FollowUser } from '../photogramApi';
 import { VerifiedCheck } from '../ui';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function DirectMessages({ me, onClose, onOpenPost, animateIn = true }: { me: User; onClose: () => void; onOpenPost?: (id: string) => void; animateIn?: boolean }) {
     const { goBack, pageStyle } = useIosPush(onClose, animateIn);
@@ -94,7 +95,7 @@ export function DirectMessages({ me, onClose, onOpenPost, animateIn = true }: { 
 
     return (
         <div className="absolute inset-0 z-40 flex flex-col overflow-hidden bg-[#f2f2f2] font-sf" style={pageStyle}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <List me={me} onClose={goBack} convos={convos} onOpen={(h) => openThread(h, true)} onCompose={() => setComposing(true)} />
 
             {open && (
@@ -184,7 +185,7 @@ function NewMessage({ onClose, onPick }: { onClose: () => void; onPick: (handle:
 
     return (
         <div className="absolute inset-0 z-50 flex flex-col bg-[#f2f2f2] font-sf" style={{ animation: 'ios-sheet-up 0.32s cubic-bezier(0.32,0.72,0,1)' }}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="flex items-center justify-between px-4 pb-2">
                 <button type="button" onClick={onClose} className="text-[16px] text-black active:opacity-50">{t('photogram.cancel', 'Cancel')}</button>
                 <span className="text-[16px] font-semibold text-black">{t('photogram.newMessage', 'New message')}</span>

--- a/web/src/apps/photogram/feed/Comments.tsx
+++ b/web/src/apps/photogram/feed/Comments.tsx
@@ -7,6 +7,7 @@ import { EmojiPanel } from '@/shared/chat/EmojiPanel';
 import { GifPickerSheet } from '@/shared/chat/GifPickerSheet';
 import { IG, type Comment as IGComment, type Post, type User } from '../data';
 import { VerifiedCheck } from '../ui';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function Comments({ post, me, comments, onBack, onSubmit, onToggleLike, onOpenProfile, animateIn = true }: {
     post:         Post;
@@ -34,7 +35,7 @@ export function Comments({ post, me, comments, onBack, onSubmit, onToggleLike, o
 
     return (
         <div className="absolute inset-0 z-40 flex flex-col bg-[#f2f2f2] font-sf" style={pageStyle}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="relative flex shrink-0 items-center px-2 pb-2">
                 <button type="button" onClick={goBack} aria-label={t('photogram.back', 'Back')} className="text-black active:opacity-50">

--- a/web/src/apps/photogram/feed/PostDetail.tsx
+++ b/web/src/apps/photogram/feed/PostDetail.tsx
@@ -4,6 +4,7 @@ import { useIosPush } from '@/hooks/useIosPush';
 import { t } from '@/i18n';
 import { type Post, type User } from '../data';
 import { PostCard } from './PostCard';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function PostDetail({ post, me, onBack, onLike, onDoubleLike, onSave, onComment, onOpenProfile, onShare, onDelete, animateIn = true }: {
     post:         Post;
@@ -22,7 +23,7 @@ export function PostDetail({ post, me, onBack, onLike, onDoubleLike, onSave, onC
 
     return (
         <div className="absolute inset-0 z-40 flex flex-col bg-[#f2f2f2] font-sf" style={pageStyle}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="relative flex shrink-0 items-center px-2 pb-2">
                 <button type="button" onClick={goBack} aria-label={t('photogram.back', 'Back')} className="text-black active:opacity-50">

--- a/web/src/apps/photogram/profile/EditProfile.tsx
+++ b/web/src/apps/photogram/profile/EditProfile.tsx
@@ -6,6 +6,7 @@ import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { ChangePasswordPage } from '@/shared/ChangePasswordPage';
 import { Toggle } from '@/ui/Toggle';
 import { IG, type ProfileData } from '../data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function EditProfile({ profile, onCancel, onSave, onSignOut, onSignOutAll, onSwitchAccount, onDelete, switchTo }: {
     onSwitchAccount: () => void;
@@ -47,7 +48,7 @@ export function EditProfile({ profile, onCancel, onSave, onSignOut, onSignOutAll
                 willChange: 'transform',
             }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <header className="flex items-center justify-between px-4 pb-2">
                 <button type="button" onClick={() => dismiss(onCancel)} className="text-[17px] text-black active:opacity-50">{t('photogram.cancel', 'Cancel')}</button>
                 <span className="text-[18px] font-semibold text-black">{t('photogram.editProfile', 'Edit profile')}</span>

--- a/web/src/apps/photogram/profile/FollowList.tsx
+++ b/web/src/apps/photogram/profile/FollowList.tsx
@@ -8,6 +8,7 @@ import { useNuiEvent } from '@/hooks/useNuiEvent';
 import { IG } from '../data';
 import { apiFollowList, apiToggleFollow, type FollowStatus, type FollowUser } from '../photogramApi';
 import { VerifiedCheck } from '../ui';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type Kind = 'followers' | 'following';
 
@@ -25,7 +26,7 @@ export function FollowList({ username, initial, onBack, onOpenProfile, onChanged
 
     return (
         <div className="absolute inset-0 z-50 flex flex-col bg-[#f2f2f2] font-sf" style={pageStyle}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="relative flex shrink-0 items-center px-2 pb-2">
                 <button type="button" onClick={goBack} aria-label={t('photogram.back', 'Back')} className="text-black active:opacity-50">
                     <ChevronLeft className="h-[36px] w-[36px]" strokeWidth={2.2} />

--- a/web/src/apps/photogram/profile/UserProfile.tsx
+++ b/web/src/apps/photogram/profile/UserProfile.tsx
@@ -9,6 +9,7 @@ import { MediaThumb } from '../create/Media';
 import { apiProfile, apiProfilePosts, apiToggleFollow, type FollowStatus, type ProfileView } from '../photogramApi';
 import { EmptyGrid, fmtCount } from './Profile';
 import { VerifiedCheck } from '../ui';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function UserProfile({ handle, me: _me, onBack, onOpenProfile: _onOpenProfile, onOpenPost, onOpenFollows, onChanged, animateIn = true }: {
     handle:        string;
@@ -68,7 +69,7 @@ export function UserProfile({ handle, me: _me, onBack, onOpenProfile: _onOpenPro
 
     return (
         <div className="absolute inset-0 z-40 flex flex-col bg-[#f2f2f2] font-sf" style={pageStyle}>
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="relative flex shrink-0 items-center px-2 pb-2">
                 <button type="button" onClick={goBack} aria-label={t('photogram.back', 'Back')} className="text-black active:opacity-50">
                     <ChevronLeft className="h-[36px] w-[36px]" strokeWidth={2.2} />

--- a/web/src/apps/photogram/stories/StoryViewer.tsx
+++ b/web/src/apps/photogram/stories/StoryViewer.tsx
@@ -7,6 +7,7 @@ import { apiMarkStorySeen } from '../photogramApi';
 import { isVideoUrl } from '../create/Media';
 import { VerifiedCheck } from '../ui';
 import { useDeckActive } from '@/shell/deckActive';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function StoryViewer({ stories, startIndex, onClose }: { stories: StoryGroup[]; startIndex: number; onClose: () => void }) {
     const [si, setSi] = useState(startIndex);
@@ -55,7 +56,7 @@ export function StoryViewer({ stories, startIndex, onClose }: { stories: StoryGr
 
     return (
         <div className="absolute inset-0 z-50 flex flex-col bg-black" style={{ animation: 'ios-sheet-backdrop-in 0.2s ease-out' }}>
-            <div className="h-[56px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex gap-1 px-2.5 pt-1">
                 {story.frames.map((f, i) => {

--- a/web/src/apps/photos/AlbumDetail.tsx
+++ b/web/src/apps/photos/AlbumDetail.tsx
@@ -5,6 +5,7 @@ import { useIosPush } from '@/hooks/useIosPush';
 import { t } from '@/i18n';
 import type { Photo } from '@/core/photosApi';
 import { PhotoTile } from './PhotoTile';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function AlbumDetail({
     title, photos, isCustom, onBack, onPhotoTap, onAddPhotos, onRemovePhotos,
@@ -36,7 +37,7 @@ export function AlbumDetail({
 
     return (
         <div className="absolute inset-0 z-20 flex flex-col bg-base" style={pageStyle}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="flex h-11 shrink-0 items-center justify-between px-2">
                 <button type="button" onClick={goBack} className="flex items-center text-ios-blue">
                     <ChevronLeft className="h-7 w-7" strokeWidth={2.4} />
@@ -109,7 +110,7 @@ export function AlbumDetail({
                         tabIndex={selectMode ? undefined : -1}
                         disabled={selected.size === 0}
                         onClick={() => { onRemovePhotos?.(Array.from(selected)); exitSelect(); }}
-                        className="flex flex-1 flex-col items-center gap-1.5 py-1 text-[#ff3b30] disabled:opacity-40"
+                        className="flex flex-1 flex-col items-center gap-1.5 py-1 text-ios-red disabled:opacity-40"
                     >
                         <Trash2 className="h-[33px] w-[33px]" strokeWidth={1.9} />
                         <span className="text-[15px] font-bold tracking-tight">

--- a/web/src/apps/photos/AlbumPickerSheet.tsx
+++ b/web/src/apps/photos/AlbumPickerSheet.tsx
@@ -55,7 +55,7 @@ export function AlbumPickerSheet({ albums, count, onPick, onNewAlbum, onClose }:
 
                                 {albums.map(a => (
                                     <button key={a.id} type="button" onClick={() => runThenClose(() => onPick(a.id))} className="text-left active:opacity-70">
-                                        <span className="block aspect-square w-full overflow-hidden rounded-[12px] bg-black/10 dark:bg-white/10">
+                                        <span className="block aspect-square w-full overflow-hidden rounded-[12px] bg-hairline/10">
                                             {a.cover
                                                 ? <img src={a.cover} alt="" className="h-full w-full object-cover" draggable={false} />
                                                 : <span className="flex h-full w-full items-center justify-center">

--- a/web/src/apps/photos/AlbumsTab.tsx
+++ b/web/src/apps/photos/AlbumsTab.tsx
@@ -193,7 +193,7 @@ function AlbumCardTile({ card, editMode, onOpen, onDelete }: {
                     type="button"
                     onClick={onDelete}
                     aria-label={t('photos.deleteName', 'Delete {name}', { name: card.title })}
-                    className="absolute -left-1.5 -top-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-[#ff3b30] text-white shadow"
+                    className="absolute -left-1.5 -top-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-ios-red text-white shadow"
                 >
                     <Minus className="h-4 w-4" strokeWidth={3} />
                 </button>

--- a/web/src/apps/photos/AlbumsTab.tsx
+++ b/web/src/apps/photos/AlbumsTab.tsx
@@ -165,7 +165,7 @@ function AlbumCardTile({ card, editMode, onOpen, onDelete }: {
                 onClick={editMode ? undefined : onOpen}
                 className="block w-full text-left active:opacity-90"
             >
-                <div className="relative aspect-square overflow-hidden rounded-[14px] bg-black/10 dark:bg-white/10">
+                <div className="relative aspect-square overflow-hidden rounded-[14px] bg-hairline/10">
                     {card.cover ? (
                         <img src={card.cover} alt="" draggable={false} className="h-full w-full object-cover" />
                     ) : (

--- a/web/src/apps/photos/PhotoPicker.tsx
+++ b/web/src/apps/photos/PhotoPicker.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 import { t } from '@/i18n';
 import { groupByDay, type Photo } from '@/core/photosApi';
 import { PhotoTile } from './PhotoTile';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function PhotoPicker({ photos, existingIds, onConfirm, onClose }: {
     photos:      Photo[];
@@ -38,7 +39,7 @@ export function PhotoPicker({ photos, existingIds, onConfirm, onClose }: {
             className="absolute inset-0 z-50 flex flex-col bg-base"
             style={{ animation: leaving ? 'ios-sheet-down 0.26s cubic-bezier(0.32,0,0.68,1) forwards' : 'ios-sheet-up 0.34s cubic-bezier(0.32,0.72,0,1)' }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="flex h-11 shrink-0 items-center justify-between px-4">
                 <button type="button" onClick={() => dismiss(onClose)} className="text-[16px] font-medium text-ios-blue">
                     {t('photos.cancel', 'Cancel')}

--- a/web/src/apps/photos/PhotoViewer.tsx
+++ b/web/src/apps/photos/PhotoViewer.tsx
@@ -8,6 +8,7 @@ import { ActionSheet } from '@/ui/ActionSheet';
 import { ShareAction, ShareSheet } from '@/shared/ShareSheet';
 import { useCopied } from '@/hooks/useCopied';
 import { VideoView } from './VideoView';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 function fmtDate(iso: string): string {
     const d = new Date(iso);
@@ -88,7 +89,7 @@ export function PhotoViewer({
             className="absolute inset-0 z-40 flex flex-col bg-base text-black dark:text-white"
             style={{ animation: leaving ? 'photo-out 0.2s ease-in forwards' : 'photo-in 0.24s cubic-bezier(0.22,1,0.36,1)' }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex h-14 shrink-0 items-center justify-between px-4">
                 <button type="button" onClick={close} aria-label={t('photos.back', 'Back')} className="text-ios-blue">

--- a/web/src/apps/photos/Photos.tsx
+++ b/web/src/apps/photos/Photos.tsx
@@ -515,7 +515,7 @@ export function Photos({ onClose }: { onClose: () => void }) {
 function EmptyState() {
     return (
         <div className="flex h-full flex-col items-center justify-center px-10 pb-16 text-center">
-            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-black/8 dark:bg-white/8">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-hairline/8">
                 <CameraIcon className="h-8 w-8 text-black/55 dark:text-white/60" strokeWidth={1.6} />
             </div>
             <div className="text-[17px] font-semibold">{t('photos.noPhotosYet','No Photos Yet')}</div>

--- a/web/src/apps/photos/Photos.tsx
+++ b/web/src/apps/photos/Photos.tsx
@@ -22,6 +22,7 @@ import { PhotoPicker } from './PhotoPicker';
 import { PhotoTabBar, type PhotosTab } from './PhotoTabBar';
 import { PhotoViewer } from './PhotoViewer';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface ViewerState { source: 'gallery' | 'album'; index: number }
 interface CreateState { addIds: string[] }
@@ -275,7 +276,7 @@ export function Photos({ onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 z-10 flex flex-col bg-base text-black dark:text-white">
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="relative flex-1 min-h-0">
                 {loading ? (
@@ -370,7 +371,7 @@ export function Photos({ onClose }: { onClose: () => void }) {
                         tabIndex={selectBarUp ? undefined : -1}
                         disabled={gallerySelected.size === 0}
                         onClick={() => setConfirmDelete({ ids: Array.from(gallerySelected), fromSelect: true })}
-                        className="flex flex-1 flex-col items-center gap-1.5 py-1 text-[#ff3b30] disabled:opacity-40"
+                        className="flex flex-1 flex-col items-center gap-1.5 py-1 text-ios-red disabled:opacity-40"
                     >
                         <Trash2 className="h-[33px] w-[33px]" strokeWidth={1.9} />
                         <span className="text-[15px] font-bold tracking-tight">{t('photos.delete','Delete')}</span>

--- a/web/src/apps/radio/Radio.tsx
+++ b/web/src/apps/radio/Radio.tsx
@@ -10,6 +10,7 @@ import { AlertDialog } from '@/ui/AlertDialog';
 import { SavedChannels } from './SavedChannels';
 import { getRadio, setRadio, listSaved, addSaved, updateSaved, removeSaved, type SavedStation } from './radioApi';
 import { t } from '@/i18n';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const fmtFreq   = (f: number) => f.toFixed(1);
 const clampFreq = (f: number) => Math.min(999.9, Math.max(1.0, Math.round(f * 10) / 10));
@@ -125,7 +126,7 @@ export function Radio({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 z-10 flex flex-col bg-base font-sf text-black dark:text-white">
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="px-5 pb-1 pt-0.5 text-[34px] font-bold tracking-tight">{t('radio.title', 'Radio')}</div>
 
             <div className="flex min-h-0 flex-1 flex-col overflow-y-auto no-scrollbar px-4 pb-5 pt-1.5">
@@ -178,7 +179,7 @@ export function Radio({ onClose: _onClose }: { onClose: () => void }) {
                         onClick={() => (on ? turnOff() : tuneIn())}
                         disabled={!on && (!canTune || !loaded)}
                         className={`flex flex-1 items-center justify-center gap-2 rounded-full py-3 text-[18px] font-semibold shadow-sm ${anim} active:opacity-80 ${
-                            on ? 'bg-[#ff3b30] text-white' : (canTune && loaded ? 'bg-[#34c759] text-white' : 'bg-black/15 text-black/30 dark:bg-white/10 dark:text-white/30')
+                            on ? 'bg-ios-red text-white' : (canTune && loaded ? 'bg-[#34c759] text-white' : 'bg-black/15 text-black/30 dark:bg-white/10 dark:text-white/30')
                         }`}
                     >
                         <Power className="h-[19px] w-[19px]" strokeWidth={2.4} /> {on ? t('radio.turnOff', 'Turn Off') : t('radio.tuneIn', 'Tune In')}

--- a/web/src/apps/radio/SavedChannels.tsx
+++ b/web/src/apps/radio/SavedChannels.tsx
@@ -6,6 +6,7 @@ import { PromptDialog } from '@/ui/PromptDialog';
 import { AlertDialog } from '@/ui/AlertDialog';
 import type { SavedStation } from './radioApi';
 import { t } from '@/i18n';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const fmtFreq = (f: number) => f.toFixed(1);
 const cleanFreq = (v: string) => {
@@ -34,7 +35,7 @@ export function SavedChannels({ saved, currentFreq, canSave, activeFreq, onTune,
 
     return (
         <div className="absolute inset-0 z-20 flex flex-col bg-base font-sf text-black dark:text-white" style={pageStyle}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="px-2 pb-0.5">
                 <button type="button" onClick={goBack} className="flex items-center gap-0.5 text-ios-blue active:opacity-60">
@@ -90,7 +91,7 @@ export function SavedChannels({ saved, currentFreq, canSave, activeFreq, onTune,
                                         type="button"
                                         onClick={() => setConfirmDel(s)}
                                         aria-label={t('radio.deleteStation', 'Delete {label}', { label: s.label })}
-                                        className="flex items-center px-3.5 text-ios-gray transition-colors hover:bg-[#ff3b30]/10 hover:text-[#ff3b30] active:opacity-60"
+                                        className="flex items-center px-3.5 text-ios-gray transition-colors hover:bg-ios-red/10 hover:text-ios-red active:opacity-60"
                                     >
                                         <Trash2 className="h-[20px] w-[20px]" strokeWidth={2} />
                                     </button>

--- a/web/src/apps/ryde/account/Leaderboard.tsx
+++ b/web/src/apps/ryde/account/Leaderboard.tsx
@@ -79,7 +79,7 @@ export function Leaderboard() {
                                     <Star className="h-[18px] w-[18px]" style={{ color: '#FF9600', fill: '#FF9600' }} /> {r.rating.toFixed(2)}
                                 </span>
                                 {i < rows.length - 1 && (
-                                    <div className="pointer-events-none absolute bottom-0 left-4 right-0 h-px bg-black/[0.07] dark:bg-white/[0.08]" />
+                                    <div className="pointer-events-none absolute bottom-0 left-4 right-0 h-px bg-hairline/[0.08]" />
                                 )}
                             </div>
                         );

--- a/web/src/apps/ryde/driver/VehiclePicker.tsx
+++ b/web/src/apps/ryde/driver/VehiclePicker.tsx
@@ -35,7 +35,7 @@ export function VehiclePicker({ onPick, onClose }: {
                                     </span>
                                 </button>
                                 {i < vehicles.length - 1 && (
-                                    <div className="absolute bottom-0 left-1 right-0 h-px bg-black/[0.07] dark:bg-white/[0.08]" />
+                                    <div className="absolute bottom-0 left-1 right-0 h-px bg-hairline/[0.08]" />
                                 )}
                             </div>
                         ))}

--- a/web/src/apps/ryde/rider/Home.tsx
+++ b/web/src/apps/ryde/rider/Home.tsx
@@ -123,7 +123,7 @@ export function Home() {
                         style={{ maxHeight: sheetOpen ? 360 : 0, transitionTimingFunction: 'cubic-bezier(0.22,0.61,0.36,1)' }}
                     >
                         <div ref={bodyRef} className="px-4 pb-4 pt-1">
-                            <button onClick={() => setPicking(true)} className="mb-3 flex w-full items-center gap-3 rounded-full bg-black/[0.07] px-5 py-[15px] active:bg-black/10 dark:bg-white/10 dark:active:bg-white/15">
+                            <button onClick={() => setPicking(true)} className="mb-3 flex w-full items-center gap-3 rounded-full bg-black/[0.07] px-5 py-[15px] active:bg-hairline/10 dark:active:bg-white/15">
                                 <Search className="h-[24px] w-[24px] shrink-0 text-black dark:text-white" strokeWidth={2.6} />
                                 <span className="flex-1 text-left text-[21px] font-bold tracking-tight text-black/85 dark:text-white/90">{t('ryde.whereTo', 'Where to?')}</span>
                             </button>
@@ -204,7 +204,7 @@ function PickRow({ onClick, icon, iconClass, name, sub, divider }: {
                     <span className="block truncate text-[15px] text-ios-gray">{sub}</span>
                 </span>
             </button>
-            {divider && <div className="absolute bottom-0 left-1 right-0 h-px bg-black/[0.07] dark:bg-white/[0.08]" />}
+            {divider && <div className="absolute bottom-0 left-1 right-0 h-px bg-hairline/[0.08]" />}
         </div>
     );
 }

--- a/web/src/apps/services/ActionsTab.tsx
+++ b/web/src/apps/services/ActionsTab.tsx
@@ -130,7 +130,7 @@ export function ActionsTab({ myCompany, multijob = false, invoicesEnabled = fals
                             <Divider />
                             <div className="flex">
                                 <SplitButton label={t('services.deposit', 'Deposit')}  onClick={() => setAmountFor('deposit')} />
-                                <div className="my-2 w-px bg-black/10 dark:bg-white/10" />
+                                <div className="my-2 w-px bg-hairline/10" />
                                 <SplitButton label={t('services.withdraw', 'Withdraw')} onClick={() => setAmountFor('withdraw')} />
                             </div>
                         </div>
@@ -393,5 +393,5 @@ function SplitButton({ label, onClick }: { label: string; onClick: () => void })
 }
 
 function Divider() {
-    return <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />;
+    return <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />;
 }

--- a/web/src/apps/services/CompaniesTab.tsx
+++ b/web/src/apps/services/CompaniesTab.tsx
@@ -123,7 +123,7 @@ function CompanyCard({ company, onLocate, onCall, onMessage }: {
                         ? t('services.dutyOpen', 'Staff on duty')
                         : t('services.dutyClosed', 'Nobody on duty')}
                     className={`absolute -right-px -top-px h-[15px] w-[15px] rounded-full ring-[3px] ring-surface ${
-                        company.onDuty ? 'bg-[#34c759]' : 'bg-[#ff3b30]'
+                        company.onDuty ? 'bg-[#34c759]' : 'bg-ios-red'
                     }`}
                 />
             </div>

--- a/web/src/apps/services/InvoicesPage.tsx
+++ b/web/src/apps/services/InvoicesPage.tsx
@@ -14,6 +14,7 @@ import { useMaskedPhone } from '@/stores/themeStore';
 import { fmtMoney } from './data';
 import { cancelInvoice, fetchSentInvoices, type SentInvoice } from './servicesApi';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 // Business sent-invoices list, mirroring the Wallet's Sent segment: contact-resolved identity,
 // reference codes in the title, status chips and cancel on pending rows.
@@ -64,7 +65,7 @@ export function InvoicesPage({ onClose }: { onClose: () => void }) {
                 willChange: 'transform',
             }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex h-11 shrink-0 items-center px-2">
                 <button type="button" onClick={dismiss} className="flex items-center gap-0.5 text-[17px] text-ios-blue active:opacity-60">

--- a/web/src/apps/services/InvoicesPage.tsx
+++ b/web/src/apps/services/InvoicesPage.tsx
@@ -88,7 +88,7 @@ export function InvoicesPage({ onClose }: { onClose: () => void }) {
                             const card = contactByNumber.get(digits(inv.toNumber));
                             return (
                             <div key={inv.id}>
-                                {i > 0 && <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+                                {i > 0 && <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />}
                                 <div className="flex items-center gap-3.5 px-4 py-4">
                                     {card ? <ContactAvatar contact={card} size={46} /> : <PlaceholderAvatar size={46} />}
                                     <div className="min-w-0 flex-1">

--- a/web/src/apps/services/InvoicesSection.tsx
+++ b/web/src/apps/services/InvoicesSection.tsx
@@ -70,5 +70,5 @@ function Tile({ color, children }: { color: string; children: ReactNode }) {
 }
 
 function Divider() {
-    return <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />;
+    return <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />;
 }

--- a/web/src/apps/services/JobsTab.tsx
+++ b/web/src/apps/services/JobsTab.tsx
@@ -265,7 +265,7 @@ function Capacity({ count, max }: { count: number; max: number }) {
                 <span className="text-[15px] font-semibold uppercase tracking-wider text-ios-gray">{t('services.myJobs', 'My Jobs')}</span>
                 <span className={`text-[15px] font-semibold ${full ? 'text-ios-red' : 'text-ios-gray'}`}>{count} / {max}</span>
             </div>
-            <div className="mt-1.5 h-[5px] w-full overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+            <div className="mt-1.5 h-[5px] w-full overflow-hidden rounded-full bg-hairline/10">
                 <div
                     className={`h-full rounded-full transition-[width] duration-300 ${full ? 'bg-ios-red' : 'bg-ios-blue'}`}
                     style={{ width: `${pct}%` }}

--- a/web/src/apps/services/NewInvoicePage.tsx
+++ b/web/src/apps/services/NewInvoicePage.tsx
@@ -10,6 +10,7 @@ import { digits } from '@/lib/format';
 import { formatPhonePartial } from '@/lib/phone';
 import { createInvoice } from './servicesApi';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const DRAFT_KEY = 'services:newInvoice';
 
@@ -71,7 +72,7 @@ export function NewInvoicePage({ onClose, onSent }: {
                     willChange: 'transform',
                 }}
             >
-                <div className="h-[58px] shrink-0" aria-hidden />
+                <StatusBarSpacer />
 
                 <div className="flex h-11 shrink-0 items-center justify-between px-2">
                     <button type="button" onClick={cancel} className="flex items-center gap-0.5 text-[17px] text-ios-blue active:opacity-60">

--- a/web/src/apps/services/ServiceMessagesTab.tsx
+++ b/web/src/apps/services/ServiceMessagesTab.tsx
@@ -26,6 +26,7 @@ import {
     messageCompany, replyCompany,
     type Inbox, type InboxMessage, type InboxThread, type ServiceDraft,
 } from './servicesApi';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 type Scope = 'personal' | 'job';
 
@@ -198,7 +199,7 @@ function Conversation({ scope, thread, onBack, onSent }: {
             className={`absolute inset-0 z-20 flex min-h-0 flex-col bg-surface font-sf dark:bg-base ${isDark ? 'dark' : ''}`}
             style={{ ...pageStyle, willChange: 'transform' }}
         >
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex items-center px-2 pb-2.5 pt-0.5">
                 <div className="flex flex-1 items-center">

--- a/web/src/apps/services/ServiceMessagesTab.tsx
+++ b/web/src/apps/services/ServiceMessagesTab.tsx
@@ -85,7 +85,7 @@ export function ServiceMessagesTab({ inbox, loaded, onInboxChange, onMarkRead }:
                                 <div key={t.key}>
                                     <ThreadRow thread={t} scope={scope} onOpen={() => setOpenKey(t.key)} />
                                     {i < threads.length - 1 && (
-                                        <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />
+                                        <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />
                                     )}
                                 </div>
                             ))}

--- a/web/src/apps/services/Services.tsx
+++ b/web/src/apps/services/Services.tsx
@@ -8,6 +8,7 @@ import { ServiceMessagesTab } from './ServiceMessagesTab';
 import { ActionsTab } from './ActionsTab';
 import { ServicesTabBar, type ServicesTab } from './ServicesTabBar';
 import { fetchDirectory, fetchInbox, markThreadRead, type Directory, type Inbox, type MyCompany } from './servicesApi';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const EMPTY_INBOX: Inbox = { personal: [], job: [], hasJob: false };
 
@@ -63,7 +64,7 @@ export function Services({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 flex flex-col bg-base font-sf">
-            <div className="h-[58px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex flex-1 flex-col overflow-hidden">
                 <div key={activeTab} className="flex min-h-0 flex-1 flex-col animate-swipe-in-left">

--- a/web/src/apps/settings/security/FaceUnlockPage.tsx
+++ b/web/src/apps/settings/security/FaceUnlockPage.tsx
@@ -217,7 +217,7 @@ function PinFlow({
                             className={`h-[14px] w-[14px] rounded-full border-2 transition-colors duration-150 ${
                                 i < pin.length
                                     ? 'bg-black dark:bg-white border-black dark:border-white'
-                                    : 'bg-transparent border-black/35 dark:border-white/35'
+                                    : 'bg-transparent border-hairline/35'
                             }`}
                         />
                     ))}

--- a/web/src/apps/stocks/AssetDetail.tsx
+++ b/web/src/apps/stocks/AssetDetail.tsx
@@ -19,7 +19,7 @@ function StatRow({ label, value, valueColor, divider }: { label: string; value: 
                 <span className="text-[16px] font-medium text-black/80 dark:text-white/80">{label}</span>
                 <span className="text-[18px] font-semibold tabular-nums" style={valueColor ? { color: valueColor } : undefined}>{value}</span>
             </div>
-            {divider && <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+            {divider && <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />}
         </>
     );
 }
@@ -150,14 +150,14 @@ export function AssetDetail({ asset, onBack, onBuy, onSell, onRefresh, animateIn
                                                 <span className="text-[16px] font-semibold" style={h.isYou ? { color: 'rgb(var(--ios-blue))' } : undefined}>{label}</span>
                                                 <span className="text-[16px] font-semibold tabular-nums">{pctText}</span>
                                             </div>
-                                            <div className="mt-2 h-[7px] w-full overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+                                            <div className="mt-2 h-[7px] w-full overflow-hidden rounded-full bg-hairline/10">
                                                 <div className="h-full rounded-full" style={{ width: `${Math.max(2, h.pct * 100)}%`, background: barColor }} />
                                             </div>
                                             <div className="mt-1 text-[13px] tabular-nums text-ios-gray">
                                                 {formatUnits(h.units)} {h.isMarket ? t('stocks.unowned', 'unowned') : t('stocks.units', 'units')}
                                             </div>
                                         </div>
-                                        {i < holders.holders.length - 1 && <div className="bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+                                        {i < holders.holders.length - 1 && <div className="bg-hairline/10" style={{ height: '0.5px' }} />}
                                     </div>
                                 );
                             })}

--- a/web/src/apps/stocks/Portfolio.tsx
+++ b/web/src/apps/stocks/Portfolio.tsx
@@ -30,7 +30,7 @@ function PortfolioRow({ asset, divider, onOpen }: { asset: Asset; divider: boole
                     <div className="text-[15px] font-semibold tabular-nums" style={{ color: trendColor(pl) }}>{formatPct(plPct)}</div>
                 </div>
             </button>
-            {divider && <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+            {divider && <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />}
         </>
     );
 }

--- a/web/src/apps/stocks/StockRow.tsx
+++ b/web/src/apps/stocks/StockRow.tsx
@@ -38,7 +38,7 @@ export function StockRow({ asset, divider, onOpen }: {
             </button>
 
             {divider && (
-                <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />
+                <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />
             )}
         </>
     );

--- a/web/src/apps/stocks/Stocks.tsx
+++ b/web/src/apps/stocks/Stocks.tsx
@@ -18,6 +18,7 @@ import {
 import { t } from '@/i18n';
 import { useStreamerHidden } from '@/stores/themeStore';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const HISTORY_CAP = 48;
 
@@ -108,7 +109,7 @@ export function Stocks({ onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 z-10 flex flex-col bg-base text-black dark:text-white">
-            <div className="h-[61px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="px-5 pb-1 pt-1 text-[34px] font-bold tracking-tight">{t('stocks.stocks', 'Stocks')}</div>
 

--- a/web/src/apps/streaks/Streaks.tsx
+++ b/web/src/apps/streaks/Streaks.tsx
@@ -13,6 +13,7 @@ import { LeaderboardTab } from './LeaderboardTab';
 import { MeTab } from './MeTab';
 import { RewardsView } from './RewardsView';
 import { StreaksTabBar } from './StreaksTabBar';
+import { Spinner } from '@/ui/Spinner';
 
 const SB_H = 61;
 const PAGE = 30;
@@ -174,7 +175,7 @@ export function Streaks({ onClose: _onClose }: { onClose: () => void }) {
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                 {loading || !state || !config ? (
                     <div className="flex flex-1 items-center justify-center">
-                        <span className="h-7 w-7 animate-spin rounded-full border-[3px] border-black/15 border-t-black/50 dark:border-white/15 dark:border-t-white/60" />
+                        <Spinner />
                     </div>
                 ) : (
                     <div

--- a/web/src/apps/voicememos/VoiceMemos.tsx
+++ b/web/src/apps/voicememos/VoiceMemos.tsx
@@ -14,6 +14,7 @@ import {
     deleteMemo, fetchMemos, fmtDuration, fmtMemoDate, renameMemo, shareMemo, uploadMemo, type VoiceMemo,
 } from './voiceApi';
 import { t } from '@/i18n';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 function pickMime(): string | undefined {
     const c = ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus', 'audio/mp4'];
@@ -126,7 +127,7 @@ export function VoiceMemos({ onClose: _onClose }: { onClose: () => void }) {
 
     return (
         <div className="absolute inset-0 z-10 flex flex-col bg-base font-sf text-black dark:text-white">
-            <div className="h-[61px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <div className="px-5 pb-1 pt-1 text-[34px] font-bold tracking-tight">{t('voicememos.title', 'Voice Memos')}</div>
 
             <SearchBar value={query} onChange={setQuery} className="mx-4 mb-2 mt-1" />

--- a/web/src/apps/weazelnews/EditArticle.tsx
+++ b/web/src/apps/weazelnews/EditArticle.tsx
@@ -7,6 +7,7 @@ import { Scroller } from '@/ui/Scroller';
 import { MediaPickerSheet } from '@/shared/MediaPickerSheet';
 import { Toggle } from '@/ui/Toggle';
 import { CATEGORIES, categoryLabel, type Article as ArticleT, type ArticleDraft, type Category, WEAZEL_RED } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function EditArticle({ initial, dark, onClose, onSave }: {
     initial:  ArticleT | null;
@@ -50,7 +51,7 @@ export function EditArticle({ initial, dark, onClose, onSave }: {
 
     return (
         <div className={`absolute inset-0 z-40 flex flex-col font-sf ${sheet}`} style={pageStyle}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex h-11 shrink-0 items-center justify-between px-4">
                 <button type="button" onClick={goBack} className="text-[16px]" style={{ color: WEAZEL_RED }}>{t('weazelnews.cancel', 'Cancel')}</button>

--- a/web/src/apps/weazelnews/EditBreaking.tsx
+++ b/web/src/apps/weazelnews/EditBreaking.tsx
@@ -4,6 +4,7 @@ import { GripVertical, Plus, X } from 'lucide-react';
 import { t } from '@/i18n';
 import { useIosPush } from '@/hooks/useIosPush';
 import { WEAZEL_RED } from './data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 const MAX_LINES = 8;
 
@@ -74,7 +75,7 @@ export function EditBreaking({ initial, dark, onClose, onSave }: {
 
     return (
         <div className={`absolute inset-0 z-40 flex flex-col font-sf ${sheet}`} style={pageStyle}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="flex h-11 shrink-0 items-center justify-between px-4">
                 <button type="button" onClick={goBack} className="text-[16px]" style={{ color: WEAZEL_RED }}>{t('weazelnews.cancel', 'Cancel')}</button>

--- a/web/src/shared/AppAuth.tsx
+++ b/web/src/shared/AppAuth.tsx
@@ -12,6 +12,7 @@ import { formatPhone } from '@/lib/phone';
 import { useStreamerHidden } from '@/stores/themeStore';
 import { HIDDEN_TEXT } from '@/shell/streamerMode';
 import { failText } from '@/core/api';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 interface AppAuthField {
     key:         string;
@@ -330,7 +331,7 @@ function Welcome({ appName, tagline, icon, theme, onCreate, onLogin, onForgot, o
             className={`relative flex h-full flex-col ${light ? 'text-white' : 'text-black'}`}
             style={{ background: theme.welcomeBg }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             {onDismiss && (
                 <button
                     type="button"
@@ -642,7 +643,7 @@ function AuthForm({ mode, appName, icon, theme, fields, notice, myNumber, myEmai
 
     return (
         <div className="relative flex h-full flex-col text-black" style={{ background: formBg }}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <header className="flex items-center px-3 py-2">
                 <button type="button" onClick={onBack} className="flex items-center active:opacity-60" style={{ color: theme.accent }}>
                     <ChevronLeft className="h-[28px] w-[28px]" strokeWidth={2.4} />
@@ -824,7 +825,7 @@ function ResetForm({ phase, appName, icon, theme, identity, onIdentity, myNumber
 
     return (
         <div className="relative flex h-full flex-col text-black" style={{ background: formBg }}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <header className="flex items-center px-3 py-2">
                 <button type="button" onClick={() => { setError(null); onBack(); }} className="flex items-center active:opacity-60" style={{ color: theme.accent }}>
                     <ChevronLeft className="h-[28px] w-[28px]" strokeWidth={2.4} />
@@ -1021,7 +1022,7 @@ export function ChangePasswordForm({ appName, icon, theme, identity, savedPasswo
 
     return (
         <div className="absolute inset-0 z-40 flex flex-col text-black" style={{ background: formBg, ...pageStyle }}>
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
             <header className="flex items-center px-3 py-2">
                 <button type="button" onClick={goBack} className="flex items-center active:opacity-60" style={{ color: theme.accent }}>
                     <ChevronLeft className="h-[28px] w-[28px]" strokeWidth={2.4} />

--- a/web/src/shared/ContactPickerSheet.tsx
+++ b/web/src/shared/ContactPickerSheet.tsx
@@ -100,7 +100,7 @@ function Row({ contact, divider, onChoose }: { contact: Contact; divider: boolea
                     <div className="mt-0.5 truncate text-[18px] font-medium text-black/55 dark:text-white/55">{phone(contact.phone)}</div>
                 </div>
             </button>
-            {divider && <div className="pointer-events-none bg-black/10 dark:bg-white/10" style={{ height: '0.5px' }} />}
+            {divider && <div className="pointer-events-none bg-hairline/10" style={{ height: '0.5px' }} />}
         </>
     );
 }

--- a/web/src/shared/MediaPickerSheet.tsx
+++ b/web/src/shared/MediaPickerSheet.tsx
@@ -194,7 +194,7 @@ function AlbumList({ albums, onOpen }: { albums: Album[]; onOpen: (a: Album) => 
         <div className="grid gap-3 px-4 pt-2" style={cols(ALBUM_COLS)}>
             {albums.map(a => (
                 <button key={a.id} type="button" onClick={() => onOpen(a)} className="text-left active:opacity-70">
-                    <div className="aspect-square overflow-hidden rounded-[12px] bg-black/10 dark:bg-white/10">
+                    <div className="aspect-square overflow-hidden rounded-[12px] bg-hairline/10">
                         {a.cover && <img src={a.cover} alt="" draggable={false} className="h-full w-full object-cover" />}
                     </div>
                     <div className="mt-1.5 truncate text-[14px] font-semibold text-black dark:text-white">{a.name}</div>

--- a/web/src/shared/ShareSheet.tsx
+++ b/web/src/shared/ShareSheet.tsx
@@ -105,7 +105,7 @@ export function ShareSheet({ onClose, onShare, children, top = '55%' }: {
 
                 {children && (
                     <>
-                        <div className="mx-4 mt-5 h-px bg-black/10 dark:bg-white/10" />
+                        <div className="mx-4 mt-5 h-px bg-hairline/10" />
                         <div className="flex flex-col gap-2.5 px-4 pt-5">{children}</div>
                     </>
                 )}

--- a/web/src/shared/chat/AddMemberSheet.tsx
+++ b/web/src/shared/chat/AddMemberSheet.tsx
@@ -91,7 +91,7 @@ export function AddMemberSheet({ groupName, contacts, existing, myNumber, onCanc
                         <div className="shrink-0 px-4 pb-2 pt-1 text-center">
                             <span className="text-[19px] font-semibold">{t('messages.addToGroup', 'Add to {groupName}', { groupName })}</span>
                         </div>
-                        <div className="h-[0.5px] bg-black/10 dark:bg-white/10" />
+                        <div className="h-[0.5px] bg-hairline/10" />
 
                         <div className="shrink-0 px-4 py-2.5">
                             <div className="flex flex-wrap items-center gap-1.5">
@@ -118,7 +118,7 @@ export function AddMemberSheet({ groupName, contacts, existing, myNumber, onCanc
                                 />
                             </div>
                         </div>
-                        <div className="h-[0.5px] bg-black/10 dark:bg-white/10" />
+                        <div className="h-[0.5px] bg-hairline/10" />
 
                         <div className="min-h-0 flex-1 overflow-y-auto no-scrollbar px-2 pt-2">
                             {query.trim().length > 0 && (

--- a/web/src/shared/chat/EditGroupSheet.tsx
+++ b/web/src/shared/chat/EditGroupSheet.tsx
@@ -62,7 +62,7 @@ export function EditGroupSheet({ groupName, groupAvatar, participants, onCancel,
                                     </button>
                                 </div>
                             </div>
-                            <div className="h-[0.5px] shrink-0 bg-black/10 dark:bg-white/10" />
+                            <div className="h-[0.5px] shrink-0 bg-hairline/10" />
 
                             <div className="min-h-0 flex-1 overflow-y-auto no-scrollbar">
                                 <div className="flex flex-col items-center gap-2.5 pt-6">
@@ -103,7 +103,7 @@ export function EditGroupSheet({ groupName, groupAvatar, participants, onCancel,
                                         <MemberRow contact={ME} displayName={t('messages.you', 'You')} />
                                         {participants.map(c => (
                                             <div key={c.id}>
-                                                <div className="ml-[68px] h-[0.5px] bg-black/10 dark:bg-white/10" />
+                                                <div className="ml-[68px] h-[0.5px] bg-hairline/10" />
                                                 <MemberRow contact={c} displayName={c.name} onRemove={() => setPendingRemove(c)} />
                                             </div>
                                         ))}

--- a/web/src/shared/chat/EditGroupSheet.tsx
+++ b/web/src/shared/chat/EditGroupSheet.tsx
@@ -148,7 +148,7 @@ function MemberRow({ contact, displayName, onRemove }: { contact: Contact; displ
                     aria-label={t('messages.removeMemberAria', 'Remove {name}', { name: displayName })}
                     className="shrink-0 pl-2 active:opacity-60"
                 >
-                    <span className="flex h-[26px] w-[26px] items-center justify-center rounded-full bg-[#ff3b30]">
+                    <span className="flex h-[26px] w-[26px] items-center justify-center rounded-full bg-ios-red">
                         <span className="h-[2.5px] w-[13px] rounded-full bg-white" />
                     </span>
                 </button>

--- a/web/src/shared/chat/EmojiPanel.tsx
+++ b/web/src/shared/chat/EmojiPanel.tsx
@@ -126,7 +126,7 @@ export function EmojiPanel({ isDark, onSelect }: Props) {
                 })}
             </div>
 
-            <div className="mx-3 h-[0.5px] bg-black/[0.07] dark:bg-white/[0.08]" />
+            <div className="mx-3 h-[0.5px] bg-hairline/[0.08]" />
 
             <div ref={scrollRef} onScroll={onScroll} className="relative min-h-0 flex-1 overflow-y-auto no-scrollbar px-3 pt-2.5">
                 {searching ? (

--- a/web/src/shell/CustomAppFrame.tsx
+++ b/web/src/shell/CustomAppFrame.tsx
@@ -633,7 +633,7 @@ export function CustomAppFrame({ appId, onClose }: { appId: string; onClose: () 
                                         key={i}
                                         type="button"
                                         onClick={() => { const r = ctxResolve.current; ctxResolve.current = null; if (r) r(b.callbackId ?? i); close(); }}
-                                        className={`flex w-full items-center px-4 py-3.5 text-left text-[18px] font-medium active:bg-black/[0.06] dark:active:bg-white/[0.06] ${i < arr.length - 1 ? 'border-b border-black/10 dark:border-white/10' : ''}`}
+                                        className={`flex w-full items-center px-4 py-3.5 text-left text-[18px] font-medium active:bg-black/[0.06] dark:active:bg-white/[0.06] ${i < arr.length - 1 ? 'border-b border-hairline/10' : ''}`}
                                         style={{ color: b.color ?? undefined }}
                                     >
                                         {b.title ?? b.text ?? b.label ?? ''}

--- a/web/src/shell/Lockscreen.tsx
+++ b/web/src/shell/Lockscreen.tsx
@@ -501,13 +501,13 @@ export function LockNotifCard({ item, onOpen, onDismiss }: { item: NotificationI
             className={[
                 'flex w-full animate-notif-drop touch-pan-y select-none items-start gap-3 rounded-[27px] px-[18px] py-4 text-left shadow-[0_6px_24px_rgba(0,0,0,0.16)]',
                 frostedWallpaper ? 'bg-white/70' : 'bg-white/55 backdrop-blur-2xl backdrop-saturate-150',
-                item.emergency ? 'ring-[1.5px] ring-inset ring-[#FF3B30]/75' : 'ring-1 ring-black/[0.04]',
+                item.emergency ? 'ring-[1.5px] ring-inset ring-ios-red/75' : 'ring-1 ring-black/[0.04]',
             ].join(' ')}
         >
             <NotifIcon item={item} size={47} />
             <div className="min-w-0 flex-1 pt-0.5">
                 {item.emergency && (
-                    <span className="mb-[2px] block text-[13.5px] font-bold uppercase leading-[1.15] tracking-[0.09em] text-[#FF3B30]">
+                    <span className="mb-[2px] block text-[13.5px] font-bold uppercase leading-[1.15] tracking-[0.09em] text-ios-red">
                         {t('shell.emergencyAlert', 'Emergency Alert')}
                     </span>
                 )}

--- a/web/src/shell/Notifications.tsx
+++ b/web/src/shell/Notifications.tsx
@@ -122,7 +122,7 @@ function NotificationBanner({ item, onDismiss, onOpen }: {
             className={[
                 'flex cursor-pointer items-start gap-2.5 rounded-[22px] bg-elevated/75 px-3 py-3 shadow-[0_10px_34px_rgba(0,0,0,0.20)] backdrop-blur-2xl backdrop-saturate-150 dark:bg-elevated/75',
                 item.emergency
-                    ? 'ring-[1.5px] ring-inset ring-[#FF3B30]/75 dark:ring-[#FF3B30]/75'
+                    ? 'ring-[1.5px] ring-inset ring-ios-red/75 dark:ring-ios-red/75'
                     : 'ring-1 ring-black/[0.06] dark:ring-white/10',
             ].join(' ')}
             style={{ willChange: 'transform', ...style }}
@@ -130,7 +130,7 @@ function NotificationBanner({ item, onDismiss, onOpen }: {
             <NotifIcon item={item} />
             <div className="min-w-0 flex-1 pt-px">
                 {item.emergency && (
-                    <span className="mb-[1px] block text-[12.5px] font-bold uppercase leading-[1.15] tracking-[0.09em] text-[#FF3B30]">
+                    <span className="mb-[1px] block text-[12.5px] font-bold uppercase leading-[1.15] tracking-[0.09em] text-ios-red">
                         {t('shell.emergencyAlert', 'Emergency Alert')}
                     </span>
                 )}

--- a/web/src/shell/ReceivedIdLayer.tsx
+++ b/web/src/shell/ReceivedIdLayer.tsx
@@ -4,6 +4,7 @@ import { t } from '@/i18n';
 import { IdCard } from '@/apps/id/IdCard';
 import { DetailsList } from '@/apps/id/DetailsList';
 import { cardTitle, formatCountdown, type ReceivedIdCard } from '@/apps/id/data';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export function ReceivedIdLayer({ shown, onDone }: {
     shown:  ReceivedIdCard;
@@ -37,7 +38,7 @@ export function ReceivedIdLayer({ shown, onDone }: {
                 ? 'ios-sheet-down 0.26s cubic-bezier(0.32,0,0.68,1) forwards'
                 : 'ios-sheet-up 0.34s cubic-bezier(0.32,0.72,0,1)' }}
         >
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="shrink-0 px-5 pb-3 pt-2 text-center">
                 <div className="text-[15px] font-semibold text-ios-gray">{t('id.shownBy', 'Shown by {name}', { name: shown.fromName })}</div>

--- a/web/src/shell/SetupFlow.tsx
+++ b/web/src/shell/SetupFlow.tsx
@@ -16,6 +16,7 @@ import { t } from '@/i18n';
 import { formatLongDate } from '@/lib/time';
 import { SUPPORTED_LOCALES, useLocaleStore } from '@/stores/localeStore';
 import type { LocaleOption } from '@/stores/localeStore';
+import { StatusBarSpacer } from '@/ui/StatusBarSpacer';
 
 export interface SetupResult {
     language:    string;
@@ -92,7 +93,7 @@ export function SetupFlow({ onDone, onHelloChange }: Props) {
                 </defs>
             </svg>
 
-            <div className="h-[54px] shrink-0" aria-hidden />
+            <StatusBarSpacer />
 
             <div className="h-10 shrink-0 px-3">
                 {canGoBack && stage !== 'done' && (
@@ -174,7 +175,7 @@ export function SetupFlow({ onDone, onHelloChange }: Props) {
                     style={{ background: HELLO_BG_LIGHT, willChange: 'transform, opacity' }}
                 >
                     <HelloAurora />
-                    <div className="h-[54px] shrink-0" aria-hidden />
+                    <StatusBarSpacer />
                     <div className="h-10 shrink-0" aria-hidden />
                     <HelloStage onContinue={beginHelloLift} frozen={helloLifting} />
                 </div>

--- a/web/src/shell/SetupFlow.tsx
+++ b/web/src/shell/SetupFlow.tsx
@@ -788,7 +788,7 @@ function WallpaperStage({
                                 />
                                 <div
                                     className={`pointer-events-none absolute inset-0 rounded-[16px] ${
-                                        isSelected ? 'border-[3px] border-ios-blue' : 'border border-black/10 dark:border-white/10'
+                                        isSelected ? 'border-[3px] border-ios-blue' : 'border border-hairline/10'
                                     }`}
                                 />
                                 {isSelected && (

--- a/web/src/ui/Spinner.tsx
+++ b/web/src/ui/Spinner.tsx
@@ -1,0 +1,9 @@
+export function Spinner({ size = 28, className = '' }: { size?: number; className?: string }) {
+    return (
+        <span
+            role="status"
+            className={`inline-block animate-spin rounded-full border-[3px] border-black/15 border-t-black/50 dark:border-white/15 dark:border-t-white/60 ${className}`}
+            style={{ width: size, height: size }}
+        />
+    );
+}

--- a/web/src/ui/StatusBarSpacer.tsx
+++ b/web/src/ui/StatusBarSpacer.tsx
@@ -1,0 +1,3 @@
+export function StatusBarSpacer() {
+    return <div className="h-[58px] shrink-0" aria-hidden />;
+}


### PR DESCRIPTION
## Summary

First mechanical slice of the visual-consistency audit. All three changes are purely presentational.

- **One status-bar spacer.** The large-title screens used four different literal spacer heights (54, 56, 58, 61px) for the same layout. A shared `StatusBarSpacer` primitive replaces all 77 literal spacer divs across 66 files at the majority height of 58px, so every app's title now sits on the same baseline.
- **One spinner.** A shared `Spinner` primitive replaces the hand-rolled ring spinner; the two identical sites are swapped now and remaining per-app spinners can move over as those apps are touched.
- **Red token instead of hex.** 21 `bg/text/ring-[#ff3b30]` class sites across 15 files now use the `ios-red` token, matching the sibling rows that already did.

Not in this PR, by design: the hand-rolled nav bars and list rows in ~50 files, the inline hairline dividers, and the light-only apps embedding theme-following dialogs. Those need per-app work and visual review rather than a sweep.

## Gates

- [x] `npm run build` (tsc + vite)
- [x] `npm run lint` (0 errors)
- [x] `npm run knip`
- [x] `npm run i18n:check`
- [x] local test suite (649 passed)

Not merged; awaiting review. The 4px shift on the screens that used 54px is the one thing worth eyeballing in-game.