### PR TITLE
fix(config): fall back to a group's own file when configs/config.lua predates it

### DIFF
--- a/client/payphone.lua
+++ b/client/payphone.lua
@@ -8,7 +8,7 @@ local companion = require 'client.companion'
 local locale = require 'bridge.shared.locale'
 
 ---@type table Payphone config (configs/payphone.lua).
-local cfg = config.Payphone
+local cfg = config.Payphone or require 'configs.payphone'
 
 ---@type string|nil Location key ('x,y,z') of the booth currently in use, nil when the UI is closed.
 local activeLocation = nil

--- a/server/calendar/actions.lua
+++ b/server/calendar/actions.lua
@@ -15,7 +15,7 @@ local util          = require 'server.util'
 local ok, fail = util.ok, util.fail
 
 ---@type table Calendar app config (config.Calendar): per-character event cap, guest cap, field caps.
-local CFG = config.Calendar
+local CFG = config.Calendar or require 'configs.calendar'
 
 ---@type table Actions module; the table returned at end of file. The organizer's row is the only
 ---copy of an event: an invitee reads it through their attendee row rather than owning a clone.

--- a/server/contacts/actions.lua
+++ b/server/contacts/actions.lua
@@ -12,7 +12,7 @@ local share    = require 'server.share.core'
 local badges   = require 'server.badges.init'
 
 ---@type table Contacts config (config.Contacts): caps for contacts, recents, and field lengths.
-local cfg = config.Contacts
+local cfg = config.Contacts or require 'configs.contacts'
 
 ---@type table Actions module; the table returned at end of file.
 local actions = {}

--- a/server/findmy/actions.lua
+++ b/server/findmy/actions.lua
@@ -13,7 +13,7 @@ local settings = require 'server.settings.store'
 local util     = require 'server.util'
 
 ---@type table Find My config (config.FindMy): tick cadence, sound length, message cap.
-local CFG = config.FindMy
+local CFG = config.FindMy or require 'configs.findmy'
 
 ---@type table Actions module; the table returned at end of file.
 local actions = {}

--- a/server/findmy/init.lua
+++ b/server/findmy/init.lua
@@ -8,8 +8,10 @@ local store   = require 'server.findmy.store'
 ---@type table Authoritative Find My handlers (server.findmy.actions): sightings + Lost Mode.
 local actions = require 'server.findmy.actions'
 
----@type table Find My app config (config.FindMy): master switch + sighting cadence.
-local CFG = config.FindMy
+---@type table Find My app config (config.FindMy): master switch + sighting cadence. Falls back to
+---the group's own file, so a configs/config.lua predating this app still reads the owner's real
+---settings rather than erroring on the first sighting tick.
+local CFG = config.FindMy or require 'configs.findmy'
 
 -- Boot thread: creates the device-sightings table.
 CreateThread(function()

--- a/server/id/actions.lua
+++ b/server/id/actions.lua
@@ -17,7 +17,7 @@ local util      = require 'server.util'
 local ok, fail  = util.ok, util.fail
 
 ---@type table ID app config (config.Id): licence catalogue, job colours, issuer, show duration.
-local CFG = config.Id
+local CFG = config.Id or require 'configs.id'
 
 ---@type string Card face for the State ID; every licence and badge picks its own from config.
 local STATE_COLOR <const> = '#2C3440'

--- a/server/messages/actions.lua
+++ b/server/messages/actions.lua
@@ -24,7 +24,7 @@ local moderation    = require 'server.admin.moderation'
 local service       = require 'server.service'
 
 ---@type table Messages knobs (configs/messages.lua): body / thread / group caps.
-local cfg = config.Messages
+local cfg = config.Messages or require 'configs.messages'
 
 ---@type table Actions module; the table returned at end of file.
 local actions = {}

--- a/server/payphone/init.lua
+++ b/server/payphone/init.lua
@@ -17,7 +17,7 @@ local settings = require 'server.settings.store'
 local money    = require 'bridge.server.money'
 
 ---@type table Payphone config (configs/payphone.lua).
-local cfg = config.Payphone
+local cfg = config.Payphone or require 'configs.payphone'
 
 local util = require 'server.util'
 local ok, fail, digits = util.ok, util.fail, util.digits

--- a/server/payphone/store.lua
+++ b/server/payphone/store.lua
@@ -5,7 +5,7 @@ local config   = require 'configs.config'
 local settings = require 'server.settings.store'
 
 ---@type table Payphone config (configs/payphone.lua).
-local cfg = config.Payphone
+local cfg = config.Payphone or require 'configs.payphone'
 
 ---Creates the payphone-number table idempotently. One row per physical booth, keyed by its
 ---rounded world position.

--- a/server/streaks/actions.lua
+++ b/server/streaks/actions.lua
@@ -12,7 +12,7 @@ local live    = require 'server.streaks.live'
 local banking = require 'server.banking.actions'
 
 ---@type table Streaks app config (config.Streaks): milestone ladder, reward account, size caps.
-local CFG = config.Streaks
+local CFG = config.Streaks or require 'configs.streaks'
 
 ---@type table Actions module; the table returned at end of file.
 local actions = {}


### PR DESCRIPTION
## The bug

Reported on a live server:

```
SCRIPT ERROR: @sd-phone/server/findmy/init.lua:73: attempt to index a nil value (upvalue 'CFG')
```

`server/findmy/init.lua` read its config group bare:

```lua
local CFG = config.FindMy
```

When that group is absent, `CFG` is nil and nothing fails until the sighting thread's first line, ~60 lines away from the actual fault.

The group is absent whenever a server owner updates the resource but keeps their own edited `configs/config.lua`, which is the normal update practice since configs are user-edited. New code, old config, missing group. Verified that no released version ever shipped one without the other, so a stale config root is the only way to reach it.

## The fix

Read the group as `config.X or require 'configs.x'`.

`require 'configs.calendar'` returns the **same cached table** that `configs/config.lua` indexes (verified with `rawequal` across all seven groups), so the guard is a no-op when the root is current and yields the owner's real settings when it is stale.

### Why not `or {}`

`or {}` is only safe where every field read already has its own fallback. That holds for Find My, but not for most modules, where it moves the crash instead of removing it:

- `calendar`, `contacts`, `messages` do `#name > cfg.MaxNameLength` -> "attempt to compare number with nil"
- `id` does `CFG.Licences[key]` and `streaks` does `CFG.Milestones[day]` -> a different nil-index crash

`or require` also invents no defaults, so nothing can drift out of sync with the shipped config.

## Scope

Ten sites: `findmy` (init + actions), `calendar`, `contacts`, `id`, `messages`, `streaks`, `payphone` (init, store, client). One line each.

The ~15 modules already using `config.X or {}` (`voice/init.lua`, `service.lua`, `appgate.lua`, `health/*`, ...) are left alone: their field reads are individually defaulted, which is why that pattern is safe there.

## Gates

- `luac -p` clean on all 10 files
- Full local Lua suite: same 6 pre-existing failures as `main` (baccarat locale stubs, settings snapshot), no new ones
- A local suite reproduces the original crash by stubbing `CreateThread` to run its body as a coroutine and `Wait` to yield, so the load-time thread reaches line 73 and parks. Before: `3 passed, 2 failed` on exactly `attempt to index a nil value (upvalue 'CFG')`. After: `4 passed, 0 failed`
- A second local suite scans `server/`, `client/` and `bridge/` for the guard pattern and asserts each fallback resolves to the same table `configs/config.lua` indexes, so a typo'd module path cannot pass unnoticed: 51 assertions, all passing
- No locale keys added, so no `en.json` regeneration needed
- No web changes, so no bundle rebuild needed

Not verified in-game: the FXServer was down during this work.
