### PR TITLE
chore(release): back out the 0.9.12 bump

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 'yes'
 
 name 'sd-phone'
 author 'Samuel#0008'
-version '0.9.12'
+version '0.9.11'
 description 'Full-featured in-game smartphone: 46 apps covering calls, messages, mail, social feeds, banking, stocks, marketplace, garages, housing, jobs, maps, camera, music and games, plus home screen widgets, icon themes you can design, cell tower and Wi-Fi coverage, payphones, unique phones and SIM cards, an API for third-party apps and widgets, and lb-phone compatibility'
 
 shared_scripts {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sd-phone-ui",
-    "version": "0.9.12",
+    "version": "0.9.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sd-phone-ui",
-            "version": "0.9.12",
+            "version": "0.9.11",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@fontsource/great-vibes": "^5.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sd-phone-ui",
     "private": true,
-    "version": "0.9.12",
+    "version": "0.9.11",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Reverts #260. The v0.9.12 release and tag were deleted, so main should not claim a version that has never been published.

`fxmanifest.lua`, `web/package.json` and the two root fields in `web/package-lock.json` go back to 0.9.11. sd-tablet returns to 0.9.8 in its own PR.

Everything merged since v0.9.11 stays on main; only the version string moves. Re-bump when the release is actually cut.