### PR TITLE
fix(messages): trim the thread through the prune instead of recursing

### DIFF
--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -40,7 +40,7 @@ local ok, fail, digits, trim, initialsFor, formatNumber = util.ok, util.fail, ut
 ---@param conversation string thread key
 local function trimThread(cid, conversation)
     if store.threadCount(cid, conversation) > cfg.MessagesPerThread then
-        trimThread(cid, conversation)
+        store.pruneThread(cid, conversation, cfg.MessagesPerThread)
     end
 end
 


### PR DESCRIPTION
## Summary

Regression from #245. The count-gated `trimThread` helper was meant to call `store.pruneThread`, but the same rewrite that replaced the prune call sites also replaced the call inside the helper's own body, so it recursed into itself. Any send into a thread already over `MessagesPerThread` overflowed the stack; the callback guard caught it and the send failed with the generic error instead of hanging.

One-line fix: the helper calls `store.pruneThread(cid, conversation, cfg.MessagesPerThread)` again.

Found by the Messages builder while adding typing indicators. Not caught earlier because no thread on the dev box was over the cap.

## Verification

- [x] `luac -p` on the file
- [x] Applied to the live dev resource and restarted

Until this merges the live box carries the fix as an uncommitted edit.