### PR TITLE
fix: fail the lockscreen face scan while the ped wears a mask (#276)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -850,8 +850,10 @@ end)
 local MASK_COMPONENT <const> = 1
 
 ---Whether something is covering the local player's face, which Face Unlock cannot scan through.
+---Always false when Lockscreen.MaskBlocksFaceUnlock is off, so a covered face scans as normal.
 ---@return boolean covered
 local function faceCovered()
+    if not config.Lockscreen.MaskBlocksFaceUnlock then return false end
     local ped = cache.ped
     if not ped or ped == 0 or not DoesEntityExist(ped) then return false end
     return GetPedDrawableVariation(ped, MASK_COMPONENT) > 0

--- a/client/main.lua
+++ b/client/main.lua
@@ -845,6 +845,26 @@ RegisterNUICallback('sd-phone:unlock', function(_, cb)
     cb({ ok = true })
 end)
 
+---@type integer Ped component slot 1 is the mask/face slot. Drawable 0 is the bare face on every
+---ped; anything above it is a mask, bandana or hood sitting over it.
+local MASK_COMPONENT <const> = 1
+
+---Whether something is covering the local player's face, which Face Unlock cannot scan through.
+---@return boolean covered
+local function faceCovered()
+    local ped = cache.ped
+    if not ped or ped == 0 or not DoesEntityExist(ped) then return false end
+    return GetPedDrawableVariation(ped, MASK_COMPONENT) > 0
+end
+
+---React to Lua: the lockscreen is running a face scan and asks whether the face is readable. A
+---covered one fails the scan there, and the lockscreen falls back to the passcode.
+---@param _ table|nil unused payload
+---@param cb fun(result: table) NUI response { covered: boolean }
+RegisterNUICallback('sd-phone:face:check', function(_, cb)
+    cb({ covered = faceCovered() })
+end)
+
 ---React to Lua: the closed-shell peek's call island was tapped; reopen the phone onto the
 ---live call.
 ---@param cb fun(result: table) NUI response

--- a/configs/lockscreen.lua
+++ b/configs/lockscreen.lua
@@ -14,4 +14,10 @@ return {
     -- 24-hour or 12-hour clock. iOS default is the device locale;
     -- here we let the server author pick once.
     Use24Hour = false,
+
+    -- Fail Face Unlock while a mask, bandana or hood covers the
+    -- player's face, the way a real phone refuses a face it cannot
+    -- read. The lockscreen falls back to the passcode. Turn this off
+    -- to let a covered face unlock the phone anyway.
+    MaskBlocksFaceUnlock = true,
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -6355,6 +6355,7 @@
     "emergencyAlert": "Emergency Alert",
     "enterPasscode": "Enter Passcode",
     "faceScan": "Face Scan",
+    "faceScanCovered": "Face Not Recognised",
     "flashlight": "Flashlight",
     "focus": "Focus",
     "fold": "Fold",

--- a/web/src/shell/Lockscreen.tsx
+++ b/web/src/shell/Lockscreen.tsx
@@ -210,7 +210,13 @@ export function Lockscreen({ use24h, showDate, wallpaper, unlockTrigger, onUnloc
 
             {authMode && (
                 <div className={`absolute inset-0 z-[80] ${exiting ? 'animate-faceid-veil-out' : ''}`}>
-                    {authMode === 'face' && <FaceScan exiting={exiting} onSuccess={() => latest.current.runPending()} />}
+                    {authMode === 'face' && (
+                        <FaceScan
+                            exiting={exiting}
+                            onSuccess={() => latest.current.runPending()}
+                            onFail={() => setAuthMode('passcode')}
+                        />
+                    )}
                     {authMode === 'passcode' && passcode && (
                         <PasscodeEntry
                             wallpaper={wallpaper}
@@ -232,15 +238,33 @@ export function Lockscreen({ use24h, showDate, wallpaper, unlockTrigger, onUnloc
 }
 
 
-function FaceScan({ exiting, onSuccess }: { exiting: boolean; onSuccess: () => void }) {
+function FaceScan({ exiting, onSuccess, onFail }: { exiting: boolean; onSuccess: () => void; onFail: () => void }) {
     const [done, setDone] = useState(false);
+    const [covered, setCovered] = useState(false);
     const cb = useRef(onSuccess);
     cb.current = onSuccess;
+    const failCb = useRef(onFail);
+    failCb.current = onFail;
 
     useEffect(() => {
-        const toDone   = window.setTimeout(() => setDone(true), 740);
-        const toUnlock = window.setTimeout(() => cb.current(), 1240);
-        return () => { window.clearTimeout(toDone); window.clearTimeout(toUnlock); };
+        let alive = true;
+        const timers: number[] = [];
+        // The face is read in the game, not here: a mask over it fails the scan, and the unlock
+        // falls back to the passcode the same as the real thing.
+        void fetchNui<{ covered?: boolean }>('sd-phone:face:check')
+            .then(res => res?.covered === true)
+            .catch(() => false)
+            .then(isCovered => {
+                if (!alive) return;
+                if (isCovered) {
+                    timers.push(window.setTimeout(() => setCovered(true), 740));
+                    timers.push(window.setTimeout(() => failCb.current(), 1500));
+                    return;
+                }
+                timers.push(window.setTimeout(() => setDone(true), 740));
+                timers.push(window.setTimeout(() => cb.current(), 1240));
+            });
+        return () => { alive = false; timers.forEach(t => window.clearTimeout(t)); };
     }, []);
 
     return (
@@ -264,13 +288,15 @@ function FaceScan({ exiting, onSuccess }: { exiting: boolean; onSuccess: () => v
 
                     <div className="relative h-[108px] w-[108px]">
                         <div className={`absolute inset-0 transition-opacity duration-150 ${done ? 'opacity-0' : 'opacity-100'}`}>
-                            <ScanFace className="h-[108px] w-[108px] text-white" strokeWidth={1.4} />
-                            <div className="absolute inset-[16px] overflow-hidden">
-                                <div
-                                    className="absolute inset-x-0 top-0 h-[2px] animate-faceid-scanline"
-                                    style={{ background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.95) 50%, transparent)', boxShadow: '0 0 12px 1px rgba(255,255,255,0.7)' }}
-                                />
-                            </div>
+                            <ScanFace className={`h-[108px] w-[108px] ${covered ? 'text-ios-red' : 'text-white'}`} strokeWidth={1.4} />
+                            {!covered && (
+                                <div className="absolute inset-[16px] overflow-hidden">
+                                    <div
+                                        className="absolute inset-x-0 top-0 h-[2px] animate-faceid-scanline"
+                                        style={{ background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.95) 50%, transparent)', boxShadow: '0 0 12px 1px rgba(255,255,255,0.7)' }}
+                                    />
+                                </div>
+                            )}
                         </div>
                         {done && (
                             <div className="absolute inset-0 flex items-center justify-center">
@@ -280,8 +306,8 @@ function FaceScan({ exiting, onSuccess }: { exiting: boolean; onSuccess: () => v
                     </div>
                 </div>
 
-                <p className={`mt-2 text-[15px] font-medium text-white/90 transition-opacity duration-200 ${done ? 'opacity-0' : 'opacity-100'}`}>
-                    {t('shell.faceScan','Face Scan')}
+                <p className={`mt-2 text-[15px] font-medium transition-opacity duration-200 ${done ? 'opacity-0' : 'opacity-100'} ${covered ? 'text-ios-red' : 'text-white/90'}`}>
+                    {covered ? t('shell.faceScanCovered', 'Face Not Recognised') : t('shell.faceScan','Face Scan')}
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Closes #276

## Root cause
The lockscreen's Face Scan was pure animation: `FaceScan` in `web/src/shell/Lockscreen.tsx` ran two timers and then called `onSuccess()` unconditionally, and no client Lua ever looked at the ped. Nothing in the resource read the ped's mask component, so a covered face unlocked the phone even though the setup flow tells the player "Nothing can be covering your face when you look at the screen."

## Changes
client/main.lua: added a `sd-phone:face:check` NUI callback next to `sd-phone:unlock`. It reads ped component 1 (the mask/face slot) on `cache.ped` and answers `{ covered = GetPedDrawableVariation(ped, 1) > 0 }`, guarding against a missing ped.

web/src/shell/Lockscreen.tsx: `FaceScan` now asks Lua before it can succeed. A readable face keeps the existing 740 ms / 1240 ms scan-and-unlock timing unchanged; a covered one stops the scanline, turns the glyph and label red with "Face Not Recognised", and after 1500 ms calls the new `onFail` prop. The lockscreen passes `onFail={() => setAuthMode('passcode')}`, so the scan falls back to the passcode keypad with the pending action (unlock, camera, notification open, app launch) intact instead of running it. Outside FiveM the stub `fetchNui` answer has no `covered` field, so the browser dev build behaves exactly as before.

locales/en.json: added `shell.faceScanCovered` ("Face Not Recognised") in the shell block, matching the inline t() fallback. Other catalogs fall back to English until they are translated.

## Testing on the dev server
**Not run** - the dev server copy has uncommitted changes, so the fix was not checked out there

Evidence:
- none

Problems:
- none

## Test plan
- On a Qbox dev server with ox_inventory, give yourself a phone item (`/giveitem <id> phone 1`) and take it out.
- Open Settings > Face Scan & Passcode, turn the passcode on (set e.g. 1234), then turn Face Scan on.
- Close and reopen the phone with a bare face, swipe up (or press Space/Enter): the scan plays, the tick appears and the phone unlocks. Confirm the existing behaviour is unchanged.
- Put a mask on your ped (any clothing menu, e.g. `/skinmenu` or an illegal-mask item from your clothing script; set the mask component to any drawable above 0).
- Take the phone out and swipe up to unlock: the scan should turn red, show "Face Not Recognised", and the passcode keypad should slide in. Typing 1234 unlocks; cancelling leaves the phone locked.
- Repeat with the lockscreen Camera button and by tapping a notification on the lockscreen while masked: each should demand the passcode first and then perform that action, not just unlock.
- Remove the mask (mask drawable back to 0) and swipe up again: the face scan should succeed as before.
- Optional: with Face Scan off and only a passcode set, confirm masking changes nothing - the keypad still appears as it always did.

Risk: **low**

---
_Drafted by bug-fixer (Claude Code) from Discord ticket #?. Review before merging._