### PR TITLE
fix(messages): keep the typing bubble alive while a long message is being written

### DIFF
--- a/web/src/shared/chat/Composer.tsx
+++ b/web/src/shared/chat/Composer.tsx
@@ -10,6 +10,7 @@ export interface ComposerHandle {
 }
 
 const TYPING_IDLE_MS = 3000;
+const TYPING_HEARTBEAT_MS = 2500;
 
 export const Composer = forwardRef<ComposerHandle, {
     convId:         string;
@@ -42,7 +43,7 @@ export const Composer = forwardRef<ComposerHandle, {
         const notify = notifyRef.current;
         if (!notify) return;
         const now = Date.now();
-        if (!activeRef.current && now - lastOnRef.current >= TYPING_IDLE_MS) {
+        if (!activeRef.current || now - lastOnRef.current >= TYPING_HEARTBEAT_MS) {
             activeRef.current = notify;
             lastOnRef.current = now;
             notify(true);


### PR DESCRIPTION
The typing bubble stops appearing partway through a message. Not intermittent — it is deterministic for any message that takes more than about five seconds to write.

## Cause

The sender and the receiver disagree about how often "still typing" is refreshed.

**Sender** — `shared/chat/Composer.tsx` emits `on` only at the *start* of a burst:

```ts
if (!activeRef.current && now - lastOnRef.current >= TYPING_IDLE_MS) { ... notify(true); }
```

While you keep typing, `activeRef.current` stays set, so **exactly one `on` is ever sent per burst**. An `off` follows 3s after the last keystroke.

**Receiver** — `shared/chat/useTypingPeers.ts` auto-clears on a safety net:

```ts
const CLEAR_AFTER_MS = 5000;
```

So: one `on` at t=0, receiver clears at t=5s, and no further `on` is ever sent. Write for twenty seconds and the peer sees the bubble for five, then nothing for the remaining fifteen. It only returns if you pause 3s (sending `off`) and start again — which is why it reads as "sometimes".

Longer messages are exactly when the indicator matters most, so the failure is concentrated where it is least wanted.

## Fix

A heartbeat: re-send `on` every 2.5s while the composer is still active.

```ts
if (!activeRef.current || now - lastOnRef.current >= TYPING_HEARTBEAT_MS) { ... }
```

2.5s sits half the receiver's 5s window, so a single dropped event still leaves margin before the bubble blinks. Dropping the old `>= TYPING_IDLE_MS` clause from the start-of-burst path also means the bubble reappears immediately when typing resumes, instead of being suppressed for up to 3s.

The receiver is untouched: `CLEAR_AFTER_MS` stays 5s, so a sender that goes offline or closes the app without an `off` still has its bubble reaped.

## Rate limit

`server/messages/actions.lua` caps typing pings at **12 per 10s** per player. Verified with sliding windows across a 60s timeline:

- steady typing: ~4 pings per 10s window
- worst case, one keystroke every 3.2s (an `on` + `off` pair each time): ~6-7 per 10s

Both comfortably inside 12, with the old start-of-burst throttle removed.

## Evidence

A throwaway suite modelled both timelines from the real constants and reproduced the bug before the fix: bubble visible at 1s and 4s, **gone at 6s and 15s** of a 20s message. After the fix it stays visible at 1s, 4s, 6s, 9s, 15s and 19s, still clears ~3s after the typist stops, reappears on resume, and holds the rate limit in both cadences. Seven cases, run red then green, then deleted rather than committed.

## Gates

- `tsc --noEmit`: clean
- `vitest`: **58 files, 731 tests**
- `oxlint src`: **0 errors**
- `knip`: clean
- `i18n:check`: 7019 keys, in sync
- Both bundles rebuilt

## Not verified

Two live phones typing at each other. The dev client's renderer is currently black (unrelated to this change), so this is verified by reading both realms and by the timeline model, not on screen. Worth one two-player check: write a 15-second message and confirm the peer's bubble never drops.
