### PR TITLE
fix: (nui): use copyToClipboard helper in Phone settings and Maps calib (#279)

### DIFF
--- a/web/src/apps/maps/Maps.tsx
+++ b/web/src/apps/maps/Maps.tsx
@@ -323,7 +323,7 @@ export function Maps({ onClose }: { onClose: () => void }) {
                     <div className="absolute left-1/2 top-3 z-40 flex -translate-x-1/2 items-center gap-2 rounded-full bg-black/85 px-3 py-1.5 text-[12px] font-semibold text-white shadow-lg">
                         <span>{me ? 'CALIBRATE · tap your real spot' : 'CALIBRATE · waiting for GPS…'} · {calib.length} pts</span>
                         <button
-                            onClick={() => { const s = JSON.stringify(calib); navigator.clipboard?.writeText(s).catch(() => {}); console.log('[mapcal]', s); }}
+                            onClick={() => { const s = JSON.stringify(calib); copyToClipboard(s); console.log('[mapcal]', s); }}
                             className="rounded-full bg-ios-blue px-2 py-0.5"
                         >Copy</button>
                         <button

--- a/web/src/apps/settings/security/PhoneSettingsPage.tsx
+++ b/web/src/apps/settings/security/PhoneSettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight, Copy, Plus, Trash2 } from 'lucide-react';
 
 import { t } from '@/i18n';
+import { copyToClipboard } from '@/lib/clipboard';
 import { digits } from '@/lib/format';
 import { formatPhone } from '@/lib/phone';
 import { useContacts } from '@/stores/contactsStore';
@@ -26,7 +27,7 @@ export function PhoneSettingsPage({ onBack }: { onBack: () => void }) {
     const [showBlocked,  setShowBlocked]  = useState(false);
 
     function copyNumber() {
-        navigator.clipboard?.writeText(number).catch(() => {});
+        if (!copyToClipboard(number)) return;
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
     }


### PR DESCRIPTION
Closes #279

## Root cause
Two NUI call sites wrote to the clipboard with the raw async Clipboard API (`navigator.clipboard?.writeText(...)`) and swallowed the rejection with `.catch(() => {})`. Inside FiveM's CEF NUI the Clipboard API is typically unavailable or blocked (no secure-context/user-gesture permission), so the promise rejects, nothing lands on the system clipboard, and the UI still reported success. Every other copy in the app uses `copyToClipboard()` in `web/src/lib/clipboard.ts`, which does a hidden-textarea + `document.execCommand('copy')` — the path that works in CEF — and returns whether it actually copied.

## Changes
web/src/apps/settings/security/PhoneSettingsPage.tsx: `copyNumber()` now calls the shared `copyToClipboard(number)` instead of `navigator.clipboard?.writeText(number).catch(() => {})`, and only sets the `copied` state (green icon) when the helper reports success, matching the existing pattern in apps/id/DetailsList.tsx. Added the `@/lib/clipboard` import.

web/src/apps/maps/Maps.tsx: the calibration overlay's "Copy" button now calls `copyToClipboard(s)` for the calibration JSON instead of the raw API. The existing `console.log('[mapcal]', s)` is left in place as the dev-tool fallback, and `copyToClipboard` was already imported in this file for the waypoint-code copy, so no import change was needed.

No behaviour outside these two buttons changed; the shared helper is untouched. web/build is not committed, so the fix ships with the normal NUI build.

## Testing on the dev server
**Not run** - the dev server copy has uncommitted changes, so the fix was not checked out there

Evidence:
- none

Problems:
- none

## Test plan
- Start the Qbox dev server with ox_inventory and sd-phone built from this branch (run the web build so web/build is regenerated), then join with a character.
- Give yourself a phone: /giveitem <id> phone 1 (or use the item name configured in configs/), and open it.
- Open Settings -> Phone. Note the number shown next to 'My Number', then click the copy icon; the icon should flash green.
- Alt-tab out of the game and paste (Ctrl+V) into Notepad/Discord: the same formatted number must appear. Before the fix nothing was pasted.
- Back in game, open the Maps app and start calibration mode (the CALIBRATE overlay appears at the top of the map), tap the map once or twice so the point counter is greater than 0.
- Click 'Copy' in the CALIBRATE overlay, then paste outside the game: a JSON array of calibration points must appear (it should match the '[mapcal]' line in the F8/CEF console). Before the fix nothing was pasted.
- Regression check: confirm the copy buttons in Contacts (contact detail), Passwords, ID and Dark Chat room code still copy correctly.

Risk: **low**

---
_Drafted by bug-fixer (Claude Code) from Discord ticket #?. Review before merging._