### PR TITLE
fix(clipboard): route Phone settings and Maps calibration copy through copyToClipboard

### DIFF
--- a/web/src/apps/maps/Maps.tsx
+++ b/web/src/apps/maps/Maps.tsx
@@ -323,7 +323,7 @@ export function Maps({ onClose }: { onClose: () => void }) {
                     <div className="absolute left-1/2 top-3 z-40 flex -translate-x-1/2 items-center gap-2 rounded-full bg-black/85 px-3 py-1.5 text-[12px] font-semibold text-white shadow-lg">
                         <span>{me ? 'CALIBRATE · tap your real spot' : 'CALIBRATE · waiting for GPS…'} · {calib.length} pts</span>
                         <button
-                            onClick={() => { const s = JSON.stringify(calib); navigator.clipboard?.writeText(s).catch(() => {}); console.log('[mapcal]', s); }}
+                            onClick={() => { const s = JSON.stringify(calib); copyToClipboard(s); console.log('[mapcal]', s); }}
                             className="rounded-full bg-ios-blue px-2 py-0.5"
                         >Copy</button>
                         <button

--- a/web/src/apps/settings/security/PhoneSettingsPage.tsx
+++ b/web/src/apps/settings/security/PhoneSettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight, Copy, Plus, Trash2 } from 'lucide-react';
 
 import { t } from '@/i18n';
+import { copyToClipboard } from '@/lib/clipboard';
 import { digits } from '@/lib/format';
 import { formatPhone } from '@/lib/phone';
 import { useContacts } from '@/stores/contactsStore';
@@ -26,7 +27,7 @@ export function PhoneSettingsPage({ onBack }: { onBack: () => void }) {
     const [showBlocked,  setShowBlocked]  = useState(false);
 
     function copyNumber() {
-        navigator.clipboard?.writeText(number).catch(() => {});
+        copyToClipboard(number);
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
     }


### PR DESCRIPTION
Fixes #279

Two copy buttons flip to a "success" state but never actually place anything on the clipboard:

1. Settings → Phone → "My Number" copy icon
2. Maps → calibration mode → "Copy" button (calibration JSON)

Both called `navigator.clipboard?.writeText(...)` directly and swallowed the rejection with `.catch(() => {})`. Inside FiveM's NUI (CEF), the Clipboard API is commonly blocked/unavailable, so the write silently fails while the UI still shows success.

Every other screen that copies text (Contacts, Passwords, ID, Racing, Dark Chat, Voice Memos) already goes through the shared `copyToClipboard()` helper in `lib/clipboard.ts`, which falls back to a hidden-textarea + `document.execCommand('copy')` — that path works fine in-game. These two call sites were the only ones still using the raw API.

This swaps both for the existing helper, matching the pattern already used everywhere else. No new dependencies, no behavior change outside the fix.