### PR TITLE
fix(sim): resolve each player's SIM session once at a time and give every number a single owner

### DIFF
--- a/server/settings/store.lua
+++ b/server/settings/store.lua
@@ -543,7 +543,8 @@ function store.numberExists(number)
     return row ~= nil
 end
 
----Persists a player's phone number as bare digits, leaving any other settings intact.
+---Persists a player's phone number as bare digits, leaving any other settings intact, and
+---releases that number from every other identity so a number lookup resolves to one owner.
 ---@param citizenid string framework per-character id
 ---@param number string phone number in any formatting (separators stripped)
 function store.setPhoneNumber(citizenid, number)
@@ -553,6 +554,20 @@ function store.setPhoneNumber(citizenid, number)
         INSERT INTO phone_settings (citizenid, device, phone_number) VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE phone_number = VALUES(phone_number)
     ]], { citizenid, 'phone', clean })
+    store.releasePhoneNumber(citizenid, clean)
+end
+
+---Clears `number` from every settings row other than `citizenid`'s, so a number lookup resolves
+---to its one live owner. A no-op when no other row holds it.
+---@param citizenid string identity that keeps the number
+---@param number string phone number in any formatting
+function store.releasePhoneNumber(citizenid, number)
+    if not citizenid or citizenid == '' then return end
+    local clean = (tostring(number or ''):gsub('%D', ''))
+    if clean == '' then return end
+    MySQL.update.await(
+        'UPDATE phone_settings SET phone_number = NULL WHERE phone_number = ? AND citizenid <> ?',
+        { clean, citizenid })
 end
 
 ---Clears a phone identity's number mirror (device mode: a phone whose SIM was pulled has no

--- a/server/sim/session.lua
+++ b/server/sim/session.lua
@@ -48,9 +48,33 @@ local TTL = 5000
 ---@type table<number, { at: number, s: SimSession|nil }> Per-source cache; `s = nil` caches "no phone".
 local cache = {}
 
+---@type table<number, table> Per-source compute in flight, so a burst of callbacks landing while
+---the first scan awaits its DB writes shares that scan instead of each minting its own identity.
+local inflight = {}
+
 ---@type table<number, { slot?: number, number?: string, color?: string }> Which phone each
 ---player last opened; matched slot > number > colour against the carried SIMs.
 local prefs = {}
+
+---@type table<number, table<string, true>> Numbers each source has asserted sole ownership of
+---this session, so rows a past double-mint left behind are released once, not on every resolve.
+local claimed = {}
+
+---Mirrors `number` onto `identity`'s settings row, announcing the attach when it changes, and
+---once per session releases the number from any other row still holding it.
+---@param source number player server id
+---@param identity string data identity the number belongs to
+---@param number string bare-digit number
+local function mirrorNumber(source, identity, number)
+    if settingsStore.getPhoneNumber(identity) ~= number then
+        settingsStore.setPhoneNumber(identity, number)
+        TriggerEvent('sd-phone:server:sim:numberAttached', source, identity, number)
+    elseif not (claimed[source] and claimed[source][number]) then
+        settingsStore.releasePhoneNumber(identity, number)
+    end
+    claimed[source] = claimed[source] or {}
+    claimed[source][number] = true
+end
 
 ---Drops one player's cached session (or everyone's with nil) so the next resolve re-scans.
 ---@param source number|nil player server id, nil to flush all
@@ -115,11 +139,7 @@ local function computeLegacy(source, phones)
         if number then
             local identity = simStore.ensureRegistered(number, realIdentifier(source))
             if identity then
-                if settingsStore.getPhoneNumber(identity) ~= number then
-                    settingsStore.setPhoneNumber(identity, number)
-                    -- Back in service: store-and-forward listeners deliver anything queued.
-                    TriggerEvent('sd-phone:server:sim:numberAttached', source, identity, number)
-                end
+                mirrorNumber(source, identity, number)
                 sims[#sims + 1] = {
                     slot     = phone.slot,
                     name     = phone.name,
@@ -216,11 +236,7 @@ local function computeDevice(source, phones)
         local identity, owner = resolveDevice(source, phone, number)
         if number then
             simStore.ensureRegistered(number, realCid)
-            if settingsStore.getPhoneNumber(identity) ~= number then
-                settingsStore.setPhoneNumber(identity, number)
-                -- Back in service: store-and-forward listeners deliver anything queued.
-                TriggerEvent('sd-phone:server:sim:numberAttached', source, identity, number)
-            end
+            mirrorNumber(source, identity, number)
         else
             local existing = settingsStore.getPhoneNumber(identity)
             if existing and existing ~= '' then settingsStore.clearPhoneNumber(identity) end
@@ -287,10 +303,7 @@ local function computeCharacter(source, phones)
     -- cleared first so ensurePhoneNumber mints a fresh innate one).
     local liveNumber = active and active.number or nil
     if liveNumber then
-        if settingsStore.getPhoneNumber(realCid) ~= liveNumber then
-            settingsStore.setPhoneNumber(realCid, liveNumber)
-            TriggerEvent('sd-phone:server:sim:numberAttached', source, realCid, liveNumber)
-        end
+        mirrorNumber(source, realCid, liveNumber)
     else
         local mirror = settingsStore.getPhoneNumber(realCid)
         if mirror and mirror ~= '' and simStore.get(mirror) then
@@ -332,8 +345,18 @@ function session.resolve(source)
     local now = GetGameTimer()
     local hit = cache[source]
     if hit and (now - hit.at) < TTL then return hit.s end
-    local s = compute(source)
+    local pending = inflight[source]
+    if pending then return Citizen.Await(pending) end
+    local p = promise.new()
+    inflight[source] = p
+    local ok, s = pcall(compute, source)
+    inflight[source] = nil
+    if not ok then
+        p:reject(s)
+        error(s, 0)
+    end
     cache[source] = { at = now, s = s }
+    p:resolve(s)
     return s
 end
 
@@ -415,6 +438,7 @@ end
 AddEventHandler('playerDropped', function()
     cache[source] = nil
     prefs[source] = nil
+    claimed[source] = nil
 end)
 
 return session


### PR DESCRIPTION
Fixes #262.

## What was happening

`session.resolve` cached its result only after `compute` returned, and `compute` awaits several database writes. Every callback that landed in that window started its own compute. A client re-sync after a resource restart, or a first phone open, fires many callbacks at once, so under `DataOwner = 'device'` each one minted its own device identity and (with `BuiltInNumbers`) its own number, and wrote its own metadata. The last write won the phone; the earlier identities became orphans that still held numbers in `phone_settings`. `getCitizenByNumber` is `LIMIT 1`, so a number could resolve to an orphan nobody carries: calls refused with the voicemail prompt, texts were stored under an identity no phone reads, and nothing errored.

Reproduced on a Qbox + ox_inventory dev box with two clients and the reporter's config: one restart with a blank phone minted three numbers for one character and left two device identities holding the same number. Not ESX-specific.

## The fix

- `session.resolve` is single-flight per source: a second caller during a compute awaits the same promise (same in-flight pattern as `server/gifs/init.lua`).
- `settingsStore.setPhoneNumber` releases the number from every other row, and a new `releasePhoneNumber` backs it.
- A `mirrorNumber` helper in the session module replaces the three duplicated mirror blocks and, once per source and number per session, releases the number even when the row already matches. That heals servers already damaged: their phones keep a matching row, so the mirror branch alone would never run.

## Verified

- Same restart burst after the fix mints exactly one number; one settings row holds it.
- Planted an orphan row holding a live number: released on the first resolve after restart, live row intact.
- Text delivered to the live identity, dial rings, no console errors.
- `luac -p` on both files.

Servers already affected: numbers players handed out during the broken period were orphans and stay dead; players should re-share their current number from Settings.