### PR TITLE
feat(phone): block the phone while cuffed or downed, and gate Squawk post notifications

### DIFF
--- a/bridge/client/playerstate.lua
+++ b/bridge/client/playerstate.lua
@@ -1,0 +1,90 @@
+---@type FrameworkInfo Framework detection (bridge.shared.framework): name ('qbx'|'qb'|'esx'|'ox') + live core handle.
+local framework = require 'bridge.shared.framework'
+
+---@type table Player-state module; the table returned at end of file. Answers whether the local
+---player is restrained or incapacitated, which the phone gates itself on.
+local playerstate = {}
+
+---@type string[] Player state-bag keys cuff scripts write, checked in order. There is no agreed
+---key: the qb family writes `ishandcuffed`, ESX forks write `handcuffed`, and several standalone
+---scripts write `cuffed`, so all three are read rather than betting on one.
+local CUFF_BAGS <const> = { 'ishandcuffed', 'handcuffed', 'cuffed', 'isHandcuffed' }
+
+---@type string[] Player state-bag keys used for a downed (bleeding out / last stand) player.
+local DOWN_BAGS <const> = { 'isdead', 'inlaststand', 'dead', 'isDead', 'laststand' }
+
+---@type string[] Framework metadata fields marking a downed player.
+local DOWN_META <const> = { 'isdead', 'inlaststand' }
+
+---Reads the framework's player-data table, or nil before the player has loaded. Mirrors the
+---resolution bridge.client.job does, so a framework added there is added here too.
+---@return table|nil data
+local function playerData()
+    if framework.name == 'qbx' then
+        local ok, data = pcall(function() return exports.qbx_core:GetPlayerData() end)
+        return ok and data or nil
+    end
+    if framework.qb then
+        if not framework.core then return nil end
+        local ok, data = pcall(function() return framework.core.Functions.GetPlayerData() end)
+        return ok and data or nil
+    end
+    if framework.name == 'esx' then
+        if not framework.core then return nil end
+        local ok, data = pcall(function() return framework.core.GetPlayerData() end)
+        return ok and data or nil
+    end
+    return nil
+end
+
+---Whether any of the named keys is truthy on the local player's state bag.
+---@param keys string[]
+---@return boolean
+local function anyBag(keys)
+    local state = LocalPlayer and LocalPlayer.state
+    if not state then return false end
+    for i = 1, #keys do
+        local ok, value = pcall(function() return state[keys[i]] end)
+        if ok and value then return true end
+    end
+    return false
+end
+
+---Whether any of the named fields is truthy on the framework's player metadata.
+---@param keys string[]
+---@return boolean
+local function anyMeta(keys)
+    local data = playerData()
+    local meta = type(data) == 'table' and data.metadata
+    if type(meta) ~= 'table' then return false end
+    for i = 1, #keys do
+        if meta[keys[i]] then return true end
+    end
+    return false
+end
+
+---Whether the local player is currently restrained.
+---
+---Three sources are consulted because cuffing is not a framework feature: most scripts only write
+---a state bag, some only set framework metadata, and a few cuff the ped properly. Reading one
+---source silently misses every script that uses another.
+---@return boolean cuffed
+function playerstate.isCuffed()
+    if anyBag(CUFF_BAGS) then return true end
+    if anyMeta({ 'ishandcuffed' }) then return true end
+    local ped = cache.ped
+    return ped ~= nil and ped ~= 0 and IsPedCuffed(ped)
+end
+
+---Whether the local player is incapacitated: bleeding out, in last stand, or flagged dead by the
+---framework while the ped itself is still alive.
+---
+---Deliberately NOT an `IsEntityDead` check. That one is true only once the ped is really dead,
+---which is the tail of the state, whereas a downed player spends most of it alive and waiting on
+---EMS. `configs/phone.lua` keeps the engine-level check under its own BlockWhileDead flag.
+---@return boolean downed
+function playerstate.isDowned()
+    return anyBag(DOWN_BAGS) or anyMeta(DOWN_META)
+end
+
+return playerstate

--- a/client/main.lua
+++ b/client/main.lua
@@ -8,6 +8,8 @@ local config = require 'configs.config'
 local locale = require 'bridge.shared.locale'
 ---@type table Notify bridge (bridge.client.notify): backend-agnostic on-screen toasts.
 local notify = require 'bridge.client.notify'
+---@type table Player-state bridge (bridge.client.playerstate): restrained / incapacitated reads.
+local playerstate = require 'bridge.client.playerstate'
 
 -- Apps disabled in configs/apps.lua never reach the NUI, so neither the home screen nor the
 -- App Store can show them. Built once - the catalog is static per boot.
@@ -458,8 +460,40 @@ AddEventHandler('sd-phone:client:cameraCursor', function(on)
 end)
 
 
+---The message explaining why the phone cannot be opened right now, or nil when it can. Each
+---locale.t call is spelled out in full because the i18n generator scans this file for literal
+---keys; handing it a key through a variable would drop these strings from every catalogue.
+---@return string|nil message nil when the phone is allowed
+local function blockedReason()
+    local ped = cache.ped
+    if config.Phone.BlockWhileDead and IsEntityDead(ped) then
+        return locale.t('phone.blocked_dead', 'You can\'t use your phone right now.')
+    end
+    if config.Phone.BlockWhileDowned and playerstate.isDowned() then
+        return locale.t('phone.blocked_downed', 'You can\'t use your phone while you are down.')
+    end
+    if config.Phone.BlockWhileCuffed and playerstate.isCuffed() then
+        return locale.t('phone.blocked_cuffed', 'You can\'t use your phone while restrained.')
+    end
+    if config.Phone.BlockWhileSwimming and IsPedSwimming(ped) then
+        return locale.t('phone.blocked_swim', 'You can\'t use your phone while swimming.')
+    end
+    return nil
+end
+
+---Whether the player is restrained or incapacitated. Only these two states take an ALREADY-OPEN
+---phone away; being dead or swimming keeps its long-standing behaviour of refusing the open and
+---otherwise leaving an open phone alone.
+---@return boolean
+local function seizesOpenPhone()
+    if config.Phone.BlockWhileCuffed and playerstate.isCuffed() then return true end
+    if config.Phone.BlockWhileDowned and playerstate.isDowned() then return true end
+    return false
+end
+
 ---Opens the phone NUI onto the lockscreen, loads installed apps, focuses the NUI, and pushes a
----weather snapshot plus the session-start timestamp. Refuses while dead, swimming, or disabled.
+---weather snapshot plus the session-start timestamp. Refuses while dead, downed, restrained,
+---swimming, or disabled.
 local function OpenPhone()
     if phoneState.open then return end
 
@@ -473,14 +507,9 @@ local function OpenPhone()
     -- third-party ones re-ask about their own gates on the same open.
     customApps.refreshGates()
 
-    local ped = cache.ped
-
-    if config.Phone.BlockWhileDead and IsEntityDead(ped) then
-        notify.show({ description = locale.t('phone.blocked_dead', 'You can\'t use your phone right now.'), type = 'error' })
-        return
-    end
-    if config.Phone.BlockWhileSwimming and IsPedSwimming(ped) then
-        notify.show({ description = locale.t('phone.blocked_swim', 'You can\'t use your phone while swimming.'), type = 'error' })
+    local blocked = blockedReason()
+    if blocked then
+        notify.show({ description = blocked, type = 'error' })
         return
     end
 
@@ -875,6 +904,19 @@ CreateThread(function()
             SendNUIMessage({ action = 'sd-phone:battery', data = phoneState.battery })
             ---First-party client event: the cosmetic battery percentage moved.
             TriggerEvent('sd-phone:client:battery', phoneState.battery)
+        end
+    end
+end)
+
+-- Cuffs go on and players go down mid-session, so gating the open is not enough on its own: an
+-- already-open phone is taken away here. Without it the block is sidestepped by opening the phone
+-- first and being cuffed after.
+CreateThread(function()
+    while true do
+        Wait(500)
+        if (phoneState.open or companion.companionOpen) and seizesOpenPhone() then
+            if companion.companionOpen then TriggerEvent('sd-phone:client:companion:close') end
+            if phoneState.open then ClosePhone() end
         end
     end
 end)

--- a/configs/birdy.lua
+++ b/configs/birdy.lua
@@ -42,6 +42,13 @@ return {
     -- Notifications returned per alerts-tab load.
     NotificationLimit = 50,
 
+    -- Notify a player whenever someone they follow posts. On, every new post alerts each of the
+    -- author's followers and badges their Squawk icon, the way a real feed app does. Off, posts
+    -- land silently in the feed and only likes, replies, reposts and follows still notify.
+    -- Worth turning off on a busy server, where a prolific poster can fill their followers'
+    -- notification list on their own.
+    PostNotifications = true,
+
     -- Account field bounds, mirrored by the React register/login forms.
     MaxNameLength     = 32,
     MinHandleLength   = 2,

--- a/configs/phone.lua
+++ b/configs/phone.lua
@@ -88,6 +88,19 @@ return {
     BlockWhileDead     = true,
     BlockWhileSwimming = true,
 
+    -- Take the phone away while the player is restrained or incapacitated. These read the
+    -- FRAMEWORK's state rather than the ped's: someone bleeding out or in last stand is still a
+    -- live ped, so BlockWhileDead above (an engine-level IsEntityDead check) misses the window
+    -- they actually spend on the floor waiting for EMS.
+    --
+    -- Cuffs have no agreed source, so the check reads the common state bags, the framework
+    -- metadata and the native, which covers cuff scripts that only write one of them.
+    --
+    -- Both close a phone that is ALREADY open too, since gating only the open would be sidestepped
+    -- by opening the phone first and being cuffed after.
+    BlockWhileCuffed   = true,
+    BlockWhileDowned   = true,
+
     -- Whether an incoming call throws the whole phone onto the screen. Off, a
     -- ringing phone shows the same closed-shell banner an alarm does, naming
     -- the caller, and the player opens their phone when they want to answer.

--- a/server/birdy/actions.lua
+++ b/server/birdy/actions.lua
@@ -22,7 +22,7 @@ local moderation = require 'server.admin.moderation'
 local watchers = require('server.watchers').of('birdy')
 
 ---@type table Birdy config (config.Birdy): field bounds + feed/notification limits.
-local birdyCfg = config.Birdy
+local birdyCfg = config.Birdy or require 'configs.birdy'
 
 ---@type table Actions module; the table returned at end of file.
 local actions = {}
@@ -675,6 +675,10 @@ function actions.create(source, payload)
     -- The TriggerEvent above is server-local; this is what reaches players. Scoped to the phones
     -- with Birdy in the foreground: every other player only refetched to discard the result.
     watchers.push('sd-phone:client:birdy:feedChanged', {})
+
+    if birdyCfg.PostNotifications == false then
+        return ok({ post = serializePost(store.getPost(id, prof.handle)) })
+    end
 
     local preview   = body ~= '' and body:sub(1, 80) or 'shared a photo'
     local followers = store.followerHandles(prof.handle)


### PR DESCRIPTION
Three requests from a server owner: disable the phone in cuffs, disable it while dead, and make Squawk's post notifications toggleable.

Two of them turned out to be partly there already, so this is smaller than it sounds.

## "Disabled while dead" already existed, but checked the wrong layer

`configs/phone.lua` has had `BlockWhileDead = true` on by default, enforced with:

```lua
if config.Phone.BlockWhileDead and IsEntityDead(ped) then
```

`IsEntityDead` is a **ped-level** check, true only once the ped is actually dead. In the qb/qbx/ESX families a downed player is not a dead ped: they are alive with `metadata.inlaststand` or `metadata.isdead` set while they bleed out. `qbx_core/server/player.lua` tracks `isdead`, `inlaststand` and `ishandcuffed` as metadata, entirely separately from the engine state.

So the phone stayed usable through exactly the window the request was about: on the floor, waiting for EMS.

`BlockWhileDead` is left alone so no existing config changes meaning. The new `BlockWhileDowned` is a separate gate covering the framework-level state.

## Cuffs have no single source

Nothing in the resource was cuff-aware. There is also no agreed key for it: the qb family writes `ishandcuffed`, ESX forks write `handcuffed`, several standalone scripts write `cuffed`, some set framework metadata instead, and a few cuff the ped properly with the native.

`bridge/client/playerstate.lua` (new, following the same shape as `bridge/client/job.lua`) reads **all** of them, so the block works across cuff scripts rather than only the one this server runs.

## What changed

| Change | Where |
|---|---|
| `isCuffed()` / `isDowned()` across bags, metadata and native | `bridge/client/playerstate.lua` (new) |
| `BlockWhileCuffed`, `BlockWhileDowned`, both default `true` | `configs/phone.lua` |
| Gates folded into one `blockedReason()` shared by the open path | `client/main.lua` |
| Watcher that closes an already-open phone | `client/main.lua` |
| `PostNotifications` toggle, default `true` | `configs/birdy.lua`, `server/birdy/actions.lua` |

The watcher matters: gating only the open is sidestepped by opening the phone first and being cuffed after. It deliberately fires **only** for cuffed/downed, so dead and swimming keep their long-standing behaviour of refusing the open while leaving an open phone alone.

Squawk already notified every follower on each new post (`kind = 'post'`, plus an app badge). That behaviour is unchanged and now sits behind a config flag, defaulting to on. When off, the follower query is skipped entirely rather than fetched and discarded.

Also guards `birdyCfg` with the `config.X or require 'configs.x'` fallback from #254, since it was an unguarded read in a file being touched anyway.

## Gates

- `luac -p` clean on all five files
- New local suite for the bridge: 21 assertions covering every cuff key, every downed key, metadata-only, native-only, cuffed-not-downed, downed-not-cuffed, and an unsupported framework answering `false` rather than throwing
- Full local Lua suite: same 6 pre-existing failures as `main` (baccarat locale stubs, settings snapshot), no new ones
- `npm run i18n:gen` reports `+0 new, -0 dead`; client-side `locale.t` keys are not catalogued in this repo (`phone.blocked_dead` and `phone.blocked_swim` are not in `en.json` either), so the two new keys behave exactly like the existing ones and `en.json` is unchanged
- No `web/src` changes, so no bundle rebuild

Not verified in-game: the FXServer was down. The cuff and downed reads in particular want a real test with a cuff script before this is trusted.
