### PR TITLE
fix(target): hand qb-target/qtarget selections to onSelect in the ox_target shape

### DIFF
--- a/bridge/client/target.lua
+++ b/bridge/client/target.lua
@@ -70,6 +70,24 @@ if not active then
     end)
 end
 
+---Wraps an ox_target onSelect so qb-target/qtarget can call it. Those backends invoke
+---action(entity, optionData) with the raw entity handle first, while ox_target passes one table
+---{ entity, coords, ... }. Handing onSelect over unwrapped meant every consumer that indexed its
+---argument crashed under qb-target with "attempt to index a number value".
+---@param onSelect fun(data: table)|nil ox_target-shaped handler
+---@return fun(entity: number|nil, data: table|nil)|nil action in the qb-target/qtarget shape
+local function adaptAction(onSelect)
+    if type(onSelect) ~= 'function' then return nil end
+    return function(entity, data)
+        local handle = type(entity) == 'number' and entity ~= 0 and entity or nil
+        onSelect({
+            entity = handle,
+            coords = handle and DoesEntityExist(handle) and GetEntityCoords(handle) or nil,
+            name   = type(data) == 'table' and data.name or nil,
+        })
+    end
+end
+
 ---Translate ox_target option entries to the qb-target/qtarget shape. A pass-through when
 ---ox_target is active.
 ---@param options table[] ox_target-shaped option entries
@@ -85,7 +103,7 @@ local function convertOptions(options)
             event       = o.event,
             icon        = o.icon,
             label       = o.label,
-            action      = o.onSelect,
+            action      = adaptAction(o.onSelect),
             canInteract = o.canInteract,
             distance    = o.distance,
             groups      = o.groups,


### PR DESCRIPTION
## Problem

Using a payphone on a qb-target server crashes:

```
SCRIPT ERROR: @sd-phone/client/payphone.lua:519: attempt to index a number value (local 'tdata')
> ref (@sd-phone/client/payphone.lua:519)
> fn (@qb-target/client.lua:506)
```

## Root cause

`bridge/client/target.lua` translated ox_target options for qb-target/qtarget by passing `onSelect` straight through as `action`. ox_target calls `onSelect({ entity, coords, ... })`, but qb-target and qtarget call `action(entity, optionData)` with the raw entity handle first. Every consumer that indexed its argument therefore crashed under qb-target. The payphone booth handler was the first to hit it because booths are the only target consumer today.

## Fix

A small adapter in the bridge wraps `onSelect` for the qb-target/qtarget shape and hands it `{ entity, coords, name }`, so consumers keep writing ox_target-style handlers and work on every backend. Zone-style calls with no entity yield a table with `entity = nil` rather than crashing. ox_target is still a pass-through.

## Gates

- `luac -p bridge/client/target.lua` clean
- Stub-native Lua harness (local, not committed): loads the bridge with qb-target reported as started, registers a model option, and invokes the produced `action(777, data)` the way qb-target does. On main `onSelect` received the number 777; on this branch it receives `{ entity = 777, coords = ... }`, and a nil-entity call yields a table with no entity.
- Client Lua only, no web rebuild.