### PR TITLE
fix: (migrate): write imported photos trusted so they can be shared (#275)

### DIFF
--- a/server/migrate/store.lua
+++ b/server/migrate/store.lua
@@ -613,9 +613,20 @@ function store.insertMessages(rows)
 end
 
 ---Insert a batch of photos. rows: { id, citizenid, url, favorite, created_at }.
+---
+---Written trusted. The URLs come out of the other phone's own database on an import an operator
+---asked for, never off a client, which is the same provenance the uploader establishes. Left
+---untrusted they still show in the gallery but server.media.guard refuses them, so a migrated
+---photo silently drops out of every post, message and profile picture it is attached to.
 ---@param rows any[][]
 function store.insertPhotos(rows)
-    insertMulti('INSERT IGNORE INTO phone_photos (id, citizenid, url, favorite, created_at) VALUES', 5, rows)
+    if type(rows) ~= 'table' then return end
+    local trusted = {}
+    for i = 1, #rows do
+        local r = rows[i]
+        trusted[i] = { r[1], r[2], r[3], r[4], r[5], 1 }
+    end
+    insertMulti('INSERT IGNORE INTO phone_photos (id, citizenid, url, favorite, created_at, trusted) VALUES', 6, trusted)
 end
 
 ---Insert a batch of albums. rows: { id, citizenid, name }.

--- a/server/photos/store.lua
+++ b/server/photos/store.lua
@@ -55,6 +55,21 @@ function store.ensureSchema()
         MySQL.update.await('UPDATE phone_photos SET trusted = 1 WHERE trusted = 0')
     end
 
+    -- Repair: the importer wrote its rows without the trust flag, which left a migrated photo
+    -- visible in the gallery but refused by server.media.guard - attaching one to a post, message
+    -- or profile picture dropped it silently. Those URLs came from the other phone's own database
+    -- on an operator-run import, so they are trusted here too. Matched on the importer's own id
+    -- shape (`p<id>` from lb-phone, `yp<id>` from YSeries) so no other row can be caught by it,
+    -- and run once: the predicate is unindexed and would otherwise scan the table every boot.
+    util.runOnce('photos_trust_imported_rows', function()
+        -- The pattern stays a parameter, as it does in listForCitizen: a regex quantifier in the
+        -- SQL text would be read by oxmysql as a placeholder.
+        local n = MySQL.update.await(
+            'UPDATE phone_photos SET trusted = 1 WHERE trusted = 0 AND id REGEXP ?',
+            { '^(p|yp)[0-9]+$' })
+        return { repaired = tonumber(n) or 0 }
+    end)
+
     -- store.urlExistsAnywhere looks up by url alone, which idx_phone_photos_owner cannot serve:
     -- its leading column is citizenid, so without this the presigned-upload claim full-scans the
     -- table on every capture, and that table only grows. A prefix index rather than the full 512


### PR DESCRIPTION
Closes #275

## Root cause
phone_photos.trusted records that the server established a URL's provenance, and server/media/guard.lua only admits a photo URL when the row has trusted = 1 (photos.store.hasUrl / urlFor). The migration importer was the only writer that omitted the column: server.migrate.store.insertPhotos inserted (id, citizenid, url, favorite, created_at), so every row from the lb-phone and YSeries porters landed at the column default 0. Migrated photos were listed in the gallery (listForCitizen ignores the flag) but mediaGuard.photos/photo dropped them from every Birdy, Photogram, Vibez, Messages and profile-picture attachment. With no caption the post then failed the "text OR at least one image" check and returned birdy.postCannotEmpty, so nothing was added and nothing was logged.

## Changes
server/migrate/store.lua: store.insertPhotos now writes the trusted column as 1 for every imported row, appending the cell in the writer so both porters (lb-phone's port/photos.lua and YSeries' port/y/photos.lua) are covered without changing their row shape. The rationale is in the doc comment: those URLs come out of the other phone's own database on an operator-run import, never off a client, which is the same provenance the uploader establishes.

server/photos/store.lua: the writer fix only helps future imports, so ensureSchema now carries a one-shot repair for data already migrated, using the existing util.runOnce pattern (as documents/settings stores do). It sets trusted = 1 on untrusted rows whose id matches the importer's own shape ('p<id>' from lb-phone, 'yp<id>' from YSeries), so no row written by any other path can be caught by it, and it is recorded in phone_migrations so later boots skip the unindexed scan. The regex is bound as a parameter rather than written into the SQL text, matching listForCitizen.

No config defaults, bridges, NUI or other resources touched.

## Testing on the dev server
**Not run** - the dev server copy has uncommitted changes, so the fix was not checked out there

Evidence:
- none

Problems:
- none

## Test plan
- On a Qbox dev server with ox_inventory, give yourself a phone: in the server console run `giveitem <your server id> phone 1` (or use ox_inventory's admin menu), then take the phone out of your inventory.
- Repair path (data already migrated before this fix). In the database run: `INSERT INTO phone_photos (id, citizenid, url, favorite, trusted) VALUES ('p9001', '<your citizenid>', 'https://r2.fivemanage.com/<any reachable image>.png', 0, 0);` and, if you are re-testing, `DELETE FROM phone_migrations WHERE name = 'photos_trust_imported_rows';`.
- Restart sd-phone. Then check the repair landed: `SELECT id, trusted FROM phone_photos WHERE id = 'p9001';` must now report trusted = 1.
- In game, open the phone -> Photos: the row shows as a photo in Recents (it did before the fix too).
- Open Birdy -> new post -> attach that photo from the picker and leave the caption empty -> Post. The post appears in the feed with the image on it. Before the fix this returned "Post cannot be empty" and nothing was added.
- Repeat the attach from Photogram, Vibez and Messages (send photo), and set it as a Birdy profile picture: the image sticks in each case.
- Fresh import path. On a database that still holds the other phone's tables, open /phoneadmin -> Migration, tick "Photos and albums" and run it (or `sdphone:migrate` from the server console). When it finishes, check `SELECT id, trusted FROM phone_photos WHERE id REGEXP '^(p|yp)[0-9]+$' LIMIT 10;` - every row reports trusted = 1.
- Log in as a player whose photos came across and post one of them to Birdy: the image is attached.
- Regression check: take a fresh photo with the Camera app and post it to Birdy, and confirm an arbitrary URL pasted into a post body is still not attachable - normal capture and the guard's refusal of foreign URLs are unchanged.

Risk: **low**

---
_Drafted by bug-fixer (Claude Code) from Discord ticket #?. Review before merging._