### PR TITLE
chore(release): 0.9.12

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 'yes'
 
 name 'sd-phone'
 author 'Samuel#0008'
-version '0.9.11'
+version '0.9.12'
 description 'Full-featured in-game smartphone: 46 apps covering calls, messages, mail, social feeds, banking, stocks, marketplace, garages, housing, jobs, maps, camera, music and games, plus home screen widgets, icon themes you can design, cell tower and Wi-Fi coverage, payphones, unique phones and SIM cards, an API for third-party apps and widgets, and lb-phone compatibility'
 
 shared_scripts {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sd-phone-ui",
-    "version": "0.9.11",
+    "version": "0.9.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sd-phone-ui",
-            "version": "0.9.11",
+            "version": "0.9.12",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@fontsource/great-vibes": "^5.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sd-phone-ui",
     "private": true,
-    "version": "0.9.11",
+    "version": "0.9.12",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Version bump for the v0.9.12 pair release.

`fxmanifest.lua`, `web/package.json` and the two root fields in `web/package-lock.json` go 0.9.11 -> 0.9.12. The lockfile was hand-edited, not regenerated, per the Windows `@emnapi/runtime` trap.

v0.9.11 was cut from `release/0.9.11` without the next-wave features while main's manifest already read 0.9.11, so this is the re-bump that was owed. sd-tablet bumps to the same number in its own PR: its release workflow checks out sd-phone at the tablet's tag, so the two versions have to move together.