### PR TITLE
fix(minesweeper): let flags go down before the first dig and make them visible

### DIFF
--- a/web/src/apps/minesweeper/Minesweeper.tsx
+++ b/web/src/apps/minesweeper/Minesweeper.tsx
@@ -41,7 +41,7 @@ const NUMBER_INK = ['', '#5AA9FF', '#5BD68A', '#FF7A70', '#B98BFF', '#FFB347', '
 
 const wrapStyle = { background: `radial-gradient(120% 90% at 50% 0%, ${pal.bg2} 0%, ${pal.bg} 62%)`, color: pal.text };
 
-const BOARD_MAX_W = 344;
+const BOARD_MAX_W = 392;
 const BOARD_MAX_H = 470;
 
 export function Minesweeper({ onClose: _onClose }: Props) {
@@ -109,7 +109,6 @@ export function Minesweeper({ onClose: _onClose }: Props) {
 
     const flag = useCallback((index: number) => {
         const current = boardRef.current;
-        if (!current.seeded) return;
         if (current.state[index] === REVEALED) return;
         setBoard(toggleFlag(current, index));
     }, []);
@@ -184,7 +183,7 @@ export function Minesweeper({ onClose: _onClose }: Props) {
     const boardW = def.cols * cell + (def.cols + 1) * gap;
     const boardH = def.rows * cell + (def.rows + 1) * gap;
     const numberSize = Math.max(11, Math.round(cell * 0.52));
-    const glyphSize = Math.max(11, Math.round(cell * 0.5));
+    const glyphSize = Math.max(13, Math.round(cell * 0.62));
 
     const cleared = safeCells(board) > 0 ? Math.round((board.revealed / safeCells(board)) * 100) : 0;
     const over = phase === 'won' || phase === 'lost';
@@ -355,7 +354,7 @@ export function Minesweeper({ onClose: _onClose }: Props) {
                             </div>
                         </div>
 
-                        <div className="flex shrink-0 items-stretch justify-center gap-2.5 px-5" style={{ paddingBottom: 24, paddingTop: 8 }}>
+                        <div className="flex shrink-0 items-stretch justify-center gap-2.5 px-5" style={{ paddingBottom: 58, paddingTop: 10 }}>
                             <ModeBtn
                                 on={!flagMode}
                                 onPress={() => setFlagMode(false)}
@@ -407,7 +406,9 @@ function Cell({ index, state, mine, adj, hit, size, numberSize, glyphSize, onDow
 
     const background = revealed
         ? (hit ? 'linear-gradient(160deg, #FF6A5E, #C7302A)' : 'rgba(255,255,255,0.045)')
-        : 'linear-gradient(160deg, #39404F 0%, #2C323E 55%, #262B36 100%)';
+        : flagged
+            ? 'linear-gradient(160deg, #5A3942 0%, #462C33 55%, #3C262C 100%)'
+            : 'linear-gradient(160deg, #39404F 0%, #2C323E 55%, #262B36 100%)';
 
     return (
         <div
@@ -429,11 +430,18 @@ function Cell({ index, state, mine, adj, hit, size, numberSize, glyphSize, onDow
                 touchAction: 'manipulation',
             }}
         >
-            {flagged && <Flag style={{ width: glyphSize, height: glyphSize, color: '#FF6B5F' }} strokeWidth={2.6} />}
+            {flagged && (
+                <Flag
+                    style={{ width: glyphSize, height: glyphSize, color: '#FF7063' }}
+                    fill="#FF3B2F"
+                    strokeWidth={2.2}
+                />
+            )}
             {revealed && mine && (
                 <Bomb
-                    style={{ width: glyphSize, height: glyphSize, color: hit ? '#FFFFFF' : '#FF8A7E', animation: hit ? 'ms-boom 0.3s ease-out' : undefined }}
-                    strokeWidth={2.4}
+                    style={{ width: glyphSize, height: glyphSize, color: hit ? '#FFFFFF' : '#FF9A8E', animation: hit ? 'ms-boom 0.3s ease-out' : undefined }}
+                    fill={hit ? '#FFFFFF' : '#FF6B5F'}
+                    strokeWidth={2.2}
                 />
             )}
             {revealed && !mine && adj > 0 && (


### PR DESCRIPTION
Two reported problems with Minesweeper: flagging appeared to do nothing, and the Dig/Flag buttons sat too low.

## Flagging: two separate causes, both reproduced

**1. Flagging before the first dig was a silent no-op.** `flag()` carried `if (!current.seeded) return;` — my own guard, on the reasoning that flagging is meaningless before mines exist. It isn't: players routinely flag first, and the result was a game that ignored every tap until you happened to dig. Reproduced on a fresh board: flag count stayed 0, mine counter stayed 45.

The guard is gone. Pre-placed flags survive seeding because `plant()` clones the board rather than rebuilding it, and `revealAt()` already refuses to dig a flagged cell, so a mine landing under an early flag is handled.

**2. The flag was nearly invisible when it did work.** A Lucide stroke icon at `cell * 0.5` is ~11px on Hard, which renders as a faint smudge on a dark cell. Mechanically the flag was going down and the mine counter was decrementing; you just couldn't see it. Now:

- glyph `cell * 0.5` → `cell * 0.62`, floor 11px → 13px
- the flag is **filled** (`#FF3B2F`) rather than a thin outline
- a flagged cell gets a warm tint so it reads as flagged even before you resolve the glyph
- revealed mines got the same fill treatment

## Layout

- Controls `paddingBottom` 24 → 58, lifting Dig/Flag clear of the home indicator
- `BOARD_MAX_W` 344 → 392, which is what the board area actually has (440 screen − `px-3`), so cells grow: **Easy 36→40, Medium 26→30, Hard 22→24**

Bigger cells make the board easier to hit *and* give every glyph more room, so this doubles as part of the visibility fix. All three boards still fit: widest is 386px against 416px available, tallest is 470px against the 470px budget.

## Gates

- `tsc --noEmit`: clean
- `vitest`: **58 files, 731 tests**
- `oxlint src`: **0 errors**
- `knip`: clean
- `i18n:check`: 7019 keys, in sync
- Both bundles rebuilt

A throwaway suite of 7 cases covered the exact regression — flagging an unseeded board, flags surviving `plant()`, digging a flagged cell being refused seeded and unseeded, unflagging, revealed cells still unflaggable, plus board-fit and a check that every difficulty gets strictly bigger cells than the old budget. Run green, then deleted rather than committed.

## Not verified

The visual result in-game. Both causes were reproduced on the live server *before* the fix, but the game client's renderer went black partway through re-testing (Lua responsive, NUI DOM alive, no NUI errors — unrelated to this change), so the fixed build has not been seen on screen. The numbers are verified arithmetically and by test; the pixels are not.
