### PR TITLE
feat(homes): give and revoke qs-housing keys from the Homes app

### DIFF
--- a/bridge/client/housing.lua
+++ b/bridge/client/housing.lua
@@ -62,6 +62,18 @@ lib.callback.register('sd-phone:client:housing:exec', function(system, action, i
             TriggerServerEvent('vms_housing:sv:removeKey', id, arg)
             return true
         end
+
+    elseif system == 'qs-housing' then
+        -- Reached only as the server bridge's fallback, when GiveMetaKey left the target without
+        -- a key. `id` is the qs house NAME, not the phone's property id. The handler on the other
+        -- end reads the owner from `source`, which is why this leaves from the owner's client
+        -- rather than the server; the server has already gated the call on ownership.
+        if action == 'give' then
+            local target = tonumber(arg)
+            if not target then return false end
+            TriggerServerEvent('housing:giveMetaKeyToPlayer', target, tostring(id))
+            return true
+        end
     end
 
     return nil

--- a/bridge/server/housing.lua
+++ b/bridge/server/housing.lua
@@ -203,7 +203,8 @@ end
 
 -- Per-system adapters, keyed by resource name: (source, id) -> Home[]. Sources per system:
 --   ps-housing   DB `properties` (owner_citizenid, street, region, apartment, price, door_data) - open source
---   qs-housing   DB `player_houses` joined to `houselocations` (owner, rented, label, price, coords, keyholders)
+--   qs-housing   DB `player_houses` joined to `houselocations` (owner, rented, label, price, coords,
+--       keyholders); exports GetPlayerHouses / GiveMetaKey / RemoveMetaKey / CheckHasMetaKey
 --   vms_housing  export GetProperty(id).metadata.enter | DB `houses`; keys via vms_housing:sv:giveKey/removeKey
 --   rtx_housing  export GetPlayerOwnedProperties / GetPropertyData(.enter.coords) / Get|SetPropertyLockStatus
 --   bcs_housing  export GetOwnedHomes / GetHome(.properties.entry) / LockHome / isLocked / Add|RemoveKeyHolder / GetKeyHolders
@@ -238,12 +239,51 @@ ADAPTERS['ps-housing'] = function(_source, id)
     return out
 end
 
+---qs-housing addresses the phone-facing property by `player_houses`.`id`, but every one of its
+---own APIs keys on the house NAME, so each write resolves the name before it calls out.
+---@param id any property id as the app echoes it back
+---@return string|nil house qs house name, nil when the row is gone
+local function qsHouseName(id)
+    local rows = dbQuery('SELECT `house` FROM `player_houses` WHERE `id` = ? OR `house` = ? LIMIT 1', { id, id })
+    return rows and rows[1] and s(rows[1].house)
+end
+
+---Whether a player currently holds the physical key item for a house. Tri-state on purpose: nil
+---means qs exposes no CheckHasMetaKey to ask, which must never be read as 'no key'.
+---@param target number holder server id
+---@param house string qs house name
+---@return boolean|nil has nil when the question cannot be asked
+local function qsHasKey(target, house)
+    local ok, has = pcall(function() return exports['qs-housing']:CheckHasMetaKey(target, house) end)
+    if not ok then return nil end
+    return has == true
+end
+
+---Live lock state per house name for the caller's own properties. Read from the server export
+---only: the client export getHouseData carries the same field, but housing.list runs behind every
+---ownership check, so a client round trip here would land on each key give and remove as well.
+---@param source number caller server id
+---@return table<string, boolean> states name -> locked, empty when qs reports none
+local function qsLockStates(source)
+    local out = {}
+    local ok, rows = pcall(function() return exports['qs-housing']:GetPlayerHouses(source) end)
+    if not ok or type(rows) ~= 'table' then return out end
+    for _, r in pairs(rows) do
+        if type(r) == 'table' then
+            local name = s(r.house) or s(r.name)
+            if name and type(r.locked) == 'boolean' then out[name] = r.locked end
+        end
+    end
+    return out
+end
+
 ---qs-housing: ownership/rental in `player_houses`, label/price/coords/keyholders from the joined
----`houselocations`; falls back to the ownership table alone when the join fails.
----@param _source number caller server id (unused - the table keys by owner identifier)
+---`houselocations`; falls back to the ownership table alone when the join fails. Lock state is
+---additive - it shows when qs reports it, and the badge is simply absent when it does not.
+---@param source number caller server id
 ---@param id string caller identifier
 ---@return table[] homes
-ADAPTERS['qs-housing'] = function(_source, id)
+ADAPTERS['qs-housing'] = function(source, id)
     local rows = dbQuery([[
         SELECT ph.*, hl.label AS hl_label, hl.name AS hl_name, hl.price AS hl_price, hl.coords AS hl_coords
         FROM `player_houses` ph
@@ -251,6 +291,7 @@ ADAPTERS['qs-housing'] = function(_source, id)
         WHERE ph.owner = ?
     ]], { id }) or dbQuery('SELECT * FROM `player_houses` WHERE `owner` = ?', { id })
     if not rows then return {} end
+    local locks = qsLockStates(source)
     local out = {}
     for _, r in ipairs(rows) do
         out[#out + 1] = home{
@@ -261,6 +302,7 @@ ADAPTERS['qs-housing'] = function(_source, id)
             value   = r.hl_price or r.price,
             status  = truthy(r.rented) and 'rented' or 'owned',
             coords  = coordsFrom(r, 'hl_coords', 'coords'),
+            locked  = locks[s(r.house) or ''],
         }
     end
     return out
@@ -603,7 +645,7 @@ local CAPS = {
     ['tk_housing']     = { lock = false, keyList = false, keyManage = false },
     ['origen_housing'] = { lock = true,  keyList = false, keyManage = true  },
     ['RxHousing']      = { lock = false, keyList = true,  keyManage = true  },
-    ['qs-housing']     = { lock = false, keyList = true,  keyManage = false },
+    ['qs-housing']     = { lock = false, keyList = true,  keyManage = true  },
     ['vms_housing']    = { lock = false, keyList = false, keyManage = true  },
     ['loaf_housing']   = { lock = false, keyList = false, keyManage = false },
     ['LNS_Housing']    = { lock = true,  keyList = true,  keyManage = true  },
@@ -868,6 +910,26 @@ function housing.giveKey(src, id, targetSrc)
         local res = clientExec(src, 'give', p, targetSrc)
         if res then refreshHomes(src, targetSrc) end
         return res and true or false
+    elseif ACTIVE == 'qs-housing' then
+        local house = qsHouseName(p)
+        if not house then return false end
+        -- The documented server export first. Its third argument names the key, which qs labels
+        -- from the house when nothing better is offered. The outcome is verified rather than
+        -- trusted: a silent no-op would otherwise reach the app as a success toast and no key.
+        local gave = pcall(function() exports['qs-housing']:GiveMetaKey(targetSrc, house, house) end)
+        local has  = qsHasKey(targetSrc, house)
+        if has ~= true and (has == false or not gave) then
+            -- Older builds expose only the net event its own key menu fires, and that handler
+            -- reads the owner from `source`, so it has to leave from the owner's client.
+            gave = clientExec(src, 'give', house, targetSrc) and true or false
+            has  = qsHasKey(targetSrc, house)
+        end
+        -- nil means qs offers no CheckHasMetaKey to ask with, so the call above is taken at its word.
+        if has == true or (has == nil and gave) then
+            refreshHomes(src, targetSrc)
+            return true
+        end
+        return false
     elseif ACTIVE == 'LNS_Housing' then
         local okPerm, allowed = pcall(function()
             return exports.LNS_Housing:CheckPermission(src, 'house', p, 'manage')
@@ -923,6 +985,21 @@ function housing.removeKey(src, id, holderId)
         local res = clientExec(src, 'remove', p, holderId) and true or false
         if res then refreshHomes(src, holderId) end
         return res
+    elseif ACTIVE == 'qs-housing' then
+        local house = qsHouseName(p)
+        if not house then return false end
+        -- RemoveMetaKey takes the holder's server id, not their citizenid: the key is an
+        -- inventory item, so it can only be taken back off someone online to take it from.
+        local holderSrc = tonumber(holderId)
+        if not holderSrc or holderSrc < 1 or holderSrc % 1 ~= 0 then
+            holderSrc = player.getSourceByIdentifier(tostring(holderId))
+        end
+        if not holderSrc then return false end
+        local ok = pcall(function() exports['qs-housing']:RemoveMetaKey(holderSrc, house) end)
+        if not ok then return false end
+        if qsHasKey(holderSrc, house) == true then return false end
+        refreshHomes(src, holderId)
+        return true
     elseif ACTIVE == 'LNS_Housing' then
         local okPerm, allowed = pcall(function()
             return exports.LNS_Housing:CheckPermission(src, 'house', p, 'manage')


### PR DESCRIPTION
Reported in ticket 0058: on qs-housing the Homes app shows the property and its key holders, but no Lock and no Give Key. That is `CAPS['qs-housing'] = { lock = false, keyList = true, keyManage = false }` doing exactly what it says — the app hides actions the active system cannot back.

The reason it sat at `false` is that our qs adapter is pure SQL (`player_houses` joined to `houselocations`), and reading another resource's table is safe where writing one is not. Every system with `keyManage = true` earns it through an export or event; qs had none wired.

## What this adds

**`keyManage = true` for qs-housing**, on Quasar's documented server exports:

| | export |
|---|---|
| give | `GiveMetaKey(source, house, keyId)` |
| revoke | `RemoveMetaKey(source, house)` |
| verify | `CheckHasMetaKey(source, house)` |
| lock state | `GetPlayerHouses(source)` |

Three helpers carry it:

- **`qsHouseName(id)`** — the app addresses a property by `player_houses`.`id`, but every qs API keys on the house **name**, so each write resolves it once. This is the non-obvious bit.
- **`qsHasKey(target, house)`** — deliberately tri-state. `nil` means qs exposes no `CheckHasMetaKey` to ask with, which must never collapse into "no key".
- **`qsLockStates(source)`** — lock state folded into the adapter as `locked`, so the badge shows when qs reports it.

`giveKey` calls the export, then **verifies through `CheckHasMetaKey` rather than trusting it**: a silent no-op would otherwise reach the app as a success toast and no key. Builds too old for the export fall back to the `housing:giveMetaKeyToPlayer` net event, routed through the owner's client because that handler reads the owner from `source`. The server has already gated on `ownsProperty` before either path runs.

## Deliberately not included

**`lock` stays `false`.** Quasar documents no lock export, and the only known route is an undocumented `qb-houses:server:lockHouse` event. Lock *state* is read and displayed; the toggle is not offered until the API is confirmed. A visible button that silently does nothing is worse than the hidden one we have today.

## Notes

- `RemoveMetaKey` takes the holder's **server id**, so revoking only works while the holder is online. The key is an inventory item, so there is nothing to take back off an offline player.
- `qsLockStates` reads the server export only. The client export `getHouseData` carries the same field, but `housing.list` runs behind every `ownsProperty` check, so a client round trip there would land on every key give and revoke as well, not just the list view.

## Gates

- `lua_check` (server's own loader): **all 623 files compile**
- `tsc --noEmit`: clean
- `vitest`: **58 files, 731 tests passed**
- `oxlint src`: **0 errors** (24 pre-existing warnings, untouched files)
- `knip`: clean
- `i18n:check`: passed, 6995 keys, en.json in sync
- `sd-phone` restarted on the dev server: clean boot, server and client, no errors

## Not verified

qs-housing is not installed here and is escrow-encrypted, so **no line of this has run against a live qs server**. The reporter has it running and has been asked to confirm give, revoke and whether the lock toggle works before we consider `lock`.
